### PR TITLE
Corrige la fermeture du mode édition après l’ajout d’une voie

### DIFF
--- a/pages/bal/commune.js
+++ b/pages/bal/commune.js
@@ -68,6 +68,7 @@ const Commune = React.memo(({baseLocale, commune, defaultVoies}) => {
       await reloadToponymes()
     }
 
+    setIsEditing(false)
     setIsAdding(false)
   }, [baseLocale._id, commune, reloadVoies, token, selectedTab, reloadToponymes, reloadGeojson])
 

--- a/pages/bal/commune.js
+++ b/pages/bal/commune.js
@@ -70,7 +70,7 @@ const Commune = React.memo(({baseLocale, commune, defaultVoies}) => {
 
     setIsEditing(false)
     setIsAdding(false)
-  }, [baseLocale._id, commune, reloadVoies, token, selectedTab, reloadToponymes, reloadGeojson])
+  }, [baseLocale._id, commune, reloadVoies, token, selectedTab, reloadToponymes, reloadGeojson, setIsEditing])
 
   const onEnableEditing = useCallback(async id => {
     setIsAdding(false)


### PR DESCRIPTION
### Problème : 
L’éditeur reste en mode édition lorsque l’on ajoute une voie.

### Correction : 
Cette PR remet la valeur de `isEditing` à `false` pour sortir du mode édition une fois la voie ajoutée.