### PR TITLE
Adapter le contenu du tooltip lorsqu'une bal est publiée

### DIFF
--- a/components/bases-locales-list/base-locale-card.js
+++ b/components/bases-locales-list/base-locale-card.js
@@ -137,12 +137,17 @@ const BaseLocaleCard = ({baseLocale, isAdmin, userEmail, initialIsOpen, onSelect
 
           {isAdmin ? (
             <Pane borderTop display='flex' justifyContent='space-between' paddingTop='1em' marginTop='1em'>
-              {isDeletable ? (
-                <Button iconAfter={TrashIcon} intent='danger' disabled={!onRemove || !hasToken} onClick={onRemove}>Supprimer</Button>
-              ) : (
-                <Tooltip content={tooltipContent}>
-                  <Button isActive iconAfter={TrashIcon}>Supprimer</Button>
-                </Tooltip>
+              {hasToken && (
+                isDeletable ? (
+                  <Button iconAfter={TrashIcon} intent='danger' disabled={!onRemove} onClick={onRemove}>Supprimer</Button>
+                ) : (
+                  <Tooltip content={tooltipContent}>
+                    {/* Button disabled props prevents pointer-events. Button is wrap in <Pane> to allow tooltip content to display => https://evergreen.segment.com/components/buttons#disabled_state */}
+                    <Pane>
+                      <Button disabled iconAfter={TrashIcon}>Supprimer</Button>
+                    </Pane>
+                  </Tooltip>
+                )
               )}
 
               {hasToken ? (
@@ -165,7 +170,6 @@ const BaseLocaleCard = ({baseLocale, isAdmin, userEmail, initialIsOpen, onSelect
           )}
         </>
       )}
-
     </Card>
   )
 }


### PR DESCRIPTION
resolve #411 

<img width="1440" alt="Capture d’écran 2021-10-11 à 15 29 34" src="https://user-images.githubusercontent.com/66621960/136801328-74a6ec1c-8758-427f-9c80-f3ee5e05162e.png">
