### PR TITLE
Déplace l'accès à l'aide interactive 

### DIFF
--- a/components/header.js
+++ b/components/header.js
@@ -1,13 +1,13 @@
-import React from 'react'
+import React, {useContext} from 'react'
 import NextLink from 'next/link'
 import Image from 'next/image'
-import {Pane, Button, Link} from 'evergreen-ui'
+import {Pane, Button, Link, HelpIcon, BookIcon} from 'evergreen-ui'
 
-const links = [
-  {text: 'Guides de l’adressage', link: 'https://adresse.data.gouv.fr/guides'}
-]
+import HelpContext from '../contexts/help'
 
 const Header = () => {
+  const {showHelp, setShowHelp} = useContext(HelpContext)
+
   return (
     <Pane borderBottom padding={16} backgroundColor='white' display='flex' justifyContent='space-between' alignItems='center' flexShrink='0' width='100%' maxHeight={76}>
       <Pane cursor='pointer'>
@@ -18,13 +18,19 @@ const Header = () => {
         </NextLink>
       </Pane>
       <Pane display='flex' justifyContent='space-around' alignItems='center'>
-        {links.map(link => (
-          <Button key={link.text} appearance='minimal' marginRight='12px' minHeight='55px'>
-            <Link href={link.link} textDecoration='none' color='neutral' target='_blank'>
-              {link.text}
-            </Link>
-          </Button>
-        ))}
+        <Button
+          appearance='minimal' marginRight='12px' minHeight='55px'
+          iconAfter={HelpIcon}
+          onClick={() => setShowHelp(!showHelp)}
+        >
+          Besoin d’aide
+        </Button>
+
+        <Button appearance='minimal' marginRight='12px' minHeight='55px' iconAfter={BookIcon}>
+          <Link href='https://adresse.data.gouv.fr/guides' textDecoration='none' color='neutral' target='_blank'>
+            Guides de l’adressage
+          </Link>
+        </Button>
       </Pane>
     </Pane>
   )

--- a/components/help/index.js
+++ b/components/help/index.js
@@ -9,54 +9,51 @@ const Help = () => {
   const {showHelp, setShowHelp, selectedIndex, setSelectedIndex} = useContext(HelpContext)
 
   return (
-    <>
-      <SideSheet
-        isShown={showHelp}
-        containerProps={{
-          display: 'flex',
-          flex: '1',
-          flexDirection: 'column'
-        }}
-        onCloseComplete={() => setShowHelp(false)}
-      >
-        <Pane zIndex={1} flexShrink={0} elevation={0} backgroundColor='white'>
-          <Pane padding={16} borderBottom='muted'>
-            <Heading size={600}>Besoin d’aide ?</Heading>
-          </Pane>
-          <Pane display='flex' padding={8}>
-            <Tablist>
-              {TABS.map(
-                (tab, index) => (
-                  <Tab
-                    key={tab}
-                    isSelected={selectedIndex === index}
-                    onSelect={() => setSelectedIndex(index)}
-                  >
-                    {tab}
-                  </Tab>
-                )
-              )}
-            </Tablist>
-          </Pane>
+    <SideSheet
+      isShown={showHelp}
+      containerProps={{
+        display: 'flex',
+        flex: '1',
+        flexDirection: 'column'
+      }}
+      onCloseComplete={() => setShowHelp(false)}
+    >
+      <Pane zIndex={1} flexShrink={0} elevation={0} backgroundColor='white'>
+        <Pane padding={16} borderBottom='muted'>
+          <Heading size={600}>Besoin d’aide ?</Heading>
         </Pane>
-
-        <Pane flex='1' overflowY='scroll' background='tint1' padding={16}>
-          <HelpTabs tab={selectedIndex} />
+        <Pane display='flex' padding={8}>
+          <Tablist>
+            {TABS.map(
+              (tab, index) => (
+                <Tab
+                  key={tab}
+                  isSelected={selectedIndex === index}
+                  onSelect={() => setSelectedIndex(index)}
+                >
+                  {tab}
+                </Tab>
+              )
+            )}
+          </Tablist>
         </Pane>
+      </Pane>
 
-        <Pane padding={16} background='tint2' elevation={1}>
-          <Heading>Vous n’avez pas trouvé la solution à votre problème ?</Heading>
-          <Paragraph>
-            <Link target='_blank' href='https://adresse.data.gouv.fr/guides'>Consultez les guides de l’adressage</Link>
-          </Paragraph>
-          <Paragraph>ou</Paragraph>
-          <Paragraph>
-            Contactez nous sur <a href='mailto:adresse@data.gouv.fr'>adresse@data.gouv.fr</a>
-          </Paragraph>
-        </Pane>
+      <Pane flex='1' overflowY='scroll' background='tint1' padding={16}>
+        <HelpTabs tab={selectedIndex} />
+      </Pane>
 
-      </SideSheet>
-    </>
+      <Pane padding={16} background='tint2' elevation={1}>
+        <Heading>Vous n’avez pas trouvé la solution à votre problème ?</Heading>
+        <Paragraph>
+          <Link target='_blank' href='https://adresse.data.gouv.fr/guides'>Consultez les guides de l’adressage</Link>
+        </Paragraph>
+        <Paragraph>ou</Paragraph>
+        <Paragraph>
+          Contactez nous sur <a href='mailto:adresse@data.gouv.fr'>adresse@data.gouv.fr</a>
+        </Paragraph>
+      </Pane>
+    </SideSheet>
   )
 }
 

--- a/components/sub-header/index.js
+++ b/components/sub-header/index.js
@@ -1,13 +1,12 @@
 import React, {useContext} from 'react'
 import PropTypes from 'prop-types'
 import NextLink from 'next/link'
-import {Pane, Popover, Menu, IconButton, Position, Button, MenuIcon, HelpIcon, CogIcon, DownloadIcon} from 'evergreen-ui'
+import {Pane, Popover, Menu, IconButton, Position, Button, MenuIcon, CogIcon, DownloadIcon, Heading} from 'evergreen-ui'
 
 import {getBaseLocaleCsvUrl, updateBaseLocale} from '../../lib/bal-api'
 
 import BalDataContext from '../../contexts/bal-data'
 import TokenContext from '../../contexts/token'
-import HelpContext from '../../contexts/help'
 import SettingsContext from '../../contexts/settings'
 
 import useError from '../../hooks/error'
@@ -22,7 +21,6 @@ const ADRESSE_URL = process.env.NEXT_PUBLIC_ADRESSE_URL || 'https://adresse.data
 
 const SubHeader = React.memo(({commune, voie, toponyme, layout, isSidebarHidden, onToggle}) => {
   const {baseLocale, reloadBaseLocale} = useContext(BalDataContext)
-  const {showHelp, setShowHelp} = useContext(HelpContext)
   const {showSettings, setShowSettings} = useContext(SettingsContext)
   const {token} = useContext(TokenContext)
 
@@ -85,17 +83,6 @@ const SubHeader = React.memo(({commune, voie, toponyme, layout, isSidebarHidden,
         />
 
         <Pane marginLeft='auto' display='flex'>
-
-          <Button
-            height={24}
-            iconAfter={HelpIcon}
-            appearance='minimal'
-            marginRight={16}
-            onClick={() => setShowHelp(!showHelp)}
-          >
-            Besoin d’aide
-          </Button>
-
           <Popover
             position={Position.BOTTOM_RIGHT}
             content={

--- a/components/sub-header/index.js
+++ b/components/sub-header/index.js
@@ -1,7 +1,7 @@
 import React, {useContext} from 'react'
 import PropTypes from 'prop-types'
 import NextLink from 'next/link'
-import {Pane, Popover, Menu, IconButton, Position, Button, MenuIcon, CogIcon, DownloadIcon, Heading} from 'evergreen-ui'
+import {Pane, Popover, Menu, IconButton, Position, Button, MenuIcon, CogIcon, DownloadIcon} from 'evergreen-ui'
 
 import {getBaseLocaleCsvUrl, updateBaseLocale} from '../../lib/bal-api'
 


### PR DESCRIPTION
## Contexte
Le bouton d'accès à l'aide interactive se situe actuellement à droite de l'en-tête d'une BAL. L'espace disponible sur cette l'en-tête étant limité et voué à évoluer, il est préférable de déplacer ce bouton afin de libérer de l'espace mais aussi le rendre plus visible.

## Évolutions
- Déplace le bouton d'accès à l'aide interactive dans la barre de navigation.
- Ajout d'icones illustrant l'aide et la documentation

-----

### Avant
![Capture d’écran 2021-09-23 à 13 40 40](https://user-images.githubusercontent.com/7040549/134500757-d37ce029-88e6-4719-855b-67eb6a6324bf.png)

### Après
![Capture d’écran 2021-09-23 à 13 39 53](https://user-images.githubusercontent.com/7040549/134500659-987b9c69-55dd-437c-a474-2b0d18ba979c.png)
