### PR TITLE
Ajout d’un indicateur de chargement sur le bouton "Créer une nouvelle Base Adresse Locale"

### DIFF
--- a/pages/new/alert-published-bal.js
+++ b/pages/new/alert-published-bal.js
@@ -85,7 +85,7 @@ const AlertPublishedBAL = ({isShown, userEmail, onClose, onConfirm, basesLocales
           `Vous avez déjà créé une Base Adresse Locale pour ${communeLabel}`
         )}
         width='800px'
-        confirmLabel='Créer une nouvelle Base Adresse Locale'
+        confirmLabel={isLoading ? 'En cours de création…' : 'Créer une nouvelle Base Adresse Locale'}
         cancelLabel='Annuler'
         isConfirmLoading={isLoading}
         onConfirm={handleConfirmation}


### PR DESCRIPTION
Cette PR ajoute une icône de chargement sur le bouton de confirmation "Créer une nouvelle Base Adresse Locale" afin d’indiquer à l’utilisateur que le programme est en train de charger les données de la commune et éviter qu’il clique plusieurs fois sur le bouton.

Fix #418 

