### PR TITLE
Désactive l'ouverture du formulaire d'édition d'un numéro en mode consultation

### DIFF
--- a/components/table-row.js
+++ b/components/table-row.js
@@ -51,7 +51,7 @@ const TableRow = React.memo(({id, code, label, warning, comment, secondary, isSe
   }, [])
 
   return (
-    <Table.Row onClick={onClick}>
+    <Table.Row onClick={token ? onClick : null}>
       {token && !isEditing && hasNumero && isSelectable && (
         <Table.Cell flex='0 1 1'>
           <Checkbox


### PR DESCRIPTION
## Contexte
Il est possible d'ouvrir l'édition d'un numéro en mode consultation en cliquant sur le raccourci "expert" situé directement sur le numéro.

## Correction
L'évènement `onClick` est désactivé si le `token` n'est pas fourni.