### PR TITLE
Bloquer la redirection après l'enregistrement d'un nouveau tracé de voie

### DIFF
--- a/components/bal/voie-editor.js
+++ b/components/bal/voie-editor.js
@@ -36,16 +36,18 @@ function VoieEditor({initialValue, onSubmit, onCancel}) {
     try {
       await onSubmit(body)
 
-      const {balId, codeCommune} = router.query
-      router.push(
-        `/bal/commune?balId=${balId}&codeCommune=${codeCommune}`,
-        `/bal/${balId}/communes/${codeCommune}`
-      )
+      if (!drawEnabled) {
+        const {balId, codeCommune} = router.query
+        router.push(
+          `/bal/commune?balId=${balId}&codeCommune=${codeCommune}`,
+          `/bal/${balId}/communes/${codeCommune}`
+        )
+      }
     } catch (error) {
       setIsLoading(false)
       setError(error.message)
     }
-  }, [router, nom, isMetric, data, onSubmit])
+  }, [router, nom, isMetric, data, drawEnabled, onSubmit])
 
   const onFormCancel = useCallback(e => {
     e.preventDefault()


### PR DESCRIPTION
Fix issue #430 

Lorsque l'on enregistre le tracé d'une voie (création ou modification) depuis la page de cette voie, nous ne sommes plus automatiquement redirigé vers la liste des voies de la commune.

