### PR TITLE
Corrige l’ouverture du panneau d’édition sans jeton

### DIFF
--- a/components/table-row.js
+++ b/components/table-row.js
@@ -19,7 +19,7 @@ const TableRow = React.memo(({id, code, label, warning, comment, secondary, isSe
   }, [toponymeId, toponymes])
 
   const onClick = useCallback(e => {
-    if (e.target.closest('[data-editable]') && !isEditing && !code) { // Not a commune
+    if (e.target.closest('[data-editable]') && !isEditing && !code && token) { // Not a commune
       onEdit(id)
     } else if (onSelect) {
       if (e.target.closest('[data-browsable]')) {


### PR DESCRIPTION
### Problème : 

Il est possible d’ouvrir le panneau d’édition d’un numéro en cliquant sur celui-ci, même sans jeton.

### Solution : 

Ajout d’une condition pour éviter l’ouverture du panneau si l’utilisateur n’est pas administrateur de la Base Adresse Locale (présence ou non du jeton) 