### PR TITLE
Corrige le message d'erreur sur le typage de `token`

### DIFF
--- a/components/settings.js
+++ b/components/settings.js
@@ -234,12 +234,6 @@ const Settings = React.memo(({nomBaseLocale}) => {
             </Button>
 
           </Pane>
-        ) : token === false ? (
-          <Pane padding={16}>
-            <Alert intent='danger' title='Jeton de sécurité invalide ou non renseigné'>
-              Vous n’avez pas accès aux paramètres de cette Base Adresse Locale.
-            </Alert>
-          </Pane>
         ) : (
           <Spinner size={64} margin='auto' />
         )}

--- a/contexts/token.js
+++ b/contexts/token.js
@@ -21,7 +21,7 @@ export function TokenContextProvider({balId, _token, ...props}) {
       setToken(baseLocale.token)
       setEmails(baseLocale.emails)
     } else {
-      setToken(false)
+      setToken(null)
     }
   }, [balId])
 


### PR DESCRIPTION
Cette PR corrige un message d'erreur dans la console en mode consultation : 
`Warning: Failed prop type: Invalid prop token of type boolean supplied to Publication, expected string.` 

À l'ouverture d'une Base Adresse Locale en mode consultation (sans jeton d'administration), le contexte du token vérifie que le jeton correspondant à la Base Locale est bien présent. S’il ne l'est pas, le token passait à `false` et était donc considéré de type "booléen".

Désormais, le jeton est défini à `null`  si l'utilisateur n'est pas administrateur de la Base Locale consultée.

Fix #401 