### PR TITLE
Mise à jour de la librairie `date-fns`

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "babel-plugin-lodash": "^3.3.4",
     "chart.js": "^2.9.4",
     "compression": "^1.7.4",
-    "date-fns": "^2.16.1",
+    "date-fns": "^2.24.0",
     "evergreen-ui": "^6.4.0",
     "express": "^4.17.1",
     "fs-extra": "^10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2052,15 +2052,15 @@ data-uri-to-buffer@3.0.1:
   resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz#594b8973938c5bc2c33046535785341abc4f3636"
   integrity sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==
 
-date-fns@^2.16.1:
-  version "2.16.1"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.16.1.tgz#05775792c3f3331da812af253e1a935851d3834b"
-  integrity sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ==
-
 date-fns@^2.17.0:
   version "2.22.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.22.1.tgz#1e5af959831ebb1d82992bf67b765052d8f0efc4"
   integrity sha512-yUFPQjrxEmIsMqlHhAhmxkuH769baF21Kk+nZwZGyrMoyLA+LugaQtC0+Tqf9CBUUULWwUJt6Q5ySI3LJDDCGg==
+
+date-fns@^2.24.0:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.24.0.tgz#7d86dc0d93c87b76b63d213b4413337cfd1c105d"
+  integrity sha512-6ujwvwgPID6zbI0o7UbURi2vlLDR9uP26+tW6Lg+Ji3w7dd0i3DOcjcClLjLPranT60SSEFBwdSyYwn/ZkPIuw==
 
 date-now@^0.1.4:
   version "0.1.4"


### PR DESCRIPTION
Mise à jour de la librairie [date-fns](https://github.com/date-fns/date-fns) : 
_de la version 2.16.1 vers la version 2.24.0_

[Changelog](https://github.com/date-fns/date-fns/releases)


