### PR TITLE
Mise à jour de la librairie `etalab/bal`

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build:geo": "node scripts/build-geo"
   },
   "dependencies": {
-    "@etalab/bal": "^1.2.0",
+    "@etalab/bal": "^1.5.1",
     "@next/bundle-analyzer": "^10.0.2",
     "@turf/bbox": "^6.0.1",
     "@turf/buffer": "^5.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -167,17 +167,17 @@
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.7.4.tgz#f14932887422c9056b15a8d222a9074a7dfa2831"
   integrity sha512-fxfMSBMX3tlIbKUdtGKxqB1fyrH6gVrX39Gsv3y8lRYKUqlgDt3UMqQyGnR1bQMa2B8aGnhLZokZgg8vT0Le+A==
 
-"@etalab/bal@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@etalab/bal/-/bal-1.2.0.tgz#2a236ba24034ca13654b6e3df147deb4dbea6a3e"
-  integrity sha512-FJHHOpW1JvKIrKcHU1hLOYY0QkFDmb61IgUXqhpMsusEWnOijQOkzd2TVHaC6PpV2iOyEazahJl/fr+6zjryUA==
+"@etalab/bal@^1.5.1":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@etalab/bal/-/bal-1.5.1.tgz#0e8d32330011a2355ee161644b4d86df76225c95"
+  integrity sha512-EJSeQ55eMAEgAezGmEtBQ0gGbPFnfY0I+h8MoNgNnyb7Z2764c8rH3YzpbahBa2zQgRl150eI3/7Us53ZUJyLg==
   dependencies:
     blob-to-buffer "^1.2.9"
-    chalk "^4.1.0"
-    date-fns "^2.17.0"
+    chalk "^4.1.1"
+    date-fns "^2.21.1"
     iconv-lite "^0.6.2"
     jschardet-french "^0.0.1"
-    lodash "^4.17.20"
+    lodash "^4.17.21"
     papaparse "^5.3.0"
     yargs "^16.2.0"
 
@@ -1563,10 +1563,10 @@ chalk@4.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.1.tgz#c80b3fab28bf6371e6863325eee67e618b77e6ad"
-  integrity sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==
+chalk@^4.1.1:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
@@ -2050,10 +2050,10 @@ date-fns@^2.16.1:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.16.1.tgz#05775792c3f3331da812af253e1a935851d3834b"
   integrity sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ==
 
-date-fns@^2.17.0:
-  version "2.22.1"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.22.1.tgz#1e5af959831ebb1d82992bf67b765052d8f0efc4"
-  integrity sha512-yUFPQjrxEmIsMqlHhAhmxkuH769baF21Kk+nZwZGyrMoyLA+LugaQtC0+Tqf9CBUUULWwUJt6Q5ySI3LJDDCGg==
+date-fns@^2.21.1:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.24.0.tgz#7d86dc0d93c87b76b63d213b4413337cfd1c105d"
+  integrity sha512-6ujwvwgPID6zbI0o7UbURi2vlLDR9uP26+tW6Lg+Ji3w7dd0i3DOcjcClLjLPranT60SSEFBwdSyYwn/ZkPIuw==
 
 date-now@^0.1.4:
   version "0.1.4"
@@ -4346,7 +4346,7 @@ lodash@^4.17.13:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
-lodash@^4.17.15, lodash@^4.17.20:
+lodash@^4.17.15:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==


### PR DESCRIPTION
Mise à jour de la librairie [etalab/bal](https://github.com/BaseAdresseNationale/bal) :
_de la version 1.2.0 vers la version 1.5.1_

[Changelog](https://github.com/BaseAdresseNationale/bal/releases)
