### PR TITLE
Fin de support de Node.js 12

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [14.x, 16.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [14.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ https://adresse.data.gouv.fr/data/docs/guide-mes-adresses-v4.0.pdf
 
 ## Pré-requis
 
-- [Node.js](https://nodejs.org) 12+
+- [Node.js](https://nodejs.org) 14+
 - [yarn](https://www.yarnpkg.com)
 
 ## Installation

--- a/package.json
+++ b/package.json
@@ -63,5 +63,8 @@
       "react/no-danger": "warn",
       "react/require-default-props": "warn"
     }
+  },
+  "engines": {
+    "node": ">= 14"
   }
 }


### PR DESCRIPTION
Version minimale : 14
Versions utilisées par GitHub Actions : 14 et 16