### PR TITLE
Ajout du fond de carte Plan IGN

### DIFF
--- a/components/map/layers/cadastre.js
+++ b/components/map/layers/cadastre.js
@@ -129,9 +129,7 @@ export const cadastreLayers = parcelles => [{
   maxzoom: 16,
   layout: {
     'text-field': '{code}',
-    'text-font': [
-      'Source Sans Pro Regular'
-    ]
+    'text-font': ['Open Sans Regular']
   },
   paint: {
     'text-halo-color': 'rgba(255, 246, 241, 1)',
@@ -149,9 +147,7 @@ export const cadastreLayers = parcelles => [{
   ],
   layout: {
     'text-field': '{numero}',
-    'text-font': [
-      'Source Sans Pro Regular'
-    ],
+    'text-font': ['Open Sans Regular'],
     'text-allow-overlap': false,
     'text-size': 16
   },

--- a/components/map/layers/cadastre.js
+++ b/components/map/layers/cadastre.js
@@ -130,7 +130,7 @@ export const cadastreLayers = parcelles => [{
   layout: {
     'text-field': '{code}',
     'text-font': [
-      'Noto Sans Bold'
+      'Source Sans Pro Regular'
     ]
   },
   paint: {
@@ -150,7 +150,7 @@ export const cadastreLayers = parcelles => [{
   layout: {
     'text-field': '{numero}',
     'text-font': [
-      'Noto Sans Bold'
+      'Source Sans Pro Regular'
     ],
     'text-allow-overlap': false,
     'text-size': 16

--- a/components/map/layers/numeros.js
+++ b/components/map/layers/numeros.js
@@ -66,7 +66,7 @@ export function getNumerosLabelLayer() {
       }
     },
     layout: {
-      'text-font': ['Noto Sans Regular'],
+      'text-font': ['Source Sans Pro Regular'],
       'text-field': [
         'case',
         ['has', 'suffixe'],

--- a/components/map/layers/numeros.js
+++ b/components/map/layers/numeros.js
@@ -66,7 +66,7 @@ export function getNumerosLabelLayer() {
       }
     },
     layout: {
-      'text-font': ['Source Sans Pro Regular'],
+      'text-font': ['Open Sans Regular'],
       'text-field': [
         'case',
         ['has', 'suffixe'],

--- a/components/map/layers/voies.js
+++ b/components/map/layers/voies.js
@@ -31,7 +31,7 @@ export function getVoiesLabelLayer(style) {
           [15, 14]
         ]
       },
-      'text-font': ['Noto Sans Regular']
+      'text-font': ['Source Sans Pro Regular']
     }
   }
 

--- a/components/map/layers/voies.js
+++ b/components/map/layers/voies.js
@@ -31,7 +31,7 @@ export function getVoiesLabelLayer(style) {
           [15, 14]
         ]
       },
-      'text-font': ['Source Sans Pro Regular']
+      'text-font': ['Open Sans Regular']
     }
   }
 

--- a/components/map/map.js
+++ b/components/map/map.js
@@ -50,7 +50,7 @@ function getBaseStyle(style) {
     case 'vector':
       return vector
 
-    case 'planIGN':
+    case 'plan-ign':
       return planIGN
     default:
       return vector

--- a/components/map/map.js
+++ b/components/map/map.js
@@ -49,10 +49,9 @@ function getBaseStyle(style) {
 
     case 'vector':
       return vector
-    
+
     case 'planIGN':
       return planIGN
-
     default:
       return vector
   }

--- a/components/map/map.js
+++ b/components/map/map.js
@@ -13,7 +13,7 @@ import ParcellesContext from '../../contexts/parcelles'
 
 import AddressEditor from '../bal/address-editor'
 
-import {vector, ortho} from './styles'
+import {vector, ortho, planIGN} from './styles'
 
 import NavControl from './nav-control'
 import EditableMarker from './editable-marker'
@@ -49,6 +49,9 @@ function getBaseStyle(style) {
 
     case 'vector':
       return vector
+    
+    case 'planIGN':
+      return planIGN
 
     default:
       return vector

--- a/components/map/style-selector.js
+++ b/components/map/style-selector.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import {Pane, SelectMenu, Button, Position, Tooltip, LayersIcon, ControlIcon} from 'evergreen-ui'
 
 const STYLES = [
-  {label: 'Plan OpenMapTiles', value: 'vector'},
+  {label: 'Plan IGN', value: 'vector'},
   {label: 'Photographie aérienne', value: 'ortho'}
 ]
 

--- a/components/map/style-selector.js
+++ b/components/map/style-selector.js
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types'
 import {Pane, SelectMenu, Button, Position, Tooltip, LayersIcon, ControlIcon} from 'evergreen-ui'
 
 const STYLES = [
-  {label: 'Plan', value: 'vector'},
-  {label: 'Plan IGN(Version Bêta)', value: 'plan-ign'},
+  {label: 'Plan OpenMapTiles', value: 'vector'},
+  {label: 'Plan IGN (Bêta)', value: 'plan-ign'},
   {label: 'Photographie aérienne', value: 'ortho'}
 ]
 

--- a/components/map/style-selector.js
+++ b/components/map/style-selector.js
@@ -4,7 +4,7 @@ import {Pane, SelectMenu, Button, Position, Tooltip, LayersIcon, ControlIcon} fr
 
 const STYLES = [
   {label: 'Plan', value: 'vector'},
-  {label: 'Plan IGN(Version Bêta)', value: 'planIGN'},
+  {label: 'Plan IGN(Version Bêta)', value: 'plan-ign'},
   {label: 'Photographie aérienne', value: 'ortho'}
 ]
 

--- a/components/map/style-selector.js
+++ b/components/map/style-selector.js
@@ -3,8 +3,10 @@ import PropTypes from 'prop-types'
 import {Pane, SelectMenu, Button, Position, Tooltip, LayersIcon, ControlIcon} from 'evergreen-ui'
 
 const STYLES = [
-  {label: 'Plan IGN', value: 'vector'},
+  {label: 'Plan', value: 'vector'},
+  {label: 'Plan IGN(Version Bêta)', value: 'planIGN'},
   {label: 'Photographie aérienne', value: 'ortho'}
+  
 ]
 
 function StyleSelector({style, isFormOpen, handleStyle, isCadastreDisplayed, handleCadastre}) {

--- a/components/map/style-selector.js
+++ b/components/map/style-selector.js
@@ -6,7 +6,6 @@ const STYLES = [
   {label: 'Plan', value: 'vector'},
   {label: 'Plan IGN(Version Bêta)', value: 'planIGN'},
   {label: 'Photographie aérienne', value: 'ortho'}
-  
 ]
 
 function StyleSelector({style, isFormOpen, handleStyle, isCadastreDisplayed, handleCadastre}) {
@@ -29,7 +28,7 @@ function StyleSelector({style, isFormOpen, handleStyle, isCadastreDisplayed, han
         position={Position.TOP_LEFT}
         title='Choix du fond de carte'
         hasFilter={false}
-        height={110}
+        height={140}
         options={STYLES}
         selected={style}
         onSelect={style => handleStyle(style.value)}

--- a/components/map/styles/index.js
+++ b/components/map/styles/index.js
@@ -2,6 +2,8 @@ import {fromJS} from 'immutable'
 
 import orthoStyle from './ortho.json'
 import vectorStyle from './vector.json'
+import planIGNStyle from './plan-ign.json'
 
 export const ortho = fromJS(orthoStyle)
 export const vector = fromJS(vectorStyle)
+export const planIGN = fromJS(planIGNStyle)

--- a/components/map/styles/ortho.json
+++ b/components/map/styles/ortho.json
@@ -1,6 +1,7 @@
 {
   "version": 8,
-  "glyphs": "https://openmaptiles.geo.data.gouv.fr/fonts/{fontstack}/{range}.pbf",
+  "glyphs":"https://wxs.ign.fr/static/vectorTiles/fonts/{fontstack}/{range}.pbf",
+	"sprite": "https://wxs.ign.fr/static/vectorTiles/styles/PLAN.IGN/sprite/PlanIgn",
   "sources": {
     "raster-tiles": {
       "type": "raster",

--- a/components/map/styles/ortho.json
+++ b/components/map/styles/ortho.json
@@ -1,7 +1,6 @@
 {
   "version": 8,
   "glyphs":"https://wxs.ign.fr/static/vectorTiles/fonts/{fontstack}/{range}.pbf",
-	"sprite": "https://wxs.ign.fr/static/vectorTiles/styles/PLAN.IGN/sprite/PlanIgn",
   "sources": {
     "raster-tiles": {
       "type": "raster",

--- a/components/map/styles/plan-ign.json
+++ b/components/map/styles/plan-ign.json
@@ -1,0 +1,14549 @@
+{
+	"version": 8,
+	"name": "PLAN IGN",
+    "glyphs":"https://wxs.ign.fr/static/vectorTiles/fonts/{fontstack}/{range}.pbf",
+	"sprite": "https://wxs.ign.fr/static/vectorTiles/styles/PLAN.IGN/sprite/PlanIgn",
+    "sources": {
+	  "plan_ign": {
+        "type": "vector",
+		"tiles": [
+		  "https://wxs.ign.fr/essentiels/geoportail/tms/1.0.0/PLAN.IGN/{z}/{x}/{y}.pbf"
+		],
+		"scheme": "xyz",
+		"attribution": "<a target='_blank' href='https://geoservices.ign.fr/'>© IGN</a>"
+	  },
+	  "cadastre": {
+		"type": "vector",
+		"url": "https://openmaptiles.geo.data.gouv.fr/data/cadastre.json"
+	  },
+	  "decoupage-administratif": {
+		"type": "vector",
+		"url": "https://openmaptiles.geo.data.gouv.fr/data/decoupage-administratif.json"
+	  }
+    },
+	"transition": {
+      "duration": 50,
+	  "delay": 0
+	},
+	"layers": [
+		{
+		 "id": "bckgrd",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "fond_opaque",
+		 "minzoom": 0,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "paint": {
+		  "fill-color": "#FFFFFF",
+		  "fill-opacity": 0.1
+		 }
+		},
+		{
+		 "id": "orographie : relief - 0m",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "oro_relief",
+		 "minzoom": 0,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "HYPSO_0"
+		 ],
+		 "paint": {
+		  "fill-color": "#D6E5BA",
+		  "fill-opacity": 1
+		 }
+		},
+		{
+		 "id": "orographie : relief - 100m",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "oro_relief",
+		 "minzoom": 0,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "HYPSO_100"
+		 ],
+		 "paint": {
+		  "fill-color": "#F7F2DA",
+		  "fill-opacity": 1
+		 }
+		},
+		{
+		 "id": "orographie : relief - 200m",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "oro_relief",
+		 "minzoom": 0,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "HYPSO_200"
+		 ],
+		 "paint": {
+		  "fill-color": "#EBDEBF",
+		  "fill-opacity": 1
+		 }
+		},
+		{
+		 "id": "orographie : relief - 1000m",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "oro_relief",
+		 "minzoom": 0,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "HYPSO_1000"
+		 ],
+		 "paint": {
+		  "fill-color": "#DABE97",
+		  "fill-opacity": 1
+		 }
+		},
+		{
+		 "id": "orographie : relief - 3000m",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "oro_relief",
+		 "minzoom": 0,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "HYPSO_3000"
+		 ],
+		 "paint": {
+		  "fill-color": "#B28773",
+		  "fill-opacity": 1
+		 }
+		},
+		{
+		 "id": "orographie : relief - 4000m",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "oro_relief",
+		 "minzoom": 0,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "HYPSO_4000"
+		 ],
+		 "paint": {
+		  "fill-color": "#9E6A54",
+		  "fill-opacity": 1
+		 }
+		},
+		{
+		 "id": "orographie : relief - 5000m",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "oro_relief",
+		 "minzoom": 0,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "HYPSO_5000"
+		 ],
+		 "paint": {
+		  "fill-color": "#773A2B",
+		  "fill-opacity": 1
+		 }
+		},
+		{
+		 "id": "orographie : relief - glacier",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "oro_relief",
+		 "minzoom": 0,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "GLACIER"
+		 ],
+		 "paint": {
+		  "fill-color": "#FFFFFF",
+		  "fill-opacity": 0.7
+		 }
+		},
+		{
+		 "id": "ocs - vegetation - zone boiséee, foret fermee, peupleraie",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "ocs_vegetation_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "ZONE_BOISEE",
+		  "ZONE_FORET_FERMEE_FEUIL",
+		  "ZONE_FORET_FERMEE_CONI",
+		  "ZONE_FORET_FERMEE_MIXTE",
+		  "ZONE_PEUPLERAIE"
+		 ],
+		 "paint": {
+		  "fill-color": "#DFE8D5",
+		  "fill-outline-color": "#DFE8D5"
+		 }
+		},
+		{
+		 "id": "ocs - vegetation - forêt ouverte",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "ocs_vegetation_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "ZONE_FORET_OUVERTE"
+		 ],
+		 "paint": {
+		  "fill-color": "#EDF2D9",
+		  "fill-outline-color": "#EDF2D9"
+		 }
+		},
+		{
+		 "id": "ocs - vegetation - lande ligneuse",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "ocs_vegetation_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "ZONE_LANDE_LIGNEUSE"
+		 ],
+		 "paint": {
+		  "fill-color": "#F2EECD"
+		 }
+		},
+		{
+		 "id": "ocs - vegetation - vigne",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "ocs_vegetation_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "ZONE_VIGNE"
+		 ],
+		 "paint": {
+		  "fill-color": "#FFEDD9"
+		 }
+		},
+		{
+		 "id": "ocs - vegetation - verger",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "ocs_vegetation_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "ZONE_VERGER"
+		 ],
+		 "paint": {
+		  "fill-color": "#FAE2C5"
+		 }
+		},
+		{
+		 "id": "ocs - vegetation - canne à sucre, bananeraie",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "ocs_vegetation_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "ZONE_CANNE_BANANE"
+		 ],
+		 "paint": {
+		  "fill-color": "#FAEDFA"
+		 }
+		},
+		{
+		 "id": "hydro surfacique - Estran",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "hydro_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "ZONE_D_ESTRAN"
+		 ],
+		 "paint": {
+		  "fill-color": "#C3DDE9",
+		  "fill-outline-color": "#C3DDE9"
+		 }
+		},
+		{
+		 "id": "ocs - vegetation - mangrovre",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "ocs_vegetation_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "ZONE_MANGROVE"
+		 ],
+		 "paint": {
+		  "fill-color": {
+		   "stops": [
+			[
+			 9,
+			 "#85CCCB"
+			],
+			[
+			 10,
+			 "#90CCCB"
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "ocs - vegetation - marais",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "ocs_vegetation_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "ZONE_MARAIS"
+		 ],
+		 "paint": {
+		  "fill-pattern": "Marais"
+		 }
+		},
+		{
+		 "id": "ocs - vegetation - marais salant",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "ocs_vegetation_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "ZONE_MARAIS_SALANT"
+		 ],
+		 "paint": {
+		  "fill-pattern": "MaraisSalant"
+		 }
+		},
+		{
+		 "id": "ocs - Zone",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "ocs_nature_sol_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "ZONE_ROCHEUSE"
+		 ],
+		 "paint": {
+		  "fill-color": "#D0D0D0",
+		  "fill-opacity": 0.3
+		 }
+		},
+		{
+		 "id": "ocs - Zone sable sec",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "ocs_nature_sol_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "ZONE_SABLE_SEC"
+		 ],
+		 "paint": {
+		  "fill-pattern": "Sable"
+		 }
+		},
+		{
+		 "id": "ocs - Zone sable humide",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "ocs_nature_sol_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "ZONE_SABLE_HUMIDE",
+		  "FOND_CUVETTE_HUMIDE"
+		 ],
+		 "paint": {
+		  "fill-pattern": "SableHumide"
+		 }
+		},
+		{
+		 "id": "ocs - Zone graviers galets secs",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "ocs_nature_sol_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "GRAVIERS_GALETS_SEC"
+		 ],
+		 "paint": {
+		  "fill-pattern": "GravierSec"
+		 }
+		},
+		{
+		 "id": "ocs - Zone graviers galets humides",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "ocs_nature_sol_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "GRAVIERS_GALETS_HUM"
+		 ],
+		 "paint": {
+		  "fill-pattern": "Gravier"
+		 }
+		},
+		{
+		 "id": "ocs - Zone rocher hydro",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "ocs_nature_sol_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "ZONE_ROCHER_HYDRO"
+		 ],
+		 "paint": {
+		  "fill-pattern": "RocherHydro"
+		 }
+		},
+		{
+		 "id": "ocs - Zone glacier",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "ocs_nature_sol_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "ZONE_GLACIER"
+		 ],
+		 "paint": {
+		  "fill-pattern": "Glacier",
+		  "fill-opacity": {
+		   "stops": [
+			[
+			 10,
+			 0.5
+			],
+			[
+			 12,
+			 0.3
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "zone batie",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_zone_surf",
+		 "minzoom": 7,
+		 "maxzoom": 21,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "ZONE_BATI"
+		 ],
+		 "paint": {
+		  "fill-color": "#E8E2D1",
+		  "fill-opacity": {
+		   "stops": [
+			[
+			 12,
+			 1
+			],
+			[
+			 13,
+			 0.9
+			],
+			[
+			 14,
+			 0.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "zone d'activité",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_zone_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "ZONE_INDUS_ACTI"
+		 ],
+		 "paint": {
+		  "fill-color": "#D9D9D9"
+		 }
+		},
+		{
+		 "id": "oro - courbe et cuvette maitresse",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "oro_courbe",
+		 "maxzoom": 21,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "CNV_MAITRESSE",
+		  "CUVETTE_MAITRESSE"
+		 ],
+		 "paint": {
+		  "line-color": "#D9C8A9",
+		  "line-width": {
+		   "stops": [
+			[
+			 13,
+			 1.7
+			],
+			[
+			 15,
+			 2
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "oro - courbe et cuvette normale",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "oro_courbe",
+		 "maxzoom": 21,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "CNV_NORMALE",
+		  "CUVETTE_NORMALE"
+		 ],
+		 "paint": {
+		  "line-color": "#D9C8A9",
+		  "line-width": {
+		   "stops": [
+			[
+			 13,
+			 1
+			],
+			[
+			 15,
+			 1.2
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "oro - courbe et cuvette intercalaire",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "oro_courbe",
+		 "maxzoom": 21,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "CNV_INTERCALAIRE",
+		  "CUVETTE_INTERCAL",
+		  "CNV_SS_INTERCALAIRE"
+		 ],
+		 "paint": {
+		  "line-color": "#D9C8A9",
+		  "line-width": 0.7,
+		  "line-dasharray": [
+		   20,
+		   7
+		  ]
+		 }
+		},
+		{
+		 "id": "oro - courbe et cuvette glacier maitresse",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "oro_courbe",
+		 "maxzoom": 21,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "CNV_GLACIER_MAITRESSE",
+		  "CUV_GLACIER_MAITRESSE"
+		 ],
+		 "paint": {
+		  "line-color": "#A4BFD9",
+		  "line-width": {
+		   "stops": [
+			[
+			 13,
+			 1.7
+			],
+			[
+			 15,
+			 2
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "oro - courbe et cuvette glacier normale",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "oro_courbe",
+		 "maxzoom": 21,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "CNV_GLACIER_NORMALE",
+		  "CUV_GLACIER_NORMALE"
+		 ],
+		 "paint": {
+		  "line-color": "#A4BFD9",
+		  "line-width": {
+		   "stops": [
+			[
+			 13,
+			 1
+			],
+			[
+			 15,
+			 1.2
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "oro - courbe et cuvette glacier intercalaire",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "oro_courbe",
+		 "maxzoom": 21,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "CNV_GLACIER_INTERCAL",
+		  "CUV_GLACIER_INTERCAL"
+		 ],
+		 "paint": {
+		  "line-color": "#A4BFD9",
+		  "line-width": {
+		   "stops": [
+			[
+			 13,
+			 0.7
+			],
+			[
+			 15,
+			 0.9
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   20,
+		   7
+		  ]
+		 }
+		},
+		{
+		 "id": "oro - courbe et cuvette rocher maitresse",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "oro_courbe",
+		 "maxzoom": 21,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "CNV_ROCHER_MAITRESSE",
+		  "CUV_ROCHER_MAITRESSE"
+		 ],
+		 "paint": {
+		  "line-color": "#AAAAAA",
+		  "line-width": 1.7
+		 }
+		},
+		{
+		 "id": "oro - courbe et cuvette rocher normale",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "oro_courbe",
+		 "maxzoom": 21,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "CNV_ROCHER_NORMALE",
+		  "CUV_ROCHER_NORMALE"
+		 ],
+		 "paint": {
+		  "line-color": "#AAAAAA",
+		  "line-width": 1
+		 }
+		},
+		{
+		 "id": "oro - courbe et cuvette rocher intercalaire",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "oro_courbe",
+		 "maxzoom": 21,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "CNV_ROCHER_INTERCAL",
+		  "CUV_ROCHER_INTERCAL"
+		 ],
+		 "paint": {
+		  "line-color": "#AAAAAA",
+		  "line-width": {
+		   "stops": [
+			[
+			 13,
+			 0.7
+			],
+			[
+			 15,
+			 0.9
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   20,
+		   7
+		  ]
+		 }
+		},
+		{
+		 "id": "oro - courbe et cuvette bathymetrique",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "oro_courbe",
+		 "maxzoom": 21,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "CNV_BATHYMETRIQUE",
+		  "CUV_BATHYMETRIQUE"
+		 ],
+		 "paint": {
+		  "line-color": "#0000FF",
+		  "line-width": 1
+		 }
+		},
+		{
+		 "id": "oro lin - talus",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "oro_lin",
+		 "minzoom": 14,
+		 "maxzoom": 21,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "TALUS"
+		 ],
+		 "paint": {
+		  "line-color": "#D9C8A9",
+		  "line-width": 1
+		 }
+		},
+		{
+		 "id": "oro lin - talus - trait perpendiculaire",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "oro_lin",
+		 "minzoom": 14,
+		 "maxzoom": 21,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "TALUS"
+		 ],
+		 "paint": {
+		  "line-color": "#D9C8A9",
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 7
+			],
+			[
+			 16,
+			 9
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   0.1,
+		   1
+		  ],
+		  "line-translate": [
+		   0,
+		   4
+		  ]
+		 }
+		},
+		{
+		 "id": "toponyme - cote de courbe normale",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "oro_courbe",
+		 "minzoom": 13,
+		 "maxzoom": 21,
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 13,
+			 10
+			],
+			[
+			 15,
+			 13
+			]
+		   ]
+		  },
+		  "text-anchor": "center",
+		  "text-rotation-alignment": "map",
+		  "text-pitch-alignment": "viewport",
+		  "text-keep-upright": false,
+		  "text-max-angle": 20,
+		  "text-max-width": 100,
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ],
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "all",
+		  [
+		   "!=",
+		   "texte",
+		   "0"
+		  ],
+		  [
+		   "==",
+		   "hors_zone",
+		   "true"
+		  ],
+		  [
+		   "in",
+		   "symbo",
+		   "CNV_MAITRESSE",
+		   "CUVETTE_MAITRESSE"
+		  ]
+		 ],
+		 "paint": {
+		  "text-color": "#604A2F",
+		  "text-halo-width": 0.5,
+		  "text-halo-color": "#FFFFFF"
+		 }
+		},
+		{
+		 "id": "toponyme - cote de courbe rocher",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "oro_courbe",
+		 "minzoom": 13,
+		 "maxzoom": 21,
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 13,
+			 10
+			],
+			[
+			 15,
+			 13
+			]
+		   ]
+		  },
+		  "text-anchor": "center",
+		  "text-rotation-alignment": "map",
+		  "text-pitch-alignment": "viewport",
+		  "text-keep-upright": false,
+		  "text-max-angle": 20,
+		  "text-max-width": 100,
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ],
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "all",
+		  [
+		   "!=",
+		   "texte",
+		   "0"
+		  ],
+		  [
+		   "==",
+		   "hors_zone",
+		   "true"
+		  ],
+		  [
+		   "in",
+		   "symbo",
+		   "CNV_ROCHER_MAITRESSE",
+		   "CUV_ROCHER_MAITRESSE"
+		  ]
+		 ],
+		 "paint": {
+		  "text-color": "#333333",
+		  "text-halo-width": 0.5,
+		  "text-halo-color": "#FFFFFF"
+		 }
+		},
+		{
+		 "id": "toponyme - cote de courbe glacier",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "oro_courbe",
+		 "minzoom": 13,
+		 "maxzoom": 21,
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 13,
+			 10
+			],
+			[
+			 15,
+			 13
+			]
+		   ]
+		  },
+		  "text-anchor": "center",
+		  "text-rotation-alignment": "map",
+		  "text-pitch-alignment": "viewport",
+		  "text-keep-upright": false,
+		  "text-max-angle": 20,
+		  "text-max-width": 100,
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ],
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "all",
+		  [
+		   "!=",
+		   "texte",
+		   "0"
+		  ],
+		  [
+		   "==",
+		   "hors_zone",
+		   "true"
+		  ],
+		  [
+		   "in",
+		   "symbo",
+		   "CNV_GLACIER_MAITRESSE",
+		   "CUV_GLACIER_MAITRESSE"
+		  ]
+		 ],
+		 "paint": {
+		  "text-color": "#629FD9",
+		  "text-halo-width": 0.5,
+		  "text-halo-color": "#FFFFFF"
+		 }
+		},
+		{
+		 "id": "hydro surfacique",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "hydro_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "SURFACE_D_EAU",
+		  "BASSIN",
+		  "ZONE_MARINE"
+		 ],
+		 "paint": {
+		  "fill-color": "#AAD5E9",
+		  "fill-outline-color": "#AAD5E9"
+		 }
+		},
+		{
+		 "id": "hydro surfacique temporaire",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "hydro_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "SURFACE_D_EAU_TEMP"
+		 ],
+		 "paint": {
+		  "fill-color": "rgba(168, 203, 220, 0.5)"
+		 }
+		},
+		{
+		 "id": "réseau hydro  - cours d'eau souterrain",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "hydro_reseau_sou",
+		 "maxzoom": 21,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "COURS_D_EAU_SOU",
+		  "COURS_D_EAU_MOY_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#AAD5E9",
+		  "line-width": {
+		   "stops": [
+			[
+			 12,
+			 1.5
+			],
+			[
+			 17,
+			 6.5
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   2,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "réseau hydro - filet interieur - aqueduc souterrain",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "hydro_reseau_sou",
+		 "minzoom": 12,
+		 "maxzoom": 21,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "AQUEDUC_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#AAD5E9",
+		  "line-width": {
+		   "stops": [
+			[
+			 12,
+			 1.4
+			],
+			[
+			 16,
+			 3.5
+			],
+			[
+			 17,
+			 5.9
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   2,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "réseau hydro - carre - aqueduc souterrain",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "hydro_reseau_sou",
+		 "minzoom": 12,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "AQUEDUC_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#AAD5E9",
+		  "line-width": {
+		   "stops": [
+			[
+			 12,
+			 3.5
+			],
+			[
+			 16,
+			 8.7
+			],
+			[
+			 17,
+			 14.7
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   1,
+		   5
+		  ]
+		 }
+		},
+		{
+		 "id": "Ferre souterrain - voie normale",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "ferre_sou",
+		 "minzoom": 10,
+		 "maxzoom": 21,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "VF_1_SOU",
+		  "VF_2_SOU",
+		  "VF_ELEC_1_SOU",
+		  "VF_FERRO_ROUTIER_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#B4B4B4",
+		  "line-width": {
+		   "stops": [
+			[
+			 10,
+			 0.8
+			],
+			[
+			 17,
+			 2.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Ferre souterrain - trait perpendic épais",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "ferre_sou",
+		 "minzoom": 10,
+		 "maxzoom": 21,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "VF_1_SOU",
+		  "VF_2_SOU",
+		  "VF_ELEC_1_SOU",
+		  "VF_FERRO_ROUTIER_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#B4B4B4",
+		  "line-width": {
+		   "stops": [
+			[
+			 10,
+			 3.5
+			],
+			[
+			 17,
+			 14.7
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   0.1,
+		   10
+		  ]
+		 }
+		},
+		{
+		 "id": "Ferre souterrain - voie etroite",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "ferre_sou",
+		 "minzoom": 10,
+		 "maxzoom": 21,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "VF_ETROITE_1_SOU",
+		  "VF_ETROITE_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#B4B4B4",
+		  "line-width": {
+		   "stops": [
+			[
+			 10,
+			 0.3
+			],
+			[
+			 17,
+			 1.8
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Ferre souterrain - trait perpendic fin",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "ferre_sou",
+		 "minzoom": 10,
+		 "maxzoom": 21,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "VF_ETROITE_1_SOU",
+		  "VF_ETROITE_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#B4B4B4",
+		  "line-width": {
+		   "stops": [
+			[
+			 10,
+			 3.5
+			],
+			[
+			 17,
+			 14.7
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   0.1,
+		   10
+		  ]
+		 }
+		},
+		{
+		 "id": "Ferre souterrain - voie service",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "ferre_sou",
+		 "minzoom": 14,
+		 "maxzoom": 21,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "VF_SERVICE_SOU",
+		  "VF_NON_EXPLOITEE_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#B4B4B4",
+		  "line-width": {
+		   "stops": [
+			[
+			 10,
+			 0.3
+			],
+			[
+			 17,
+			 1.8
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   5,
+		   2,
+		   1,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "Ferre souterrain - funic/urbain",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "ferre_sou",
+		 "maxzoom": 21,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "FUNI_CREMAILLERE_SOU",
+		  "TRANSPORT_URBAIN_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#B4B4B4",
+		  "line-width": {
+		   "stops": [
+			[
+			 10,
+			 0.3
+			],
+			[
+			 17,
+			 1.8
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Ferre souterrain - 2 trait perpendic - funic/urbain",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "ferre_sou",
+		 "maxzoom": 21,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "FUNI_CREMAILLERE_SOU",
+		  "TRANSPORT_URBAIN_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#B4B4B4",
+		  "line-width": {
+		   "stops": [
+			[
+			 10,
+			 3.5
+			],
+			[
+			 17,
+			 17
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   0.1,
+		   0.2,
+		   0.1,
+		   10
+		  ]
+		 }
+		},
+		{
+		 "id": "Chemin souterrain - piste cyclable",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_chemin_sou",
+		 "minzoom": 13,
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "PISTE_CYCLABLE_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#AB81CC",
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 1.1
+			],
+			[
+			 15,
+			 1.7
+			],
+			[
+			 16,
+			 2
+			],
+			[
+			 17,
+			 3.5
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   6,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "Chemin souterrain - filet exterieur - escalier",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_chemin_sou",
+		 "minzoom": 14,
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "ESCALIER_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#B3989A",
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 1.75
+			],
+			[
+			 15,
+			 3
+			],
+			[
+			 16,
+			 4.2
+			],
+			[
+			 17,
+			 9.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Chemin souterrain - filet interieur - escalier",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_chemin_sou",
+		 "minzoom": 14,
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "ESCALIER_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#EDF1FF",
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 1
+			],
+			[
+			 15,
+			 1.9
+			],
+			[
+			 16,
+			 2.7
+			],
+			[
+			 17,
+			 5.8
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   1,
+		   0.2
+		  ]
+		 }
+		},
+		{
+		 "id": "Chemin souterrain - Rue pietonne",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_chemin_sou",
+		 "minzoom": 14,
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "RUE_PIETONNE_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#B3989A",
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 1
+			],
+			[
+			 15,
+			 1.2
+			],
+			[
+			 16,
+			 1.4
+			],
+			[
+			 17,
+			 2
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   1,
+		   3
+		  ]
+		 }
+		},
+		{
+		 "id": "Chemin souterrain - sentier",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_chemin_sou",
+		 "minzoom": 13,
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "SENTIER_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#B3989A",
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 1
+			],
+			[
+			 15,
+			 1.2
+			],
+			[
+			 16,
+			 1.4
+			],
+			[
+			 17,
+			 2
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   4,
+		   3
+		  ]
+		 }
+		},
+		{
+		 "id": "Chemin souterrain - chemin",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_chemin_sou",
+		 "minzoom": 12,
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "CHEMIN_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#B3989A",
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 1
+			],
+			[
+			 15,
+			 1.2
+			],
+			[
+			 16,
+			 1.4
+			],
+			[
+			 17,
+			 2
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier souterrain - filet extérieur - route non revetu carrosable",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sou",
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "NON_REVETUE_CARRO_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#AFAFAF",
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 3.2
+			],
+			[
+			 15,
+			 5.4
+			],
+			[
+			 16,
+			 7.7
+			],
+			[
+			 17,
+			 16.8
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   2,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "Routier souterrain - filet extérieur - bretelle autoroute",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sou",
+		 "minzoom": 12,
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BRET_AUTO_PEAGE_3_SOU",
+		  "BRET_AUTO_PEAGE_2_SOU",
+		  "BRET_AUTO_PEAGE_1_SOU",
+		  "BRET_AUTO_LIBRE_3_SOU",
+		  "BRET_AUTO_LIBRE_2_SOU",
+		  "BRET_AUTO_LIBRE_1_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "rgba(222, 70, 14, 0.5)",
+		  "line-width": {
+		   "stops": [
+			[
+			 12,
+			 2.5
+			],
+			[
+			 14,
+			 3.7
+			],
+			[
+			 15,
+			 6.8
+			],
+			[
+			 16,
+			 8.4
+			],
+			[
+			 17,
+			 14
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier souterrain - filet extérieur - route non classee restreint",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sou",
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "NON_CLASSEE_RESTREINT_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#AFAFAF",
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 3.2
+			],
+			[
+			 15,
+			 5.4
+			],
+			[
+			 16,
+			 7.7
+			],
+			[
+			 17,
+			 16.8
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier souterrain - filet extérieur - route non classee",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sou",
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "NON_CLASSEE_4_SOU",
+		  "NON_CLASSEE_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#AFAFAF",
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 3.2
+			],
+			[
+			 15,
+			 5.4
+			],
+			[
+			 16,
+			 7.7
+			],
+			[
+			 17,
+			 16.8
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier souterrain - filet extérieur - route locale",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sou",
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BRET_LOCALE_SOU",
+		  "LOCALE_4_SOU",
+		  "LOCALE_3_SOU",
+		  "LOCALE_2_SOU",
+		  "LOCALE_1_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "rgba(130, 130, 130, 0.5)",
+		  "line-width": {
+		   "stops": [
+			[
+			 9,
+			 2
+			],
+			[
+			 14,
+			 3.5
+			],
+			[
+			 15,
+			 6
+			],
+			[
+			 16,
+			 8.4
+			],
+			[
+			 17,
+			 18.3
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier souterrain - filet extérieur - route locale en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sou",
+		 "minzoom": 11,
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "LOCALE_CONSTR_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#C8C8C8",
+		  "line-width": {
+		   "stops": [
+			[
+			 9,
+			 2
+			],
+			[
+			 14,
+			 3.5
+			],
+			[
+			 15,
+			 6
+			],
+			[
+			 16,
+			 8.4
+			],
+			[
+			 17,
+			 18.3
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier souterrain - filet extérieur - route regionale",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sou",
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BRET_REGIONALE_SOU",
+		  "REGIONALE_4_SOU",
+		  "REGIONALE_3_SOU",
+		  "REGIONALE_2_SOU",
+		  "REGIONALE_1_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "rgba(130, 130, 130, 0.5)",
+		  "line-width": {
+		   "stops": [
+			[
+			 6,
+			 1.5
+			],
+			[
+			 9,
+			 2.3
+			],
+			[
+			 14,
+			 5
+			],
+			[
+			 15,
+			 8.1
+			],
+			[
+			 16,
+			 11.2
+			],
+			[
+			 17,
+			 22
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier souterrain - filet extérieur - route regionale en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sou",
+		 "minzoom": 10,
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "REGIONALE_CONSTR_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#C8C8C8",
+		  "line-width": {
+		   "stops": [
+			[
+			 6,
+			 1.5
+			],
+			[
+			 9,
+			 2.3
+			],
+			[
+			 14,
+			 5
+			],
+			[
+			 15,
+			 8.1
+			],
+			[
+			 16,
+			 11.2
+			],
+			[
+			 17,
+			 22
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier souterrain - filet extérieur - route principale",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sou",
+		 "minzoom": 7,
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BRET_PRINCIPALE_SOU",
+		  "PRINCIPALE_4_SOU",
+		  "PRINCIPALE_3_SOU",
+		  "PRINCIPALE_2_SOU",
+		  "PRINCIPALE_1_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "rgba(222, 70, 14, 0.5)",
+		  "line-width": {
+		   "stops": [
+			[
+			 6,
+			 1.8
+			],
+			[
+			 9,
+			 2.7
+			],
+			[
+			 14,
+			 5.9
+			],
+			[
+			 15,
+			 9
+			],
+			[
+			 16,
+			 12.2
+			],
+			[
+			 17,
+			 22.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier souterrain - filet extérieur - route principale en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sou",
+		 "minzoom": 10,
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "PRINCIPALE_CONSTR_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#C8C8C8",
+		  "line-width": {
+		   "stops": [
+			[
+			 6,
+			 1.8
+			],
+			[
+			 9,
+			 2.7
+			],
+			[
+			 14,
+			 5.9
+			],
+			[
+			 15,
+			 9
+			],
+			[
+			 16,
+			 12.2
+			],
+			[
+			 17,
+			 22.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier souterrain - filet extérieur - autoroute",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sou",
+		 "minzoom": 7,
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "AUTOROU_PEAGE_SOU",
+		  "AUTOROU_LIBRE_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "rgba(222, 70, 14, 0.5)",
+		  "line-width": {
+		   "stops": [
+			[
+			 6,
+			 2.5
+			],
+			[
+			 9,
+			 3.5
+			],
+			[
+			 14,
+			 7.5
+			],
+			[
+			 15,
+			 11
+			],
+			[
+			 16,
+			 15
+			],
+			[
+			 17,
+			 26
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier souterrain - filet extérieur - autoroute en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sou",
+		 "minzoom": 10,
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "AUTOROU_CONSTR_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#C8C8C8",
+		  "line-width": {
+		   "stops": [
+			[
+			 6,
+			 2.5
+			],
+			[
+			 9,
+			 3.5
+			],
+			[
+			 14,
+			 7.5
+			],
+			[
+			 15,
+			 11
+			],
+			[
+			 16,
+			 15
+			],
+			[
+			 17,
+			 26
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier souterrain - filet interieur - route non revetu carrosable",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sou",
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "NON_REVETUE_CARRO_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#DCDCDC",
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 2.3
+			],
+			[
+			 15,
+			 4.1
+			],
+			[
+			 16,
+			 6.3
+			],
+			[
+			 17,
+			 13.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier souterrain - filet interieur - bretelle autoroute",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sou",
+		 "minzoom": 12,
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BRET_AUTO_PEAGE_3_SOU",
+		  "BRET_AUTO_PEAGE_2_SOU",
+		  "BRET_AUTO_PEAGE_1_SOU",
+		  "BRET_AUTO_LIBRE_3_SOU",
+		  "BRET_AUTO_LIBRE_2_SOU",
+		  "BRET_AUTO_LIBRE_1_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "rgba(255, 255, 255, 0.5)",
+		  "line-width": {
+		   "stops": [
+			[
+			 12,
+			 1.5
+			],
+			[
+			 14,
+			 2.6
+			],
+			[
+			 15,
+			 5.2
+			],
+			[
+			 16,
+			 6.7
+			],
+			[
+			 17,
+			 10.8
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier souterrain - filet interieur - route non classee restreint",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sou",
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "NON_CLASSEE_RESTREINT_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#F2F5FF",
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 2.3
+			],
+			[
+			 15,
+			 4.1
+			],
+			[
+			 16,
+			 6.3
+			],
+			[
+			 17,
+			 13.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier souterrain - filet interieur - route non classee",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sou",
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "NON_CLASSEE_4_SOU",
+		  "NON_CLASSEE_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#DCDCDC",
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 2.3
+			],
+			[
+			 15,
+			 4.1
+			],
+			[
+			 16,
+			 6.3
+			],
+			[
+			 17,
+			 13.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier souterrain - filet interieur - route locale",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sou",
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BRET_LOCALE_SOU",
+		  "LOCALE_4_SOU",
+		  "LOCALE_3_SOU",
+		  "LOCALE_2_SOU",
+		  "LOCALE_1_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "rgba(255, 255, 255, 0.5)",
+		  "line-width": {
+		   "stops": [
+			[
+			 9,
+			 1.3
+			],
+			[
+			 14,
+			 2.3
+			],
+			[
+			 15,
+			 4.1
+			],
+			[
+			 16,
+			 6.1
+			],
+			[
+			 17,
+			 13.1
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier souterrain - filet interieur - route locale en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sou",
+		 "minzoom": 11,
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "LOCALE_CONSTR_SOU"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 12,
+			 "#EDF1FF"
+			],
+			[
+			 13,
+			 "#FCF4A8"
+			],
+			[
+			 17,
+			 "#FCF7C1"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 9,
+			 2
+			],
+			[
+			 14,
+			 3.5
+			],
+			[
+			 15,
+			 6
+			],
+			[
+			 16,
+			 8.4
+			],
+			[
+			 17,
+			 18.3
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   2,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "Routier souterrain - filet interieur - route regionale",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sou",
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BRET_REGIONALE_SOU",
+		  "REGIONALE_4_SOU",
+		  "REGIONALE_3_SOU",
+		  "REGIONALE_2_SOU",
+		  "REGIONALE_1_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "rgba(255, 255, 255, 0.5)",
+		  "line-width": {
+		   "stops": [
+			[
+			 6,
+			 1.4
+			],
+			[
+			 9,
+			 1.5
+			],
+			[
+			 14,
+			 3.2
+			],
+			[
+			 15,
+			 5.8
+			],
+			[
+			 16,
+			 8.3
+			],
+			[
+			 17,
+			 16.2
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier souterrain - filet interieur - route regionale en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sou",
+		 "minzoom": 10,
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "REGIONALE_CONSTR_SOU"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 9,
+			 "#EDF1FF"
+			],
+			[
+			 10,
+			 "#FDF28B"
+			],
+			[
+			 17,
+			 "#FCF6BD"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 4,
+			 0.4
+			],
+			[
+			 6,
+			 1.5
+			],
+			[
+			 9,
+			 2.3
+			],
+			[
+			 14,
+			 5
+			],
+			[
+			 15,
+			 8.1
+			],
+			[
+			 16,
+			 11.2
+			],
+			[
+			 17,
+			 22
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   2,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "Routier souterrain - filet interieur - route principale",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sou",
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BRET_PRINCIPALE_SOU",
+		  "PRINCIPALE_4_SOU",
+		  "PRINCIPALE_3_SOU",
+		  "PRINCIPALE_2_SOU",
+		  "PRINCIPALE_1_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "rgba(255, 255, 255, 0.5)",
+		  "line-width": {
+		   "stops": [
+			[
+			 4,
+			 0.5
+			],
+			[
+			 6,
+			 1.8
+			],
+			[
+			 9,
+			 2.1
+			],
+			[
+			 14,
+			 4.4
+			],
+			[
+			 15,
+			 7.3
+			],
+			[
+			 16,
+			 10
+			],
+			[
+			 17,
+			 18.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier souterrain - filet interieur - route principale en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sou",
+		 "minzoom": 10,
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "PRINCIPALE_CONSTR_SOU"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 9,
+			 "#F3C66D"
+			],
+			[
+			 17,
+			 "#F2DDB3"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 4,
+			 0.5
+			],
+			[
+			 6,
+			 1.8
+			],
+			[
+			 9,
+			 2.7
+			],
+			[
+			 14,
+			 5.9
+			],
+			[
+			 15,
+			 9
+			],
+			[
+			 16,
+			 12.2
+			],
+			[
+			 17,
+			 22.5
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   2,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "Routier souterrain - filet interieur - autoroute",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sou",
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "AUTOROU_PEAGE_SOU",
+		  "AUTOROU_LIBRE_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "rgba(255, 255, 255, 0.5)",
+		  "line-width": {
+		   "stops": [
+			[
+			 4,
+			 0.7
+			],
+			[
+			 6,
+			 2.5
+			],
+			[
+			 9,
+			 2.7
+			],
+			[
+			 14,
+			 5.8
+			],
+			[
+			 15,
+			 9
+			],
+			[
+			 16,
+			 12
+			],
+			[
+			 17,
+			 20.8
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier souterrain - axe central - autoroute",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sou",
+		 "minzoom": 13,
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "AUTOROU_PEAGE_SOU",
+		  "AUTOROU_LIBRE_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#EDF1FF",
+		  "line-width": {
+		   "stops": [
+			[
+			 9,
+			 0.6
+			],
+			[
+			 14,
+			 0.7
+			],
+			[
+			 15,
+			 1
+			],
+			[
+			 16,
+			 1.2
+			],
+			[
+			 17,
+			 2.1
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier souterrain - filet interieur - autoroute en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sou",
+		 "minzoom": 10,
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "AUTOROU_CONSTR_SOU"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 9,
+			 "#F2BA59"
+			],
+			[
+			 17,
+			 "#F2C261"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 4,
+			 0.7
+			],
+			[
+			 6,
+			 2.5
+			],
+			[
+			 9,
+			 3.5
+			],
+			[
+			 14,
+			 7.5
+			],
+			[
+			 15,
+			 11
+			],
+			[
+			 16,
+			 15
+			],
+			[
+			 17,
+			 26
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   2,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "Routier souterrain - axe central - autoroute en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sou",
+		 "minzoom": 13,
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "AUTOROU_CONSTR_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#808080",
+		  "line-width": {
+		   "stops": [
+			[
+			 9,
+			 0.6
+			],
+			[
+			 14,
+			 0.7
+			],
+			[
+			 15,
+			 1
+			],
+			[
+			 16,
+			 1.2
+			],
+			[
+			 17,
+			 2.1
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "réseau hydro - cours d'eau temporaire",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "hydro_reseau",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "COURS_D_EAU_TEMP",
+		  "COURS_D_EAU_TEMP_MOY"
+		 ],
+		 "paint": {
+		  "line-color": "#AAD5E9",
+		  "line-width": {
+		   "stops": [
+			[
+			 12,
+			 1.5
+			],
+			[
+			 17,
+			 4
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   6,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "réseau hydro - cours d'eau",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "hydro_reseau",
+		 "minzoom": 3,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "COURS_D_EAU"
+		 ],
+		 "paint": {
+		  "line-color": "#AAD5E9",
+		  "line-width": {
+		   "stops": [
+			[
+			 4,
+			 0.3
+			],
+			[
+			 7,
+			 1.5
+			],
+			[
+			 12,
+			 1.5
+			],
+			[
+			 17,
+			 6.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "réseau hydro - canal",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "hydro_reseau",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "CANAL"
+		 ],
+		 "paint": {
+		  "line-color": "#AAD5E9",
+		  "line-width": {
+		   "stops": [
+			[
+			 12,
+			 1.4
+			],
+			[
+			 17,
+			 5.9
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "réseau hydro - filet interieur - aqueduc",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "hydro_reseau",
+		 "minzoom": 12,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "AQUEDUC_AU_SOL"
+		 ],
+		 "paint": {
+		  "line-color": "#AAD5E9",
+		  "line-width": {
+		   "stops": [
+			[
+			 12,
+			 1.4
+			],
+			[
+			 16,
+			 3.5
+			],
+			[
+			 17,
+			 5.9
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "réseau hydro - carre - aqueduc",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "hydro_reseau",
+		 "minzoom": 12,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "AQUEDUC_AU_SOL"
+		 ],
+		 "paint": {
+		  "line-color": "#AAD5E9",
+		  "line-width": {
+		   "stops": [
+			[
+			 12,
+			 3.5
+			],
+			[
+			 16,
+			 8.7
+			],
+			[
+			 17,
+			 14.7
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   1,
+		   5
+		  ]
+		 }
+		},
+		{
+		 "id": "réseau hydro - cours d'eau moyen ",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "hydro_reseau",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "COURS_D_EAU_MOY"
+		 ],
+		 "paint": {
+		  "line-color": "#AAD5E9",
+		  "line-width": {
+		   "stops": [
+			[
+			 7,
+			 2
+			],
+			[
+			 12,
+			 2.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "réseau hydro - cours d'eau large ",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "hydro_reseau",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "COURS_D_EAU_LAR"
+		 ],
+		 "paint": {
+		  "line-color": "#AAD5E9",
+		  "line-width": {
+		   "stops": [
+			[
+			 7,
+			 3
+			],
+			[
+			 11,
+			 5
+			]
+		   ]
+		  }
+		 }
+		},
+		
+		{
+		 "id": "bati surfacique mairie - Zoom 14",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "maxzoom": 14,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "MAIRIE",
+		  "MAIRIE_ANNEXE"
+		 ],
+		 "paint": {
+		  "fill-color": "#FFA6A6"
+		 }
+		},
+		{
+		 "id": "bati surfacique mairie - Zoom 15,16,17,18",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "minzoom": 14,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "MAIRIE",
+		  "MAIRIE_ANNEXE"
+		 ],
+		 "paint": {
+		  "fill-color": {
+		   "stops": [
+			[
+			 14,
+			 "#FFA6A6"
+			],
+			[
+			 15,
+			 "#FFAEAE"
+			]
+		   ]
+		  },
+		  "fill-outline-color": "#FF7C7C"
+		 }
+		},
+		{
+		 "id": "bati surfacique fonctionnel industriel ou commercial - Zoom 14,15",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "maxzoom": 21,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BATI_COMMERCIAL",
+		  "BATI_INDUSTRIEL",
+		  "HANGAR",
+		  "HANGAR_COMMERCIAL",
+		  "HANGAR_INDUSTRIEL"
+		 ],
+		 "paint": {
+		  "fill-color": "#C8C8C8"
+		 }
+		},
+		{
+		 "id": "bati surfacique fonctionnel industriel ou commercial - Zoom 16,17,18",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "minzoom": 15,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BATI_COMMERCIAL",
+		  "BATI_INDUSTRIEL",
+		  "HANGAR",
+		  "HANGAR_COMMERCIAL",
+		  "HANGAR_INDUSTRIEL"
+		 ],
+		 "paint": {
+		  "fill-color": {
+		   "stops": [
+			[
+			 15,
+			 "#D1D1D1"
+			],
+			[
+			 16,
+			 "#E6E6E6"
+			]
+		   ]
+		  },
+		  "fill-outline-color": "#B8B8B8"
+		 }
+		},
+		{
+		 "id": "bati surfacique fonctionnel public - Zoom 14,15",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "maxzoom": 21,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BATI_PUBLIC",
+		  "HANGAR_PUBLIC"
+		 ],
+		 "paint": {
+		  "fill-color": "#B9B6D6"
+		 }
+		},
+		{
+		 "id": "bati surfacique fonctionnel public - Zoom 16,17,18",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "minzoom": 21,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BATI_PUBLIC",
+		  "HANGAR_PUBLIC"
+		 ],
+		 "paint": {
+		  "fill-color": {
+		   "stops": [
+			[
+			 15,
+			 "#CFC5DE"
+			],
+			[
+			 16,
+			 "#E4DAF3"
+			]
+		   ]
+		  },
+		  "fill-outline-color": "#A6A1D6"
+		 }
+		},
+		{
+		 "id": "bati surfacique fonctionnel sportif - bordure",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "minzoom": 15,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "BATI_SPORTIF"
+		 ],
+		 "paint": {
+		  "line-color": "#BCD9AB",
+		  "line-width": 4
+		 }
+		},
+		{
+		 "id": "bati surfacique fonctionnel sportif",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "minzoom": 13,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "BATI_SPORTIF"
+		 ],
+		 "paint": {
+		  "fill-color": {
+		   "stops": [
+			[
+			 14,
+			 "#C9E1DD"
+			],
+			[
+			 15,
+			 "#DCE6E4"
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "bati surfacique fonctionnel gare - Zoom 14,15",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "maxzoom": 21,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "BATI_GARE"
+		 ],
+		 "paint": {
+		  "fill-color": "#B3B5F5"
+		 }
+		},
+		{
+		 "id": "bati surfacique fonctionnel gare - Zoom 16,17,18",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "minzoom": 15,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "BATI_GARE"
+		 ],
+		 "paint": {
+		  "fill-color": {
+		   "stops": [
+			[
+			 15,
+			 "#BFC1F5"
+			],
+			[
+			 16,
+			 "#CBCDF5"
+			]
+		   ]
+		  },
+		  "fill-outline-color": "#9B9EF6"
+		 }
+		},
+		{
+		 "id": "bati surfacique quelconque - Zoom 15",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "minzoom": 14,
+		 "maxzoom": 21,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "BATI_QQUE"
+		 ],
+		 "paint": {
+		  "fill-color": "#D6C6B8"
+		 }
+		},
+		{
+		 "id": "bati surfacique quelconque - Zoom 16,17,18",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "minzoom": 15,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "BATI_QQUE"
+		 ],
+		 "paint": {
+		  "fill-color": {
+		   "stops": [
+			[
+			 15,
+			 "#E6E0CF"
+			],
+			[
+			 16,
+			 "#F1EBD9"
+			]
+		   ]
+		  },
+		  "fill-outline-color": "#C3AA8E"
+		 }
+		},
+		{
+		 "id": "cimetiere surfacique 1",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "CIMETIERE_SURF",
+		  "CIMETIERE_MILI_SURF",
+		  "NECROPOLE_NATIONALE"
+		 ],
+		 "paint": {
+		  "fill-color": "#F0F0F0",
+		  "fill-opacity": 0.5,
+		  "fill-outline-color": "#818181"
+		 }
+		},
+		{
+		 "id": "cimetiere surfacique 2",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "CIMETIERE_SURF",
+		  "CIMETIERE_MILI_SURF",
+		  "NECROPOLE_NATIONALE"
+		 ],
+		 "paint": {
+		  "fill-pattern": "Cimetiere"
+		 }
+		},
+		{
+		 "id": "bati hydro surfacique - Autre",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "ECLUSE_SURF",
+		  "RESERVOIR_EAU_SURF"
+		 ],
+		 "paint": {
+		  "fill-color": "#ADCCD9",
+		  "fill-outline-color": "#336699"
+		 }
+		},
+		{
+		 "id": "bati hydro surfacique - Pecherie",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "PECHERIE_SURF"
+		 ],
+		 "paint": {
+		  "fill-color": "#BFE2F0",
+		  "fill-outline-color": "#509FEF"
+		 }
+		},
+		{
+		 "id": "bati hydro surfacique - Barrage",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "BARRAGE_SURF"
+		 ],
+		 "paint": {
+		  "fill-color": "#FFFFFF",
+		  "fill-outline-color": "#464646"
+		 }
+		},
+		{
+		 "id": "bati hydro surfacique - Chateau d'eau",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "CHATEAU_EAU_SURF"
+		 ],
+		 "paint": {
+		  "fill-color": "#1466B2"
+		 }
+		},
+		{
+		 "id": "bati infra surfacique - Silo",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "minzoom": 15,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "SILO_SURF"
+		 ],
+		 "paint": {
+		  "fill-color": "#C7A9AA",
+		  "fill-outline-color": "#696969"
+		 }
+		},
+		{
+		 "id": "bati infra surfacique - Reservoir indus",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "minzoom": 14,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "RESERVOIR_INDUS_SURF"
+		 ],
+		 "paint": {
+		  "fill-color": "#8D9DAA",
+		  "fill-outline-color": "#464646"
+		 }
+		},
+		{
+		 "id": "bati infra surfacique - Serre",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "minzoom": 13,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "SERRE_SURF"
+		 ],
+		 "paint": {
+		  "fill-color": "#CAD6D9",
+		  "fill-outline-color": "#8C8C8C"
+		 }
+		},
+		{
+		 "id": "bati infra surfacique - poste electrique",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "POSTE_ELEC_SURF"
+		 ],
+		 "paint": {
+		  "fill-color": "#7993B6",
+		  "fill-opacity": 0.3
+		 }
+		},
+		{
+		 "id": "bati infra surfacique - poste electrique bord",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "POSTE_ELEC_SURF"
+		 ],
+		 "paint": {
+		  "line-color": "#000000",
+		  "line-width": {
+		   "stops": [
+			[
+			 12,
+			 0.3
+			],
+			[
+			 17,
+			 1.2
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "bati religieux surfacique - Zoom 14",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "maxzoom": 14,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "CHAPELLE_SURF",
+		  "EGLISE_SURF",
+		  "CHRETIEN_SURF",
+		  "SYNAGOGUE_SURF",
+		  "MOSQUEE_SURF",
+		  "AUTRE_CULTE_SURF"
+		 ],
+		 "paint": {
+		  "fill-color": "#F7CBCB"
+		 }
+		},
+		{
+		 "id": "bati religieux surfacique - Zoom 15,16,17,18",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "minzoom": 14,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "CHAPELLE_SURF",
+		  "EGLISE_SURF",
+		  "CHRETIEN_SURF",
+		  "SYNAGOGUE_SURF",
+		  "MOSQUEE_SURF",
+		  "AUTRE_CULTE_SURF"
+		 ],
+		 "paint": {
+		  "fill-color": {
+		   "stops": [
+			[
+			 14,
+			 "#F7CBCB"
+			],
+			[
+			 15,
+			 "#F7E1E1"
+			]
+		   ]
+		  },
+		  "fill-outline-color": {
+		   "stops": [
+			[
+			 14,
+			 "#F7A8A8"
+			],
+			[
+			 15,
+			 "#F7B7B7"
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "bati remarquable surfacique",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "minzoom": 13,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "FORTIF_SURF",
+		  "CHATEAU_SURF",
+		  "TOUR_MOULIN_SURF",
+		  "ARENE_THEATRE",
+		  "ARC_TRIOMPHE_SURF",
+		  "MONUMENT_SURF"
+		 ],
+		 "paint": {
+		  "fill-color": "#9B9B9B",
+		  "fill-outline-color": "#6E6E6E"
+		 }
+		},
+		{
+		 "id": "bati sportif surfacique fond",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "TENNIS_SURF",
+		  "SPORT_INDIF_SURF",
+		  "FOOT_SURF",
+		  "MULTI_SPORT_SURF",
+		  "PISTE_SPORT_SURF",
+		  "NATATION_SURF"
+		 ],
+		 "paint": {
+		  "fill-color": "#FFFFFF",
+		  "fill-outline-color": "#FFFFFF"
+		 }
+		},
+		{
+		 "id": "bati sportif surfacique",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "TENNIS_SURF",
+		  "SPORT_INDIF_SURF",
+		  "FOOT_SURF",
+		  "MULTI_SPORT_SURF",
+		  "PISTE_SPORT_SURF",
+		  "NATATION_SURF"
+		 ],
+		 "paint": {
+		  "line-color": "#BCD9AB",
+		  "line-width": 2
+		 }
+		},
+		{
+		 "id": "bati transport surfacique - piste",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "PISTE_DUR",
+		  "PISTE_HERBE"
+		 ],
+		 "paint": {
+		  "fill-color": "#DBDBDB",
+		  "fill-outline-color": "#808080"
+		 }
+		},
+		{
+		 "id": "bati ZAI - Autres",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_zai",
+		 "minzoom": 15,
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "in",
+		  "nature",
+		  "Lycée",
+		  "Université",
+		  "Capitainerie",
+		  "Gendarmerie",
+		  "Siège d'EPCI",
+		  "Musée",
+		  "Collège",
+		  "Maison de retraite",
+		  "Etablissement thermal",
+		  "Autre service déconcentré de l'Etat",
+		  "Etablissement pénitentiaire",
+		  "Divers public ou administratif",
+		  "Autre établissement d'enseignement",
+		  "Maison du parc",
+		  "Palais de justice",
+		  "Enseignement primaire",
+		  "Office de tourisme",
+		  "Hôpital",
+		  "Police",
+		  "Piscine",
+		  "Enseignement supérieur",
+		  "Poste",
+		  "Caserne",
+		  "Etablissement hospitalier",
+		  "Etablissement extraterritorial",
+		  "Science",
+		  "Structure d'accueil pour personnes handicapées",
+		  "Administration centrale de l'Etat",
+		  "Caserne de pompiers"
+		 ],
+		 "paint": {
+		  "fill-color": "#E3BFE2",
+		  "fill-opacity": 0.5,
+		  "fill-outline-color": "#E39FE1"
+		 }
+		},
+		{
+		 "id": "bati ZAI - Commandement",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_zai",
+		 "minzoom": 15,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "in",
+		  "nature",
+		  "Hôtel de département",
+		  "Hôtel de région",
+		  "Préfecture de région",
+		  "Préfecture",
+		  "Sous-préfecture"
+		 ],
+		 "paint": {
+		  "fill-color": "#FF0000",
+		  "fill-opacity": 0.3,
+		  "fill-outline-color": "#B40000"
+		 }
+		},
+		{
+		 "id": "construction linéaire - mur",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "bati_lin",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "MUR"
+		 ],
+		 "paint": {
+		  "line-color": "#8C8C8C",
+		  "line-width": 0.3
+		 }
+		},
+		{
+		 "id": "construction linéaire - autre",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "bati_lin",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "RUINE_LIN",
+		  "MUR_SOUTENEMENT",
+		  "FORTIF_LIN"
+		 ],
+		 "paint": {
+		  "line-color": "#646464",
+		  "line-width": 0.5
+		 }
+		},
+		{
+		 "id": "construction hydrographique linéaire - Barrage",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "bati_lin",
+		 "minzoom": 13,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "BARRAGE_LIN"
+		 ],
+		 "paint": {
+		  "line-color": "#646464",
+		  "line-width": {
+		   "stops": [
+			[
+			 13,
+			 1.5
+			],
+			[
+			 17,
+			 5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "construction hydrographique linéaire - Quai",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "bati_lin",
+		 "minzoom": 12,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "QUAI",
+		  "DIGUE"
+		 ],
+		 "paint": {
+		  "line-color": "#828282",
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 1
+			],
+			[
+			 17,
+			 2.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "construction hydrographique linéaire - Pecherie",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "bati_lin",
+		 "minzoom": 12,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "PECHERIE_LIN"
+		 ],
+		 "paint": {
+		  "line-color": "#0066CC",
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 1
+			],
+			[
+			 17,
+			 2.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Chemin a niveau - piste cyclable",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_chemin",
+		 "minzoom": 13,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "PISTE_CYCLABLE"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 17,
+			 "#9B5CCC"
+			],
+			[
+			 18,
+			 "#EDF1FF"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 1.1
+			],
+			[
+			 15,
+			 1.7
+			],
+			[
+			 16,
+			 2
+			],
+			[
+			 17,
+			 3.5
+			],
+			[
+			 18,
+			 6
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   6,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "Chemin a niveau - filet exterieur - escalier",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_chemin",
+		 "minzoom": 14,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "ESCALIER"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 17,
+			 "#8C7274"
+			],
+			[
+			 18,
+			 "#C8C8C8"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 1.75
+			],
+			[
+			 15,
+			 3
+			],
+			[
+			 16,
+			 4.2
+			],
+			[
+			 17,
+			 9.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Chemin a niveau - filet interieur - escalier",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_chemin",
+		 "minzoom": 14,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "ESCALIER"
+		 ],
+		 "paint": {
+		  "line-color": "#EDF1FF",
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 1
+			],
+			[
+			 15,
+			 1.9
+			],
+			[
+			 16,
+			 2.7
+			],
+			[
+			 17,
+			 5.8
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   1,
+		   0.2
+		  ]
+		 }
+		},
+		{
+		 "id": "Chemin a niveau - Rue pietonne",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_chemin",
+		 "minzoom": 14,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "RUE_PIETONNE"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 17,
+			 "#8C7274"
+			],
+			[
+			 18,
+			 "#F8E5D5"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 1
+			],
+			[
+			 15,
+			 1.2
+			],
+			[
+			 16,
+			 1.4
+			],
+			[
+			 17,
+			 2
+			],
+			[
+			 18,
+			 5
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   1,
+		   3
+		  ]
+		 }
+		},
+		{
+		 "id": "Chemin a niveau - sentier",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_chemin",
+		 "minzoom": 13,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "SENTIER"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 17,
+			 "#8C7274"
+			],
+			[
+			 18,
+			 "#EDF1FF"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 1
+			],
+			[
+			 15,
+			 1.2
+			],
+			[
+			 16,
+			 1.4
+			],
+			[
+			 17,
+			 2
+			],
+			[
+			 18,
+			 6
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   4,
+		   3
+		  ]
+		 }
+		},
+		{
+		 "id": "Chemin a niveau - chemin",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_chemin",
+		 "minzoom": 12,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "CHEMIN"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 17,
+			 "#8C7274"
+			],
+			[
+			 18,
+			 "#EDF1FF"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 1
+			],
+			[
+			 15,
+			 1.2
+			],
+			[
+			 16,
+			 1.4
+			],
+			[
+			 17,
+			 2
+			],
+			[
+			 18,
+			 7
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier a niveau - filet extérieur - route non revetu carrosable",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route",
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "NON_REVETUE_CARRO"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 12,
+			 "#646464"
+			],
+			[
+			 17,
+			 "#8C8C8C"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 3.2
+			],
+			[
+			 15,
+			 5.4
+			],
+			[
+			 16,
+			 7.7
+			],
+			[
+			 17,
+			 16.8
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   2,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "Routier a niveau - filet interieur - route non revetu carrosable",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "NON_REVETUE_CARRO"
+		 ],
+		 "paint": {
+		  "line-color": "#EDF1FF",
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 2.3
+			],
+			[
+			 15,
+			 4.1
+			],
+			[
+			 16,
+			 6.3
+			],
+			[
+			 17,
+			 13.5
+			],
+			[
+			 18,
+			 16.8
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier a niveau - filet extérieur - bretelle autoroute",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route",
+		 "minzoom": 12,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BRET_AUTO_PEAGE_3",
+		  "BRET_AUTO_PEAGE_2",
+		  "BRET_AUTO_PEAGE_1",
+		  "BRET_AUTO_LIBRE_3",
+		  "BRET_AUTO_LIBRE_2",
+		  "BRET_AUTO_LIBRE_1"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 9,
+			 "#DE460E"
+			],
+			[
+			 17,
+			 "#F18800"
+			],
+			[
+			 18,
+			 "#EDF1FF"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 12,
+			 2.5
+			],
+			[
+			 14,
+			 3.7
+			],
+			[
+			 15,
+			 6.8
+			],
+			[
+			 16,
+			 8.4
+			],
+			[
+			 17,
+			 14
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier a niveau - filet extérieur - route non classee restreint",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "NON_CLASSEE_RESTREINT"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 17,
+			 "#969696"
+			],
+			[
+			 18,
+			 "#EDF1FF"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 3.2
+			],
+			[
+			 15,
+			 5.4
+			],
+			[
+			 16,
+			 7.7
+			],
+			[
+			 17,
+			 16.8
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier a niveau - filet extérieur - route non classee",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "NON_CLASSEE_4",
+		  "NON_CLASSEE"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 17,
+			 "#969696"
+			],
+			[
+			 18,
+			 "#EDF1FF"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 3.2
+			],
+			[
+			 15,
+			 5.4
+			],
+			[
+			 16,
+			 7.7
+			],
+			[
+			 17,
+			 16.8
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier a niveau - filet extérieur - route locale",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route",
+		 "minzoom": 7,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BRET_LOCALE",
+		  "LOCALE_4",
+		  "LOCALE_3",
+		  "LOCALE_2",
+		  "LOCALE_1"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 12,
+			 "#8C8C8C"
+			],
+			[
+			 13,
+			 "#B4B4B4"
+			],
+			[
+			 17,
+			 "#B4B4B4"
+			],
+			[
+			 18,
+			 "#EDF1FF"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 9,
+			 2
+			],
+			[
+			 14,
+			 3.5
+			],
+			[
+			 15,
+			 6
+			],
+			[
+			 16,
+			 8.4
+			],
+			[
+			 17,
+			 18.3
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier a niveau - filet extérieur - route locale en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route",
+		 "minzoom": 11,
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "LOCALE_CONSTR"
+		 ],
+		 "paint": {
+		  "line-color": "#C8C8C8",
+		  "line-width": {
+		   "stops": [
+			[
+			 9,
+			 2
+			],
+			[
+			 14,
+			 3.5
+			],
+			[
+			 15,
+			 6
+			],
+			[
+			 16,
+			 8.4
+			],
+			[
+			 17,
+			 18.3
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier a niveau - filet extérieur - route regionale",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route",
+		 "minzoom": 8,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BRET_REGIONALE",
+		  "REGIONALE_4",
+		  "REGIONALE_3",
+		  "REGIONALE_2",
+		  "REGIONALE_1"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 9,
+			 "#828282"
+			],
+			[
+			 10,
+			 "#B4B4B4"
+			],
+			[
+			 17,
+			 "#B4B4B4"
+			],
+			[
+			 18,
+			 "#EDF1FF"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 6,
+			 1.5
+			],
+			[
+			 9,
+			 2.3
+			],
+			[
+			 14,
+			 5
+			],
+			[
+			 15,
+			 8.1
+			],
+			[
+			 16,
+			 11.2
+			],
+			[
+			 17,
+			 22
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier a niveau - filet extérieur - route regionale en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route",
+		 "minzoom": 10,
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "REGIONALE_CONSTR"
+		 ],
+		 "paint": {
+		  "line-color": "#C8C8C8",
+		  "line-width": {
+		   "stops": [
+			[
+			 6,
+			 1.5
+			],
+			[
+			 9,
+			 2.3
+			],
+			[
+			 14,
+			 5
+			],
+			[
+			 15,
+			 8.1
+			],
+			[
+			 16,
+			 11.2
+			],
+			[
+			 17,
+			 22
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier a niveau - filet extérieur - route principale",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route",
+		 "minzoom": 8,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BRET_PRINCIPALE",
+		  "PRINCIPALE_4",
+		  "PRINCIPALE_3",
+		  "PRINCIPALE_2",
+		  "PRINCIPALE_1"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 17,
+			 "#E2A52A"
+			],
+			[
+			 18,
+			 "#EDF1FF"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 6,
+			 1.8
+			],
+			[
+			 9,
+			 2.7
+			],
+			[
+			 14,
+			 5.9
+			],
+			[
+			 15,
+			 9
+			],
+			[
+			 16,
+			 12.2
+			],
+			[
+			 17,
+			 22.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier a niveau - filet extérieur - route principale en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route",
+		 "minzoom": 10,
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "PRINCIPALE_CONSTR"
+		 ],
+		 "paint": {
+		  "line-color": "#C8C8C8",
+		  "line-width": {
+		   "stops": [
+			[
+			 6,
+			 1.8
+			],
+			[
+			 9,
+			 2.7
+			],
+			[
+			 14,
+			 5.9
+			],
+			[
+			 15,
+			 9
+			],
+			[
+			 16,
+			 12.2
+			],
+			[
+			 17,
+			 22.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier a niveau - filet extérieur - autoroute",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route",
+		 "minzoom": 8,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "AUTOROU_PEAGE",
+		  "AUTOROU_LIBRE"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 9,
+			 "#DE460E"
+			],
+			[
+			 17,
+			 "#F18800"
+			],
+			[
+			 18,
+			 "#EDF1FF"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 6,
+			 2.5
+			],
+			[
+			 9,
+			 3.5
+			],
+			[
+			 14,
+			 7.5
+			],
+			[
+			 15,
+			 11
+			],
+			[
+			 16,
+			 15
+			],
+			[
+			 17,
+			 26
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier a niveau - filet extérieur - autoroute en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route",
+		 "minzoom": 8,
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "AUTOROU_CONSTR"
+		 ],
+		 "paint": {
+		  "line-color": "#C8C8C8",
+		  "line-width": {
+		   "stops": [
+			[
+			 6,
+			 2.5
+			],
+			[
+			 9,
+			 3.5
+			],
+			[
+			 14,
+			 7.5
+			],
+			[
+			 15,
+			 11
+			],
+			[
+			 16,
+			 15
+			],
+			[
+			 17,
+			 26
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier a niveau - filet interieur - bretelle autoroute",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route",
+		 "minzoom": 12,
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BRET_AUTO_PEAGE_3",
+		  "BRET_AUTO_PEAGE_2",
+		  "BRET_AUTO_PEAGE_1",
+		  "BRET_AUTO_LIBRE_3",
+		  "BRET_AUTO_LIBRE_2",
+		  "BRET_AUTO_LIBRE_1"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 9,
+			 "#F18800"
+			],
+			[
+			 17,
+			 "#F2B230"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 12,
+			 1.5
+			],
+			[
+			 14,
+			 2.6
+			],
+			[
+			 15,
+			 5.2
+			],
+			[
+			 16,
+			 6.7
+			],
+			[
+			 17,
+			 10.8
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier a niveau - filet interieur - route non classee restreint",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route",
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "NON_CLASSEE_RESTREINT"
+		 ],
+		 "paint": {
+		  "line-color": "#EDF1FF",
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 2.3
+			],
+			[
+			 15,
+			 4.1
+			],
+			[
+			 16,
+			 6.3
+			],
+			[
+			 17,
+			 13.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier a niveau - filet interieur - route non classee",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route",
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "NON_CLASSEE_4",
+		  "NON_CLASSEE"
+		 ],
+		 "paint": {
+		  "line-color": "#EDF1FF",
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 2.3
+			],
+			[
+			 15,
+			 4.1
+			],
+			[
+			 16,
+			 6.3
+			],
+			[
+			 17,
+			 13.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier a niveau - filet interieur - route locale",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route",
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BRET_LOCALE",
+		  "LOCALE_4",
+		  "LOCALE_3",
+		  "LOCALE_2",
+		  "LOCALE_1"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 6,
+			 "#F2B361"
+			],
+			[
+			 7,
+			 "#EDF1FF"
+			],
+			[
+			 12,
+			 "#EDF1FF"
+			],
+			[
+			 13,
+			 "#FCF4A8"
+			],
+			[
+			 17,
+			 "#FCF7C1"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 9,
+			 1.3
+			],
+			[
+			 14,
+			 2.3
+			],
+			[
+			 15,
+			 4.1
+			],
+			[
+			 16,
+			 6.1
+			],
+			[
+			 17,
+			 13.1
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier a niveau - filet interieur - route locale en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route",
+		 "minzoom": 11,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "LOCALE_CONSTR"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 12,
+			 "#EDF1FF"
+			],
+			[
+			 13,
+			 "#FCF4A8"
+			],
+			[
+			 17,
+			 "#FCF7C1"
+			],
+			[
+			 18,
+			 "#EDEDED"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 9,
+			 2
+			],
+			[
+			 14,
+			 3.5
+			],
+			[
+			 15,
+			 6
+			],
+			[
+			 16,
+			 8.4
+			],
+			[
+			 17,
+			 18.3
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   2,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "Routier a niveau - filet interieur - route regionale",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route",
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BRET_REGIONALE",
+		  "REGIONALE_4",
+		  "REGIONALE_3",
+		  "REGIONALE_2",
+		  "REGIONALE_1"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 6,
+			 "#F2A949"
+			],
+			[
+			 7,
+			 "#EDF1FF"
+			],
+			[
+			 9,
+			 "#EDF1FF"
+			],
+			[
+			 10,
+			 "#FDF28B"
+			],
+			[
+			 17,
+			 "#FCF6BD"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 4,
+			 1.1
+			],
+			[
+			 6,
+			 1.4
+			],
+			[
+			 9,
+			 1.5
+			],
+			[
+			 14,
+			 3.2
+			],
+			[
+			 15,
+			 5.8
+			],
+			[
+			 16,
+			 8.3
+			],
+			[
+			 17,
+			 16.2
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier a niveau - filet interieur - route regionale en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route",
+		 "minzoom": 10,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "REGIONALE_CONSTR"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 9,
+			 "#EDF1FF"
+			],
+			[
+			 10,
+			 "#FDF28B"
+			],
+			[
+			 17,
+			 "#FCF6BD"
+			],
+			[
+			 18,
+			 "#EDEDED"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 4,
+			 0.4
+			],
+			[
+			 6,
+			 1.5
+			],
+			[
+			 9,
+			 2.3
+			],
+			[
+			 14,
+			 5
+			],
+			[
+			 15,
+			 8.1
+			],
+			[
+			 16,
+			 11.2
+			],
+			[
+			 17,
+			 22
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   2,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "Routier a niveau - filet interieur - route principale",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route",
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BRET_PRINCIPALE",
+		  "PRINCIPALE_4",
+		  "PRINCIPALE_3",
+		  "PRINCIPALE_2",
+		  "PRINCIPALE_1"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 6,
+			 "#F29924"
+			],
+			[
+			 7,
+			 "#F3C66D"
+			],
+			[
+			 9,
+			 "#F3C66D"
+			],
+			[
+			 17,
+			 "#F2DDB3"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 4,
+			 0.6
+			],
+			[
+			 6,
+			 1.8
+			],
+			[
+			 9,
+			 2.1
+			],
+			[
+			 14,
+			 4.4
+			],
+			[
+			 15,
+			 7.3
+			],
+			[
+			 16,
+			 10
+			],
+			[
+			 17,
+			 18.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier a niveau - filet interieur - route principale en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route",
+		 "minzoom": 10,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "PRINCIPALE_CONSTR"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 9,
+			 "#F3C66D"
+			],
+			[
+			 17,
+			 "#F2DDB3"
+			],
+			[
+			 18,
+			 "#EDEDED"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 4,
+			 0.5
+			],
+			[
+			 6,
+			 1.8
+			],
+			[
+			 9,
+			 2.7
+			],
+			[
+			 14,
+			 5.9
+			],
+			[
+			 15,
+			 9
+			],
+			[
+			 16,
+			 12.2
+			],
+			[
+			 17,
+			 22.5
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   2,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "Routier a niveau - filet interieur - autoroute",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route",
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "AUTOROU_PEAGE",
+		  "AUTOROU_LIBRE"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 9,
+			 "#F18800"
+			],
+			[
+			 17,
+			 "#F2B230"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 4,
+			 0.7
+			],
+			[
+			 6,
+			 2.5
+			],
+			[
+			 9,
+			 2.7
+			],
+			[
+			 14,
+			 5.8
+			],
+			[
+			 15,
+			 9
+			],
+			[
+			 16,
+			 12
+			],
+			[
+			 17,
+			 20.8
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier a niveau - axe central - autoroute",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route",
+		 "minzoom": 13,
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "AUTOROU_PEAGE",
+		  "AUTOROU_LIBRE"
+		 ],
+		 "paint": {
+		  "line-color": "#EDF1FF",
+		  "line-width": {
+		   "stops": [
+			[
+			 9,
+			 0.6
+			],
+			[
+			 14,
+			 0.7
+			],
+			[
+			 15,
+			 1
+			],
+			[
+			 16,
+			 1.2
+			],
+			[
+			 17,
+			 2.1
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier a niveau - filet interieur - autoroute en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route",
+		 "minzoom": 8,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "AUTOROU_CONSTR"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 9,
+			 "#F18800"
+			],
+			[
+			 17,
+			 "#F2B230"
+			],
+			[
+			 18,
+			 "#EDEDED"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 4,
+			 0.7
+			],
+			[
+			 6,
+			 2.5
+			],
+			[
+			 9,
+			 3.5
+			],
+			[
+			 14,
+			 7.5
+			],
+			[
+			 15,
+			 11
+			],
+			[
+			 16,
+			 15
+			],
+			[
+			 17,
+			 26
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   2,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "Routier a niveau - axe centrale - autoroute en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route",
+		 "minzoom": 13,
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "AUTOROU_CONSTR"
+		 ],
+		 "paint": {
+		  "line-color": "#808080",
+		  "line-width": {
+		   "stops": [
+			[
+			 9,
+			 0.6
+			],
+			[
+			 14,
+			 0.7
+			],
+			[
+			 15,
+			 1
+			],
+			[
+			 16,
+			 1.2
+			],
+			[
+			 17,
+			 2.1
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Ferre a niveau - voie normale",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "ferre",
+		 "minzoom": 10,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "VF_1",
+		  "VF_2",
+		  "VF_3",
+		  "VF_4",
+		  "VF_ELEC_1",
+		  "VF_ELEC_2",
+		  "VF_ELEC_3",
+		  "VF_ELEC_4"
+		 ],
+		 "paint": {
+		  "line-color": "#787878",
+		  "line-width": {
+		   "stops": [
+			[
+			 10,
+			 0.8
+			],
+			[
+			 17,
+			 2.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Ferre a niveau - voie normale trait perpendic",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "ferre",
+		 "minzoom": 10,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "VF_1",
+		  "VF_2",
+		  "VF_3",
+		  "VF_4",
+		  "VF_ELEC_1",
+		  "VF_ELEC_2",
+		  "VF_ELEC_3",
+		  "VF_ELEC_4"
+		 ],
+		 "paint": {
+		  "line-color": "#787878",
+		  "line-width": {
+		   "stops": [
+			[
+			 10,
+			 3.5
+			],
+			[
+			 17,
+			 14.7
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   0.1,
+		   10
+		  ]
+		 }
+		},
+		{
+		 "id": "Ferre a niveau - voie etroite",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "ferre",
+		 "minzoom": 10,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "VF_ETROITE_1",
+		  "VF_ETROITE_2",
+		  "VF_ETROITE"
+		 ],
+		 "paint": {
+		  "line-color": "#787878",
+		  "line-width": {
+		   "stops": [
+			[
+			 10,
+			 0.3
+			],
+			[
+			 17,
+			 1.8
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Ferre a niveau - voie etroite trait perpendic",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "ferre",
+		 "minzoom": 10,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "VF_ETROITE_1",
+		  "VF_ETROITE_2",
+		  "VF_ETROITE"
+		 ],
+		 "paint": {
+		  "line-color": "#787878",
+		  "line-width": {
+		   "stops": [
+			[
+			 10,
+			 3.5
+			],
+			[
+			 17,
+			 14.7
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   0.1,
+		   10
+		  ]
+		 }
+		},
+		{
+		 "id": "Ferre a niveau - voie service",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "ferre",
+		 "minzoom": 14,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "VF_SERVICE",
+		  "VF_NON_EXPLOITEE"
+		 ],
+		 "paint": {
+		  "line-color": "#787878",
+		  "line-width": {
+		   "stops": [
+			[
+			 10,
+			 0.3
+			],
+			[
+			 17,
+			 1.8
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   5,
+		   2,
+		   1,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "Ferre a niveau - voie en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "ferre",
+		 "minzoom": 10,
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "VF_EN_CONSTR"
+		 ],
+		 "paint": {
+		  "line-color": "#787878",
+		  "line-width": {
+		   "stops": [
+			[
+			 10,
+			 0.3
+			],
+			[
+			 17,
+			 1.8
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   2,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "Ferre a niveau - voie en construction trait perpendic",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "ferre",
+		 "minzoom": 10,
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "VF_EN_CONSTR"
+		 ],
+		 "paint": {
+		  "line-color": "#787878",
+		  "line-width": {
+		   "stops": [
+			[
+			 10,
+			 3.5
+			],
+			[
+			 17,
+			 14.7
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   0.1,
+		   10
+		  ]
+		 }
+		},
+		{
+		 "id": "Ferre a niveau - funic/urbain",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "ferre",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "FUNI_CREMAILLERE",
+		  "TRANSPORT_URBAIN"
+		 ],
+		 "paint": {
+		  "line-color": "#787878",
+		  "line-width": {
+		   "stops": [
+			[
+			 10,
+			 0.3
+			],
+			[
+			 17,
+			 1.8
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Ferre a niveau - 2 trait perpendic - funic/urbain",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "ferre",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "FUNI_CREMAILLERE",
+		  "TRANSPORT_URBAIN"
+		 ],
+		 "paint": {
+		  "line-color": "#787878",
+		  "line-width": {
+		   "stops": [
+			[
+			 10,
+			 3.5
+			],
+			[
+			 17,
+			 17
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   0.1,
+		   0.2,
+		   0.1,
+		   10
+		  ]
+		 }
+		},
+		{
+		 "id": "liaison routiere - Bac Liaison Maritime",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_liaison",
+		 "minzoom": 8,
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BAC_AUTO",
+		  "LIAISON_MARITIME",
+		  "BAC_LIAISON_MARITIME"
+		 ],
+		 "paint": {
+		  "line-color": "#5792C2",
+		  "line-width": {
+		   "stops": [
+			[
+			 8,
+			 1
+			],
+			[
+			 13,
+			 2.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "liaison routiere - Gue route",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_liaison",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "GUE_ROUTE"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 13,
+			 "#BEBEBE"
+			],
+			[
+			 17,
+			 "#646464"
+			],
+			[
+			 18,
+			 "#EDF1FF"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 2.3
+			],
+			[
+			 15,
+			 4.1
+			],
+			[
+			 16,
+			 6.3
+			],
+			[
+			 17,
+			 13.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "liaison routiere - Gue chemin",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_liaison",
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "GUE_CHEMIN"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 13,
+			 "#BEBEBE"
+			],
+			[
+			 17,
+			 "#646464"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 1.6
+			],
+			[
+			 15,
+			 2.9
+			],
+			[
+			 16,
+			 4.4
+			],
+			[
+			 17,
+			 6.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "liaison routiere - filet extérieur - Pont passerelle",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_liaison",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "PONT_PASSERELLE",
+		  "PONT_LIN",
+		  "PONT_MOBILE_LIN"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 17,
+			 "#C8C8C8"
+			],
+			[
+			 18,
+			 "#EDF1FF"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 2.2
+			],
+			[
+			 15,
+			 3.8
+			],
+			[
+			 16,
+			 5.4
+			],
+			[
+			 17,
+			 11.8
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "liaison routiere - filet intérieur - Pont passerelle",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_liaison",
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "PONT_PASSERELLE",
+		  "PONT_LIN",
+		  "PONT_MOBILE_LIN"
+		 ],
+		 "paint": {
+		  "line-color": "#EDF1FF",
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 0.7
+			],
+			[
+			 15,
+			 1.1
+			],
+			[
+			 16,
+			 1.7
+			],
+			[
+			 17,
+			 3.8
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier surfacique",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "routier_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "SURF_ROUT_PRINC",
+		  "SURF_ROUT_REG",
+		  "SURF_ROUT_LOC",
+		  "SURF_ROUT_NON_CLA"
+		 ],
+		 "paint": {
+		  "fill-color": "#EDF1FF",
+		  "fill-outline-color": "#000000"
+		 }
+		},
+		{
+		 "id": "Routier surfacique - Dalle de protection",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "routier_surf",
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "DALLE_DE_PROTECTION"
+		 ],
+		 "paint": {
+		  "fill-opacity": 0.5,
+		  "fill-color": "#FFFFFF",
+		  "fill-outline-color": "#000000"
+		 }
+		},
+		{
+		 "id": "Routier surfacique - Escalier surfacique",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "routier_surf",
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "ESCALIER_SURF"
+		 ],
+		 "paint": {
+		  "fill-opacity": 0.8,
+		  "fill-color": "#FFFFFF",
+		  "fill-outline-color": "#918091"
+		 }
+		},
+		{
+		 "id": "Routier surfacique - Péage surfacique",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "routier_surf",
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "SURF_PEAGE"
+		 ],
+		 "paint": {
+		  "fill-color": "#F2DAAA",
+		  "fill-outline-color": "#E2A52A"
+		 }
+		},
+		{
+		 "id": "bati transport surfacique - bati peage",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "minzoom": 13,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "BATI_PEAGE"
+		 ],
+		 "paint": {
+		  "fill-color": "#DCDCDC",
+		  "fill-outline-color": "#808080"
+		 }
+		},
+		{
+		 "id": "réseau hydro  - cours d'eau superieur",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "hydro_reseau_sup",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "COURS_D_EAU_SUP",
+		  "COURS_D_EAU_MOY_SUP"
+		 ],
+		 "paint": {
+		  "line-color": "#AAD5E9",
+		  "line-width": {
+		   "stops": [
+			[
+			 12,
+			 1.5
+			],
+			[
+			 17,
+			 6.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "réseau hydro - canal superieur",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "hydro_reseau_sup",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "CANAL_SUP"
+		 ],
+		 "paint": {
+		  "line-color": "#AAD5E9",
+		  "line-width": {
+		   "stops": [
+			[
+			 12,
+			 1.4
+			],
+			[
+			 17,
+			 5.9
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "réseau hydro - filet interieur - aqueduc superieur",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "hydro_reseau_sup",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "AQUEDUC_SUP"
+		 ],
+		 "paint": {
+		  "line-color": "#AAD5E9",
+		  "line-width": {
+		   "stops": [
+			[
+			 12,
+			 1.4
+			],
+			[
+			 16,
+			 3.5
+			],
+			[
+			 17,
+			 5.9
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "réseau hydro - carre - aqueduc superieur",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "hydro_reseau_sup",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "AQUEDUC_SUP"
+		 ],
+		 "paint": {
+		  "line-color": "#AAD5E9",
+		  "line-width": {
+		   "stops": [
+			[
+			 12,
+			 3.5
+			],
+			[
+			 16,
+			 8.7
+			],
+			[
+			 17,
+			 14.7
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   1,
+		   5
+		  ]
+		 }
+		},
+		{
+		 "id": "Chemin superieur - piste cyclable",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_chemin_sup",
+		 "minzoom": 13,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "PISTE_CYCLABLE_SUP"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 17,
+			 "#9B5CCC"
+			],
+			[
+			 18,
+			 "#EDF1FF"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 1.1
+			],
+			[
+			 15,
+			 1.7
+			],
+			[
+			 16,
+			 2
+			],
+			[
+			 17,
+			 3.5
+			],
+			[
+			 18,
+			 6
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   6,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "Chemin superieur - filet exterieur - escalier",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_chemin_sup",
+		 "minzoom": 14,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "ESCALIER_SUP"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 17,
+			 "#8C7274"
+			],
+			[
+			 18,
+			 "#C8C8C8"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 1.75
+			],
+			[
+			 15,
+			 3
+			],
+			[
+			 16,
+			 4.2
+			],
+			[
+			 17,
+			 9.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Chemin superieur - filet interieur - escalier",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_chemin_sup",
+		 "minzoom": 14,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "ESCALIER_SUP"
+		 ],
+		 "paint": {
+		  "line-color": "#FFFFFF",
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 1
+			],
+			[
+			 15,
+			 1.9
+			],
+			[
+			 16,
+			 2.7
+			],
+			[
+			 17,
+			 5.8
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   1,
+		   0.2
+		  ]
+		 }
+		},
+		{
+		 "id": "Chemin superieur - Rue pietonne",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_chemin_sup",
+		 "minzoom": 14,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "RUE_PIETONNE_SUP"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 17,
+			 "#8C7274"
+			],
+			[
+			 18,
+			 "#EBEBEB"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 1
+			],
+			[
+			 15,
+			 1.2
+			],
+			[
+			 16,
+			 1.4
+			],
+			[
+			 17,
+			 2
+			],
+			[
+			 18,
+			 5
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   1,
+		   3
+		  ]
+		 }
+		},
+		{
+		 "id": "Chemin superieur - sentier",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_chemin_sup",
+		 "minzoom": 13,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "SENTIER_SUP"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 17,
+			 "#8C7274"
+			],
+			[
+			 18,
+			 "#FFFFFF"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 1
+			],
+			[
+			 15,
+			 1.2
+			],
+			[
+			 16,
+			 1.4
+			],
+			[
+			 17,
+			 2
+			],
+			[
+			 18,
+			 6
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   4,
+		   3
+		  ]
+		 }
+		},
+		{
+		 "id": "Chemin superieur - chemin",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_chemin_sup",
+		 "minzoom": 12,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "CHEMIN_SUP"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 17,
+			 "#8C7274"
+			],
+			[
+			 18,
+			 "#EDF1FF"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 1
+			],
+			[
+			 15,
+			 1.2
+			],
+			[
+			 16,
+			 1.4
+			],
+			[
+			 17,
+			 2
+			],
+			[
+			 18,
+			 7
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier superieur - filet extérieur - route non revetu carrosable",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sup",
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "NON_REVETUE_CARRO_SUP"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 12,
+			 "#646464"
+			],
+			[
+			 17,
+			 "#8C8C8C"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 3.2
+			],
+			[
+			 15,
+			 5.4
+			],
+			[
+			 16,
+			 7.7
+			],
+			[
+			 17,
+			 16.8
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   2,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "Routier superieur - filet extérieur - bretelle autoroute",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sup",
+		 "minzoom": 12,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BRET_AUTO_PEAGE_3_SUP",
+		  "BRET_AUTO_PEAGE_2_SUP",
+		  "BRET_AUTO_PEAGE_1_SUP",
+		  "BRET_AUTO_LIBRE_3_SUP",
+		  "BRET_AUTO_LIBRE_2_SUP",
+		  "BRET_AUTO_LIBRE_1_SUP"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 9,
+			 "#DE460E"
+			],
+			[
+			 17,
+			 "#F18800"
+			],
+			[
+			 18,
+			 "#EDF1FF"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 12,
+			 2.5
+			],
+			[
+			 14,
+			 3.7
+			],
+			[
+			 15,
+			 6.8
+			],
+			[
+			 16,
+			 8.4
+			],
+			[
+			 17,
+			 14
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier superieur - filet extérieur - route non classee restreint",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sup",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "NON_CLASSEE_RESTREINT_SUP"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 17,
+			 "#969696"
+			],
+			[
+			 18,
+			 "#EDF1FF"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 3.2
+			],
+			[
+			 15,
+			 5.4
+			],
+			[
+			 16,
+			 7.7
+			],
+			[
+			 17,
+			 16.8
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier superieur - filet extérieur - route non classee",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sup",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "NON_CLASSEE_4_SUP",
+		  "NON_CLASSEE_SUP"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 17,
+			 "#969696"
+			],
+			[
+			 18,
+			 "#EDF1FF"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 3.2
+			],
+			[
+			 15,
+			 5.4
+			],
+			[
+			 16,
+			 7.7
+			],
+			[
+			 17,
+			 16.8
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier superieur - filet extérieur - route locale",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sup",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BRET_LOCALE_SUP",
+		  "LOCALE_4_SUP",
+		  "LOCALE_3_SUP",
+		  "LOCALE_2_SUP",
+		  "LOCALE_1_SUP"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 12,
+			 "#8C8C8C"
+			],
+			[
+			 13,
+			 "#B4B4B4"
+			],
+			[
+			 17,
+			 "#B4B4B4"
+			],
+			[
+			 18,
+			 "#EDF1FF"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 9,
+			 2
+			],
+			[
+			 14,
+			 3.5
+			],
+			[
+			 15,
+			 6
+			],
+			[
+			 16,
+			 8.4
+			],
+			[
+			 17,
+			 18.3
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier superieur - filet extérieur - route locale en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sup",
+		 "minzoom": 11,
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "LOCALE_CONSTR_SUP"
+		 ],
+		 "paint": {
+		  "line-color": "#C8C8C8",
+		  "line-width": {
+		   "stops": [
+			[
+			 9,
+			 2
+			],
+			[
+			 14,
+			 3.5
+			],
+			[
+			 15,
+			 6
+			],
+			[
+			 16,
+			 8.4
+			],
+			[
+			 17,
+			 18.3
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier superieur - filet extérieur - route regionale",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sup",
+		 "minzoom": 8,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BRET_REGIONALE_SUP",
+		  "REGIONALE_4_SUP",
+		  "REGIONALE_3_SUP",
+		  "REGIONALE_2_SUP",
+		  "REGIONALE_1_SUP"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 9,
+			 "#828282"
+			],
+			[
+			 10,
+			 "#B4B4B4"
+			],
+			[
+			 17,
+			 "#B4B4B4"
+			],
+			[
+			 18,
+			 "#EDF1FF"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 6,
+			 1.5
+			],
+			[
+			 9,
+			 2.3
+			],
+			[
+			 14,
+			 5
+			],
+			[
+			 15,
+			 8.1
+			],
+			[
+			 16,
+			 11.2
+			],
+			[
+			 17,
+			 22
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier superieur - filet extérieur - route regionale en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sup",
+		 "minzoom": 10,
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "REGIONALE_CONSTR_SUP"
+		 ],
+		 "paint": {
+		  "line-color": "#C8C8C8",
+		  "line-width": {
+		   "stops": [
+			[
+			 6,
+			 1.5
+			],
+			[
+			 9,
+			 2.3
+			],
+			[
+			 14,
+			 5
+			],
+			[
+			 15,
+			 8.1
+			],
+			[
+			 16,
+			 11.2
+			],
+			[
+			 17,
+			 22
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier superieur - filet extérieur - route principale",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sup",
+		 "minzoom": 8,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BRET_PRINCIPALE_SUP",
+		  "PRINCIPALE_4_SUP",
+		  "PRINCIPALE_3_SUP",
+		  "PRINCIPALE_2_SUP",
+		  "PRINCIPALE_1_SUP"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 17,
+			 "#E2A52A"
+			],
+			[
+			 18,
+			 "#EDF1FF"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 6,
+			 1.8
+			],
+			[
+			 9,
+			 2.7
+			],
+			[
+			 14,
+			 5.9
+			],
+			[
+			 15,
+			 9
+			],
+			[
+			 16,
+			 12.2
+			],
+			[
+			 17,
+			 22.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier superieur - filet extérieur - route principale en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sup",
+		 "minzoom": 10,
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "PRINCIPALE_CONSTR_SUP"
+		 ],
+		 "paint": {
+		  "line-color": "#C8C8C8",
+		  "line-width": {
+		   "stops": [
+			[
+			 6,
+			 1.8
+			],
+			[
+			 9,
+			 2.7
+			],
+			[
+			 14,
+			 5.9
+			],
+			[
+			 15,
+			 9
+			],
+			[
+			 16,
+			 12.2
+			],
+			[
+			 17,
+			 22.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier superieur - filet extérieur - autoroute",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sup",
+		 "minzoom": 8,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "AUTOROU_PEAGE_SUP",
+		  "AUTOROU_LIBRE_SUP"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 9,
+			 "#DE460E"
+			],
+			[
+			 17,
+			 "#F18800"
+			],
+			[
+			 18,
+			 "#EDF1FF"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 6,
+			 2.5
+			],
+			[
+			 9,
+			 3.5
+			],
+			[
+			 14,
+			 7.5
+			],
+			[
+			 15,
+			 11
+			],
+			[
+			 16,
+			 15
+			],
+			[
+			 17,
+			 26
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier superieur - filet extérieur - autoroute en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sup",
+		 "minzoom": 10,
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "AUTOROU_CONSTR_SUP"
+		 ],
+		 "paint": {
+		  "line-color": "#C8C8C8",
+		  "line-width": {
+		   "stops": [
+			[
+			 6,
+			 2.5
+			],
+			[
+			 9,
+			 3.5
+			],
+			[
+			 14,
+			 7.5
+			],
+			[
+			 15,
+			 11
+			],
+			[
+			 16,
+			 15
+			],
+			[
+			 17,
+			 26
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier superieur - filet interieur - route non revetu carrosable",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sup",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "NON_REVETUE_CARRO_SUP"
+		 ],
+		 "paint": {
+		  "line-color": "#EDF1FF",
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 2.3
+			],
+			[
+			 15,
+			 4.1
+			],
+			[
+			 16,
+			 6.3
+			],
+			[
+			 17,
+			 13.5
+			],
+			[
+			 18,
+			 16.8
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier superieur - filet interieur - bretelle autoroute",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sup",
+		 "minzoom": 12,
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BRET_AUTO_PEAGE_3_SUP",
+		  "BRET_AUTO_PEAGE_2_SUP",
+		  "BRET_AUTO_PEAGE_1_SUP",
+		  "BRET_AUTO_LIBRE_3_SUP",
+		  "BRET_AUTO_LIBRE_2_SUP",
+		  "BRET_AUTO_LIBRE_1_SUP"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 9,
+			 "#F18800"
+			],
+			[
+			 17,
+			 "#F2B230"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 12,
+			 1.5
+			],
+			[
+			 14,
+			 2.6
+			],
+			[
+			 15,
+			 5.2
+			],
+			[
+			 16,
+			 6.7
+			],
+			[
+			 17,
+			 10.8
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier superieur - filet interieur - route non classee restreint",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sup",
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "NON_CLASSEE_RESTREINT_SUP"
+		 ],
+		 "paint": {
+		  "line-color": "#EDF1FF",
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 2.3
+			],
+			[
+			 15,
+			 4.1
+			],
+			[
+			 16,
+			 6.3
+			],
+			[
+			 17,
+			 13.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier superieur - filet interieur - route non classee",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sup",
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "NON_CLASSEE_4_SUP",
+		  "NON_CLASSEE_SUP"
+		 ],
+		 "paint": {
+		  "line-color": "#EDF1FF",
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 2.3
+			],
+			[
+			 15,
+			 4.1
+			],
+			[
+			 16,
+			 6.3
+			],
+			[
+			 17,
+			 13.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier superieur - filet interieur - route locale",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sup",
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BRET_LOCALE_SUP",
+		  "LOCALE_4_SUP",
+		  "LOCALE_3_SUP",
+		  "LOCALE_2_SUP",
+		  "LOCALE_1_SUP"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 12,
+			 "#EDF1FF"
+			],
+			[
+			 13,
+			 "#FCF4A8"
+			],
+			[
+			 17,
+			 "#FCF7C1"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 9,
+			 1.3
+			],
+			[
+			 14,
+			 2.3
+			],
+			[
+			 15,
+			 4.1
+			],
+			[
+			 16,
+			 6.1
+			],
+			[
+			 17,
+			 13.1
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier superieur - filet interieur - route locale en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sup",
+		 "minzoom": 11,
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "LOCALE_CONSTR_SUP"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 12,
+			 "#EDF1FF"
+			],
+			[
+			 13,
+			 "#FCF4A8"
+			],
+			[
+			 17,
+			 "#FCF7C1"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 9,
+			 2
+			],
+			[
+			 14,
+			 3.5
+			],
+			[
+			 15,
+			 6
+			],
+			[
+			 16,
+			 8.4
+			],
+			[
+			 17,
+			 18.3
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   2,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "Routier superieur - filet interieur - route regionale",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sup",
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BRET_REGIONALE_SUP",
+		  "REGIONALE_4_SUP",
+		  "REGIONALE_3_SUP",
+		  "REGIONALE_2_SUP",
+		  "REGIONALE_1_SUP"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 9,
+			 "#EDF1FF"
+			],
+			[
+			 10,
+			 "#FDF28B"
+			],
+			[
+			 17,
+			 "#FCF6BD"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 6,
+			 1.4
+			],
+			[
+			 9,
+			 1.5
+			],
+			[
+			 14,
+			 3.2
+			],
+			[
+			 15,
+			 5.8
+			],
+			[
+			 16,
+			 8.3
+			],
+			[
+			 17,
+			 16.2
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier superieur - filet interieur - route regionale en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sup",
+		 "minzoom": 10,
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "REGIONALE_CONSTR_SUP"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 9,
+			 "#EDF1FF"
+			],
+			[
+			 10,
+			 "#FDF28B"
+			],
+			[
+			 17,
+			 "#FCF6BD"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 6,
+			 1.5
+			],
+			[
+			 9,
+			 2.3
+			],
+			[
+			 14,
+			 5
+			],
+			[
+			 15,
+			 8.1
+			],
+			[
+			 16,
+			 11.2
+			],
+			[
+			 17,
+			 22
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   2,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "Routier superieur - filet interieur - route principale",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sup",
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BRET_PRINCIPALE_SUP",
+		  "PRINCIPALE_4_SUP",
+		  "PRINCIPALE_3_SUP",
+		  "PRINCIPALE_2_SUP",
+		  "PRINCIPALE_1_SUP"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 9,
+			 "#F3C66D"
+			],
+			[
+			 17,
+			 "#F2DDB3"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 4,
+			 0.5
+			],
+			[
+			 6,
+			 1.8
+			],
+			[
+			 9,
+			 2.1
+			],
+			[
+			 14,
+			 4.4
+			],
+			[
+			 15,
+			 7.3
+			],
+			[
+			 16,
+			 10
+			],
+			[
+			 17,
+			 18.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier superieur - filet interieur - route principale en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sup",
+		 "minzoom": 10,
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "PRINCIPALE_CONSTR_SUP"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 9,
+			 "#F3C66D"
+			],
+			[
+			 17,
+			 "#F2DDB3"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 6,
+			 1.8
+			],
+			[
+			 9,
+			 2.7
+			],
+			[
+			 14,
+			 5.9
+			],
+			[
+			 15,
+			 9
+			],
+			[
+			 16,
+			 12.2
+			],
+			[
+			 17,
+			 22.5
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   2,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "Routier superieur - filet interieur - autoroute",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sup",
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "AUTOROU_PEAGE_SUP",
+		  "AUTOROU_LIBRE_SUP"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 9,
+			 "#F18800"
+			],
+			[
+			 17,
+			 "#F2B230"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 4,
+			 0.7
+			],
+			[
+			 6,
+			 2.5
+			],
+			[
+			 9,
+			 2.7
+			],
+			[
+			 14,
+			 5.8
+			],
+			[
+			 15,
+			 9
+			],
+			[
+			 16,
+			 12
+			],
+			[
+			 17,
+			 20.8
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier superieur - axe central - autoroute",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sup",
+		 "minzoom": 13,
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "AUTOROU_PEAGE_SUP",
+		  "AUTOROU_LIBRE_SUP"
+		 ],
+		 "paint": {
+		  "line-color": "#EDF1FF",
+		  "line-width": {
+		   "stops": [
+			[
+			 9,
+			 0.6
+			],
+			[
+			 14,
+			 0.7
+			],
+			[
+			 15,
+			 1
+			],
+			[
+			 16,
+			 1.2
+			],
+			[
+			 17,
+			 2.1
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier superieur - filet interieur - autoroute en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sup",
+		 "minzoom": 10,
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "AUTOROU_CONSTR_SUP"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 9,
+			 "#F18800"
+			],
+			[
+			 17,
+			 "#F2B230"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 4,
+			 0.7
+			],
+			[
+			 6,
+			 2.5
+			],
+			[
+			 9,
+			 3.5
+			],
+			[
+			 14,
+			 7.5
+			],
+			[
+			 15,
+			 11
+			],
+			[
+			 16,
+			 15
+			],
+			[
+			 17,
+			 26
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   2,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "Routier superieur - axe centrale - autoroute en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sup",
+		 "minzoom": 13,
+		 "maxzoom": 22,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "AUTOROU_CONSTR_SUP"
+		 ],
+		 "paint": {
+		  "line-color": "#808080",
+		  "line-width": {
+		   "stops": [
+			[
+			 9,
+			 0.6
+			],
+			[
+			 14,
+			 0.7
+			],
+			[
+			 15,
+			 1
+			],
+			[
+			 16,
+			 1.2
+			],
+			[
+			 17,
+			 2.1
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Ferre superieur - voie normale",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "ferre_sup",
+		 "minzoom": 10,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "VF_1_SUP",
+		  "VF_2_SUP",
+		  "VF_ELEC_1_SUP"
+		 ],
+		 "paint": {
+		  "line-color": "#787878",
+		  "line-width": {
+		   "stops": [
+			[
+			 10,
+			 0.8
+			],
+			[
+			 17,
+			 2.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Ferre superieur - voie normale trait perpendic",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "ferre_sup",
+		 "minzoom": 10,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "VF_1_SUP",
+		  "VF_2_SUP",
+		  "VF_ELEC_1_SUP"
+		 ],
+		 "paint": {
+		  "line-color": "#787878",
+		  "line-width": {
+		   "stops": [
+			[
+			 10,
+			 3.5
+			],
+			[
+			 17,
+			 14.7
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   0.1,
+		   10
+		  ]
+		 }
+		},
+		{
+		 "id": "Ferre superieur - voie etroite",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "ferre_sup",
+		 "minzoom": 10,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "VF_ETROITE_1_SUP",
+		  "VF_ETROITE_SUP"
+		 ],
+		 "paint": {
+		  "line-color": "#787878",
+		  "line-width": {
+		   "stops": [
+			[
+			 10,
+			 0.3
+			],
+			[
+			 17,
+			 1.8
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Ferre superieur - voie etroite trait perpendic",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "ferre_sup",
+		 "minzoom": 10,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "VF_ETROITE_1_SUP",
+		  "VF_ETROITE_SUP"
+		 ],
+		 "paint": {
+		  "line-color": "#787878",
+		  "line-width": {
+		   "stops": [
+			[
+			 10,
+			 3.5
+			],
+			[
+			 17,
+			 14.7
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   0.1,
+		   10
+		  ]
+		 }
+		},
+		{
+		 "id": "Ferre superieur - voie service",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "ferre_sup",
+		 "minzoom": 14,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "VF_SERVICE_SUP",
+		  "VF_NON_EXPLOITEE_SUP"
+		 ],
+		 "paint": {
+		  "line-color": "#787878",
+		  "line-width": {
+		   "stops": [
+			[
+			 10,
+			 0.3
+			],
+			[
+			 17,
+			 1.8
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   5,
+		   2,
+		   1,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "Ferre superieur - voie en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "ferre_sup",
+		 "minzoom": 10,
+		 "maxzoom": 21,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "VF_EN_CONSTR_SUP"
+		 ],
+		 "paint": {
+		  "line-color": "#787878",
+		  "line-width": {
+		   "stops": [
+			[
+			 10,
+			 0.3
+			],
+			[
+			 17,
+			 1.8
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   2,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "Ferre superieur - voie en construction trait perpendic",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "ferre_sup",
+		 "minzoom": 10,
+		 "maxzoom": 21,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "VF_EN_CONSTR_SUP"
+		 ],
+		 "paint": {
+		  "line-color": "#787878",
+		  "line-width": {
+		   "stops": [
+			[
+			 10,
+			 3.5
+			],
+			[
+			 17,
+			 14.7
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   0.1,
+		   10
+		  ]
+		 }
+		},
+		{
+		 "id": "Ferre superieur - funic/urbain",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "ferre_sup",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "FUNI_CREMAILLERE_SUP",
+		  "TRANSPORT_URBAIN_SUP"
+		 ],
+		 "paint": {
+		  "line-color": "#787878",
+		  "line-width": {
+		   "stops": [
+			[
+			 10,
+			 0.3
+			],
+			[
+			 17,
+			 1.8
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Ferre superieur - 2 trait perpendic - funic/urbain",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "ferre_sup",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "FUNI_CREMAILLERE_SUP",
+		  "TRANSPORT_URBAIN_SUP"
+		 ],
+		 "paint": {
+		  "line-color": "#787878",
+		  "line-width": {
+		   "stops": [
+			[
+			 10,
+			 3.5
+			],
+			[
+			 17,
+			 17
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   0.1,
+		   0.2,
+		   0.1,
+		   10
+		  ]
+		 }
+		},
+		{
+		 "id": "Limite - cloture",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "limite_lin",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "CLOTURE"
+		 ],
+		 "paint": {
+		  "line-color": "#000000",
+		  "line-width": {
+		   "stops": [
+			[
+			 13,
+			 0.6
+			],
+			[
+			 17,
+			 1
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   1.5,
+		   4
+		  ]
+		 }
+		},
+		{
+		 "id": "Limite - layon",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "limite_lin",
+		 "minzoom": 14,
+		 "maxzoom": 21,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "LAYON"
+		 ],
+		 "paint": {
+		  "line-color": "#B3989A",
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 1
+			],
+			[
+			 15,
+			 1.2
+			],
+			[
+			 16,
+			 1.4
+			],
+			[
+			 17,
+			 2
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   4,
+		   7
+		  ]
+		 }
+		},
+		{
+		 "id": "Zone Règlementee - Enceinte militaire",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "limite_lin",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "LIM_ZONE_REGLEMENTEE",
+		  "LIM_ENCEINTE_MILITAIRE",
+		  "LIM_ENCEINTE_MILI",
+		  "LIM_CHAMP_TIR"
+		 ],
+		 "paint": {
+		  "line-color": "rgba(226, 130, 92, 0.8)",
+		  "line-width": {
+		   "stops": [
+			[
+			 13,
+			 1.7
+			],
+			[
+			 17,
+			 3.1
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   4,
+		   1,
+		   2,
+		   5
+		  ]
+		 }
+		},
+		{
+		 "id": "limite zone naturelle",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "limite_lin",
+		 "maxzoom": 21,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "LIM_ZONE_NATURELLE",
+		  "LIM_ZONE_NATURELLE_ILE",
+		  "LIM_RESERVE_NATURELLE"
+		 ],
+		 "paint": {
+		  "line-color": "#FFC2CB",
+		  "line-width": {
+		   "stops": [
+			[
+			 13,
+			 2
+			],
+			[
+			 17,
+			 4
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   2,
+		   1
+		  ]
+		 }
+		},
+		{
+		 "id": "limite zone naturelle - Parc naturel 10",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "limite_lin",
+		 "maxzoom": 10,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "LIM_PARC_NATUREL",
+		  "LIM_PARC_NATUREL_ILE"
+		 ],
+		 "paint": {
+		  "line-color": "#42A266",
+		  "line-width": {
+		   "stops": [
+			[
+			 13,
+			 2
+			],
+			[
+			 17,
+			 4
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   2,
+		   1
+		  ]
+		 }
+		},
+		{
+		 "id": "limite zone naturelle - Parc naturel 11",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "limite_lin",
+		 "minzoom": 10,
+		 "maxzoom": 21,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "LIM_PARC_NATUREL",
+		  "LIM_PARC_NATUREL_ILE"
+		 ],
+		 "paint": {
+		  "line-color": "#42A266",
+		  "line-width": {
+		   "stops": [
+			[
+			 13,
+			 2
+			],
+			[
+			 17,
+			 4
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   2,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "limite zone naturelle - Parc naturel 12",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "limite_lin",
+		 "minzoom": 11,
+		 "maxzoom": 21,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "LIM_PARC_NATUREL",
+		  "LIM_PARC_NATUREL_ILE"
+		 ],
+		 "paint": {
+		  "line-color": "#42A266",
+		  "line-width": {
+		   "stops": [
+			[
+			 13,
+			 2
+			],
+			[
+			 17,
+			 4
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   2,
+		   3
+		  ]
+		 }
+		},
+		{
+		 "id": "limite zone naturelle - Parc naturel 13",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "limite_lin",
+		 "minzoom": 12,
+		 "maxzoom": 21,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "LIM_PARC_NATUREL",
+		  "LIM_PARC_NATUREL_ILE"
+		 ],
+		 "paint": {
+		  "line-color": "#42A266",
+		  "line-width": {
+		   "stops": [
+			[
+			 13,
+			 2
+			],
+			[
+			 17,
+			 4
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   2,
+		   4
+		  ]
+		 }
+		},
+		{
+		 "id": "limite zone naturelle - Parc naturel 14",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "limite_lin",
+		 "minzoom": 13,
+		 "maxzoom": 21,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "LIM_PARC_NATUREL",
+		  "LIM_PARC_NATUREL_ILE"
+		 ],
+		 "paint": {
+		  "line-color": "rgba(66, 162, 102, 0.7)",
+		  "line-width": {
+		   "stops": [
+			[
+			 13,
+			 2
+			],
+			[
+			 17,
+			 4
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   2,
+		   5
+		  ]
+		 }
+		},
+		{
+		 "id": "limite zone naturelle - Parc marin",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "limite_lin",
+		 "maxzoom": 21,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "LIM_PARC_NATUREL_MARIN"
+		 ],
+		 "paint": {
+		  "line-color": "#2A81A2",
+		  "line-width": {
+		   "stops": [
+			[
+			 13,
+			 2
+			],
+			[
+			 17,
+			 4
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   2,
+		   1
+		  ]
+		 }
+		},
+		
+		{
+		 "id": "limite admin - limite de commune",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "limite_lin",
+		 "minzoom": 13,
+		 "maxzoom": 21,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "LIM_COMMUNE",
+		  "LIM_CANTON",
+		  "LIM_ARRONDISSEMENT"
+		 ],
+		 "paint": {
+		  "line-color": "rgba(126, 119, 184, 0.5)",
+		  "line-width": {
+		   "stops": [
+			[
+			 13,
+			 3
+			],
+			[
+			 17,
+			 5.5
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   4,
+		   2,
+		   1,
+		   1,
+		   1,
+		   1,
+		   1,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "limite admin - limite de département bandeau",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "limite_lin",
+		 "minzoom": 8,
+		 "maxzoom": 21,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "LIM_DEPARTEMENT"
+		 ],
+		 "paint": {
+		  "line-color": "rgba(178, 175, 219, 0.4)",
+		  "line-width": {
+		   "stops": [
+			[
+			 9,
+			 4.1
+			],
+			[
+			 12,
+			 6
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "limite admin - limite de département tiret",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "limite_lin",
+		 "minzoom": 13,
+		 "maxzoom": 21,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "LIM_DEPARTEMENT"
+		 ],
+		 "paint": {
+		  "line-color": "rgba(126, 119, 184, 0.5)",
+		  "line-width": {
+		   "stops": [
+			[
+			 13,
+			 3
+			],
+			[
+			 17,
+			 5.5
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   4,
+		   2,
+		   1,
+		   1,
+		   1,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "limite admin - limite de région bandeau",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "limite_lin",
+		 "minzoom": 7,
+		 "maxzoom": 21,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "LIM_REGION"
+		 ],
+		 "paint": {
+		  "line-color": "rgba(178, 175, 219, 0.5)",
+		  "line-width": {
+		   "stops": [
+			[
+			 9,
+			 4.5
+			],
+			[
+			 12,
+			 6.7
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "limite admin - limite de région tiret",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "limite_lin",
+		 "minzoom": 13,
+		 "maxzoom": 21,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "LIM_REGION"
+		 ],
+		 "paint": {
+		  "line-color": "rgba(126, 119, 184, 0.5)",
+		  "line-width": {
+		   "stops": [
+			[
+			 13,
+			 3
+			],
+			[
+			 17,
+			 5.5
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   4,
+		   2,
+		   1,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "limite etat 1",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "limite_lin",
+		 "minzoom": 2,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "LIM_ETAT",
+		  "LIM_ETAT_ETRANGER"
+		 ],
+		 "paint": {
+		  "line-color": "rgba(178, 175, 219, 0.6)",
+		  "line-width": {
+		   "stops": [
+			[
+			 2,
+			 2
+			],
+			[
+			 3,
+			 3.5
+			],
+			[
+			 9,
+			 5
+			],
+			[
+			 14,
+			 13
+			],
+			[
+			 15,
+			 20
+			],
+			[
+			 16,
+			 24
+			],
+			[
+			 17,
+			 42
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "limite etat 2",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "limite_lin",
+		 "minzoom": 7,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "LIM_ETAT",
+		  "LIM_ETAT_ETRANGER"
+		 ],
+		 "paint": {
+		  "line-color": "#9F9CB8",
+		  "line-width": {
+		   "stops": [
+			[
+			 9,
+			 1.5
+			],
+			[
+			 14,
+			 3.5
+			],
+			[
+			 15,
+			 5.5
+			],
+			[
+			 16,
+			 6.5
+			],
+			[
+			 17,
+			 11
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   4,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "limite cote",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "limite_lin",
+		 "minzoom": 7,
+		 "maxzoom": 10,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "LIM_COTE"
+		 ],
+		 "paint": {
+		  "line-color": "#82A3B2",
+		  "line-width": 1
+		 }
+		},
+		{
+		 "id": "ligne electrique",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "bati_lin",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "LIGNE_ELECTRIQUE"
+		 ],
+		 "paint": {
+		  "line-color": "#808080",
+		  "line-width": {
+		   "stops": [
+			[
+			 13,
+			 1
+			],
+			[
+			 17,
+			 2
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "autre construction linéaire",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "bati_lin",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "CABLE",
+		  "REMONTEE_MEC",
+		  "HYDROCARBURES",
+		  "CONDUITE_MATIERES_P",
+		  "SPORT_MONTAGNE_LIN",
+		  "PISTE_BOBSLEIGH",
+		  "PISTE_LUGE",
+		  "PISTE_AERO_LIN"
+		 ],
+		 "paint": {
+		  "line-color": "#808080",
+		  "line-width": 1
+		 }
+		},
+		{
+		 "id": "autre construction linéaire - trait perpend cable",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "bati_lin",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "CABLE"
+		 ],
+		 "paint": {
+		  "line-color": "#808080",
+		  "line-width": 5,
+		  "line-dasharray": [
+		   0.5,
+		   10
+		  ]
+		 }
+		},
+		{
+		 "id": "autre construction linéaire - trait perpend 1 remont",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "bati_lin",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "REMONTEE_MEC"
+		 ],
+		 "paint": {
+		  "line-color": "#808080",
+		  "line-width": 6,
+		  "line-dasharray": [
+		   1,
+		   10
+		  ]
+		 }
+		},
+		{
+		 "id": "autre construction linéaire - trait perpend 2 remont",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "bati_lin",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "REMONTEE_MEC"
+		 ],
+		 "paint": {
+		  "line-color": "#BEBEBE",
+		  "line-width": 6,
+		  "line-dasharray": [
+		   0.3,
+		   0.4,
+		   0.3,
+		   10
+		  ]
+		 }
+		},
+		{
+		 "id": "autre construction linéaire - trait perpend carbur",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "bati_lin",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "HYDROCARBURES",
+		  "CONDUITE_MATIERES_P"
+		 ],
+		 "paint": {
+		  "line-color": "#808080",
+		  "line-width": 5,
+		  "line-dasharray": [
+		   1,
+		   10
+		  ]
+		 }
+		},
+		{
+		 "id": "routier ponctuel - peage ponctuel",
+		 "type": "circle",
+		 "source": "plan_ign",
+		 "source-layer": "routier_ponc",
+		 "minzoom": 8,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "PEAGE_PONC"
+		 ],
+		 "paint": {
+		  "circle-radius": {
+		   "stops": [
+			[
+			 9,
+			 3.5
+			],
+			[
+			 12,
+			 6.5
+			]
+		   ]
+		  },
+		  "circle-color": "#E2A52A",
+		  "circle-stroke-width": 1,
+		  "circle-stroke-color": "#808080"
+		 }
+		},
+		{
+		 "id": "routier ponctuel - barriere",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "routier_ponc",
+		 "minzoom": 12,
+		 "layout": {
+		  "visibility": "visible",
+		  "icon-image": "Barriere",
+		  "icon-size": {
+		   "stops": [
+			[
+			 13,
+			 0.25
+			],
+			[
+			 16,
+			 0.45
+			],
+			[
+			 17,
+			 0.7
+			]
+		   ]
+		  },
+		  "icon-allow-overlap": true,
+		  "icon-rotate": [
+		   "get",
+		   "rotation"
+		  ]
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "BARRIERE"
+		 ],
+		 "paint": {
+		  "icon-color": "#969696"
+		 }
+		},
+		{
+		 "id": "hydro ponctuel",
+		 "type": "circle",
+		 "source": "plan_ign",
+		 "source-layer": "hydro_ponc",
+		 "minzoom": 13,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "FONTAINE",
+		  "POINT_D_EAU",
+		  "SOURCE",
+		  "SOURCE_CAPTEE",
+		  "PERTE",
+		  "RESURGENCE",
+		  "CASCADE",
+		  "AUTRE_HYDRO_PONC"
+		 ],
+		 "paint": {
+		  "circle-radius": {
+		   "stops": [
+			[
+			 14,
+			 3
+			],
+			[
+			 17,
+			 7
+			]
+		   ]
+		  },
+		  "circle-color": "#FFFFFF",
+		  "circle-opacity": 1,
+		  "circle-stroke-width": {
+		   "stops": [
+			[
+			 14,
+			 2
+			],
+			[
+			 17,
+			 5
+			]
+		   ]
+		  },
+		  "circle-stroke-color": "#1466B2"
+		 }
+		},
+		{
+		 "id": "point coté",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "oro_ponc",
+		 "minzoom": 11,
+		 "maxzoom": 21,
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "POINT_COTE",
+		  "POINT_COTE_TOPO",
+		  "POINT_COTE_RESEAU",
+		  "POINT_RBF"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "icon-image": "Localite",
+		  "icon-size": 0.1,
+		  "text-field": "{texte}",
+		  "text-size": 10,
+		  "text-allow-overlap": false,
+		  "text-anchor": "bottom-left",
+		  "text-offset": [
+		   0.2,
+		   0.4
+		  ],
+		  "text-padding": 2,
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#505050"
+		 }
+		},
+		{
+		 "id": "bati ponctuel : Hopital",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "bati_ponc",
+		 "layout": {
+		  "visibility": "visible",
+		  "icon-image": "Hopital",
+		  "icon-size": 0.33
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "HOPITAL_PONC"
+		 ],
+		 "paint": {
+		  "icon-color": "#646464"
+		 }
+		},
+		{
+		 "id": "bati ponctuel hydrographique",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "bati_ponc",
+		 "minzoom": 14,
+		 "layout": {
+		  "visibility": "visible",
+		  "icon-image": "Pompage",
+		  "icon-size": {
+		   "stops": [
+			[
+			 13,
+			 0.2
+			],
+			[
+			 17,
+			 0.6
+			]
+		   ]
+		  },
+		  "icon-allow-overlap": true
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "CITERNE",
+		  "LAVOIR",
+		  "STATION_EPURATION",
+		  "STATION_DE_POMPAGE",
+		  "USINE_PRODUCTION_EAU",
+		  "USINE_ELEVATRICE"
+		 ],
+		 "paint": {
+		  "icon-color": "#1C62A6"
+		 }
+		},
+		{
+		 "id": "bati ponctuel hydrographique - Puits-Abreuvoir",
+		 "type": "circle",
+		 "source": "plan_ign",
+		 "source-layer": "bati_ponc",
+		 "minzoom": 13,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "PUITS",
+		  "ABREUVOIR"
+		 ],
+		 "paint": {
+		  "circle-radius": {
+		   "stops": [
+			[
+			 14,
+			 3
+			],
+			[
+			 17,
+			 7
+			]
+		   ]
+		  },
+		  "circle-color": "#FFFFFF",
+		  "circle-opacity": 1,
+		  "circle-stroke-width": {
+		   "stops": [
+			[
+			 14,
+			 2
+			],
+			[
+			 17,
+			 5
+			]
+		   ]
+		  },
+		  "circle-stroke-color": "#1466B2"
+		 }
+		},
+		{
+		 "id": "bati ponctuel hydrographique - Phare",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "bati_ponc",
+		 "minzoom": 13,
+		 "layout": {
+		  "visibility": "visible",
+		  "icon-image": "Phare",
+		  "icon-size": {
+		   "stops": [
+			[
+			 13,
+			 0.7
+			],
+			[
+			 17,
+			 1.3
+			]
+		   ]
+		  }
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "PHARE"
+		 ],
+		 "paint": {
+		  "icon-color": "#646464"
+		 }
+		},
+		{
+		 "id": "bati ponctuel hydrographique - Amer-Feu",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "bati_ponc",
+		 "minzoom": 13,
+		 "layout": {
+		  "visibility": "visible",
+		  "icon-image": "Feu",
+		  "icon-size": {
+		   "stops": [
+			[
+			 13,
+			 0.7
+			],
+			[
+			 17,
+			 1.3
+			]
+		   ]
+		  }
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "AMER",
+		  "FEU",
+		  "FEU_PONC",
+		  "TOURELLE_LUMINEUSE"
+		 ],
+		 "paint": {
+		  "icon-color": "#646464"
+		 }
+		},
+		{
+		 "id": "bati ponctuel hydrographique - Balise",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "bati_ponc",
+		 "minzoom": 13,
+		 "layout": {
+		  "visibility": "visible",
+		  "icon-image": "Balise",
+		  "icon-size": {
+		   "stops": [
+			[
+			 13,
+			 0.7
+			],
+			[
+			 17,
+			 1.3
+			]
+		   ]
+		  }
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BALISE",
+		  "TOURELLE"
+		 ],
+		 "paint": {
+		  "icon-color": "#646464"
+		 }
+		},
+		{
+		 "id": "bati ponctuel hydrographique - Ecluse",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "bati_ponc",
+		 "minzoom": 12,
+		 "maxzoom": 21,
+		 "layout": {
+		  "visibility": "visible",
+		  "icon-image": "Ecluse",
+		  "icon-size": 0.2
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "ECLUSE_PONC"
+		 ],
+		 "paint": {
+		  "icon-color": "#1C62A6"
+		 }
+		},
+		{
+		 "id": "bati ponctuel hydrographique - Barrage",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "bati_ponc",
+		 "minzoom": 12,
+		 "maxzoom": 14,
+		 "layout": {
+		  "visibility": "visible",
+		  "icon-image": "Barrage",
+		  "icon-size": 0.25
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "BARRAGE_PONC"
+		 ],
+		 "paint": {
+		  "icon-color": "#1C62A6"
+		 }
+		},
+		{
+		 "id": "bati ponctuel hydrographique - Chateau d'eau",
+		 "type": "circle",
+		 "source": "plan_ign",
+		 "source-layer": "bati_ponc",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "CHATEAU_EAU_PONC"
+		 ],
+		 "paint": {
+		  "circle-radius": {
+		   "stops": [
+			[
+			 14,
+			 3
+			],
+			[
+			 17,
+			 8
+			]
+		   ]
+		  },
+		  "circle-color": "#1466B2"
+		 }
+		},
+		{
+		 "id": "bati ponctuel hydrographique - Réservoir d'eau",
+		 "type": "circle",
+		 "source": "plan_ign",
+		 "source-layer": "bati_ponc",
+		 "maxzoom": 21,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "RESERVOIR_EAU_PONC"
+		 ],
+		 "paint": {
+		  "circle-radius": {
+		   "stops": [
+			[
+			 14,
+			 3
+			],
+			[
+			 17,
+			 8
+			]
+		   ]
+		  },
+		  "circle-color": "#AAD5E9",
+		  "circle-opacity": 1,
+		  "circle-stroke-width": {
+		   "stops": [
+			[
+			 14,
+			 1
+			],
+			[
+			 17,
+			 2.5
+			]
+		   ]
+		  },
+		  "circle-stroke-color": "#1466B2"
+		 }
+		},
+		{
+		 "id": "bati ponctuel infrastructure - Constr spé",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "bati_ponc",
+		 "layout": {
+		  "visibility": "visible",
+		  "icon-image": "ConstrSpeciale",
+		  "icon-size": {
+		   "stops": [
+			[
+			 13,
+			 0.22
+			],
+			[
+			 17,
+			 0.5
+			]
+		   ]
+		  }
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "ANTENNE",
+		  "CONSTR_SPE_TECHNIQUE",
+		  "CONSTR_INDIF_PONC",
+		  "CHEMINEE",
+		  "CHEVALEMENT",
+		  "PUITS_GAZ",
+		  "PUITS_PETROLE",
+		  "PYLONE_METEO",
+		  "TORCHERE",
+		  "TOUR_GUET",
+		  "TOUR_HERTZIENNE"
+		 ],
+		 "paint": {
+		  "icon-color": "#646464"
+		 }
+		},
+		{
+		 "id": "bati ponctuel infrastructure - Silo",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "bati_ponc",
+		 "maxzoom": 21,
+		 "layout": {
+		  "visibility": "visible",
+		  "icon-image": "Silo",
+		  "icon-size": {
+		   "stops": [
+			[
+			 13,
+			 0.22
+			],
+			[
+			 17,
+			 0.5
+			]
+		   ]
+		  }
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "SILO_PONC"
+		 ],
+		 "paint": {
+		  "icon-color": "#646464"
+		 }
+		},
+		{
+		 "id": "bati ponctuel infrastructure - Eolienne",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "bati_ponc",
+		 "layout": {
+		  "visibility": "visible",
+		  "icon-image": "Eolienne",
+		  "icon-size": {
+		   "stops": [
+			[
+			 13,
+			 0.4
+			],
+			[
+			 17,
+			 1
+			],
+			[
+			 18,
+			 0.8
+			]
+		   ]
+		  }
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "EOLIENNE"
+		 ],
+		 "paint": {
+		  "icon-color": "#646464"
+		 }
+		},
+		{
+		 "id": "bati ponctuel infrastructure - Reservoir",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "bati_ponc",
+		 "maxzoom": 21,
+		 "layout": {
+		  "visibility": "visible",
+		  "icon-image": "Reservoir",
+		  "icon-size": {
+		   "stops": [
+			[
+			 13,
+			 0.26
+			],
+			[
+			 17,
+			 0.5
+			]
+		   ]
+		  }
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "RESERVOIR_PONC"
+		 ],
+		 "paint": {
+		  "icon-color": "#646464"
+		 }
+		},
+		{
+		 "id": "bati ponctuel infrastructure - pylone électrique",
+		 "type": "circle",
+		 "source": "plan_ign",
+		 "source-layer": "bati_ponc",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "PYLONE_ELEC"
+		 ],
+		 "paint": {
+		  "circle-radius": {
+		   "stops": [
+			[
+			 13,
+			 1
+			],
+			[
+			 17,
+			 2
+			]
+		   ]
+		  },
+		  "circle-color": "#000000"
+		 }
+		},
+		{
+		 "id": "bati ponctuel montagne - Abri",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "bati_ponc",
+		 "layout": {
+		  "visibility": "visible",
+		  "icon-image": "Abri",
+		  "icon-size": {
+		   "stops": [
+			[
+			 13,
+			 0.4
+			],
+			[
+			 15,
+			 0.6
+			],
+			[
+			 17,
+			 0.9
+			]
+		   ]
+		  }
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "ABRI"
+		 ],
+		 "paint": {
+		  "icon-color": "#246138"
+		 }
+		},
+		{
+		 "id": "bati ponctuel montagne - Refuge Garde",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "bati_ponc",
+		 "layout": {
+		  "visibility": "visible",
+		  "icon-image": "Refugegard",
+		  "icon-size": {
+		   "stops": [
+			[
+			 13,
+			 0.4
+			],
+			[
+			 15,
+			 0.6
+			],
+			[
+			 17,
+			 0.9
+			]
+		   ]
+		  }
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "REFUGE_GARDE"
+		 ],
+		 "paint": {
+		  "icon-color": "#246138"
+		 }
+		},
+		{
+		 "id": "bati ponctuel montagne - Refuge Non Garde",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "bati_ponc",
+		 "layout": {
+		  "visibility": "visible",
+		  "icon-image": "Refugenongard",
+		  "icon-size": {
+		   "stops": [
+			[
+			 13,
+			 0.4
+			],
+			[
+			 15,
+			 0.6
+			],
+			[
+			 17,
+			 0.9
+			]
+		   ]
+		  }
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "REFUGE"
+		 ],
+		 "paint": {
+		  "icon-color": "#246138"
+		 }
+		},
+		{
+		 "id": "bati ponctuel transport aerien - Aeroport FXX",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "bati_ponc",
+		 "layout": {
+		  "visibility": "visible",
+		  "icon-image": "Aeroport",
+		  "icon-size": 0.5
+		 },
+		 "filter": [
+		  "all",
+		  [
+		   "==",
+		   "symbo",
+		   "AEROPORT_PONC"
+		  ],
+		  [
+		   "==",
+		   "territoire",
+		   "FXX"
+		  ]
+		 ],
+		 "paint": {
+		  "icon-color": "#646464"
+		 }
+		},
+		{
+		 "id": "bati ponctuel transport aerien - Aerodrome FXX",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "bati_ponc",
+		 "layout": {
+		  "visibility": "visible",
+		  "icon-image": "Aerodrome",
+		  "icon-size": 0.4
+		 },
+		 "filter": [
+		  "all",
+		  [
+		   "==",
+		   "symbo",
+		   "AERODROME_PONC"
+		  ],
+		  [
+		   "==",
+		   "territoire",
+		   "FXX"
+		  ]
+		 ],
+		 "paint": {
+		  "icon-color": "#646464"
+		 }
+		},
+		{
+		 "id": "bati ponctuel transport aerien - Aeroport DOM",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "bati_ponc",
+		 "minzoom": 8,
+		 "layout": {
+		  "visibility": "visible",
+		  "icon-image": "Aeroport",
+		  "icon-size": 0.5
+		 },
+		 "filter": [
+		  "all",
+		  [
+		   "==",
+		   "symbo",
+		   "AEROPORT_PONC"
+		  ],
+		  [
+		   "!=",
+		   "territoire",
+		   "FXX"
+		  ]
+		 ],
+		 "paint": {
+		  "icon-color": "#646464"
+		 }
+		},
+		{
+		 "id": "bati ponctuel transport aerien - Aerodrome DOM",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "bati_ponc",
+		 "minzoom": 8,
+		 "layout": {
+		  "visibility": "visible",
+		  "icon-image": "Aerodrome",
+		  "icon-size": 0.4
+		 },
+		 "filter": [
+		  "all",
+		  [
+		   "==",
+		   "symbo",
+		   "AERODROME_PONC"
+		  ],
+		  [
+		   "!=",
+		   "territoire",
+		   "FXX"
+		  ]
+		 ],
+		 "paint": {
+		  "icon-color": "#646464"
+		 }
+		},
+		{
+		 "id": "bati ponctuel transport ferroviaire",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "bati_ponc",
+		 "layout": {
+		  "visibility": "visible",
+		  "icon-image": "Gare",
+		  "icon-size": 0.33
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "GARE_VOYAGEURS"
+		 ],
+		 "paint": {
+		  "icon-color": "#787878"
+		 }
+		},
+		{
+		 "id": "toponyme - bornes postales haute - chemins",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_routier_borne",
+		 "minzoom": 17,
+		 "maxzoom": 22,
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "CHEMIN",
+		  "CHEMIN_SOU",
+		  "CHEMIN_SUP",
+		  "PISTE_CYCLABLE",
+		  "PISTE_CYCLABLE_SOU",
+		  "PISTE_CYCLABLE_SUP",
+		  "RUE_PIETONNE",
+		  "RUE_PIETONNE_SOU",
+		  "RUE_PIETONNE_SUP",
+		  "SENTIER",
+		  "SENTIER_SOU",
+		  "SENTIER_SUP",
+		  "ESCALIER",
+		  "ESCALIER_SUP"
+		 ],
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{borne_sur}",
+		  "text-size": 11,
+		  "text-anchor": "center",
+		  "text-allow-overlap": true,
+		  "text-offset": [
+		   0,
+		   -1
+		  ],
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ],
+		  "visibility": "none"
+		 },
+		 "paint": {
+		  "text-color": "#79654F",
+		  "text-halo-width": 1,
+		  "text-halo-color": "#FFFFFF"
+		 }
+		},
+		{
+		 "id": "toponyme - bornes postales haute - non revetue, non classee",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_routier_borne",
+		 "minzoom": 17,
+		 "maxzoom": 22,
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "NON_CLASSEE",
+		  "NON_CLASSEE_4",
+		  "NON_CLASSEE_4_SUP",
+		  "NON_CLASSEE_RESTREINT",
+		  "NON_CLASSEE_RESTREINT_SUP",
+		  "NON_CLASSEE_SOU",
+		  "NON_CLASSEE_SUP",
+		  "NON_REVETUE_CARRO",
+		  "NON_REVETUE_CARRO_SUP"
+		 ],
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{borne_sur}",
+		  "text-size": 11,
+		  "text-anchor": "center",
+		  "text-allow-overlap": true,
+		  "text-offset": [
+		   0,
+		   -1.3
+		  ],
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ],
+		  "visibility": "none"
+		 },
+		 "paint": {
+		  "text-color": "#79654F",
+		  "text-halo-width": 1,
+		  "text-halo-color": "#FFFFFF"
+		 }
+		},
+		{
+		 "id": "toponyme - bornes postales haute - locales",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_routier_borne",
+		 "minzoom": 17,
+		 "maxzoom": 22,
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "LOCALE_1",
+		  "LOCALE_1_SOU",
+		  "LOCALE_1_SUP",
+		  "LOCALE_2",
+		  "LOCALE_2_SOU",
+		  "LOCALE_2_SUP",
+		  "LOCALE_3",
+		  "LOCALE_3_SOU",
+		  "LOCALE_3_SUP",
+		  "LOCALE_4",
+		  "LOCALE_4_SOU",
+		  "LOCALE_4_SUP",
+		  "LOCALE_CONSTR",
+		  "LOCALE_CONSTR_SUP"
+		 ],
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{borne_sur}",
+		  "text-size": 11,
+		  "text-anchor": "center",
+		  "text-allow-overlap": true,
+		  "text-offset": [
+		   0,
+		   -1.4
+		  ],
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ],
+		  "visibility": "none"
+		 },
+		 "paint": {
+		  "text-color": "#79654F",
+		  "text-halo-width": 1,
+		  "text-halo-color": "#FFFFFF"
+		 }
+		},
+		{
+		 "id": "toponyme - bornes postales haute - regionales",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_routier_borne",
+		 "minzoom": 17,
+		 "maxzoom": 22,
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "REGIONALE_1",
+		  "REGIONALE_1_SOU",
+		  "REGIONALE_1_SUP",
+		  "REGIONALE_2",
+		  "REGIONALE_2_SOU",
+		  "REGIONALE_2_SUP",
+		  "REGIONALE_3",
+		  "REGIONALE_3_SOU",
+		  "REGIONALE_3_SUP",
+		  "REGIONALE_4",
+		  "REGIONALE_4_SUP",
+		  "REGIONALE_CONSTR"
+		 ],
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{borne_sur}",
+		  "text-size": 11,
+		  "text-anchor": "center",
+		  "text-allow-overlap": true,
+		  "text-offset": [
+		   0,
+		   -1.5
+		  ],
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ],
+		  "visibility": "none"
+		 },
+		 "paint": {
+		  "text-color": "#79654F",
+		  "text-halo-width": 1,
+		  "text-halo-color": "#FFFFFF"
+		 }
+		},
+		{
+		 "id": "toponyme - bornes postales haute - principales",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_routier_borne",
+		 "minzoom": 17,
+		 "maxzoom": 22,
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "PRINCIPALE_1",
+		  "PRINCIPALE_1_SOU",
+		  "PRINCIPALE_1_SUP",
+		  "PRINCIPALE_2",
+		  "PRINCIPALE_2_SOU",
+		  "PRINCIPALE_2_SUP",
+		  "PRINCIPALE_3",
+		  "PRINCIPALE_3_SOU",
+		  "PRINCIPALE_3_SUP",
+		  "PRINCIPALE_4",
+		  "PRINCIPALE_4_SOU",
+		  "PRINCIPALE_4_SUP",
+		  "PRINCIPALE_CONSTR"
+		 ],
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{borne_sur}",
+		  "text-size": 11,
+		  "text-anchor": "center",
+		  "text-allow-overlap": true,
+		  "text-offset": [
+		   0,
+		   -1.6
+		  ],
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ],
+		  "visibility": "none"
+		 },
+		 "paint": {
+		  "text-color": "#79654F",
+		  "text-halo-width": 1,
+		  "text-halo-color": "#FFFFFF"
+		 }
+		},
+		{
+		 "id": "toponyme - bornes postales bas - chemins",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_routier_borne",
+		 "minzoom": 17,
+		 "maxzoom": 22,
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "CHEMIN",
+		  "CHEMIN_SOU",
+		  "CHEMIN_SUP",
+		  "PISTE_CYCLABLE",
+		  "PISTE_CYCLABLE_SOU",
+		  "PISTE_CYCLABLE_SUP",
+		  "RUE_PIETONNE",
+		  "RUE_PIETONNE_SOU",
+		  "RUE_PIETONNE_SUP",
+		  "SENTIER",
+		  "SENTIER_SOU",
+		  "SENTIER_SUP",
+		  "ESCALIER",
+		  "ESCALIER_SUP"
+		 ],
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{borne_sous}",
+		  "text-size": 11,
+		  "text-anchor": "center",
+		  "text-allow-overlap": true,
+		  "text-offset": [
+		   0,
+		   1
+		  ],
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ],
+		  "visibility": "none"
+		 },
+		 "paint": {
+		  "text-color": "#79654F",
+		  "text-halo-width": 1,
+		  "text-halo-color": "#FFFFFF"
+		 }
+		},
+		{
+		 "id": "toponyme - bornes postales bas - non revetue, non classee",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_routier_borne",
+		 "minzoom": 17,
+		 "maxzoom": 22,
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "NON_CLASSEE",
+		  "NON_CLASSEE_4",
+		  "NON_CLASSEE_4_SUP",
+		  "NON_CLASSEE_RESTREINT",
+		  "NON_CLASSEE_RESTREINT_SUP",
+		  "NON_CLASSEE_SOU",
+		  "NON_CLASSEE_SUP",
+		  "NON_REVETUE_CARRO",
+		  "NON_REVETUE_CARRO_SUP"
+		 ],
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{borne_sous}",
+		  "text-size": 11,
+		  "text-anchor": "center",
+		  "text-allow-overlap": true,
+		  "text-offset": [
+		   0,
+		   1.3
+		  ],
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ],
+		  "visibility": "none"
+		 },
+		 "paint": {
+		  "text-color": "#79654F",
+		  "text-halo-width": 1,
+		  "text-halo-color": "#FFFFFF"
+		 }
+		},
+		{
+		 "id": "toponyme - bornes postales bas - locales",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_routier_borne",
+		 "minzoom": 17,
+		 "maxzoom": 22,
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "LOCALE_1",
+		  "LOCALE_1_SOU",
+		  "LOCALE_1_SUP",
+		  "LOCALE_2",
+		  "LOCALE_2_SOU",
+		  "LOCALE_2_SUP",
+		  "LOCALE_3",
+		  "LOCALE_3_SOU",
+		  "LOCALE_3_SUP",
+		  "LOCALE_4",
+		  "LOCALE_4_SOU",
+		  "LOCALE_4_SUP",
+		  "LOCALE_CONSTR",
+		  "LOCALE_CONSTR_SUP"
+		 ],
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{borne_sous}",
+		  "text-size": 11,
+		  "text-anchor": "center",
+		  "text-allow-overlap": true,
+		  "text-offset": [
+		   0,
+		   1.4
+		  ],
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ],
+		  "visibility": "none"
+		 },
+		 "paint": {
+		  "text-color": "#79654F",
+		  "text-halo-width": 1,
+		  "text-halo-color": "#FFFFFF"
+		 }
+		},
+		{
+		 "id": "toponyme - bornes postales bas - regionales",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_routier_borne",
+		 "minzoom": 17,
+		 "maxzoom": 22,
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "REGIONALE_1",
+		  "REGIONALE_1_SOU",
+		  "REGIONALE_1_SUP",
+		  "REGIONALE_2",
+		  "REGIONALE_2_SOU",
+		  "REGIONALE_2_SUP",
+		  "REGIONALE_3",
+		  "REGIONALE_3_SOU",
+		  "REGIONALE_3_SUP",
+		  "REGIONALE_4",
+		  "REGIONALE_4_SUP",
+		  "REGIONALE_CONSTR"
+		 ],
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{borne_sous}",
+		  "text-size": 11,
+		  "text-anchor": "center",
+		  "text-allow-overlap": true,
+		  "text-offset": [
+		   0,
+		   1.5
+		  ],
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ],
+		  "visibility": "none"
+		 },
+		 "paint": {
+		  "text-color": "#79654F",
+		  "text-halo-width": 1,
+		  "text-halo-color": "#FFFFFF"
+		 }
+		},
+		{
+		 "id": "toponyme - bornes postales bas - principales",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_routier_borne",
+		 "minzoom": 17,
+		 "maxzoom": 22,
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "PRINCIPALE_1",
+		  "PRINCIPALE_1_SOU",
+		  "PRINCIPALE_1_SUP",
+		  "PRINCIPALE_2",
+		  "PRINCIPALE_2_SOU",
+		  "PRINCIPALE_2_SUP",
+		  "PRINCIPALE_3",
+		  "PRINCIPALE_3_SOU",
+		  "PRINCIPALE_3_SUP",
+		  "PRINCIPALE_4",
+		  "PRINCIPALE_4_SOU",
+		  "PRINCIPALE_4_SUP",
+		  "PRINCIPALE_CONSTR"
+		 ],
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{borne_sous}",
+		  "text-size": 11,
+		  "text-anchor": "center",
+		  "text-allow-overlap": true,
+		  "text-offset": [
+		   0,
+		   1.6
+		  ],
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ],
+		  "visibility": "none"
+		 },
+		 "paint": {
+		  "text-color": "#79654F",
+		  "text-halo-width": 1,
+		  "text-halo-color": "#FFFFFF"
+		 }
+		},
+		{
+		 "id": "toponyme - courbe rocher maitresse",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_oro_ponc",
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "ORO_COURBE_ROCHER"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 10,
+		  "text-allow-overlap": false,
+		  "text-padding": 30,
+		  "text-rotate": {
+		   "type": "identity",
+		   "property": "rotation"
+		  },
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#333333",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 1
+		 }
+		},
+		{
+		 "id": "toponyme - courbe glacier maitresse",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_oro_ponc",
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "ORO_COURBE_GLACIER"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 10,
+		  "text-allow-overlap": false,
+		  "text-padding": 30,
+		  "text-rotate": {
+		   "type": "identity",
+		   "property": "rotation"
+		  },
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#629FD9",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 1
+		 }
+		},
+		{
+		 "id": "toponyme - courbe maitresse",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_oro_ponc",
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "ORO_COURBE"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 10,
+		  "text-allow-overlap": false,
+		  "text-padding": 30,
+		  "text-rotate": {
+		   "type": "identity",
+		   "property": "rotation"
+		  },
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#604A2F",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 1
+		 }
+		},
+		{
+		 "id": "toponyme - liaison maritime",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_routier_liaison_lin",
+		 "minzoom": 8,
+		 "maxzoom": 22,
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "LIAISON_MARITIME"
+		 ],
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{texte}",
+		  "text-size": 15,
+		  "text-anchor": "center",
+		  "text-keep-upright": true,
+		  "text-max-angle": 45,
+		  "text-padding": 10,
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ],
+		  "visibility": "visible"
+		 },
+		 "paint": {
+		  "text-color": "#5792C2",
+		  "text-halo-width": 5,
+		  "text-halo-color": "#AAD5E9"
+		 }
+		},
+		{
+		 "id": "toponyme bati station de métro + bati ponctuel metro",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_bati_ponc",
+		 "minzoom": 14,
+		 "filter": [
+		  "all",
+		  [
+		   "==",
+		   "txt_typo",
+		   "TYPO_E_1"
+		  ],
+		  [
+		   "==",
+		   "symbo",
+		   "STATION_METRO"
+		  ]
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 11,
+		  "text-allow-overlap": false,
+		  "text-offset": [
+		   0.3,
+		   -0.25
+		  ],
+		  "text-padding": 3,
+		  "text-anchor": "bottom-left",
+		  "text-font": [
+		   "Source Sans Pro"
+		  ],
+		  "icon-image": "Metro",
+		  "icon-size": {
+		   "stops": [
+			[
+			 15,
+			 0.33
+			],
+			[
+			 17,
+			 0.6
+			]
+		   ]
+		  }
+		 },
+		 "paint": {
+		  "text-color": "#3C3C3C",
+		  "icon-color": "#646464"
+		 }
+		},
+		{
+		 "id": "toponyme ferre lineaire",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_ferre_lin",
+		 "minzoom": 12,
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "FER_NOM",
+		  "FER_OUVRAGE"
+		 ],
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{texte}",
+		  "text-size": 10,
+		  "text-anchor": "center",
+		  "text-offset": [
+		   0,
+		   -1
+		  ],
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ],
+		  "visibility": "visible"
+		 },
+		 "paint": {
+		  "text-color": "#000000",
+		  "text-halo-width": 1,
+		  "text-halo-color": "rgba(255, 255, 255, 1)"
+		 }
+		},
+		{
+		 "id": "toponyme station epuration, de pompage, usine de production eau",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_bati_ponc",
+		 "minzoom": 14,
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "station"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{designation}",
+		  "text-anchor": "left",
+		  "text-offset": [
+		   0.8,
+		   0
+		  ],
+		  "text-size": 11,
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#447FB3"
+		 }
+		},
+		{
+		 "id": "toponyme bati ponc gare",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_bati_ponc",
+		 "minzoom": 15,
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "gore"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{designation}",
+		  "text-size": 11,
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#000000"
+		 }
+		},
+		{
+		 "id": "toponyme bati ponc barrage",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_bati_ponc",
+		 "minzoom": 12,
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "BARRAGE_PONC"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-anchor": "left",
+		  "text-offset": [
+		   0.8,
+		   0
+		  ],
+		  "text-size": 11,
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#447FB3"
+		 }
+		},
+		{
+		 "id": "toponyme bati ponc phare - niveau 13",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_bati_ponc",
+		 "maxzoom": 21,
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "PHARE"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-anchor": "right",
+		  "text-size": 11,
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#532A2A"
+		 }
+		},
+		{
+		 "id": "toponyme bati ponc phare - niveau 14à19",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_bati_ponc",
+		 "minzoom": 13,
+		 "filter": [
+		  "all",
+		  [
+		   "==",
+		   "symbo",
+		   "PHARE"
+		  ],
+		  [
+		   "in",
+		   "txt_typo",
+		   "TYPO_C_6",
+		   "TYPO_C_7",
+		   "TYPO_C_8",
+		   "TYPO_E_GE"
+		  ]
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-anchor": "right",
+		  "text-size": {
+		   "stops": [
+			[
+			 13,
+			 12
+			],
+			[
+			 18,
+			 18
+			]
+		   ]
+		  },
+		  "text-allow-overlap": false,
+		  "text-offset": [
+		   -2,
+		   0
+		  ],
+		  "text-padding": 3,
+		  "text-font": [
+		   "Source Sans Pro"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#532A2A"
+		 }
+		},
+		{
+		 "id": "toponyme bati ponc autre",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_bati_ponc",
+		 "minzoom": 12,
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "BAT_ACTIVITE",
+		  "BAT_FORTIF",
+		  "BAT_VILLAGE_DETRUIT"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-anchor": "center",
+		  "text-size": 11,
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#532A2A"
+		 }
+		},
+		{
+		 "id": "toponyme bati ponc aerogare",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_bati_ponc",
+		 "minzoom": 14,
+		 "maxzoom": 21,
+		 "filter": [
+		  "all",
+		  [
+		   "==",
+		   "txt_typo",
+		   "TYPO_E_GE"
+		  ],
+		  [
+		   "==",
+		   "symbo",
+		   "AEROGARE"
+		  ]
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-anchor": "center",
+		  "text-size": {
+		   "stops": [
+			[
+			 12,
+			 9
+			],
+			[
+			 16,
+			 11
+			]
+		   ]
+		  },
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#120049",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 1
+		 }
+		},
+		{
+		 "id": "toponyme bati ponc aeroport 12",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_bati_ponc",
+		 "minzoom": 11,
+		 "maxzoom": 21,
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "AEROPORT_PONC"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-anchor": "bottom",
+		  "text-offset": [
+		   0,
+		   -1.3
+		  ],
+		  "text-size": 10.5,
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#120049",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme bati ponc aeroport 13",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_bati_ponc",
+		 "minzoom": 12,
+		 "maxzoom": 21,
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "AEROPORT_PONC"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-anchor": "bottom",
+		  "text-offset": [
+		   0,
+		   -2
+		  ],
+		  "text-size": 11,
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#120049",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme bati ponc aeroport",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_bati_ponc",
+		 "minzoom": 13,
+		 "maxzoom": 21,
+		 "filter": [
+		  "all",
+		  [
+		   "==",
+		   "txt_typo",
+		   "TYPO_A_5"
+		  ],
+		  [
+		   "==",
+		   "symbo",
+		   "AEROPORT"
+		  ]
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-anchor": "center",
+		  "text-size": {
+		   "stops": [
+			[
+			 12,
+			 11
+			],
+			[
+			 16,
+			 13
+			]
+		   ]
+		  },
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#120049",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme bati ponc aerodrome 12",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_bati_ponc",
+		 "minzoom": 11,
+		 "maxzoom": 21,
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "AERODROME_PONC"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-anchor": "bottom",
+		  "text-offset": [
+		   0,
+		   -1.3
+		  ],
+		  "text-size": 9.5,
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#120049",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme bati ponc aerodrome 13",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_bati_ponc",
+		 "minzoom": 12,
+		 "maxzoom": 21,
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "AERODROME_PONC"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-anchor": "bottom",
+		  "text-offset": [
+		   0,
+		   -2
+		  ],
+		  "text-size": 10,
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#120049",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme bati ponc aerodrome",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_bati_ponc",
+		 "minzoom": 13,
+		 "maxzoom": 21,
+		 "filter": [
+		  "all",
+		  [
+		   "==",
+		   "txt_typo",
+		   "TYPO_A_7"
+		  ],
+		  [
+		   "==",
+		   "symbo",
+		   "AERODROME"
+		  ]
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-anchor": "center",
+		  "text-size": {
+		   "stops": [
+			[
+			 12,
+			 10
+			],
+			[
+			 16,
+			 12
+			]
+		   ]
+		  },
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#120049",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme - hydro ponc 5",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_hydro_ponc",
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "TYPO_D_9",
+		  "TYPO_D_10",
+		  "TYPO_E_1_cyan"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 15,
+			 11
+			],
+			[
+			 17,
+			 14
+			]
+		   ]
+		  },
+		  "text-allow-overlap": true,
+		  "text-padding": 5,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#447FB3",
+		  "text-halo-color": "#FFFFFF",
+		  "text-halo-width": 1
+		 }
+		},
+		{
+		 "id": "toponyme - hydro ponc glacier",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_hydro_ponc",
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "ORO_GLACIER_2"
+		 ],
+		 "layout": {
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 14,
+		  "text-anchor": "center",
+		  "text-allow-overlap": true,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ],
+		  "visibility": "visible"
+		 },
+		 "paint": {
+		  "text-color": "#447FB3",
+		  "text-halo-width": 2,
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)"
+		 }
+		},
+		{
+		 "id": "toponyme - limite militaire ponc 3 et 4",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_limite_ponc",
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "LIM_MILI_3",
+		  "LIM_MILI_4"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 12,
+		  "text-allow-overlap": false,
+		  "text-padding": 2,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#0D2000",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 1
+		 }
+		},
+		{
+		 "id": "toponyme - limite parc ponc 3 et 4",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_limite_ponc",
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "LIM_PARC_3",
+		  "LIM_PARC_4",
+		  "RESERVE_NATURELLE_PONC"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 13,
+		  "text-allow-overlap": false,
+		  "text-padding": 2,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#287B00",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 1
+		 }
+		},
+		{
+		 "id": "toponyme numéro de route - départementale",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_routier_numero_lin",
+		 "minzoom": 11,
+		 "maxzoom": 22,
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "Départementale"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "line",
+		  "text-field": "{texte}",
+		  "text-size": 10.5,
+		  "text-allow-overlap": false,
+		  "text-padding": 2,
+		  "text-anchor": "center",
+		  "text-font": [
+		   "Source Sans Pro Semibold"
+		  ],
+		  "text-rotation-alignment": "viewport"
+		 },
+		 "paint": {
+		  "text-color": "#4D4D4D",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 4
+		 }
+		},
+		{
+		 "id": "toponyme numéro de route - nationale",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_routier_numero_lin",
+		 "minzoom": 7,
+		 "maxzoom": 22,
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "Nationale"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "line",
+		  "text-field": "{texte}",
+		  "text-size": 12,
+		  "text-allow-overlap": false,
+		  "text-padding": 0,
+		  "text-anchor": "center",
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ],
+		  "icon-image": "Ecluse",
+		  "icon-rotation-alignment": "viewport",
+		  "text-rotation-alignment": "viewport",
+		  "icon-text-fit": "both",
+		  "icon-size": 0
+		 },
+		 "paint": {
+		  "text-color": "#F0F0F0",
+		  "icon-color": "#646464",
+		  "text-halo-color": "rgba(80, 80, 80, 0.5)",
+		  "text-halo-width": 4
+		 }
+		},
+		{
+		 "id": "toponyme numéro de route - autoroute",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_routier_numero_lin",
+		 "minzoom": 7,
+		 "maxzoom": 22,
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "Autoroute"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "line",
+		  "text-field": "{texte}",
+		  "text-size": 15,
+		  "text-allow-overlap": false,
+		  "text-padding": 0,
+		  "text-anchor": "center",
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ],
+		  "icon-image": "Ecluse",
+		  "icon-rotation-alignment": "viewport",
+		  "text-rotation-alignment": "viewport",
+		  "icon-text-fit": "both",
+		  "icon-size": 0
+		 },
+		 "paint": {
+		  "text-color": "#F0F0F0",
+		  "icon-color": "#646464",
+		  "text-halo-color": "rgba(80, 80, 80, 0.5)",
+		  "text-halo-width": 5
+		 }
+		},
+		{
+		 "id": "toponyme - odonyme abrégé",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_routier_odonyme_lin",
+		 "minzoom": 15,
+		 "maxzoom": 22,
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{nom_gauche}",
+		  "text-size": 10,
+		  "text-anchor": "center",
+		  "text-max-angle": 30,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ],
+		  "visibility": "none"
+		 },
+		 "paint": {
+		  "text-color": "#000000",
+		  "text-halo-width": 2,
+		  "text-halo-color": "rgba(255, 255, 255, 1)"
+		 }
+		},
+		{
+		 "id": "toponyme - odonyme desabrégé",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_routier_odonyme_lin",
+		 "minzoom": 17,
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{nom_desabrege}",
+		  "text-size": 11,
+		  "text-anchor": "center",
+		  "text-max-angle": 30,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ],
+		  "visibility": "none"
+		 },
+		 "paint": {
+		  "text-color": "#000000",
+		  "text-halo-width": 2,
+		  "text-halo-color": "rgba(255, 255, 255, 1)"
+		 }
+		},
+		{
+		 "id": "toponyme - lieu dit non habité 3",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_ocs_ponc",
+		 "filter": [
+		  "all",
+		  [
+		   "==",
+		   "symbo",
+		   "LIEU-DIT_NON_HABITE"
+		  ],
+		  [
+		   "in",
+		   "txt_typo",
+		   "TYPO_B_10",
+		   "TYPO_B_11"
+		  ]
+		 ],
+		 "layout": {
+		  "visibility": "none",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 11,
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#000000",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 1
+		 }
+		},
+		{
+		 "id": "toponyme - bois",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_ocs_ponc",
+		 "filter": [
+		  "all",
+		  [
+		   "==",
+		   "symbo",
+		   "BOIS"
+		  ],
+		  [
+		   "in",
+		   "txt_typo",
+		   "TYPO_F_10",
+		   "TYPO_F_11"
+		  ]
+		 ],
+		 "layout": {
+		  "visibility": "none",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 13,
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#287B00",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 1
+		 }
+		},
+		{
+		 "id": "toponyme - oro lineaire 4",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_oro_lin",
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "ORO_SOMMET_3",
+		  "ORO_GORGE_2"
+		 ],
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{texte}",
+		  "text-size": 11,
+		  "text-anchor": "center",
+		  "text-keep-upright": true,
+		  "text-max-angle": 45,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ],
+		  "visibility": "visible"
+		 },
+		 "paint": {
+		  "text-color": "#863831",
+		  "text-halo-width": 1.5,
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)"
+		 }
+		},
+		{
+		 "id": "toponyme - oro ponc 4",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_oro_ponc",
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "ORO_SOMMET_3",
+		  "ORO_GORGE_2",
+		  "GROTTE",
+		  "GORGE",
+		  "TYPO_G_9",
+		  "TYPO_G_10"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 13,
+			 11
+			],
+			[
+			 16,
+			 16
+			]
+		   ]
+		  },
+		  "text-allow-overlap": true,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#863831",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 1.5
+		 }
+		},
+		{
+		 "id": "toponyme - hydro ponc 4",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_hydro_ponc",
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "lac - étang - bassin",
+		  "HYD_SURF_4",
+		  "HYD_SURF_4_T",
+		  "HYD_SURF_5",
+		  "HYD_SURF_5_T",
+		  "TYPO_D_8",
+		  "SOURCE"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 14,
+			 13
+			],
+			[
+			 17,
+			 16
+			]
+		   ]
+		  },
+		  "text-allow-overlap": true,
+		  "text-padding": 5,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#447FB3",
+		  "text-halo-color": "#FFFFFF",
+		  "text-halo-width": 1
+		 }
+		},
+		{
+		 "id": "toponyme - lieu dit non habité",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_ocs_ponc",
+		 "filter": [
+		  "all",
+		  [
+		   "==",
+		   "symbo",
+		   "LIEU-DIT_NON_HABITE"
+		  ],
+		  [
+		   "in",
+		   "txt_typo",
+		   "TYPO_B_7",
+		   "TYPO_B_8",
+		   "TYPO_B_9"
+		  ]
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 12,
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#000000",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 1
+		 }
+		},
+		{
+		 "id": "toponyme - bois 2",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_ocs_ponc",
+		 "filter": [
+		  "all",
+		  [
+		   "==",
+		   "symbo",
+		   "BOIS"
+		  ],
+		  [
+		   "in",
+		   "txt_typo",
+		   "TYPO_F_7",
+		   "TYPO_F_8",
+		   "TYPO_F_9"
+		  ]
+		 ],
+		 "layout": {
+		  "visibility": "none",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 16,
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#287B00",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme localite importance 5",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_localite_ponc",
+		 "minzoom": 9,
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "commune 5",
+		  "BAT_COMMUNE_5",
+		  "BAT_COMMUNE_5_T",
+		  "BAT_CHEF_LIEU_COM",
+		  "BAT_CHEF_LIEU_COM_T",
+		  "BAT_CHEF_LIEU_COM-T",
+		  "BAT_ANCIENNE_COM",
+		  "BAT_ANCIENNE_COM_T",
+		  "BAT_COMMUNE_ASSOCIEE",
+		  "BAT_COMMUNE_ASSOCIEE_T",
+		  "Commune très petite"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "icon-image": "Localite",
+		  "icon-size": 0.21,
+		  "text-field": "{texte}",
+		  "text-size": 11.5,
+		  "text-allow-overlap": false,
+		  "text-anchor": "bottom-left",
+		  "text-offset": [
+		   0.3,
+		   0.1
+		  ],
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#000000",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme - ocs lineaire 3",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_ocs_lin",
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "OCS_FORET_3"
+		 ],
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 10,
+			 12
+			],
+			[
+			 12,
+			 15
+			]
+		   ]
+		  },
+		  "text-anchor": "center",
+		  "text-keep-upright": true,
+		  "text-max-angle": 45,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ],
+		  "visibility": "visible"
+		 },
+		 "paint": {
+		  "text-color": "#287B00",
+		  "text-halo-width": 1,
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)"
+		 }
+		},
+		{
+		 "id": "toponyme - lieu dit non habité 1",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_ocs_ponc",
+		 "filter": [
+		  "all",
+		  [
+		   "==",
+		   "symbo",
+		   "LIEU-DIT_NON_HABITE"
+		  ],
+		  [
+		   "in",
+		   "txt_typo",
+		   "TYPO_B_5",
+		   "TYPO_B_4"
+		  ]
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 15,
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#000000",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 1
+		 }
+		},
+		{
+		 "id": "toponyme - bois 1",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_ocs_ponc",
+		 "filter": [
+		  "all",
+		  [
+		   "==",
+		   "symbo",
+		   "BOIS"
+		  ],
+		  [
+		   "in",
+		   "txt_typo",
+		   "TYPO_F_5",
+		   "TYPO_F_4"
+		  ]
+		 ],
+		 "layout": {
+		  "visibility": "none",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 19,
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#287B00",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme - bois 0",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_ocs_ponc",
+		 "filter": [
+		  "all",
+		  [
+		   "==",
+		   "symbo",
+		   "BOIS"
+		  ],
+		  [
+		   "in",
+		   "txt_typo",
+		   "TYPO_F_3",
+		   "TYPO_F_2"
+		  ]
+		 ],
+		 "layout": {
+		  "visibility": "none",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 22,
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#287B00",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme - ocs ponc 3",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_ocs_ponc",
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "OCS_FORET_3"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 10,
+			 12
+			],
+			[
+			 12,
+			 15
+			]
+		   ]
+		  },
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-anchor": "center",
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#287B00",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 1
+		 }
+		},
+		{
+		 "id": "toponyme - oro lineaire 3",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_oro_lin",
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "ORO_ILE_3",
+		  "ORO_RELIEF_3",
+		  "ORO_RELIEF_3_T",
+		  "ORO_RELIEF_4",
+		  "ORO_RELIEF_4_T",
+		  "ORO_CAP_2",
+		  "ORO_CAP_3",
+		  "ORO_SOMMET_2",
+		  "ORO_COL_2",
+		  "ORO_GORGE_1",
+		  "ORO_GORGE-1"
+		 ],
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{texte}",
+		  "text-size": 12,
+		  "text-anchor": "center",
+		  "text-keep-upright": true,
+		  "text-max-angle": 45,
+		  "text-padding": 10,
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ],
+		  "visibility": "visible"
+		 },
+		 "paint": {
+		  "text-color": "#863831",
+		  "text-halo-width": 1.5,
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)"
+		 }
+		},
+		{
+		 "id": "toponyme - oro ponc 3",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_oro_ponc",
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "ORO_ILE_3",
+		  "ORO_RELIEF_3",
+		  "ORO_RELIEF_3_T",
+		  "ORO_RELIEF_4",
+		  "ORO_RELIEF_4_T",
+		  "ORO_CAP_2",
+		  "ORO_CAP_3",
+		  "ORO_SOMMET_2",
+		  "ORO_COL_2",
+		  "ORO_GORGE_1",
+		  "ORO_GORGE-1",
+		  "TYPO_G_7",
+		  "TYPO_G_8"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 13,
+			 12
+			],
+			[
+			 16,
+			 17
+			]
+		   ]
+		  },
+		  "text-allow-overlap": true,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#863831",
+		  "text-halo-color": "#FFFFFF",
+		  "text-halo-width": 1.5
+		 }
+		},
+		{
+		 "id": "toponyme - hydro lineaire 3",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_hydro_lin",
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "HYD_LIN_3",
+		  "HYD_LIN_4",
+		  "HYD_LIN_5",
+		  "petite rivière",
+		  "canal",
+		  "HYD_SURF_3",
+		  "HYD_SURF_3_T",
+		  "HYD_SURF_4",
+		  "HYD_SURF_4_T",
+		  "HYD_SURF_5",
+		  "HYD_SURF_5_T",
+		  "TYPO_D_5"
+		 ],
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 14,
+			 12
+			],
+			[
+			 18,
+			 19
+			]
+		   ]
+		  },
+		  "text-anchor": "center",
+		  "text-keep-upright": true,
+		  "text-max-angle": 45,
+		  "text-padding": 10,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ],
+		  "visibility": "visible"
+		 },
+		 "paint": {
+		  "text-color": "#447FB3",
+		  "text-halo-width": 1.5,
+		  "text-halo-color": "rgba(255, 255, 255, 0.7)"
+		 }
+		},
+		{
+		 "id": "toponyme - hydro lineaire 4",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_hydro_lin",
+		 "minzoom": 14,
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "TYPO_D_6",
+		  "TYPO_D_8",
+		  "TYPO_D_9",
+		  "TYPO_D_10"
+		 ],
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 14,
+			 10
+			],
+			[
+			 18,
+			 16
+			]
+		   ]
+		  },
+		  "text-anchor": "center",
+		  "text-keep-upright": true,
+		  "text-max-angle": 45,
+		  "text-padding": 10,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ],
+		  "visibility": "visible"
+		 },
+		 "paint": {
+		  "text-color": "#447FB3",
+		  "text-halo-width": 1.5,
+		  "text-halo-color": "rgba(255, 255, 255, 0.7)"
+		 }
+		},
+		{
+		 "id": "toponyme - hydro ponc 3",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_hydro_ponc",
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "petit golfe",
+		  "grande baie",
+		  "baie",
+		  "HYD_SURF_3",
+		  "TYPO_D_5",
+		  "TYPO_D_6",
+		  "TYPO_D_7"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 15,
+			 15
+			],
+			[
+			 17,
+			 18
+			]
+		   ]
+		  },
+		  "text-allow-overlap": true,
+		  "text-padding": 10,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#447FB3",
+		  "text-halo-color": "#FFFFFF",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme bati ponc zai zoom 16",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_bati_ponc",
+		 "minzoom": 15,
+		 "maxzoom": 21,
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "zai"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{designation}",
+		  "text-size": 11,
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#000000"
+		 }
+		},
+		{
+		 "id": "toponyme bati ponc zai zoom 17 et 18",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_bati_ponc",
+		 "minzoom": 16,
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "zai"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 11,
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#000000"
+		 }
+		},
+		{
+		 "id": "toponyme localite importance 4",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_localite_ponc",
+		 "minzoom": 7,
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "commune 4",
+		  "BAT_COMMUNE_4",
+		  "BAT_COMMUNE_4_T"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "icon-image": "Localite",
+		  "icon-size": 0.21,
+		  "text-field": "{texte}",
+		  "text-size": 13,
+		  "text-allow-overlap": false,
+		  "text-anchor": "bottom-left",
+		  "text-offset": [
+		   0.3,
+		   0.1
+		  ],
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#000000",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme - limite militaire ponc 1 et 2",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_limite_ponc",
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "LIM_MILI_1",
+		  "LIM_MILI_2"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 15,
+		  "text-allow-overlap": false,
+		  "text-padding": 5,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#0D2000",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme - limite parc marin",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_limite_ponc",
+		 "minzoom": 8,
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "LIM_PARC_NATUREL_MARIN"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 15,
+		  "text-allow-overlap": false,
+		  "text-padding": 10,
+		  "text-transform": "uppercase",
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#2A81A2",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme - limite parc ponc 1 et 2",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_limite_ponc",
+		 "minzoom": 8,
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "LIM_PARC_1",
+		  "LIM_PARC_2",
+		  "LIM_PARC_NATUREL"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 15,
+		  "text-allow-overlap": false,
+		  "text-padding": 10,
+		  "text-transform": "uppercase",
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#287B00",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme - ocs lineaire 2",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_ocs_lin",
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "OCS_FORET_2"
+		 ],
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 10,
+			 15
+			],
+			[
+			 12,
+			 18
+			]
+		   ]
+		  },
+		  "text-anchor": "center",
+		  "text-keep-upright": true,
+		  "text-max-angle": 45,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ],
+		  "visibility": "visible"
+		 },
+		 "paint": {
+		  "text-color": "#287B00",
+		  "text-halo-width": 2,
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)"
+		 }
+		},
+		{
+		 "id": "toponyme - ocs ponc 2",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_ocs_ponc",
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "OCS_FORET_2"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 10,
+			 15
+			],
+			[
+			 12,
+			 18
+			]
+		   ]
+		  },
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-anchor": "center",
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#287B00",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme - oro lineaire 2",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_oro_lin",
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "ORO_ILE_2",
+		  "ORO_RELIEF_2",
+		  "ORO_RELIEF_2_T",
+		  "ORO_CAP_1",
+		  "ORO_SOMMET_1"
+		 ],
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{texte}",
+		  "text-size": 15,
+		  "text-anchor": "center",
+		  "text-keep-upright": true,
+		  "text-padding": 10,
+		  "text-max-angle": 45,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ],
+		  "visibility": "visible"
+		 },
+		 "paint": {
+		  "text-color": "#863831",
+		  "text-halo-width": 2,
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)"
+		 }
+		},
+		{
+		 "id": "toponyme - oro ponc 2",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_oro_ponc",
+		 "minzoom": 9,
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "ORO_ILE_2",
+		  "ORO_RELIEF_2",
+		  "ORO_RELIEF_2_T",
+		  "ORO_CAP_1",
+		  "ORO_COL_1",
+		  "sommet ou col",
+		  "ORO_SOMMET_1",
+		  "TYPO_G_4",
+		  "TYPO_G_6"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 9,
+			 13
+			],
+			[
+			 10,
+			 15
+			],
+			[
+			 13,
+			 15
+			],
+			[
+			 16,
+			 19
+			]
+		   ]
+		  },
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#863831",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme - oro ponc 2B",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_oro_ponc",
+		 "minzoom": 8,
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "île",
+		  "cap ou pointe"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 15,
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#863831",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme - hydro lineaire 2",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_hydro_lin",
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "HYD_LIN_2",
+		  "rivière moyenne",
+		  "HYD_SURF_2",
+		  "HYD_SURF_2_T",
+		  "TYPO_D_3"
+		 ],
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 14,
+			 15
+			],
+			[
+			 18,
+			 21
+			]
+		   ]
+		  },
+		  "text-anchor": "center",
+		  "text-keep-upright": true,
+		  "text-max-angle": 45,
+		  "text-padding": 10,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ],
+		  "visibility": "visible"
+		 },
+		 "paint": {
+		  "text-color": "#447FB3",
+		  "text-halo-width": 2,
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)"
+		 }
+		},
+		{
+		 "id": "toponyme - hydro ponc 2",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_hydro_ponc",
+		 "minzoom": 5,
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "moyen",
+		  "golfe moyen",
+		  "HYD_SURF_2",
+		  "TYPO_D_2",
+		  "TYPO_D_3",
+		  "TYPO_D_4"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 5,
+			 12
+			],
+			[
+			 6,
+			 18
+			],
+			[
+			 10,
+			 17
+			],
+			[
+			 18,
+			 21
+			]
+		   ]
+		  },
+		  "text-allow-overlap": false,
+		  "text-padding": 10,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#447FB3",
+		  "text-halo-color": "#FFFFFF",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme localite importance 3",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_localite_ponc",
+		 "minzoom": 5,
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "commune 3",
+		  "BAT_COMMUNE_3",
+		  "BAT_COMMUNE_3_T"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "icon-image": "Localite",
+		  "icon-size": 0.21,
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 5,
+			 10
+			],
+			[
+			 6,
+			 15
+			]
+		   ]
+		  },
+		  "text-allow-overlap": false,
+		  "text-anchor": "bottom-left",
+		  "text-offset": [
+		   0.3,
+		   0.1
+		  ],
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#000000",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme localite n0 typoA7 non commune",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_localite_ponc",
+		 "maxzoom": 21,
+		 "filter": [
+		  "all",
+		  [
+		   "!=",
+		   "symbo",
+		   "COMMUNE_FUSIONNEE"
+		  ],
+		  [
+		   "!=",
+		   "symbo",
+		   "COMMUNE_CHEF_LIEU"
+		  ],
+		  [
+		   "==",
+		   "txt_typo",
+		   "TYPO_A_7"
+		  ]
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 15,
+			 13
+			],
+			[
+			 17,
+			 16
+			]
+		   ]
+		  },
+		  "text-allow-overlap": true,
+		  "text-anchor": "center",
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#000000",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme localite n0 typoA6 non commune",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_localite_ponc",
+		 "maxzoom": 21,
+		 "filter": [
+		  "all",
+		  [
+		   "!=",
+		   "symbo",
+		   "COMMUNE_FUSIONNEE"
+		  ],
+		  [
+		   "!=",
+		   "symbo",
+		   "COMMUNE_CHEF_LIEU"
+		  ],
+		  [
+		   "==",
+		   "txt_typo",
+		   "TYPO_A_6"
+		  ]
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 15,
+			 15
+			],
+			[
+			 17,
+			 18
+			]
+		   ]
+		  },
+		  "text-allow-overlap": true,
+		  "text-anchor": "center",
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#000000",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme - oro lineaire 1",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_oro_lin",
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "ORO_ILE_1",
+		  "ORO_RELIEF_1",
+		  "ORO_RELIEF_1_T"
+		 ],
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{texte}",
+		  "text-size": 20,
+		  "text-anchor": "center",
+		  "text-keep-upright": true,
+		  "text-padding": 5,
+		  "text-max-angle": 45,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ],
+		  "visibility": "visible"
+		 },
+		 "paint": {
+		  "text-color": "#863831",
+		  "text-halo-width": 2,
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)"
+		 }
+		},
+		{
+		 "id": "toponyme - oro ponc monde",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_oro_ponc",
+		 "minzoom": 5,
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "Basin",
+		  "Depression",
+		  "Desert",
+		  "Geoarea",
+		  "Gorge",
+		  "Isthmus",
+		  "Lake",
+		  "Lowland",
+		  "Pen/cape",
+		  "Plain",
+		  "Plateau",
+		  "Range/mtn",
+		  "Tundra",
+		  "Valley",
+		  "Island",
+		  "Island group"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 11,
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#863831",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme localite n0 typoA4 non commune",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_localite_ponc",
+		 "maxzoom": 21,
+		 "filter": [
+		  "all",
+		  [
+		   "!=",
+		   "symbo",
+		   "COMMUNE_FUSIONNEE"
+		  ],
+		  [
+		   "!=",
+		   "symbo",
+		   "COMMUNE_CHEF_LIEU"
+		  ],
+		  [
+		   "==",
+		   "txt_typo",
+		   "TYPO_A_4"
+		  ]
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 17,
+		  "text-allow-overlap": true,
+		  "text-anchor": "center",
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#000000",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 3
+		 }
+		},
+		{
+		 "id": "toponyme - ocs lineaire 1",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_ocs_lin",
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "OCS_FORET_1"
+		 ],
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 10,
+			 18
+			],
+			[
+			 12,
+			 22
+			]
+		   ]
+		  },
+		  "text-anchor": "center",
+		  "text-keep-upright": true,
+		  "text-padding": 1,
+		  "text-max-angle": 45,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ],
+		  "visibility": "visible"
+		 },
+		 "paint": {
+		  "text-color": "#287B00",
+		  "text-halo-width": 2,
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)"
+		 }
+		},
+		{
+		 "id": "toponyme - ocs ponc 1",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_ocs_ponc",
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "OCS_FORET_1"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 10,
+			 18
+			],
+			[
+			 12,
+			 22
+			]
+		   ]
+		  },
+		  "text-allow-overlap": true,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#287B00",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme - oro ponc 1",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_oro_ponc",
+		 "minzoom": 8,
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "grande île",
+		  "ORO_ILE_1",
+		  "ORO_RELIEF_1",
+		  "ORO_RELIEF_1_T",
+		  "TYPO_G_3",
+		  "TYPO_G_2",
+		  "TYPO_G_1"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 21,
+		  "text-allow-overlap": true,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#863831",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme - hydro lineaire glacier",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_hydro_lin",
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "ORO_GLACIER_1",
+		  "ORO_GLACIER_2"
+		 ],
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{texte}",
+		  "text-size": 15,
+		  "text-anchor": "center",
+		  "text-keep-upright": true,
+		  "text-max-angle": 45,
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ],
+		  "visibility": "visible"
+		 },
+		 "paint": {
+		  "text-color": "#447FB3",
+		  "text-halo-width": 2,
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)"
+		 }
+		},
+		{
+		 "id": "toponyme - hydro lineaire 1",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_hydro_lin",
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "HYD_LIN_1",
+		  "HYD-LIN-1",
+		  "grande rivière",
+		  "HYD_SURF_1",
+		  "HYD_SURF_1_T",
+		  "TYPO_D_1",
+		  "TYPO_D_2"
+		 ],
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{texte}",
+		  "text-size": 18,
+		  "text-anchor": "center",
+		  "text-keep-upright": true,
+		  "text-max-angle": 45,
+		  "text-padding": 10,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ],
+		  "visibility": "visible"
+		 },
+		 "paint": {
+		  "text-color": "#447FB3",
+		  "text-halo-width": 2,
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)"
+		 }
+		},
+		{
+		 "id": "toponyme - hydro lineaire ocean",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_hydro_lin",
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "mer et océan"
+		 ],
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{texte}",
+		  "text-size": 30,
+		  "text-anchor": "center",
+		  "text-keep-upright": true,
+		  "text-max-angle": 45,
+		  "text-padding": 10,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ],
+		  "visibility": "visible"
+		 },
+		 "paint": {
+		  "text-color": "#447FB3",
+		  "text-halo-width": 4,
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)"
+		 }
+		},
+		{
+		 "id": "toponyme - hydro ponc 1",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_hydro_ponc",
+		 "minzoom": 4,
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "mer",
+		  "grand",
+		  "grand golfe",
+		  "HYD_SURF_1",
+		  "TYPO_D_1"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 4,
+			 16
+			],
+			[
+			 6,
+			 30
+			],
+			[
+			 10,
+			 25
+			]
+		   ]
+		  },
+		  "text-allow-overlap": true,
+		  "text-padding": 10,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#447FB3",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 4
+		 }
+		},
+		{
+		 "id": "toponyme localite importance 2",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_localite_ponc",
+		 "minzoom": 4,
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "commune 2",
+		  "BAT_COMMUNE_2",
+		  "BAT_COMMUNE-2",
+		  "BAT_COMMUNE_2_T"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "icon-image": "Localite",
+		  "icon-size": 0.25,
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 4,
+			 10
+			],
+			[
+			 6,
+			 17
+			]
+		   ]
+		  },
+		  "text-allow-overlap": true,
+		  "text-anchor": "bottom-left",
+		  "text-offset": [
+		   0.3,
+		   0.2
+		  ],
+		  "text-padding": 1,
+		  "text-transform": "uppercase",
+		  "text-font": {
+		   "stops": [
+			[
+			 1,
+			 [
+			  "Source Sans Pro Regular"
+			 ]
+			],
+			[
+			 7,
+			 [
+			  "Source Sans Pro Bold"
+			 ]
+			],
+			[
+			 10,
+			 [
+			  "Source Sans Pro Regular"
+			 ]
+			]
+		   ]
+		  }
+		 },
+		 "paint": {
+		  "text-color": "#000000",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 3
+		 }
+		},
+		{
+		 "id": "toponyme localite n0 typoA3 non commune",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_localite_ponc",
+		 "maxzoom": 21,
+		 "filter": [
+		  "all",
+		  [
+		   "!=",
+		   "symbo",
+		   "COMMUNE_FUSIONNEE"
+		  ],
+		  [
+		   "!=",
+		   "symbo",
+		   "COMMUNE_CHEF_LIEU"
+		  ],
+		  [
+		   "==",
+		   "txt_typo",
+		   "TYPO_A_3"
+		  ]
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 19,
+		  "text-allow-overlap": true,
+		  "text-anchor": "center",
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#000000",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 3
+		 }
+		},
+		{
+		 "id": "toponyme localite n0 typoA2 non commune",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_localite_ponc",
+		 "maxzoom": 21,
+		 "filter": [
+		  "all",
+		  [
+		   "!=",
+		   "symbo",
+		   "COMMUNE_FUSIONNEE"
+		  ],
+		  [
+		   "!=",
+		   "symbo",
+		   "COMMUNE_CHEF_LIEU"
+		  ],
+		  [
+		   "==",
+		   "txt_typo",
+		   "TYPO_A_2"
+		  ]
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 21,
+		  "text-allow-overlap": true,
+		  "text-anchor": "center",
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#000000",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 4
+		 }
+		},
+		{
+		 "id": "toponyme localite n0 typoA7 commune",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_localite_ponc",
+		 "maxzoom": 21,
+		 "filter": [
+		  "all",
+		  [
+		   "in",
+		   "symbo",
+		   "COMMUNE_FUSIONNEE",
+		   "COMMUNE_CHEF_LIEU"
+		  ],
+		  [
+		   "==",
+		   "txt_typo",
+		   "TYPO_A_7"
+		  ]
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 15,
+			 13
+			],
+			[
+			 17,
+			 16
+			]
+		   ]
+		  },
+		  "text-allow-overlap": true,
+		  "text-anchor": "center",
+		  "text-padding": 1,
+		  "text-transform": "uppercase",
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#000000",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme localite n0 typoA6 commune",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_localite_ponc",
+		 "maxzoom": 21,
+		 "filter": [
+		  "all",
+		  [
+		   "in",
+		   "symbo",
+		   "COMMUNE_FUSIONNEE",
+		   "COMMUNE_CHEF_LIEU"
+		  ],
+		  [
+		   "==",
+		   "txt_typo",
+		   "TYPO_A_6"
+		  ]
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 15,
+			 15
+			],
+			[
+			 17,
+			 18
+			]
+		   ]
+		  },
+		  "text-allow-overlap": true,
+		  "text-anchor": "center",
+		  "text-padding": 1,
+		  "text-transform": "uppercase",
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#000000",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme localite n0 typoA1 non commune",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_localite_ponc",
+		 "maxzoom": 21,
+		 "filter": [
+		  "all",
+		  [
+		   "!=",
+		   "symbo",
+		   "COMMUNE_FUSIONNEE"
+		  ],
+		  [
+		   "!=",
+		   "symbo",
+		   "COMMUNE_CHEF_LIEU"
+		  ],
+		  [
+		   "==",
+		   "txt_typo",
+		   "TYPO_A_1"
+		  ]
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 23,
+		  "text-allow-overlap": true,
+		  "text-anchor": "center",
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#000000",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 4
+		 }
+		},
+		{
+		 "id": "toponyme localite n0 typoA4 commune",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_localite_ponc",
+		 "maxzoom": 21,
+		 "filter": [
+		  "all",
+		  [
+		   "in",
+		   "symbo",
+		   "COMMUNE_FUSIONNEE",
+		   "COMMUNE_CHEF_LIEU"
+		  ],
+		  [
+		   "==",
+		   "txt_typo",
+		   "TYPO_A_4"
+		  ]
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 17,
+		  "text-allow-overlap": true,
+		  "text-anchor": "center",
+		  "text-padding": 1,
+		  "text-transform": "uppercase",
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#000000",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 3
+		 }
+		},
+		{
+		 "id": "toponyme localite n0 typoA3 commune",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_localite_ponc",
+		 "maxzoom": 21,
+		 "filter": [
+		  "all",
+		  [
+		   "in",
+		   "symbo",
+		   "COMMUNE_FUSIONNEE",
+		   "COMMUNE_CHEF_LIEU"
+		  ],
+		  [
+		   "==",
+		   "txt_typo",
+		   "TYPO_A_3"
+		  ]
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 19,
+		  "text-allow-overlap": true,
+		  "text-anchor": "center",
+		  "text-padding": 1,
+		  "text-transform": "uppercase",
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#000000",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 3
+		 }
+		},
+		{
+		 "id": "toponyme localite n0 typoA2 commune",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_localite_ponc",
+		 "maxzoom": 21,
+		 "filter": [
+		  "all",
+		  [
+		   "in",
+		   "symbo",
+		   "COMMUNE_FUSIONNEE",
+		   "COMMUNE_CHEF_LIEU"
+		  ],
+		  [
+		   "==",
+		   "txt_typo",
+		   "TYPO_A_2"
+		  ]
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 21,
+		  "text-allow-overlap": true,
+		  "text-anchor": "center",
+		  "text-padding": 1,
+		  "text-transform": "uppercase",
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#000000",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 4
+		 }
+		},
+		{
+		 "id": "toponyme localite importance 1",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_localite_ponc",
+		 "minzoom": 3,
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "commune 1",
+		  "BAT_COMMUNE_1",
+		  "BAT_COMMUNE_1_T"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "icon-image": "Localite",
+		  "icon-size": 0.3,
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 3,
+			 10
+			],
+			[
+			 6,
+			 20
+			]
+		   ]
+		  },
+		  "text-allow-overlap": false,
+		  "text-anchor": "bottom-left",
+		  "text-offset": [
+		   0.25,
+		   -0.1
+		  ],
+		  "text-padding": 1,
+		  "text-transform": "uppercase",
+		  "text-font": {
+		   "stops": [
+			[
+			 1,
+			 [
+			  "Source Sans Pro Regular"
+			 ]
+			],
+			[
+			 7,
+			 [
+			  "Source Sans Pro Bold"
+			 ]
+			],
+			[
+			 10,
+			 [
+			  "Source Sans Pro Regular"
+			 ]
+			]
+		   ]
+		  }
+		 },
+		 "paint": {
+		  "text-color": "#000000",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 4
+		 }
+		},
+		{
+		 "id": "toponyme localite n0 typoA1 commune",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_localite_ponc",
+		 "maxzoom": 21,
+		 "filter": [
+		  "all",
+		  [
+		   "in",
+		   "symbo",
+		   "COMMUNE_FUSIONNEE",
+		   "COMMUNE_CHEF_LIEU"
+		  ],
+		  [
+		   "==",
+		   "txt_typo",
+		   "TYPO_A_1"
+		  ]
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 23,
+		  "text-allow-overlap": true,
+		  "text-anchor": "center",
+		  "text-padding": 1,
+		  "text-transform": "uppercase",
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#000000",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 4
+		 }
+		},
+		{
+		 "id": "toponyme - hydro ponc ocean",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_hydro_ponc",
+		 "minzoom": 1,
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "ocean"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 1,
+			 16
+			],
+			[
+			 6,
+			 30
+			]
+		   ]
+		  },
+		  "text-allow-overlap": true,
+		  "text-anchor": "center",
+		  "text-padding": 10,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#447FB3",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 4
+		 }
+		},
+		{
+		 "id": "toponyme pays 3",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_localite_ponc",
+		 "minzoom": 4,
+		 "maxzoom": 5,
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "pays 3"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "text-field": "{texte}",
+		  "text-size": 9,
+		  "text-allow-overlap": true,
+		  "text-anchor": "center",
+		  "text-padding": 1,
+		  "text-transform": "uppercase",
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#787878",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 4
+		 }
+		},
+		{
+		 "id": "toponyme pays 2",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_localite_ponc",
+		 "minzoom": 2,
+		 "maxzoom": 5,
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "pays 2"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "text-field": "{texte}",
+		  "text-size": 13,
+		  "text-allow-overlap": true,
+		  "text-anchor": "center",
+		  "text-padding": 2,
+		  "text-transform": "uppercase",
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#787878",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 4
+		 }
+		},
+		{
+		 "id": "toponyme pays 1",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_localite_ponc",
+		 "minzoom": 2,
+		 "maxzoom": 5,
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "pays 1"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "text-field": "{texte}",
+		  "text-size": 13,
+		  "text-allow-overlap": true,
+		  "text-anchor": "center",
+		  "text-padding": 2,
+		  "text-transform": "uppercase",
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#787878",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 4
+		 }
+		},
+		{
+		 "id": "toponyme continent",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_localite_ponc",
+		 "maxzoom": 3,
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "continent"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "text-field": "{texte}",
+		  "text-size": 15,
+		  "text-allow-overlap": true,
+		  "text-anchor": "center",
+		  "text-padding": 1,
+		  "text-transform": "uppercase",
+		  "text-font": [
+		   "Source Sans Pro Bold"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#787878",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 4
+		 }
+		}
+	   ]
+	  }

--- a/components/map/styles/plan-ign.json
+++ b/components/map/styles/plan-ign.json
@@ -1,14549 +1,14549 @@
 {
-	"version": 8,
-	"name": "PLAN IGN",
+  "version": 8,
+  "name": "PLAN IGN",
     "glyphs":"https://wxs.ign.fr/static/vectorTiles/fonts/{fontstack}/{range}.pbf",
-	"sprite": "https://wxs.ign.fr/static/vectorTiles/styles/PLAN.IGN/sprite/PlanIgn",
+  "sprite": "https://wxs.ign.fr/static/vectorTiles/styles/PLAN.IGN/sprite/PlanIgn",
     "sources": {
-	  "plan_ign": {
+    "plan_ign": {
         "type": "vector",
-		"tiles": [
-		  "https://wxs.ign.fr/essentiels/geoportail/tms/1.0.0/PLAN.IGN/{z}/{x}/{y}.pbf"
-		],
-		"scheme": "xyz",
-		"attribution": "<a target='_blank' href='https://geoservices.ign.fr/documentation/donnees/cartes/planign'>© IGN</a>"
-	  },
-	  "cadastre": {
-		"type": "vector",
-		"url": "https://openmaptiles.geo.data.gouv.fr/data/cadastre.json"
-	  },
-	  "decoupage-administratif": {
-		"type": "vector",
-		"url": "https://openmaptiles.geo.data.gouv.fr/data/decoupage-administratif.json"
-	  }
+    "tiles": [
+      "https://wxs.ign.fr/essentiels/geoportail/tms/1.0.0/PLAN.IGN/{z}/{x}/{y}.pbf"
+    ],
+    "scheme": "xyz",
+    "attribution": "<a target='_blank' href='https://geoservices.ign.fr/documentation/donnees/cartes/planign'>© IGN</a>"
     },
-	"transition": {
+    "cadastre": {
+    "type": "vector",
+    "url": "https://openmaptiles.geo.data.gouv.fr/data/cadastre.json"
+    },
+    "decoupage-administratif": {
+    "type": "vector",
+    "url": "https://openmaptiles.geo.data.gouv.fr/data/decoupage-administratif.json"
+    }
+    },
+  "transition": {
       "duration": 50,
-	  "delay": 0
-	},
-	"layers": [
-		{
-		 "id": "bckgrd",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "fond_opaque",
-		 "minzoom": 0,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "paint": {
-		  "fill-color": "#FFFFFF",
-		  "fill-opacity": 0.1
-		 }
-		},
-		{
-		 "id": "orographie : relief - 0m",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "oro_relief",
-		 "minzoom": 0,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "HYPSO_0"
-		 ],
-		 "paint": {
-		  "fill-color": "#D6E5BA",
-		  "fill-opacity": 1
-		 }
-		},
-		{
-		 "id": "orographie : relief - 100m",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "oro_relief",
-		 "minzoom": 0,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "HYPSO_100"
-		 ],
-		 "paint": {
-		  "fill-color": "#F7F2DA",
-		  "fill-opacity": 1
-		 }
-		},
-		{
-		 "id": "orographie : relief - 200m",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "oro_relief",
-		 "minzoom": 0,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "HYPSO_200"
-		 ],
-		 "paint": {
-		  "fill-color": "#EBDEBF",
-		  "fill-opacity": 1
-		 }
-		},
-		{
-		 "id": "orographie : relief - 1000m",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "oro_relief",
-		 "minzoom": 0,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "HYPSO_1000"
-		 ],
-		 "paint": {
-		  "fill-color": "#DABE97",
-		  "fill-opacity": 1
-		 }
-		},
-		{
-		 "id": "orographie : relief - 3000m",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "oro_relief",
-		 "minzoom": 0,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "HYPSO_3000"
-		 ],
-		 "paint": {
-		  "fill-color": "#B28773",
-		  "fill-opacity": 1
-		 }
-		},
-		{
-		 "id": "orographie : relief - 4000m",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "oro_relief",
-		 "minzoom": 0,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "HYPSO_4000"
-		 ],
-		 "paint": {
-		  "fill-color": "#9E6A54",
-		  "fill-opacity": 1
-		 }
-		},
-		{
-		 "id": "orographie : relief - 5000m",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "oro_relief",
-		 "minzoom": 0,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "HYPSO_5000"
-		 ],
-		 "paint": {
-		  "fill-color": "#773A2B",
-		  "fill-opacity": 1
-		 }
-		},
-		{
-		 "id": "orographie : relief - glacier",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "oro_relief",
-		 "minzoom": 0,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "GLACIER"
-		 ],
-		 "paint": {
-		  "fill-color": "#FFFFFF",
-		  "fill-opacity": 0.7
-		 }
-		},
-		{
-		 "id": "ocs - vegetation - zone boiséee, foret fermee, peupleraie",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "ocs_vegetation_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "ZONE_BOISEE",
-		  "ZONE_FORET_FERMEE_FEUIL",
-		  "ZONE_FORET_FERMEE_CONI",
-		  "ZONE_FORET_FERMEE_MIXTE",
-		  "ZONE_PEUPLERAIE"
-		 ],
-		 "paint": {
-		  "fill-color": "#DFE8D5",
-		  "fill-outline-color": "#DFE8D5"
-		 }
-		},
-		{
-		 "id": "ocs - vegetation - forêt ouverte",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "ocs_vegetation_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "ZONE_FORET_OUVERTE"
-		 ],
-		 "paint": {
-		  "fill-color": "#EDF2D9",
-		  "fill-outline-color": "#EDF2D9"
-		 }
-		},
-		{
-		 "id": "ocs - vegetation - lande ligneuse",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "ocs_vegetation_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "ZONE_LANDE_LIGNEUSE"
-		 ],
-		 "paint": {
-		  "fill-color": "#F2EECD"
-		 }
-		},
-		{
-		 "id": "ocs - vegetation - vigne",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "ocs_vegetation_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "ZONE_VIGNE"
-		 ],
-		 "paint": {
-		  "fill-color": "#FFEDD9"
-		 }
-		},
-		{
-		 "id": "ocs - vegetation - verger",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "ocs_vegetation_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "ZONE_VERGER"
-		 ],
-		 "paint": {
-		  "fill-color": "#FAE2C5"
-		 }
-		},
-		{
-		 "id": "ocs - vegetation - canne à sucre, bananeraie",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "ocs_vegetation_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "ZONE_CANNE_BANANE"
-		 ],
-		 "paint": {
-		  "fill-color": "#FAEDFA"
-		 }
-		},
-		{
-		 "id": "hydro surfacique - Estran",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "hydro_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "ZONE_D_ESTRAN"
-		 ],
-		 "paint": {
-		  "fill-color": "#C3DDE9",
-		  "fill-outline-color": "#C3DDE9"
-		 }
-		},
-		{
-		 "id": "ocs - vegetation - mangrovre",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "ocs_vegetation_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "ZONE_MANGROVE"
-		 ],
-		 "paint": {
-		  "fill-color": {
-		   "stops": [
-			[
-			 9,
-			 "#85CCCB"
-			],
-			[
-			 10,
-			 "#90CCCB"
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "ocs - vegetation - marais",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "ocs_vegetation_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "ZONE_MARAIS"
-		 ],
-		 "paint": {
-		  "fill-pattern": "Marais"
-		 }
-		},
-		{
-		 "id": "ocs - vegetation - marais salant",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "ocs_vegetation_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "ZONE_MARAIS_SALANT"
-		 ],
-		 "paint": {
-		  "fill-pattern": "MaraisSalant"
-		 }
-		},
-		{
-		 "id": "ocs - Zone",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "ocs_nature_sol_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "ZONE_ROCHEUSE"
-		 ],
-		 "paint": {
-		  "fill-color": "#D0D0D0",
-		  "fill-opacity": 0.3
-		 }
-		},
-		{
-		 "id": "ocs - Zone sable sec",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "ocs_nature_sol_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "ZONE_SABLE_SEC"
-		 ],
-		 "paint": {
-		  "fill-pattern": "Sable"
-		 }
-		},
-		{
-		 "id": "ocs - Zone sable humide",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "ocs_nature_sol_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "ZONE_SABLE_HUMIDE",
-		  "FOND_CUVETTE_HUMIDE"
-		 ],
-		 "paint": {
-		  "fill-pattern": "SableHumide"
-		 }
-		},
-		{
-		 "id": "ocs - Zone graviers galets secs",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "ocs_nature_sol_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "GRAVIERS_GALETS_SEC"
-		 ],
-		 "paint": {
-		  "fill-pattern": "GravierSec"
-		 }
-		},
-		{
-		 "id": "ocs - Zone graviers galets humides",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "ocs_nature_sol_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "GRAVIERS_GALETS_HUM"
-		 ],
-		 "paint": {
-		  "fill-pattern": "Gravier"
-		 }
-		},
-		{
-		 "id": "ocs - Zone rocher hydro",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "ocs_nature_sol_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "ZONE_ROCHER_HYDRO"
-		 ],
-		 "paint": {
-		  "fill-pattern": "RocherHydro"
-		 }
-		},
-		{
-		 "id": "ocs - Zone glacier",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "ocs_nature_sol_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "ZONE_GLACIER"
-		 ],
-		 "paint": {
-		  "fill-pattern": "Glacier",
-		  "fill-opacity": {
-		   "stops": [
-			[
-			 10,
-			 0.5
-			],
-			[
-			 12,
-			 0.3
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "zone batie",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_zone_surf",
-		 "minzoom": 7,
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "ZONE_BATI"
-		 ],
-		 "paint": {
-		  "fill-color": "#E8E2D1",
-		  "fill-opacity": {
-		   "stops": [
-			[
-			 12,
-			 1
-			],
-			[
-			 13,
-			 0.9
-			],
-			[
-			 14,
-			 0.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "zone d'activité",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_zone_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "ZONE_INDUS_ACTI"
-		 ],
-		 "paint": {
-		  "fill-color": "#D9D9D9"
-		 }
-		},
-		{
-		 "id": "oro - courbe et cuvette maitresse",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "oro_courbe",
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "CNV_MAITRESSE",
-		  "CUVETTE_MAITRESSE"
-		 ],
-		 "paint": {
-		  "line-color": "#D9C8A9",
-		  "line-width": {
-		   "stops": [
-			[
-			 13,
-			 1.7
-			],
-			[
-			 15,
-			 2
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "oro - courbe et cuvette normale",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "oro_courbe",
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "CNV_NORMALE",
-		  "CUVETTE_NORMALE"
-		 ],
-		 "paint": {
-		  "line-color": "#D9C8A9",
-		  "line-width": {
-		   "stops": [
-			[
-			 13,
-			 1
-			],
-			[
-			 15,
-			 1.2
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "oro - courbe et cuvette intercalaire",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "oro_courbe",
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "CNV_INTERCALAIRE",
-		  "CUVETTE_INTERCAL",
-		  "CNV_SS_INTERCALAIRE"
-		 ],
-		 "paint": {
-		  "line-color": "#D9C8A9",
-		  "line-width": 0.7,
-		  "line-dasharray": [
-		   20,
-		   7
-		  ]
-		 }
-		},
-		{
-		 "id": "oro - courbe et cuvette glacier maitresse",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "oro_courbe",
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "CNV_GLACIER_MAITRESSE",
-		  "CUV_GLACIER_MAITRESSE"
-		 ],
-		 "paint": {
-		  "line-color": "#A4BFD9",
-		  "line-width": {
-		   "stops": [
-			[
-			 13,
-			 1.7
-			],
-			[
-			 15,
-			 2
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "oro - courbe et cuvette glacier normale",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "oro_courbe",
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "CNV_GLACIER_NORMALE",
-		  "CUV_GLACIER_NORMALE"
-		 ],
-		 "paint": {
-		  "line-color": "#A4BFD9",
-		  "line-width": {
-		   "stops": [
-			[
-			 13,
-			 1
-			],
-			[
-			 15,
-			 1.2
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "oro - courbe et cuvette glacier intercalaire",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "oro_courbe",
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "CNV_GLACIER_INTERCAL",
-		  "CUV_GLACIER_INTERCAL"
-		 ],
-		 "paint": {
-		  "line-color": "#A4BFD9",
-		  "line-width": {
-		   "stops": [
-			[
-			 13,
-			 0.7
-			],
-			[
-			 15,
-			 0.9
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   20,
-		   7
-		  ]
-		 }
-		},
-		{
-		 "id": "oro - courbe et cuvette rocher maitresse",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "oro_courbe",
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "CNV_ROCHER_MAITRESSE",
-		  "CUV_ROCHER_MAITRESSE"
-		 ],
-		 "paint": {
-		  "line-color": "#AAAAAA",
-		  "line-width": 1.7
-		 }
-		},
-		{
-		 "id": "oro - courbe et cuvette rocher normale",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "oro_courbe",
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "CNV_ROCHER_NORMALE",
-		  "CUV_ROCHER_NORMALE"
-		 ],
-		 "paint": {
-		  "line-color": "#AAAAAA",
-		  "line-width": 1
-		 }
-		},
-		{
-		 "id": "oro - courbe et cuvette rocher intercalaire",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "oro_courbe",
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "CNV_ROCHER_INTERCAL",
-		  "CUV_ROCHER_INTERCAL"
-		 ],
-		 "paint": {
-		  "line-color": "#AAAAAA",
-		  "line-width": {
-		   "stops": [
-			[
-			 13,
-			 0.7
-			],
-			[
-			 15,
-			 0.9
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   20,
-		   7
-		  ]
-		 }
-		},
-		{
-		 "id": "oro - courbe et cuvette bathymetrique",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "oro_courbe",
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "CNV_BATHYMETRIQUE",
-		  "CUV_BATHYMETRIQUE"
-		 ],
-		 "paint": {
-		  "line-color": "#0000FF",
-		  "line-width": 1
-		 }
-		},
-		{
-		 "id": "oro lin - talus",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "oro_lin",
-		 "minzoom": 14,
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "TALUS"
-		 ],
-		 "paint": {
-		  "line-color": "#D9C8A9",
-		  "line-width": 1
-		 }
-		},
-		{
-		 "id": "oro lin - talus - trait perpendiculaire",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "oro_lin",
-		 "minzoom": 14,
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "TALUS"
-		 ],
-		 "paint": {
-		  "line-color": "#D9C8A9",
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 7
-			],
-			[
-			 16,
-			 9
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   0.1,
-		   1
-		  ],
-		  "line-translate": [
-		   0,
-		   4
-		  ]
-		 }
-		},
-		{
-		 "id": "toponyme - cote de courbe normale",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "oro_courbe",
-		 "minzoom": 13,
-		 "maxzoom": 21,
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 13,
-			 10
-			],
-			[
-			 15,
-			 13
-			]
-		   ]
-		  },
-		  "text-anchor": "center",
-		  "text-rotation-alignment": "map",
-		  "text-pitch-alignment": "viewport",
-		  "text-keep-upright": false,
-		  "text-max-angle": 20,
-		  "text-max-width": 100,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ],
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "all",
-		  [
-		   "!=",
-		   "texte",
-		   "0"
-		  ],
-		  [
-		   "==",
-		   "hors_zone",
-		   "true"
-		  ],
-		  [
-		   "in",
-		   "symbo",
-		   "CNV_MAITRESSE",
-		   "CUVETTE_MAITRESSE"
-		  ]
-		 ],
-		 "paint": {
-		  "text-color": "#604A2F",
-		  "text-halo-width": 0.5,
-		  "text-halo-color": "#FFFFFF"
-		 }
-		},
-		{
-		 "id": "toponyme - cote de courbe rocher",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "oro_courbe",
-		 "minzoom": 13,
-		 "maxzoom": 21,
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 13,
-			 10
-			],
-			[
-			 15,
-			 13
-			]
-		   ]
-		  },
-		  "text-anchor": "center",
-		  "text-rotation-alignment": "map",
-		  "text-pitch-alignment": "viewport",
-		  "text-keep-upright": false,
-		  "text-max-angle": 20,
-		  "text-max-width": 100,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ],
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "all",
-		  [
-		   "!=",
-		   "texte",
-		   "0"
-		  ],
-		  [
-		   "==",
-		   "hors_zone",
-		   "true"
-		  ],
-		  [
-		   "in",
-		   "symbo",
-		   "CNV_ROCHER_MAITRESSE",
-		   "CUV_ROCHER_MAITRESSE"
-		  ]
-		 ],
-		 "paint": {
-		  "text-color": "#333333",
-		  "text-halo-width": 0.5,
-		  "text-halo-color": "#FFFFFF"
-		 }
-		},
-		{
-		 "id": "toponyme - cote de courbe glacier",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "oro_courbe",
-		 "minzoom": 13,
-		 "maxzoom": 21,
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 13,
-			 10
-			],
-			[
-			 15,
-			 13
-			]
-		   ]
-		  },
-		  "text-anchor": "center",
-		  "text-rotation-alignment": "map",
-		  "text-pitch-alignment": "viewport",
-		  "text-keep-upright": false,
-		  "text-max-angle": 20,
-		  "text-max-width": 100,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ],
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "all",
-		  [
-		   "!=",
-		   "texte",
-		   "0"
-		  ],
-		  [
-		   "==",
-		   "hors_zone",
-		   "true"
-		  ],
-		  [
-		   "in",
-		   "symbo",
-		   "CNV_GLACIER_MAITRESSE",
-		   "CUV_GLACIER_MAITRESSE"
-		  ]
-		 ],
-		 "paint": {
-		  "text-color": "#629FD9",
-		  "text-halo-width": 0.5,
-		  "text-halo-color": "#FFFFFF"
-		 }
-		},
-		{
-		 "id": "hydro surfacique",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "hydro_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "SURFACE_D_EAU",
-		  "BASSIN",
-		  "ZONE_MARINE"
-		 ],
-		 "paint": {
-		  "fill-color": "#AAD5E9",
-		  "fill-outline-color": "#AAD5E9"
-		 }
-		},
-		{
-		 "id": "hydro surfacique temporaire",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "hydro_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "SURFACE_D_EAU_TEMP"
-		 ],
-		 "paint": {
-		  "fill-color": "rgba(168, 203, 220, 0.5)"
-		 }
-		},
-		{
-		 "id": "réseau hydro  - cours d'eau souterrain",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "hydro_reseau_sou",
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "COURS_D_EAU_SOU",
-		  "COURS_D_EAU_MOY_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#AAD5E9",
-		  "line-width": {
-		   "stops": [
-			[
-			 12,
-			 1.5
-			],
-			[
-			 17,
-			 6.5
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   2,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "réseau hydro - filet interieur - aqueduc souterrain",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "hydro_reseau_sou",
-		 "minzoom": 12,
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "AQUEDUC_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#AAD5E9",
-		  "line-width": {
-		   "stops": [
-			[
-			 12,
-			 1.4
-			],
-			[
-			 16,
-			 3.5
-			],
-			[
-			 17,
-			 5.9
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   2,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "réseau hydro - carre - aqueduc souterrain",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "hydro_reseau_sou",
-		 "minzoom": 12,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "AQUEDUC_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#AAD5E9",
-		  "line-width": {
-		   "stops": [
-			[
-			 12,
-			 3.5
-			],
-			[
-			 16,
-			 8.7
-			],
-			[
-			 17,
-			 14.7
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   1,
-		   5
-		  ]
-		 }
-		},
-		{
-		 "id": "Ferre souterrain - voie normale",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "ferre_sou",
-		 "minzoom": 10,
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "VF_1_SOU",
-		  "VF_2_SOU",
-		  "VF_ELEC_1_SOU",
-		  "VF_FERRO_ROUTIER_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#B4B4B4",
-		  "line-width": {
-		   "stops": [
-			[
-			 10,
-			 0.8
-			],
-			[
-			 17,
-			 2.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Ferre souterrain - trait perpendic épais",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "ferre_sou",
-		 "minzoom": 10,
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "VF_1_SOU",
-		  "VF_2_SOU",
-		  "VF_ELEC_1_SOU",
-		  "VF_FERRO_ROUTIER_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#B4B4B4",
-		  "line-width": {
-		   "stops": [
-			[
-			 10,
-			 3.5
-			],
-			[
-			 17,
-			 14.7
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   0.1,
-		   10
-		  ]
-		 }
-		},
-		{
-		 "id": "Ferre souterrain - voie etroite",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "ferre_sou",
-		 "minzoom": 10,
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "VF_ETROITE_1_SOU",
-		  "VF_ETROITE_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#B4B4B4",
-		  "line-width": {
-		   "stops": [
-			[
-			 10,
-			 0.3
-			],
-			[
-			 17,
-			 1.8
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Ferre souterrain - trait perpendic fin",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "ferre_sou",
-		 "minzoom": 10,
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "VF_ETROITE_1_SOU",
-		  "VF_ETROITE_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#B4B4B4",
-		  "line-width": {
-		   "stops": [
-			[
-			 10,
-			 3.5
-			],
-			[
-			 17,
-			 14.7
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   0.1,
-		   10
-		  ]
-		 }
-		},
-		{
-		 "id": "Ferre souterrain - voie service",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "ferre_sou",
-		 "minzoom": 14,
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "VF_SERVICE_SOU",
-		  "VF_NON_EXPLOITEE_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#B4B4B4",
-		  "line-width": {
-		   "stops": [
-			[
-			 10,
-			 0.3
-			],
-			[
-			 17,
-			 1.8
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   5,
-		   2,
-		   1,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "Ferre souterrain - funic/urbain",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "ferre_sou",
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "FUNI_CREMAILLERE_SOU",
-		  "TRANSPORT_URBAIN_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#B4B4B4",
-		  "line-width": {
-		   "stops": [
-			[
-			 10,
-			 0.3
-			],
-			[
-			 17,
-			 1.8
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Ferre souterrain - 2 trait perpendic - funic/urbain",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "ferre_sou",
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "FUNI_CREMAILLERE_SOU",
-		  "TRANSPORT_URBAIN_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#B4B4B4",
-		  "line-width": {
-		   "stops": [
-			[
-			 10,
-			 3.5
-			],
-			[
-			 17,
-			 17
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   0.1,
-		   0.2,
-		   0.1,
-		   10
-		  ]
-		 }
-		},
-		{
-		 "id": "Chemin souterrain - piste cyclable",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_chemin_sou",
-		 "minzoom": 13,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "PISTE_CYCLABLE_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#AB81CC",
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 1.1
-			],
-			[
-			 15,
-			 1.7
-			],
-			[
-			 16,
-			 2
-			],
-			[
-			 17,
-			 3.5
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   6,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "Chemin souterrain - filet exterieur - escalier",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_chemin_sou",
-		 "minzoom": 14,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "ESCALIER_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#B3989A",
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 1.75
-			],
-			[
-			 15,
-			 3
-			],
-			[
-			 16,
-			 4.2
-			],
-			[
-			 17,
-			 9.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Chemin souterrain - filet interieur - escalier",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_chemin_sou",
-		 "minzoom": 14,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "ESCALIER_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#EDF1FF",
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 1
-			],
-			[
-			 15,
-			 1.9
-			],
-			[
-			 16,
-			 2.7
-			],
-			[
-			 17,
-			 5.8
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   1,
-		   0.2
-		  ]
-		 }
-		},
-		{
-		 "id": "Chemin souterrain - Rue pietonne",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_chemin_sou",
-		 "minzoom": 14,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "RUE_PIETONNE_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#B3989A",
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 1
-			],
-			[
-			 15,
-			 1.2
-			],
-			[
-			 16,
-			 1.4
-			],
-			[
-			 17,
-			 2
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   1,
-		   3
-		  ]
-		 }
-		},
-		{
-		 "id": "Chemin souterrain - sentier",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_chemin_sou",
-		 "minzoom": 13,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "SENTIER_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#B3989A",
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 1
-			],
-			[
-			 15,
-			 1.2
-			],
-			[
-			 16,
-			 1.4
-			],
-			[
-			 17,
-			 2
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   4,
-		   3
-		  ]
-		 }
-		},
-		{
-		 "id": "Chemin souterrain - chemin",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_chemin_sou",
-		 "minzoom": 12,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "CHEMIN_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#B3989A",
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 1
-			],
-			[
-			 15,
-			 1.2
-			],
-			[
-			 16,
-			 1.4
-			],
-			[
-			 17,
-			 2
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier souterrain - filet extérieur - route non revetu carrosable",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sou",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "NON_REVETUE_CARRO_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#AFAFAF",
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 3.2
-			],
-			[
-			 15,
-			 5.4
-			],
-			[
-			 16,
-			 7.7
-			],
-			[
-			 17,
-			 16.8
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   2,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "Routier souterrain - filet extérieur - bretelle autoroute",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sou",
-		 "minzoom": 12,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BRET_AUTO_PEAGE_3_SOU",
-		  "BRET_AUTO_PEAGE_2_SOU",
-		  "BRET_AUTO_PEAGE_1_SOU",
-		  "BRET_AUTO_LIBRE_3_SOU",
-		  "BRET_AUTO_LIBRE_2_SOU",
-		  "BRET_AUTO_LIBRE_1_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "rgba(222, 70, 14, 0.5)",
-		  "line-width": {
-		   "stops": [
-			[
-			 12,
-			 2.5
-			],
-			[
-			 14,
-			 3.7
-			],
-			[
-			 15,
-			 6.8
-			],
-			[
-			 16,
-			 8.4
-			],
-			[
-			 17,
-			 14
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier souterrain - filet extérieur - route non classee restreint",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sou",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "NON_CLASSEE_RESTREINT_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#AFAFAF",
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 3.2
-			],
-			[
-			 15,
-			 5.4
-			],
-			[
-			 16,
-			 7.7
-			],
-			[
-			 17,
-			 16.8
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier souterrain - filet extérieur - route non classee",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sou",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "NON_CLASSEE_4_SOU",
-		  "NON_CLASSEE_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#AFAFAF",
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 3.2
-			],
-			[
-			 15,
-			 5.4
-			],
-			[
-			 16,
-			 7.7
-			],
-			[
-			 17,
-			 16.8
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier souterrain - filet extérieur - route locale",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sou",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BRET_LOCALE_SOU",
-		  "LOCALE_4_SOU",
-		  "LOCALE_3_SOU",
-		  "LOCALE_2_SOU",
-		  "LOCALE_1_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "rgba(130, 130, 130, 0.5)",
-		  "line-width": {
-		   "stops": [
-			[
-			 9,
-			 2
-			],
-			[
-			 14,
-			 3.5
-			],
-			[
-			 15,
-			 6
-			],
-			[
-			 16,
-			 8.4
-			],
-			[
-			 17,
-			 18.3
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier souterrain - filet extérieur - route locale en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sou",
-		 "minzoom": 11,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "LOCALE_CONSTR_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#C8C8C8",
-		  "line-width": {
-		   "stops": [
-			[
-			 9,
-			 2
-			],
-			[
-			 14,
-			 3.5
-			],
-			[
-			 15,
-			 6
-			],
-			[
-			 16,
-			 8.4
-			],
-			[
-			 17,
-			 18.3
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier souterrain - filet extérieur - route regionale",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sou",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BRET_REGIONALE_SOU",
-		  "REGIONALE_4_SOU",
-		  "REGIONALE_3_SOU",
-		  "REGIONALE_2_SOU",
-		  "REGIONALE_1_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "rgba(130, 130, 130, 0.5)",
-		  "line-width": {
-		   "stops": [
-			[
-			 6,
-			 1.5
-			],
-			[
-			 9,
-			 2.3
-			],
-			[
-			 14,
-			 5
-			],
-			[
-			 15,
-			 8.1
-			],
-			[
-			 16,
-			 11.2
-			],
-			[
-			 17,
-			 22
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier souterrain - filet extérieur - route regionale en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sou",
-		 "minzoom": 10,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "REGIONALE_CONSTR_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#C8C8C8",
-		  "line-width": {
-		   "stops": [
-			[
-			 6,
-			 1.5
-			],
-			[
-			 9,
-			 2.3
-			],
-			[
-			 14,
-			 5
-			],
-			[
-			 15,
-			 8.1
-			],
-			[
-			 16,
-			 11.2
-			],
-			[
-			 17,
-			 22
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier souterrain - filet extérieur - route principale",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sou",
-		 "minzoom": 7,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BRET_PRINCIPALE_SOU",
-		  "PRINCIPALE_4_SOU",
-		  "PRINCIPALE_3_SOU",
-		  "PRINCIPALE_2_SOU",
-		  "PRINCIPALE_1_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "rgba(222, 70, 14, 0.5)",
-		  "line-width": {
-		   "stops": [
-			[
-			 6,
-			 1.8
-			],
-			[
-			 9,
-			 2.7
-			],
-			[
-			 14,
-			 5.9
-			],
-			[
-			 15,
-			 9
-			],
-			[
-			 16,
-			 12.2
-			],
-			[
-			 17,
-			 22.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier souterrain - filet extérieur - route principale en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sou",
-		 "minzoom": 10,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "PRINCIPALE_CONSTR_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#C8C8C8",
-		  "line-width": {
-		   "stops": [
-			[
-			 6,
-			 1.8
-			],
-			[
-			 9,
-			 2.7
-			],
-			[
-			 14,
-			 5.9
-			],
-			[
-			 15,
-			 9
-			],
-			[
-			 16,
-			 12.2
-			],
-			[
-			 17,
-			 22.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier souterrain - filet extérieur - autoroute",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sou",
-		 "minzoom": 7,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "AUTOROU_PEAGE_SOU",
-		  "AUTOROU_LIBRE_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "rgba(222, 70, 14, 0.5)",
-		  "line-width": {
-		   "stops": [
-			[
-			 6,
-			 2.5
-			],
-			[
-			 9,
-			 3.5
-			],
-			[
-			 14,
-			 7.5
-			],
-			[
-			 15,
-			 11
-			],
-			[
-			 16,
-			 15
-			],
-			[
-			 17,
-			 26
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier souterrain - filet extérieur - autoroute en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sou",
-		 "minzoom": 10,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "AUTOROU_CONSTR_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#C8C8C8",
-		  "line-width": {
-		   "stops": [
-			[
-			 6,
-			 2.5
-			],
-			[
-			 9,
-			 3.5
-			],
-			[
-			 14,
-			 7.5
-			],
-			[
-			 15,
-			 11
-			],
-			[
-			 16,
-			 15
-			],
-			[
-			 17,
-			 26
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier souterrain - filet interieur - route non revetu carrosable",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sou",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "NON_REVETUE_CARRO_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#DCDCDC",
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 2.3
-			],
-			[
-			 15,
-			 4.1
-			],
-			[
-			 16,
-			 6.3
-			],
-			[
-			 17,
-			 13.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier souterrain - filet interieur - bretelle autoroute",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sou",
-		 "minzoom": 12,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BRET_AUTO_PEAGE_3_SOU",
-		  "BRET_AUTO_PEAGE_2_SOU",
-		  "BRET_AUTO_PEAGE_1_SOU",
-		  "BRET_AUTO_LIBRE_3_SOU",
-		  "BRET_AUTO_LIBRE_2_SOU",
-		  "BRET_AUTO_LIBRE_1_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "rgba(255, 255, 255, 0.5)",
-		  "line-width": {
-		   "stops": [
-			[
-			 12,
-			 1.5
-			],
-			[
-			 14,
-			 2.6
-			],
-			[
-			 15,
-			 5.2
-			],
-			[
-			 16,
-			 6.7
-			],
-			[
-			 17,
-			 10.8
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier souterrain - filet interieur - route non classee restreint",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sou",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "NON_CLASSEE_RESTREINT_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#F2F5FF",
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 2.3
-			],
-			[
-			 15,
-			 4.1
-			],
-			[
-			 16,
-			 6.3
-			],
-			[
-			 17,
-			 13.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier souterrain - filet interieur - route non classee",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sou",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "NON_CLASSEE_4_SOU",
-		  "NON_CLASSEE_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#DCDCDC",
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 2.3
-			],
-			[
-			 15,
-			 4.1
-			],
-			[
-			 16,
-			 6.3
-			],
-			[
-			 17,
-			 13.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier souterrain - filet interieur - route locale",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sou",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BRET_LOCALE_SOU",
-		  "LOCALE_4_SOU",
-		  "LOCALE_3_SOU",
-		  "LOCALE_2_SOU",
-		  "LOCALE_1_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "rgba(255, 255, 255, 0.5)",
-		  "line-width": {
-		   "stops": [
-			[
-			 9,
-			 1.3
-			],
-			[
-			 14,
-			 2.3
-			],
-			[
-			 15,
-			 4.1
-			],
-			[
-			 16,
-			 6.1
-			],
-			[
-			 17,
-			 13.1
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier souterrain - filet interieur - route locale en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sou",
-		 "minzoom": 11,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "LOCALE_CONSTR_SOU"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 12,
-			 "#EDF1FF"
-			],
-			[
-			 13,
-			 "#FCF4A8"
-			],
-			[
-			 17,
-			 "#FCF7C1"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 9,
-			 2
-			],
-			[
-			 14,
-			 3.5
-			],
-			[
-			 15,
-			 6
-			],
-			[
-			 16,
-			 8.4
-			],
-			[
-			 17,
-			 18.3
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   2,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "Routier souterrain - filet interieur - route regionale",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sou",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BRET_REGIONALE_SOU",
-		  "REGIONALE_4_SOU",
-		  "REGIONALE_3_SOU",
-		  "REGIONALE_2_SOU",
-		  "REGIONALE_1_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "rgba(255, 255, 255, 0.5)",
-		  "line-width": {
-		   "stops": [
-			[
-			 6,
-			 1.4
-			],
-			[
-			 9,
-			 1.5
-			],
-			[
-			 14,
-			 3.2
-			],
-			[
-			 15,
-			 5.8
-			],
-			[
-			 16,
-			 8.3
-			],
-			[
-			 17,
-			 16.2
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier souterrain - filet interieur - route regionale en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sou",
-		 "minzoom": 10,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "REGIONALE_CONSTR_SOU"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 9,
-			 "#EDF1FF"
-			],
-			[
-			 10,
-			 "#FDF28B"
-			],
-			[
-			 17,
-			 "#FCF6BD"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 4,
-			 0.4
-			],
-			[
-			 6,
-			 1.5
-			],
-			[
-			 9,
-			 2.3
-			],
-			[
-			 14,
-			 5
-			],
-			[
-			 15,
-			 8.1
-			],
-			[
-			 16,
-			 11.2
-			],
-			[
-			 17,
-			 22
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   2,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "Routier souterrain - filet interieur - route principale",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sou",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BRET_PRINCIPALE_SOU",
-		  "PRINCIPALE_4_SOU",
-		  "PRINCIPALE_3_SOU",
-		  "PRINCIPALE_2_SOU",
-		  "PRINCIPALE_1_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "rgba(255, 255, 255, 0.5)",
-		  "line-width": {
-		   "stops": [
-			[
-			 4,
-			 0.5
-			],
-			[
-			 6,
-			 1.8
-			],
-			[
-			 9,
-			 2.1
-			],
-			[
-			 14,
-			 4.4
-			],
-			[
-			 15,
-			 7.3
-			],
-			[
-			 16,
-			 10
-			],
-			[
-			 17,
-			 18.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier souterrain - filet interieur - route principale en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sou",
-		 "minzoom": 10,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "PRINCIPALE_CONSTR_SOU"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 9,
-			 "#F3C66D"
-			],
-			[
-			 17,
-			 "#F2DDB3"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 4,
-			 0.5
-			],
-			[
-			 6,
-			 1.8
-			],
-			[
-			 9,
-			 2.7
-			],
-			[
-			 14,
-			 5.9
-			],
-			[
-			 15,
-			 9
-			],
-			[
-			 16,
-			 12.2
-			],
-			[
-			 17,
-			 22.5
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   2,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "Routier souterrain - filet interieur - autoroute",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sou",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "AUTOROU_PEAGE_SOU",
-		  "AUTOROU_LIBRE_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "rgba(255, 255, 255, 0.5)",
-		  "line-width": {
-		   "stops": [
-			[
-			 4,
-			 0.7
-			],
-			[
-			 6,
-			 2.5
-			],
-			[
-			 9,
-			 2.7
-			],
-			[
-			 14,
-			 5.8
-			],
-			[
-			 15,
-			 9
-			],
-			[
-			 16,
-			 12
-			],
-			[
-			 17,
-			 20.8
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier souterrain - axe central - autoroute",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sou",
-		 "minzoom": 13,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "AUTOROU_PEAGE_SOU",
-		  "AUTOROU_LIBRE_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#EDF1FF",
-		  "line-width": {
-		   "stops": [
-			[
-			 9,
-			 0.6
-			],
-			[
-			 14,
-			 0.7
-			],
-			[
-			 15,
-			 1
-			],
-			[
-			 16,
-			 1.2
-			],
-			[
-			 17,
-			 2.1
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier souterrain - filet interieur - autoroute en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sou",
-		 "minzoom": 10,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "AUTOROU_CONSTR_SOU"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 9,
-			 "#F2BA59"
-			],
-			[
-			 17,
-			 "#F2C261"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 4,
-			 0.7
-			],
-			[
-			 6,
-			 2.5
-			],
-			[
-			 9,
-			 3.5
-			],
-			[
-			 14,
-			 7.5
-			],
-			[
-			 15,
-			 11
-			],
-			[
-			 16,
-			 15
-			],
-			[
-			 17,
-			 26
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   2,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "Routier souterrain - axe central - autoroute en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sou",
-		 "minzoom": 13,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "AUTOROU_CONSTR_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#808080",
-		  "line-width": {
-		   "stops": [
-			[
-			 9,
-			 0.6
-			],
-			[
-			 14,
-			 0.7
-			],
-			[
-			 15,
-			 1
-			],
-			[
-			 16,
-			 1.2
-			],
-			[
-			 17,
-			 2.1
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "réseau hydro - cours d'eau temporaire",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "hydro_reseau",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "COURS_D_EAU_TEMP",
-		  "COURS_D_EAU_TEMP_MOY"
-		 ],
-		 "paint": {
-		  "line-color": "#AAD5E9",
-		  "line-width": {
-		   "stops": [
-			[
-			 12,
-			 1.5
-			],
-			[
-			 17,
-			 4
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   6,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "réseau hydro - cours d'eau",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "hydro_reseau",
-		 "minzoom": 3,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "COURS_D_EAU"
-		 ],
-		 "paint": {
-		  "line-color": "#AAD5E9",
-		  "line-width": {
-		   "stops": [
-			[
-			 4,
-			 0.3
-			],
-			[
-			 7,
-			 1.5
-			],
-			[
-			 12,
-			 1.5
-			],
-			[
-			 17,
-			 6.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "réseau hydro - canal",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "hydro_reseau",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "CANAL"
-		 ],
-		 "paint": {
-		  "line-color": "#AAD5E9",
-		  "line-width": {
-		   "stops": [
-			[
-			 12,
-			 1.4
-			],
-			[
-			 17,
-			 5.9
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "réseau hydro - filet interieur - aqueduc",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "hydro_reseau",
-		 "minzoom": 12,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "AQUEDUC_AU_SOL"
-		 ],
-		 "paint": {
-		  "line-color": "#AAD5E9",
-		  "line-width": {
-		   "stops": [
-			[
-			 12,
-			 1.4
-			],
-			[
-			 16,
-			 3.5
-			],
-			[
-			 17,
-			 5.9
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "réseau hydro - carre - aqueduc",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "hydro_reseau",
-		 "minzoom": 12,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "AQUEDUC_AU_SOL"
-		 ],
-		 "paint": {
-		  "line-color": "#AAD5E9",
-		  "line-width": {
-		   "stops": [
-			[
-			 12,
-			 3.5
-			],
-			[
-			 16,
-			 8.7
-			],
-			[
-			 17,
-			 14.7
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   1,
-		   5
-		  ]
-		 }
-		},
-		{
-		 "id": "réseau hydro - cours d'eau moyen ",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "hydro_reseau",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "COURS_D_EAU_MOY"
-		 ],
-		 "paint": {
-		  "line-color": "#AAD5E9",
-		  "line-width": {
-		   "stops": [
-			[
-			 7,
-			 2
-			],
-			[
-			 12,
-			 2.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "réseau hydro - cours d'eau large ",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "hydro_reseau",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "COURS_D_EAU_LAR"
-		 ],
-		 "paint": {
-		  "line-color": "#AAD5E9",
-		  "line-width": {
-		   "stops": [
-			[
-			 7,
-			 3
-			],
-			[
-			 11,
-			 5
-			]
-		   ]
-		  }
-		 }
-		},
-		
-		{
-		 "id": "bati surfacique mairie - Zoom 14",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "maxzoom": 14,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "MAIRIE",
-		  "MAIRIE_ANNEXE"
-		 ],
-		 "paint": {
-		  "fill-color": "#FFA6A6"
-		 }
-		},
-		{
-		 "id": "bati surfacique mairie - Zoom 15,16,17,18",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "minzoom": 14,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "MAIRIE",
-		  "MAIRIE_ANNEXE"
-		 ],
-		 "paint": {
-		  "fill-color": {
-		   "stops": [
-			[
-			 14,
-			 "#FFA6A6"
-			],
-			[
-			 15,
-			 "#FFAEAE"
-			]
-		   ]
-		  },
-		  "fill-outline-color": "#FF7C7C"
-		 }
-		},
-		{
-		 "id": "bati surfacique fonctionnel industriel ou commercial - Zoom 14,15",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BATI_COMMERCIAL",
-		  "BATI_INDUSTRIEL",
-		  "HANGAR",
-		  "HANGAR_COMMERCIAL",
-		  "HANGAR_INDUSTRIEL"
-		 ],
-		 "paint": {
-		  "fill-color": "#C8C8C8"
-		 }
-		},
-		{
-		 "id": "bati surfacique fonctionnel industriel ou commercial - Zoom 16,17,18",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "minzoom": 15,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BATI_COMMERCIAL",
-		  "BATI_INDUSTRIEL",
-		  "HANGAR",
-		  "HANGAR_COMMERCIAL",
-		  "HANGAR_INDUSTRIEL"
-		 ],
-		 "paint": {
-		  "fill-color": {
-		   "stops": [
-			[
-			 15,
-			 "#D1D1D1"
-			],
-			[
-			 16,
-			 "#E6E6E6"
-			]
-		   ]
-		  },
-		  "fill-outline-color": "#B8B8B8"
-		 }
-		},
-		{
-		 "id": "bati surfacique fonctionnel public - Zoom 14,15",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BATI_PUBLIC",
-		  "HANGAR_PUBLIC"
-		 ],
-		 "paint": {
-		  "fill-color": "#B9B6D6"
-		 }
-		},
-		{
-		 "id": "bati surfacique fonctionnel public - Zoom 16,17,18",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "minzoom": 21,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BATI_PUBLIC",
-		  "HANGAR_PUBLIC"
-		 ],
-		 "paint": {
-		  "fill-color": {
-		   "stops": [
-			[
-			 15,
-			 "#CFC5DE"
-			],
-			[
-			 16,
-			 "#E4DAF3"
-			]
-		   ]
-		  },
-		  "fill-outline-color": "#A6A1D6"
-		 }
-		},
-		{
-		 "id": "bati surfacique fonctionnel sportif - bordure",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "minzoom": 15,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "BATI_SPORTIF"
-		 ],
-		 "paint": {
-		  "line-color": "#BCD9AB",
-		  "line-width": 4
-		 }
-		},
-		{
-		 "id": "bati surfacique fonctionnel sportif",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "minzoom": 13,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "BATI_SPORTIF"
-		 ],
-		 "paint": {
-		  "fill-color": {
-		   "stops": [
-			[
-			 14,
-			 "#C9E1DD"
-			],
-			[
-			 15,
-			 "#DCE6E4"
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "bati surfacique fonctionnel gare - Zoom 14,15",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "BATI_GARE"
-		 ],
-		 "paint": {
-		  "fill-color": "#B3B5F5"
-		 }
-		},
-		{
-		 "id": "bati surfacique fonctionnel gare - Zoom 16,17,18",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "minzoom": 15,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "BATI_GARE"
-		 ],
-		 "paint": {
-		  "fill-color": {
-		   "stops": [
-			[
-			 15,
-			 "#BFC1F5"
-			],
-			[
-			 16,
-			 "#CBCDF5"
-			]
-		   ]
-		  },
-		  "fill-outline-color": "#9B9EF6"
-		 }
-		},
-		{
-		 "id": "bati surfacique quelconque - Zoom 15",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "minzoom": 14,
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "BATI_QQUE"
-		 ],
-		 "paint": {
-		  "fill-color": "#D6C6B8"
-		 }
-		},
-		{
-		 "id": "bati surfacique quelconque - Zoom 16,17,18",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "minzoom": 15,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "BATI_QQUE"
-		 ],
-		 "paint": {
-		  "fill-color": {
-		   "stops": [
-			[
-			 15,
-			 "#E6E0CF"
-			],
-			[
-			 16,
-			 "#F1EBD9"
-			]
-		   ]
-		  },
-		  "fill-outline-color": "#C3AA8E"
-		 }
-		},
-		{
-		 "id": "cimetiere surfacique 1",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "CIMETIERE_SURF",
-		  "CIMETIERE_MILI_SURF",
-		  "NECROPOLE_NATIONALE"
-		 ],
-		 "paint": {
-		  "fill-color": "#F0F0F0",
-		  "fill-opacity": 0.5,
-		  "fill-outline-color": "#818181"
-		 }
-		},
-		{
-		 "id": "cimetiere surfacique 2",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "CIMETIERE_SURF",
-		  "CIMETIERE_MILI_SURF",
-		  "NECROPOLE_NATIONALE"
-		 ],
-		 "paint": {
-		  "fill-pattern": "Cimetiere"
-		 }
-		},
-		{
-		 "id": "bati hydro surfacique - Autre",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "ECLUSE_SURF",
-		  "RESERVOIR_EAU_SURF"
-		 ],
-		 "paint": {
-		  "fill-color": "#ADCCD9",
-		  "fill-outline-color": "#336699"
-		 }
-		},
-		{
-		 "id": "bati hydro surfacique - Pecherie",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "PECHERIE_SURF"
-		 ],
-		 "paint": {
-		  "fill-color": "#BFE2F0",
-		  "fill-outline-color": "#509FEF"
-		 }
-		},
-		{
-		 "id": "bati hydro surfacique - Barrage",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "BARRAGE_SURF"
-		 ],
-		 "paint": {
-		  "fill-color": "#FFFFFF",
-		  "fill-outline-color": "#464646"
-		 }
-		},
-		{
-		 "id": "bati hydro surfacique - Chateau d'eau",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "CHATEAU_EAU_SURF"
-		 ],
-		 "paint": {
-		  "fill-color": "#1466B2"
-		 }
-		},
-		{
-		 "id": "bati infra surfacique - Silo",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "minzoom": 15,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "SILO_SURF"
-		 ],
-		 "paint": {
-		  "fill-color": "#C7A9AA",
-		  "fill-outline-color": "#696969"
-		 }
-		},
-		{
-		 "id": "bati infra surfacique - Reservoir indus",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "minzoom": 14,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "RESERVOIR_INDUS_SURF"
-		 ],
-		 "paint": {
-		  "fill-color": "#8D9DAA",
-		  "fill-outline-color": "#464646"
-		 }
-		},
-		{
-		 "id": "bati infra surfacique - Serre",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "minzoom": 13,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "SERRE_SURF"
-		 ],
-		 "paint": {
-		  "fill-color": "#CAD6D9",
-		  "fill-outline-color": "#8C8C8C"
-		 }
-		},
-		{
-		 "id": "bati infra surfacique - poste electrique",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "POSTE_ELEC_SURF"
-		 ],
-		 "paint": {
-		  "fill-color": "#7993B6",
-		  "fill-opacity": 0.3
-		 }
-		},
-		{
-		 "id": "bati infra surfacique - poste electrique bord",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "POSTE_ELEC_SURF"
-		 ],
-		 "paint": {
-		  "line-color": "#000000",
-		  "line-width": {
-		   "stops": [
-			[
-			 12,
-			 0.3
-			],
-			[
-			 17,
-			 1.2
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "bati religieux surfacique - Zoom 14",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "maxzoom": 14,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "CHAPELLE_SURF",
-		  "EGLISE_SURF",
-		  "CHRETIEN_SURF",
-		  "SYNAGOGUE_SURF",
-		  "MOSQUEE_SURF",
-		  "AUTRE_CULTE_SURF"
-		 ],
-		 "paint": {
-		  "fill-color": "#F7CBCB"
-		 }
-		},
-		{
-		 "id": "bati religieux surfacique - Zoom 15,16,17,18",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "minzoom": 14,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "CHAPELLE_SURF",
-		  "EGLISE_SURF",
-		  "CHRETIEN_SURF",
-		  "SYNAGOGUE_SURF",
-		  "MOSQUEE_SURF",
-		  "AUTRE_CULTE_SURF"
-		 ],
-		 "paint": {
-		  "fill-color": {
-		   "stops": [
-			[
-			 14,
-			 "#F7CBCB"
-			],
-			[
-			 15,
-			 "#F7E1E1"
-			]
-		   ]
-		  },
-		  "fill-outline-color": {
-		   "stops": [
-			[
-			 14,
-			 "#F7A8A8"
-			],
-			[
-			 15,
-			 "#F7B7B7"
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "bati remarquable surfacique",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "minzoom": 13,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "FORTIF_SURF",
-		  "CHATEAU_SURF",
-		  "TOUR_MOULIN_SURF",
-		  "ARENE_THEATRE",
-		  "ARC_TRIOMPHE_SURF",
-		  "MONUMENT_SURF"
-		 ],
-		 "paint": {
-		  "fill-color": "#9B9B9B",
-		  "fill-outline-color": "#6E6E6E"
-		 }
-		},
-		{
-		 "id": "bati sportif surfacique fond",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "TENNIS_SURF",
-		  "SPORT_INDIF_SURF",
-		  "FOOT_SURF",
-		  "MULTI_SPORT_SURF",
-		  "PISTE_SPORT_SURF",
-		  "NATATION_SURF"
-		 ],
-		 "paint": {
-		  "fill-color": "#FFFFFF",
-		  "fill-outline-color": "#FFFFFF"
-		 }
-		},
-		{
-		 "id": "bati sportif surfacique",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "TENNIS_SURF",
-		  "SPORT_INDIF_SURF",
-		  "FOOT_SURF",
-		  "MULTI_SPORT_SURF",
-		  "PISTE_SPORT_SURF",
-		  "NATATION_SURF"
-		 ],
-		 "paint": {
-		  "line-color": "#BCD9AB",
-		  "line-width": 2
-		 }
-		},
-		{
-		 "id": "bati transport surfacique - piste",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "PISTE_DUR",
-		  "PISTE_HERBE"
-		 ],
-		 "paint": {
-		  "fill-color": "#DBDBDB",
-		  "fill-outline-color": "#808080"
-		 }
-		},
-		{
-		 "id": "bati ZAI - Autres",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_zai",
-		 "minzoom": 15,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "in",
-		  "nature",
-		  "Lycée",
-		  "Université",
-		  "Capitainerie",
-		  "Gendarmerie",
-		  "Siège d'EPCI",
-		  "Musée",
-		  "Collège",
-		  "Maison de retraite",
-		  "Etablissement thermal",
-		  "Autre service déconcentré de l'Etat",
-		  "Etablissement pénitentiaire",
-		  "Divers public ou administratif",
-		  "Autre établissement d'enseignement",
-		  "Maison du parc",
-		  "Palais de justice",
-		  "Enseignement primaire",
-		  "Office de tourisme",
-		  "Hôpital",
-		  "Police",
-		  "Piscine",
-		  "Enseignement supérieur",
-		  "Poste",
-		  "Caserne",
-		  "Etablissement hospitalier",
-		  "Etablissement extraterritorial",
-		  "Science",
-		  "Structure d'accueil pour personnes handicapées",
-		  "Administration centrale de l'Etat",
-		  "Caserne de pompiers"
-		 ],
-		 "paint": {
-		  "fill-color": "#E3BFE2",
-		  "fill-opacity": 0.5,
-		  "fill-outline-color": "#E39FE1"
-		 }
-		},
-		{
-		 "id": "bati ZAI - Commandement",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_zai",
-		 "minzoom": 15,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "in",
-		  "nature",
-		  "Hôtel de département",
-		  "Hôtel de région",
-		  "Préfecture de région",
-		  "Préfecture",
-		  "Sous-préfecture"
-		 ],
-		 "paint": {
-		  "fill-color": "#FF0000",
-		  "fill-opacity": 0.3,
-		  "fill-outline-color": "#B40000"
-		 }
-		},
-		{
-		 "id": "construction linéaire - mur",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "bati_lin",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "MUR"
-		 ],
-		 "paint": {
-		  "line-color": "#8C8C8C",
-		  "line-width": 0.3
-		 }
-		},
-		{
-		 "id": "construction linéaire - autre",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "bati_lin",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "RUINE_LIN",
-		  "MUR_SOUTENEMENT",
-		  "FORTIF_LIN"
-		 ],
-		 "paint": {
-		  "line-color": "#646464",
-		  "line-width": 0.5
-		 }
-		},
-		{
-		 "id": "construction hydrographique linéaire - Barrage",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "bati_lin",
-		 "minzoom": 13,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "BARRAGE_LIN"
-		 ],
-		 "paint": {
-		  "line-color": "#646464",
-		  "line-width": {
-		   "stops": [
-			[
-			 13,
-			 1.5
-			],
-			[
-			 17,
-			 5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "construction hydrographique linéaire - Quai",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "bati_lin",
-		 "minzoom": 12,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "QUAI",
-		  "DIGUE"
-		 ],
-		 "paint": {
-		  "line-color": "#828282",
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 1
-			],
-			[
-			 17,
-			 2.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "construction hydrographique linéaire - Pecherie",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "bati_lin",
-		 "minzoom": 12,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "PECHERIE_LIN"
-		 ],
-		 "paint": {
-		  "line-color": "#0066CC",
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 1
-			],
-			[
-			 17,
-			 2.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Chemin a niveau - piste cyclable",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_chemin",
-		 "minzoom": 13,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "PISTE_CYCLABLE"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 17,
-			 "#9B5CCC"
-			],
-			[
-			 18,
-			 "#EDF1FF"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 1.1
-			],
-			[
-			 15,
-			 1.7
-			],
-			[
-			 16,
-			 2
-			],
-			[
-			 17,
-			 3.5
-			],
-			[
-			 18,
-			 6
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   6,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "Chemin a niveau - filet exterieur - escalier",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_chemin",
-		 "minzoom": 14,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "ESCALIER"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 17,
-			 "#8C7274"
-			],
-			[
-			 18,
-			 "#C8C8C8"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 1.75
-			],
-			[
-			 15,
-			 3
-			],
-			[
-			 16,
-			 4.2
-			],
-			[
-			 17,
-			 9.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Chemin a niveau - filet interieur - escalier",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_chemin",
-		 "minzoom": 14,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "ESCALIER"
-		 ],
-		 "paint": {
-		  "line-color": "#EDF1FF",
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 1
-			],
-			[
-			 15,
-			 1.9
-			],
-			[
-			 16,
-			 2.7
-			],
-			[
-			 17,
-			 5.8
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   1,
-		   0.2
-		  ]
-		 }
-		},
-		{
-		 "id": "Chemin a niveau - Rue pietonne",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_chemin",
-		 "minzoom": 14,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "RUE_PIETONNE"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 17,
-			 "#8C7274"
-			],
-			[
-			 18,
-			 "#F8E5D5"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 1
-			],
-			[
-			 15,
-			 1.2
-			],
-			[
-			 16,
-			 1.4
-			],
-			[
-			 17,
-			 2
-			],
-			[
-			 18,
-			 5
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   1,
-		   3
-		  ]
-		 }
-		},
-		{
-		 "id": "Chemin a niveau - sentier",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_chemin",
-		 "minzoom": 13,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "SENTIER"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 17,
-			 "#8C7274"
-			],
-			[
-			 18,
-			 "#EDF1FF"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 1
-			],
-			[
-			 15,
-			 1.2
-			],
-			[
-			 16,
-			 1.4
-			],
-			[
-			 17,
-			 2
-			],
-			[
-			 18,
-			 6
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   4,
-		   3
-		  ]
-		 }
-		},
-		{
-		 "id": "Chemin a niveau - chemin",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_chemin",
-		 "minzoom": 12,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "CHEMIN"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 17,
-			 "#8C7274"
-			],
-			[
-			 18,
-			 "#EDF1FF"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 1
-			],
-			[
-			 15,
-			 1.2
-			],
-			[
-			 16,
-			 1.4
-			],
-			[
-			 17,
-			 2
-			],
-			[
-			 18,
-			 7
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier a niveau - filet extérieur - route non revetu carrosable",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "NON_REVETUE_CARRO"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 12,
-			 "#646464"
-			],
-			[
-			 17,
-			 "#8C8C8C"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 3.2
-			],
-			[
-			 15,
-			 5.4
-			],
-			[
-			 16,
-			 7.7
-			],
-			[
-			 17,
-			 16.8
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   2,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "Routier a niveau - filet interieur - route non revetu carrosable",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "NON_REVETUE_CARRO"
-		 ],
-		 "paint": {
-		  "line-color": "#EDF1FF",
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 2.3
-			],
-			[
-			 15,
-			 4.1
-			],
-			[
-			 16,
-			 6.3
-			],
-			[
-			 17,
-			 13.5
-			],
-			[
-			 18,
-			 16.8
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier a niveau - filet extérieur - bretelle autoroute",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route",
-		 "minzoom": 12,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BRET_AUTO_PEAGE_3",
-		  "BRET_AUTO_PEAGE_2",
-		  "BRET_AUTO_PEAGE_1",
-		  "BRET_AUTO_LIBRE_3",
-		  "BRET_AUTO_LIBRE_2",
-		  "BRET_AUTO_LIBRE_1"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 9,
-			 "#DE460E"
-			],
-			[
-			 17,
-			 "#F18800"
-			],
-			[
-			 18,
-			 "#EDF1FF"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 12,
-			 2.5
-			],
-			[
-			 14,
-			 3.7
-			],
-			[
-			 15,
-			 6.8
-			],
-			[
-			 16,
-			 8.4
-			],
-			[
-			 17,
-			 14
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier a niveau - filet extérieur - route non classee restreint",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "NON_CLASSEE_RESTREINT"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 17,
-			 "#969696"
-			],
-			[
-			 18,
-			 "#EDF1FF"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 3.2
-			],
-			[
-			 15,
-			 5.4
-			],
-			[
-			 16,
-			 7.7
-			],
-			[
-			 17,
-			 16.8
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier a niveau - filet extérieur - route non classee",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "NON_CLASSEE_4",
-		  "NON_CLASSEE"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 17,
-			 "#969696"
-			],
-			[
-			 18,
-			 "#EDF1FF"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 3.2
-			],
-			[
-			 15,
-			 5.4
-			],
-			[
-			 16,
-			 7.7
-			],
-			[
-			 17,
-			 16.8
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier a niveau - filet extérieur - route locale",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route",
-		 "minzoom": 7,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BRET_LOCALE",
-		  "LOCALE_4",
-		  "LOCALE_3",
-		  "LOCALE_2",
-		  "LOCALE_1"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 12,
-			 "#8C8C8C"
-			],
-			[
-			 13,
-			 "#B4B4B4"
-			],
-			[
-			 17,
-			 "#B4B4B4"
-			],
-			[
-			 18,
-			 "#EDF1FF"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 9,
-			 2
-			],
-			[
-			 14,
-			 3.5
-			],
-			[
-			 15,
-			 6
-			],
-			[
-			 16,
-			 8.4
-			],
-			[
-			 17,
-			 18.3
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier a niveau - filet extérieur - route locale en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route",
-		 "minzoom": 11,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "LOCALE_CONSTR"
-		 ],
-		 "paint": {
-		  "line-color": "#C8C8C8",
-		  "line-width": {
-		   "stops": [
-			[
-			 9,
-			 2
-			],
-			[
-			 14,
-			 3.5
-			],
-			[
-			 15,
-			 6
-			],
-			[
-			 16,
-			 8.4
-			],
-			[
-			 17,
-			 18.3
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier a niveau - filet extérieur - route regionale",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route",
-		 "minzoom": 8,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BRET_REGIONALE",
-		  "REGIONALE_4",
-		  "REGIONALE_3",
-		  "REGIONALE_2",
-		  "REGIONALE_1"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 9,
-			 "#828282"
-			],
-			[
-			 10,
-			 "#B4B4B4"
-			],
-			[
-			 17,
-			 "#B4B4B4"
-			],
-			[
-			 18,
-			 "#EDF1FF"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 6,
-			 1.5
-			],
-			[
-			 9,
-			 2.3
-			],
-			[
-			 14,
-			 5
-			],
-			[
-			 15,
-			 8.1
-			],
-			[
-			 16,
-			 11.2
-			],
-			[
-			 17,
-			 22
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier a niveau - filet extérieur - route regionale en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route",
-		 "minzoom": 10,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "REGIONALE_CONSTR"
-		 ],
-		 "paint": {
-		  "line-color": "#C8C8C8",
-		  "line-width": {
-		   "stops": [
-			[
-			 6,
-			 1.5
-			],
-			[
-			 9,
-			 2.3
-			],
-			[
-			 14,
-			 5
-			],
-			[
-			 15,
-			 8.1
-			],
-			[
-			 16,
-			 11.2
-			],
-			[
-			 17,
-			 22
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier a niveau - filet extérieur - route principale",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route",
-		 "minzoom": 8,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BRET_PRINCIPALE",
-		  "PRINCIPALE_4",
-		  "PRINCIPALE_3",
-		  "PRINCIPALE_2",
-		  "PRINCIPALE_1"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 17,
-			 "#E2A52A"
-			],
-			[
-			 18,
-			 "#EDF1FF"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 6,
-			 1.8
-			],
-			[
-			 9,
-			 2.7
-			],
-			[
-			 14,
-			 5.9
-			],
-			[
-			 15,
-			 9
-			],
-			[
-			 16,
-			 12.2
-			],
-			[
-			 17,
-			 22.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier a niveau - filet extérieur - route principale en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route",
-		 "minzoom": 10,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "PRINCIPALE_CONSTR"
-		 ],
-		 "paint": {
-		  "line-color": "#C8C8C8",
-		  "line-width": {
-		   "stops": [
-			[
-			 6,
-			 1.8
-			],
-			[
-			 9,
-			 2.7
-			],
-			[
-			 14,
-			 5.9
-			],
-			[
-			 15,
-			 9
-			],
-			[
-			 16,
-			 12.2
-			],
-			[
-			 17,
-			 22.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier a niveau - filet extérieur - autoroute",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route",
-		 "minzoom": 8,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "AUTOROU_PEAGE",
-		  "AUTOROU_LIBRE"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 9,
-			 "#DE460E"
-			],
-			[
-			 17,
-			 "#F18800"
-			],
-			[
-			 18,
-			 "#EDF1FF"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 6,
-			 2.5
-			],
-			[
-			 9,
-			 3.5
-			],
-			[
-			 14,
-			 7.5
-			],
-			[
-			 15,
-			 11
-			],
-			[
-			 16,
-			 15
-			],
-			[
-			 17,
-			 26
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier a niveau - filet extérieur - autoroute en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route",
-		 "minzoom": 8,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "AUTOROU_CONSTR"
-		 ],
-		 "paint": {
-		  "line-color": "#C8C8C8",
-		  "line-width": {
-		   "stops": [
-			[
-			 6,
-			 2.5
-			],
-			[
-			 9,
-			 3.5
-			],
-			[
-			 14,
-			 7.5
-			],
-			[
-			 15,
-			 11
-			],
-			[
-			 16,
-			 15
-			],
-			[
-			 17,
-			 26
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier a niveau - filet interieur - bretelle autoroute",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route",
-		 "minzoom": 12,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BRET_AUTO_PEAGE_3",
-		  "BRET_AUTO_PEAGE_2",
-		  "BRET_AUTO_PEAGE_1",
-		  "BRET_AUTO_LIBRE_3",
-		  "BRET_AUTO_LIBRE_2",
-		  "BRET_AUTO_LIBRE_1"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 9,
-			 "#F18800"
-			],
-			[
-			 17,
-			 "#F2B230"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 12,
-			 1.5
-			],
-			[
-			 14,
-			 2.6
-			],
-			[
-			 15,
-			 5.2
-			],
-			[
-			 16,
-			 6.7
-			],
-			[
-			 17,
-			 10.8
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier a niveau - filet interieur - route non classee restreint",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "NON_CLASSEE_RESTREINT"
-		 ],
-		 "paint": {
-		  "line-color": "#EDF1FF",
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 2.3
-			],
-			[
-			 15,
-			 4.1
-			],
-			[
-			 16,
-			 6.3
-			],
-			[
-			 17,
-			 13.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier a niveau - filet interieur - route non classee",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "NON_CLASSEE_4",
-		  "NON_CLASSEE"
-		 ],
-		 "paint": {
-		  "line-color": "#EDF1FF",
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 2.3
-			],
-			[
-			 15,
-			 4.1
-			],
-			[
-			 16,
-			 6.3
-			],
-			[
-			 17,
-			 13.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier a niveau - filet interieur - route locale",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BRET_LOCALE",
-		  "LOCALE_4",
-		  "LOCALE_3",
-		  "LOCALE_2",
-		  "LOCALE_1"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 6,
-			 "#F2B361"
-			],
-			[
-			 7,
-			 "#EDF1FF"
-			],
-			[
-			 12,
-			 "#EDF1FF"
-			],
-			[
-			 13,
-			 "#FCF4A8"
-			],
-			[
-			 17,
-			 "#FCF7C1"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 9,
-			 1.3
-			],
-			[
-			 14,
-			 2.3
-			],
-			[
-			 15,
-			 4.1
-			],
-			[
-			 16,
-			 6.1
-			],
-			[
-			 17,
-			 13.1
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier a niveau - filet interieur - route locale en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route",
-		 "minzoom": 11,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "LOCALE_CONSTR"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 12,
-			 "#EDF1FF"
-			],
-			[
-			 13,
-			 "#FCF4A8"
-			],
-			[
-			 17,
-			 "#FCF7C1"
-			],
-			[
-			 18,
-			 "#EDEDED"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 9,
-			 2
-			],
-			[
-			 14,
-			 3.5
-			],
-			[
-			 15,
-			 6
-			],
-			[
-			 16,
-			 8.4
-			],
-			[
-			 17,
-			 18.3
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   2,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "Routier a niveau - filet interieur - route regionale",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BRET_REGIONALE",
-		  "REGIONALE_4",
-		  "REGIONALE_3",
-		  "REGIONALE_2",
-		  "REGIONALE_1"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 6,
-			 "#F2A949"
-			],
-			[
-			 7,
-			 "#EDF1FF"
-			],
-			[
-			 9,
-			 "#EDF1FF"
-			],
-			[
-			 10,
-			 "#FDF28B"
-			],
-			[
-			 17,
-			 "#FCF6BD"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 4,
-			 1.1
-			],
-			[
-			 6,
-			 1.4
-			],
-			[
-			 9,
-			 1.5
-			],
-			[
-			 14,
-			 3.2
-			],
-			[
-			 15,
-			 5.8
-			],
-			[
-			 16,
-			 8.3
-			],
-			[
-			 17,
-			 16.2
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier a niveau - filet interieur - route regionale en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route",
-		 "minzoom": 10,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "REGIONALE_CONSTR"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 9,
-			 "#EDF1FF"
-			],
-			[
-			 10,
-			 "#FDF28B"
-			],
-			[
-			 17,
-			 "#FCF6BD"
-			],
-			[
-			 18,
-			 "#EDEDED"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 4,
-			 0.4
-			],
-			[
-			 6,
-			 1.5
-			],
-			[
-			 9,
-			 2.3
-			],
-			[
-			 14,
-			 5
-			],
-			[
-			 15,
-			 8.1
-			],
-			[
-			 16,
-			 11.2
-			],
-			[
-			 17,
-			 22
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   2,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "Routier a niveau - filet interieur - route principale",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BRET_PRINCIPALE",
-		  "PRINCIPALE_4",
-		  "PRINCIPALE_3",
-		  "PRINCIPALE_2",
-		  "PRINCIPALE_1"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 6,
-			 "#F29924"
-			],
-			[
-			 7,
-			 "#F3C66D"
-			],
-			[
-			 9,
-			 "#F3C66D"
-			],
-			[
-			 17,
-			 "#F2DDB3"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 4,
-			 0.6
-			],
-			[
-			 6,
-			 1.8
-			],
-			[
-			 9,
-			 2.1
-			],
-			[
-			 14,
-			 4.4
-			],
-			[
-			 15,
-			 7.3
-			],
-			[
-			 16,
-			 10
-			],
-			[
-			 17,
-			 18.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier a niveau - filet interieur - route principale en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route",
-		 "minzoom": 10,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "PRINCIPALE_CONSTR"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 9,
-			 "#F3C66D"
-			],
-			[
-			 17,
-			 "#F2DDB3"
-			],
-			[
-			 18,
-			 "#EDEDED"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 4,
-			 0.5
-			],
-			[
-			 6,
-			 1.8
-			],
-			[
-			 9,
-			 2.7
-			],
-			[
-			 14,
-			 5.9
-			],
-			[
-			 15,
-			 9
-			],
-			[
-			 16,
-			 12.2
-			],
-			[
-			 17,
-			 22.5
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   2,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "Routier a niveau - filet interieur - autoroute",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "AUTOROU_PEAGE",
-		  "AUTOROU_LIBRE"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 9,
-			 "#F18800"
-			],
-			[
-			 17,
-			 "#F2B230"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 4,
-			 0.7
-			],
-			[
-			 6,
-			 2.5
-			],
-			[
-			 9,
-			 2.7
-			],
-			[
-			 14,
-			 5.8
-			],
-			[
-			 15,
-			 9
-			],
-			[
-			 16,
-			 12
-			],
-			[
-			 17,
-			 20.8
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier a niveau - axe central - autoroute",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route",
-		 "minzoom": 13,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "AUTOROU_PEAGE",
-		  "AUTOROU_LIBRE"
-		 ],
-		 "paint": {
-		  "line-color": "#EDF1FF",
-		  "line-width": {
-		   "stops": [
-			[
-			 9,
-			 0.6
-			],
-			[
-			 14,
-			 0.7
-			],
-			[
-			 15,
-			 1
-			],
-			[
-			 16,
-			 1.2
-			],
-			[
-			 17,
-			 2.1
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier a niveau - filet interieur - autoroute en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route",
-		 "minzoom": 8,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "AUTOROU_CONSTR"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 9,
-			 "#F18800"
-			],
-			[
-			 17,
-			 "#F2B230"
-			],
-			[
-			 18,
-			 "#EDEDED"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 4,
-			 0.7
-			],
-			[
-			 6,
-			 2.5
-			],
-			[
-			 9,
-			 3.5
-			],
-			[
-			 14,
-			 7.5
-			],
-			[
-			 15,
-			 11
-			],
-			[
-			 16,
-			 15
-			],
-			[
-			 17,
-			 26
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   2,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "Routier a niveau - axe centrale - autoroute en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route",
-		 "minzoom": 13,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "AUTOROU_CONSTR"
-		 ],
-		 "paint": {
-		  "line-color": "#808080",
-		  "line-width": {
-		   "stops": [
-			[
-			 9,
-			 0.6
-			],
-			[
-			 14,
-			 0.7
-			],
-			[
-			 15,
-			 1
-			],
-			[
-			 16,
-			 1.2
-			],
-			[
-			 17,
-			 2.1
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Ferre a niveau - voie normale",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "ferre",
-		 "minzoom": 10,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "VF_1",
-		  "VF_2",
-		  "VF_3",
-		  "VF_4",
-		  "VF_ELEC_1",
-		  "VF_ELEC_2",
-		  "VF_ELEC_3",
-		  "VF_ELEC_4"
-		 ],
-		 "paint": {
-		  "line-color": "#787878",
-		  "line-width": {
-		   "stops": [
-			[
-			 10,
-			 0.8
-			],
-			[
-			 17,
-			 2.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Ferre a niveau - voie normale trait perpendic",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "ferre",
-		 "minzoom": 10,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "VF_1",
-		  "VF_2",
-		  "VF_3",
-		  "VF_4",
-		  "VF_ELEC_1",
-		  "VF_ELEC_2",
-		  "VF_ELEC_3",
-		  "VF_ELEC_4"
-		 ],
-		 "paint": {
-		  "line-color": "#787878",
-		  "line-width": {
-		   "stops": [
-			[
-			 10,
-			 3.5
-			],
-			[
-			 17,
-			 14.7
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   0.1,
-		   10
-		  ]
-		 }
-		},
-		{
-		 "id": "Ferre a niveau - voie etroite",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "ferre",
-		 "minzoom": 10,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "VF_ETROITE_1",
-		  "VF_ETROITE_2",
-		  "VF_ETROITE"
-		 ],
-		 "paint": {
-		  "line-color": "#787878",
-		  "line-width": {
-		   "stops": [
-			[
-			 10,
-			 0.3
-			],
-			[
-			 17,
-			 1.8
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Ferre a niveau - voie etroite trait perpendic",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "ferre",
-		 "minzoom": 10,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "VF_ETROITE_1",
-		  "VF_ETROITE_2",
-		  "VF_ETROITE"
-		 ],
-		 "paint": {
-		  "line-color": "#787878",
-		  "line-width": {
-		   "stops": [
-			[
-			 10,
-			 3.5
-			],
-			[
-			 17,
-			 14.7
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   0.1,
-		   10
-		  ]
-		 }
-		},
-		{
-		 "id": "Ferre a niveau - voie service",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "ferre",
-		 "minzoom": 14,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "VF_SERVICE",
-		  "VF_NON_EXPLOITEE"
-		 ],
-		 "paint": {
-		  "line-color": "#787878",
-		  "line-width": {
-		   "stops": [
-			[
-			 10,
-			 0.3
-			],
-			[
-			 17,
-			 1.8
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   5,
-		   2,
-		   1,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "Ferre a niveau - voie en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "ferre",
-		 "minzoom": 10,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "VF_EN_CONSTR"
-		 ],
-		 "paint": {
-		  "line-color": "#787878",
-		  "line-width": {
-		   "stops": [
-			[
-			 10,
-			 0.3
-			],
-			[
-			 17,
-			 1.8
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   2,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "Ferre a niveau - voie en construction trait perpendic",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "ferre",
-		 "minzoom": 10,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "VF_EN_CONSTR"
-		 ],
-		 "paint": {
-		  "line-color": "#787878",
-		  "line-width": {
-		   "stops": [
-			[
-			 10,
-			 3.5
-			],
-			[
-			 17,
-			 14.7
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   0.1,
-		   10
-		  ]
-		 }
-		},
-		{
-		 "id": "Ferre a niveau - funic/urbain",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "ferre",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "FUNI_CREMAILLERE",
-		  "TRANSPORT_URBAIN"
-		 ],
-		 "paint": {
-		  "line-color": "#787878",
-		  "line-width": {
-		   "stops": [
-			[
-			 10,
-			 0.3
-			],
-			[
-			 17,
-			 1.8
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Ferre a niveau - 2 trait perpendic - funic/urbain",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "ferre",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "FUNI_CREMAILLERE",
-		  "TRANSPORT_URBAIN"
-		 ],
-		 "paint": {
-		  "line-color": "#787878",
-		  "line-width": {
-		   "stops": [
-			[
-			 10,
-			 3.5
-			],
-			[
-			 17,
-			 17
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   0.1,
-		   0.2,
-		   0.1,
-		   10
-		  ]
-		 }
-		},
-		{
-		 "id": "liaison routiere - Bac Liaison Maritime",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_liaison",
-		 "minzoom": 8,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BAC_AUTO",
-		  "LIAISON_MARITIME",
-		  "BAC_LIAISON_MARITIME"
-		 ],
-		 "paint": {
-		  "line-color": "#5792C2",
-		  "line-width": {
-		   "stops": [
-			[
-			 8,
-			 1
-			],
-			[
-			 13,
-			 2.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "liaison routiere - Gue route",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_liaison",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "GUE_ROUTE"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 13,
-			 "#BEBEBE"
-			],
-			[
-			 17,
-			 "#646464"
-			],
-			[
-			 18,
-			 "#EDF1FF"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 2.3
-			],
-			[
-			 15,
-			 4.1
-			],
-			[
-			 16,
-			 6.3
-			],
-			[
-			 17,
-			 13.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "liaison routiere - Gue chemin",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_liaison",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "GUE_CHEMIN"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 13,
-			 "#BEBEBE"
-			],
-			[
-			 17,
-			 "#646464"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 1.6
-			],
-			[
-			 15,
-			 2.9
-			],
-			[
-			 16,
-			 4.4
-			],
-			[
-			 17,
-			 6.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "liaison routiere - filet extérieur - Pont passerelle",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_liaison",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "PONT_PASSERELLE",
-		  "PONT_LIN",
-		  "PONT_MOBILE_LIN"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 17,
-			 "#C8C8C8"
-			],
-			[
-			 18,
-			 "#EDF1FF"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 2.2
-			],
-			[
-			 15,
-			 3.8
-			],
-			[
-			 16,
-			 5.4
-			],
-			[
-			 17,
-			 11.8
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "liaison routiere - filet intérieur - Pont passerelle",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_liaison",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "PONT_PASSERELLE",
-		  "PONT_LIN",
-		  "PONT_MOBILE_LIN"
-		 ],
-		 "paint": {
-		  "line-color": "#EDF1FF",
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 0.7
-			],
-			[
-			 15,
-			 1.1
-			],
-			[
-			 16,
-			 1.7
-			],
-			[
-			 17,
-			 3.8
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier surfacique",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "routier_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "SURF_ROUT_PRINC",
-		  "SURF_ROUT_REG",
-		  "SURF_ROUT_LOC",
-		  "SURF_ROUT_NON_CLA"
-		 ],
-		 "paint": {
-		  "fill-color": "#EDF1FF",
-		  "fill-outline-color": "#000000"
-		 }
-		},
-		{
-		 "id": "Routier surfacique - Dalle de protection",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "routier_surf",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "DALLE_DE_PROTECTION"
-		 ],
-		 "paint": {
-		  "fill-opacity": 0.5,
-		  "fill-color": "#FFFFFF",
-		  "fill-outline-color": "#000000"
-		 }
-		},
-		{
-		 "id": "Routier surfacique - Escalier surfacique",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "routier_surf",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "ESCALIER_SURF"
-		 ],
-		 "paint": {
-		  "fill-opacity": 0.8,
-		  "fill-color": "#FFFFFF",
-		  "fill-outline-color": "#918091"
-		 }
-		},
-		{
-		 "id": "Routier surfacique - Péage surfacique",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "routier_surf",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "SURF_PEAGE"
-		 ],
-		 "paint": {
-		  "fill-color": "#F2DAAA",
-		  "fill-outline-color": "#E2A52A"
-		 }
-		},
-		{
-		 "id": "bati transport surfacique - bati peage",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "minzoom": 13,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "BATI_PEAGE"
-		 ],
-		 "paint": {
-		  "fill-color": "#DCDCDC",
-		  "fill-outline-color": "#808080"
-		 }
-		},
-		{
-		 "id": "réseau hydro  - cours d'eau superieur",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "hydro_reseau_sup",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "COURS_D_EAU_SUP",
-		  "COURS_D_EAU_MOY_SUP"
-		 ],
-		 "paint": {
-		  "line-color": "#AAD5E9",
-		  "line-width": {
-		   "stops": [
-			[
-			 12,
-			 1.5
-			],
-			[
-			 17,
-			 6.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "réseau hydro - canal superieur",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "hydro_reseau_sup",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "CANAL_SUP"
-		 ],
-		 "paint": {
-		  "line-color": "#AAD5E9",
-		  "line-width": {
-		   "stops": [
-			[
-			 12,
-			 1.4
-			],
-			[
-			 17,
-			 5.9
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "réseau hydro - filet interieur - aqueduc superieur",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "hydro_reseau_sup",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "AQUEDUC_SUP"
-		 ],
-		 "paint": {
-		  "line-color": "#AAD5E9",
-		  "line-width": {
-		   "stops": [
-			[
-			 12,
-			 1.4
-			],
-			[
-			 16,
-			 3.5
-			],
-			[
-			 17,
-			 5.9
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "réseau hydro - carre - aqueduc superieur",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "hydro_reseau_sup",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "AQUEDUC_SUP"
-		 ],
-		 "paint": {
-		  "line-color": "#AAD5E9",
-		  "line-width": {
-		   "stops": [
-			[
-			 12,
-			 3.5
-			],
-			[
-			 16,
-			 8.7
-			],
-			[
-			 17,
-			 14.7
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   1,
-		   5
-		  ]
-		 }
-		},
-		{
-		 "id": "Chemin superieur - piste cyclable",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_chemin_sup",
-		 "minzoom": 13,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "PISTE_CYCLABLE_SUP"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 17,
-			 "#9B5CCC"
-			],
-			[
-			 18,
-			 "#EDF1FF"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 1.1
-			],
-			[
-			 15,
-			 1.7
-			],
-			[
-			 16,
-			 2
-			],
-			[
-			 17,
-			 3.5
-			],
-			[
-			 18,
-			 6
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   6,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "Chemin superieur - filet exterieur - escalier",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_chemin_sup",
-		 "minzoom": 14,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "ESCALIER_SUP"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 17,
-			 "#8C7274"
-			],
-			[
-			 18,
-			 "#C8C8C8"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 1.75
-			],
-			[
-			 15,
-			 3
-			],
-			[
-			 16,
-			 4.2
-			],
-			[
-			 17,
-			 9.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Chemin superieur - filet interieur - escalier",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_chemin_sup",
-		 "minzoom": 14,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "ESCALIER_SUP"
-		 ],
-		 "paint": {
-		  "line-color": "#FFFFFF",
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 1
-			],
-			[
-			 15,
-			 1.9
-			],
-			[
-			 16,
-			 2.7
-			],
-			[
-			 17,
-			 5.8
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   1,
-		   0.2
-		  ]
-		 }
-		},
-		{
-		 "id": "Chemin superieur - Rue pietonne",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_chemin_sup",
-		 "minzoom": 14,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "RUE_PIETONNE_SUP"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 17,
-			 "#8C7274"
-			],
-			[
-			 18,
-			 "#EBEBEB"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 1
-			],
-			[
-			 15,
-			 1.2
-			],
-			[
-			 16,
-			 1.4
-			],
-			[
-			 17,
-			 2
-			],
-			[
-			 18,
-			 5
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   1,
-		   3
-		  ]
-		 }
-		},
-		{
-		 "id": "Chemin superieur - sentier",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_chemin_sup",
-		 "minzoom": 13,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "SENTIER_SUP"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 17,
-			 "#8C7274"
-			],
-			[
-			 18,
-			 "#FFFFFF"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 1
-			],
-			[
-			 15,
-			 1.2
-			],
-			[
-			 16,
-			 1.4
-			],
-			[
-			 17,
-			 2
-			],
-			[
-			 18,
-			 6
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   4,
-		   3
-		  ]
-		 }
-		},
-		{
-		 "id": "Chemin superieur - chemin",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_chemin_sup",
-		 "minzoom": 12,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "CHEMIN_SUP"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 17,
-			 "#8C7274"
-			],
-			[
-			 18,
-			 "#EDF1FF"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 1
-			],
-			[
-			 15,
-			 1.2
-			],
-			[
-			 16,
-			 1.4
-			],
-			[
-			 17,
-			 2
-			],
-			[
-			 18,
-			 7
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier superieur - filet extérieur - route non revetu carrosable",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sup",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "NON_REVETUE_CARRO_SUP"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 12,
-			 "#646464"
-			],
-			[
-			 17,
-			 "#8C8C8C"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 3.2
-			],
-			[
-			 15,
-			 5.4
-			],
-			[
-			 16,
-			 7.7
-			],
-			[
-			 17,
-			 16.8
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   2,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "Routier superieur - filet extérieur - bretelle autoroute",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sup",
-		 "minzoom": 12,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BRET_AUTO_PEAGE_3_SUP",
-		  "BRET_AUTO_PEAGE_2_SUP",
-		  "BRET_AUTO_PEAGE_1_SUP",
-		  "BRET_AUTO_LIBRE_3_SUP",
-		  "BRET_AUTO_LIBRE_2_SUP",
-		  "BRET_AUTO_LIBRE_1_SUP"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 9,
-			 "#DE460E"
-			],
-			[
-			 17,
-			 "#F18800"
-			],
-			[
-			 18,
-			 "#EDF1FF"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 12,
-			 2.5
-			],
-			[
-			 14,
-			 3.7
-			],
-			[
-			 15,
-			 6.8
-			],
-			[
-			 16,
-			 8.4
-			],
-			[
-			 17,
-			 14
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier superieur - filet extérieur - route non classee restreint",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sup",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "NON_CLASSEE_RESTREINT_SUP"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 17,
-			 "#969696"
-			],
-			[
-			 18,
-			 "#EDF1FF"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 3.2
-			],
-			[
-			 15,
-			 5.4
-			],
-			[
-			 16,
-			 7.7
-			],
-			[
-			 17,
-			 16.8
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier superieur - filet extérieur - route non classee",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sup",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "NON_CLASSEE_4_SUP",
-		  "NON_CLASSEE_SUP"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 17,
-			 "#969696"
-			],
-			[
-			 18,
-			 "#EDF1FF"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 3.2
-			],
-			[
-			 15,
-			 5.4
-			],
-			[
-			 16,
-			 7.7
-			],
-			[
-			 17,
-			 16.8
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier superieur - filet extérieur - route locale",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sup",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BRET_LOCALE_SUP",
-		  "LOCALE_4_SUP",
-		  "LOCALE_3_SUP",
-		  "LOCALE_2_SUP",
-		  "LOCALE_1_SUP"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 12,
-			 "#8C8C8C"
-			],
-			[
-			 13,
-			 "#B4B4B4"
-			],
-			[
-			 17,
-			 "#B4B4B4"
-			],
-			[
-			 18,
-			 "#EDF1FF"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 9,
-			 2
-			],
-			[
-			 14,
-			 3.5
-			],
-			[
-			 15,
-			 6
-			],
-			[
-			 16,
-			 8.4
-			],
-			[
-			 17,
-			 18.3
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier superieur - filet extérieur - route locale en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sup",
-		 "minzoom": 11,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "LOCALE_CONSTR_SUP"
-		 ],
-		 "paint": {
-		  "line-color": "#C8C8C8",
-		  "line-width": {
-		   "stops": [
-			[
-			 9,
-			 2
-			],
-			[
-			 14,
-			 3.5
-			],
-			[
-			 15,
-			 6
-			],
-			[
-			 16,
-			 8.4
-			],
-			[
-			 17,
-			 18.3
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier superieur - filet extérieur - route regionale",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sup",
-		 "minzoom": 8,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BRET_REGIONALE_SUP",
-		  "REGIONALE_4_SUP",
-		  "REGIONALE_3_SUP",
-		  "REGIONALE_2_SUP",
-		  "REGIONALE_1_SUP"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 9,
-			 "#828282"
-			],
-			[
-			 10,
-			 "#B4B4B4"
-			],
-			[
-			 17,
-			 "#B4B4B4"
-			],
-			[
-			 18,
-			 "#EDF1FF"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 6,
-			 1.5
-			],
-			[
-			 9,
-			 2.3
-			],
-			[
-			 14,
-			 5
-			],
-			[
-			 15,
-			 8.1
-			],
-			[
-			 16,
-			 11.2
-			],
-			[
-			 17,
-			 22
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier superieur - filet extérieur - route regionale en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sup",
-		 "minzoom": 10,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "REGIONALE_CONSTR_SUP"
-		 ],
-		 "paint": {
-		  "line-color": "#C8C8C8",
-		  "line-width": {
-		   "stops": [
-			[
-			 6,
-			 1.5
-			],
-			[
-			 9,
-			 2.3
-			],
-			[
-			 14,
-			 5
-			],
-			[
-			 15,
-			 8.1
-			],
-			[
-			 16,
-			 11.2
-			],
-			[
-			 17,
-			 22
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier superieur - filet extérieur - route principale",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sup",
-		 "minzoom": 8,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BRET_PRINCIPALE_SUP",
-		  "PRINCIPALE_4_SUP",
-		  "PRINCIPALE_3_SUP",
-		  "PRINCIPALE_2_SUP",
-		  "PRINCIPALE_1_SUP"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 17,
-			 "#E2A52A"
-			],
-			[
-			 18,
-			 "#EDF1FF"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 6,
-			 1.8
-			],
-			[
-			 9,
-			 2.7
-			],
-			[
-			 14,
-			 5.9
-			],
-			[
-			 15,
-			 9
-			],
-			[
-			 16,
-			 12.2
-			],
-			[
-			 17,
-			 22.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier superieur - filet extérieur - route principale en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sup",
-		 "minzoom": 10,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "PRINCIPALE_CONSTR_SUP"
-		 ],
-		 "paint": {
-		  "line-color": "#C8C8C8",
-		  "line-width": {
-		   "stops": [
-			[
-			 6,
-			 1.8
-			],
-			[
-			 9,
-			 2.7
-			],
-			[
-			 14,
-			 5.9
-			],
-			[
-			 15,
-			 9
-			],
-			[
-			 16,
-			 12.2
-			],
-			[
-			 17,
-			 22.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier superieur - filet extérieur - autoroute",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sup",
-		 "minzoom": 8,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "AUTOROU_PEAGE_SUP",
-		  "AUTOROU_LIBRE_SUP"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 9,
-			 "#DE460E"
-			],
-			[
-			 17,
-			 "#F18800"
-			],
-			[
-			 18,
-			 "#EDF1FF"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 6,
-			 2.5
-			],
-			[
-			 9,
-			 3.5
-			],
-			[
-			 14,
-			 7.5
-			],
-			[
-			 15,
-			 11
-			],
-			[
-			 16,
-			 15
-			],
-			[
-			 17,
-			 26
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier superieur - filet extérieur - autoroute en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sup",
-		 "minzoom": 10,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "AUTOROU_CONSTR_SUP"
-		 ],
-		 "paint": {
-		  "line-color": "#C8C8C8",
-		  "line-width": {
-		   "stops": [
-			[
-			 6,
-			 2.5
-			],
-			[
-			 9,
-			 3.5
-			],
-			[
-			 14,
-			 7.5
-			],
-			[
-			 15,
-			 11
-			],
-			[
-			 16,
-			 15
-			],
-			[
-			 17,
-			 26
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier superieur - filet interieur - route non revetu carrosable",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sup",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "NON_REVETUE_CARRO_SUP"
-		 ],
-		 "paint": {
-		  "line-color": "#EDF1FF",
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 2.3
-			],
-			[
-			 15,
-			 4.1
-			],
-			[
-			 16,
-			 6.3
-			],
-			[
-			 17,
-			 13.5
-			],
-			[
-			 18,
-			 16.8
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier superieur - filet interieur - bretelle autoroute",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sup",
-		 "minzoom": 12,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BRET_AUTO_PEAGE_3_SUP",
-		  "BRET_AUTO_PEAGE_2_SUP",
-		  "BRET_AUTO_PEAGE_1_SUP",
-		  "BRET_AUTO_LIBRE_3_SUP",
-		  "BRET_AUTO_LIBRE_2_SUP",
-		  "BRET_AUTO_LIBRE_1_SUP"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 9,
-			 "#F18800"
-			],
-			[
-			 17,
-			 "#F2B230"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 12,
-			 1.5
-			],
-			[
-			 14,
-			 2.6
-			],
-			[
-			 15,
-			 5.2
-			],
-			[
-			 16,
-			 6.7
-			],
-			[
-			 17,
-			 10.8
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier superieur - filet interieur - route non classee restreint",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sup",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "NON_CLASSEE_RESTREINT_SUP"
-		 ],
-		 "paint": {
-		  "line-color": "#EDF1FF",
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 2.3
-			],
-			[
-			 15,
-			 4.1
-			],
-			[
-			 16,
-			 6.3
-			],
-			[
-			 17,
-			 13.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier superieur - filet interieur - route non classee",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sup",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "NON_CLASSEE_4_SUP",
-		  "NON_CLASSEE_SUP"
-		 ],
-		 "paint": {
-		  "line-color": "#EDF1FF",
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 2.3
-			],
-			[
-			 15,
-			 4.1
-			],
-			[
-			 16,
-			 6.3
-			],
-			[
-			 17,
-			 13.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier superieur - filet interieur - route locale",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sup",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BRET_LOCALE_SUP",
-		  "LOCALE_4_SUP",
-		  "LOCALE_3_SUP",
-		  "LOCALE_2_SUP",
-		  "LOCALE_1_SUP"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 12,
-			 "#EDF1FF"
-			],
-			[
-			 13,
-			 "#FCF4A8"
-			],
-			[
-			 17,
-			 "#FCF7C1"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 9,
-			 1.3
-			],
-			[
-			 14,
-			 2.3
-			],
-			[
-			 15,
-			 4.1
-			],
-			[
-			 16,
-			 6.1
-			],
-			[
-			 17,
-			 13.1
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier superieur - filet interieur - route locale en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sup",
-		 "minzoom": 11,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "LOCALE_CONSTR_SUP"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 12,
-			 "#EDF1FF"
-			],
-			[
-			 13,
-			 "#FCF4A8"
-			],
-			[
-			 17,
-			 "#FCF7C1"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 9,
-			 2
-			],
-			[
-			 14,
-			 3.5
-			],
-			[
-			 15,
-			 6
-			],
-			[
-			 16,
-			 8.4
-			],
-			[
-			 17,
-			 18.3
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   2,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "Routier superieur - filet interieur - route regionale",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sup",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BRET_REGIONALE_SUP",
-		  "REGIONALE_4_SUP",
-		  "REGIONALE_3_SUP",
-		  "REGIONALE_2_SUP",
-		  "REGIONALE_1_SUP"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 9,
-			 "#EDF1FF"
-			],
-			[
-			 10,
-			 "#FDF28B"
-			],
-			[
-			 17,
-			 "#FCF6BD"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 6,
-			 1.4
-			],
-			[
-			 9,
-			 1.5
-			],
-			[
-			 14,
-			 3.2
-			],
-			[
-			 15,
-			 5.8
-			],
-			[
-			 16,
-			 8.3
-			],
-			[
-			 17,
-			 16.2
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier superieur - filet interieur - route regionale en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sup",
-		 "minzoom": 10,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "REGIONALE_CONSTR_SUP"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 9,
-			 "#EDF1FF"
-			],
-			[
-			 10,
-			 "#FDF28B"
-			],
-			[
-			 17,
-			 "#FCF6BD"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 6,
-			 1.5
-			],
-			[
-			 9,
-			 2.3
-			],
-			[
-			 14,
-			 5
-			],
-			[
-			 15,
-			 8.1
-			],
-			[
-			 16,
-			 11.2
-			],
-			[
-			 17,
-			 22
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   2,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "Routier superieur - filet interieur - route principale",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sup",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BRET_PRINCIPALE_SUP",
-		  "PRINCIPALE_4_SUP",
-		  "PRINCIPALE_3_SUP",
-		  "PRINCIPALE_2_SUP",
-		  "PRINCIPALE_1_SUP"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 9,
-			 "#F3C66D"
-			],
-			[
-			 17,
-			 "#F2DDB3"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 4,
-			 0.5
-			],
-			[
-			 6,
-			 1.8
-			],
-			[
-			 9,
-			 2.1
-			],
-			[
-			 14,
-			 4.4
-			],
-			[
-			 15,
-			 7.3
-			],
-			[
-			 16,
-			 10
-			],
-			[
-			 17,
-			 18.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier superieur - filet interieur - route principale en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sup",
-		 "minzoom": 10,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "PRINCIPALE_CONSTR_SUP"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 9,
-			 "#F3C66D"
-			],
-			[
-			 17,
-			 "#F2DDB3"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 6,
-			 1.8
-			],
-			[
-			 9,
-			 2.7
-			],
-			[
-			 14,
-			 5.9
-			],
-			[
-			 15,
-			 9
-			],
-			[
-			 16,
-			 12.2
-			],
-			[
-			 17,
-			 22.5
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   2,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "Routier superieur - filet interieur - autoroute",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sup",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "AUTOROU_PEAGE_SUP",
-		  "AUTOROU_LIBRE_SUP"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 9,
-			 "#F18800"
-			],
-			[
-			 17,
-			 "#F2B230"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 4,
-			 0.7
-			],
-			[
-			 6,
-			 2.5
-			],
-			[
-			 9,
-			 2.7
-			],
-			[
-			 14,
-			 5.8
-			],
-			[
-			 15,
-			 9
-			],
-			[
-			 16,
-			 12
-			],
-			[
-			 17,
-			 20.8
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier superieur - axe central - autoroute",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sup",
-		 "minzoom": 13,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "AUTOROU_PEAGE_SUP",
-		  "AUTOROU_LIBRE_SUP"
-		 ],
-		 "paint": {
-		  "line-color": "#EDF1FF",
-		  "line-width": {
-		   "stops": [
-			[
-			 9,
-			 0.6
-			],
-			[
-			 14,
-			 0.7
-			],
-			[
-			 15,
-			 1
-			],
-			[
-			 16,
-			 1.2
-			],
-			[
-			 17,
-			 2.1
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier superieur - filet interieur - autoroute en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sup",
-		 "minzoom": 10,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "AUTOROU_CONSTR_SUP"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 9,
-			 "#F18800"
-			],
-			[
-			 17,
-			 "#F2B230"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 4,
-			 0.7
-			],
-			[
-			 6,
-			 2.5
-			],
-			[
-			 9,
-			 3.5
-			],
-			[
-			 14,
-			 7.5
-			],
-			[
-			 15,
-			 11
-			],
-			[
-			 16,
-			 15
-			],
-			[
-			 17,
-			 26
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   2,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "Routier superieur - axe centrale - autoroute en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sup",
-		 "minzoom": 13,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "AUTOROU_CONSTR_SUP"
-		 ],
-		 "paint": {
-		  "line-color": "#808080",
-		  "line-width": {
-		   "stops": [
-			[
-			 9,
-			 0.6
-			],
-			[
-			 14,
-			 0.7
-			],
-			[
-			 15,
-			 1
-			],
-			[
-			 16,
-			 1.2
-			],
-			[
-			 17,
-			 2.1
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Ferre superieur - voie normale",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "ferre_sup",
-		 "minzoom": 10,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "VF_1_SUP",
-		  "VF_2_SUP",
-		  "VF_ELEC_1_SUP"
-		 ],
-		 "paint": {
-		  "line-color": "#787878",
-		  "line-width": {
-		   "stops": [
-			[
-			 10,
-			 0.8
-			],
-			[
-			 17,
-			 2.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Ferre superieur - voie normale trait perpendic",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "ferre_sup",
-		 "minzoom": 10,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "VF_1_SUP",
-		  "VF_2_SUP",
-		  "VF_ELEC_1_SUP"
-		 ],
-		 "paint": {
-		  "line-color": "#787878",
-		  "line-width": {
-		   "stops": [
-			[
-			 10,
-			 3.5
-			],
-			[
-			 17,
-			 14.7
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   0.1,
-		   10
-		  ]
-		 }
-		},
-		{
-		 "id": "Ferre superieur - voie etroite",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "ferre_sup",
-		 "minzoom": 10,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "VF_ETROITE_1_SUP",
-		  "VF_ETROITE_SUP"
-		 ],
-		 "paint": {
-		  "line-color": "#787878",
-		  "line-width": {
-		   "stops": [
-			[
-			 10,
-			 0.3
-			],
-			[
-			 17,
-			 1.8
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Ferre superieur - voie etroite trait perpendic",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "ferre_sup",
-		 "minzoom": 10,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "VF_ETROITE_1_SUP",
-		  "VF_ETROITE_SUP"
-		 ],
-		 "paint": {
-		  "line-color": "#787878",
-		  "line-width": {
-		   "stops": [
-			[
-			 10,
-			 3.5
-			],
-			[
-			 17,
-			 14.7
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   0.1,
-		   10
-		  ]
-		 }
-		},
-		{
-		 "id": "Ferre superieur - voie service",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "ferre_sup",
-		 "minzoom": 14,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "VF_SERVICE_SUP",
-		  "VF_NON_EXPLOITEE_SUP"
-		 ],
-		 "paint": {
-		  "line-color": "#787878",
-		  "line-width": {
-		   "stops": [
-			[
-			 10,
-			 0.3
-			],
-			[
-			 17,
-			 1.8
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   5,
-		   2,
-		   1,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "Ferre superieur - voie en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "ferre_sup",
-		 "minzoom": 10,
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "VF_EN_CONSTR_SUP"
-		 ],
-		 "paint": {
-		  "line-color": "#787878",
-		  "line-width": {
-		   "stops": [
-			[
-			 10,
-			 0.3
-			],
-			[
-			 17,
-			 1.8
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   2,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "Ferre superieur - voie en construction trait perpendic",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "ferre_sup",
-		 "minzoom": 10,
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "VF_EN_CONSTR_SUP"
-		 ],
-		 "paint": {
-		  "line-color": "#787878",
-		  "line-width": {
-		   "stops": [
-			[
-			 10,
-			 3.5
-			],
-			[
-			 17,
-			 14.7
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   0.1,
-		   10
-		  ]
-		 }
-		},
-		{
-		 "id": "Ferre superieur - funic/urbain",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "ferre_sup",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "FUNI_CREMAILLERE_SUP",
-		  "TRANSPORT_URBAIN_SUP"
-		 ],
-		 "paint": {
-		  "line-color": "#787878",
-		  "line-width": {
-		   "stops": [
-			[
-			 10,
-			 0.3
-			],
-			[
-			 17,
-			 1.8
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Ferre superieur - 2 trait perpendic - funic/urbain",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "ferre_sup",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "FUNI_CREMAILLERE_SUP",
-		  "TRANSPORT_URBAIN_SUP"
-		 ],
-		 "paint": {
-		  "line-color": "#787878",
-		  "line-width": {
-		   "stops": [
-			[
-			 10,
-			 3.5
-			],
-			[
-			 17,
-			 17
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   0.1,
-		   0.2,
-		   0.1,
-		   10
-		  ]
-		 }
-		},
-		{
-		 "id": "Limite - cloture",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "limite_lin",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "CLOTURE"
-		 ],
-		 "paint": {
-		  "line-color": "#000000",
-		  "line-width": {
-		   "stops": [
-			[
-			 13,
-			 0.6
-			],
-			[
-			 17,
-			 1
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   1.5,
-		   4
-		  ]
-		 }
-		},
-		{
-		 "id": "Limite - layon",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "limite_lin",
-		 "minzoom": 14,
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "LAYON"
-		 ],
-		 "paint": {
-		  "line-color": "#B3989A",
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 1
-			],
-			[
-			 15,
-			 1.2
-			],
-			[
-			 16,
-			 1.4
-			],
-			[
-			 17,
-			 2
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   4,
-		   7
-		  ]
-		 }
-		},
-		{
-		 "id": "Zone Règlementee - Enceinte militaire",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "limite_lin",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "LIM_ZONE_REGLEMENTEE",
-		  "LIM_ENCEINTE_MILITAIRE",
-		  "LIM_ENCEINTE_MILI",
-		  "LIM_CHAMP_TIR"
-		 ],
-		 "paint": {
-		  "line-color": "rgba(226, 130, 92, 0.8)",
-		  "line-width": {
-		   "stops": [
-			[
-			 13,
-			 1.7
-			],
-			[
-			 17,
-			 3.1
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   4,
-		   1,
-		   2,
-		   5
-		  ]
-		 }
-		},
-		{
-		 "id": "limite zone naturelle",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "limite_lin",
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "LIM_ZONE_NATURELLE",
-		  "LIM_ZONE_NATURELLE_ILE",
-		  "LIM_RESERVE_NATURELLE"
-		 ],
-		 "paint": {
-		  "line-color": "#FFC2CB",
-		  "line-width": {
-		   "stops": [
-			[
-			 13,
-			 2
-			],
-			[
-			 17,
-			 4
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   2,
-		   1
-		  ]
-		 }
-		},
-		{
-		 "id": "limite zone naturelle - Parc naturel 10",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "limite_lin",
-		 "maxzoom": 10,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "LIM_PARC_NATUREL",
-		  "LIM_PARC_NATUREL_ILE"
-		 ],
-		 "paint": {
-		  "line-color": "#42A266",
-		  "line-width": {
-		   "stops": [
-			[
-			 13,
-			 2
-			],
-			[
-			 17,
-			 4
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   2,
-		   1
-		  ]
-		 }
-		},
-		{
-		 "id": "limite zone naturelle - Parc naturel 11",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "limite_lin",
-		 "minzoom": 10,
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "LIM_PARC_NATUREL",
-		  "LIM_PARC_NATUREL_ILE"
-		 ],
-		 "paint": {
-		  "line-color": "#42A266",
-		  "line-width": {
-		   "stops": [
-			[
-			 13,
-			 2
-			],
-			[
-			 17,
-			 4
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   2,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "limite zone naturelle - Parc naturel 12",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "limite_lin",
-		 "minzoom": 11,
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "LIM_PARC_NATUREL",
-		  "LIM_PARC_NATUREL_ILE"
-		 ],
-		 "paint": {
-		  "line-color": "#42A266",
-		  "line-width": {
-		   "stops": [
-			[
-			 13,
-			 2
-			],
-			[
-			 17,
-			 4
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   2,
-		   3
-		  ]
-		 }
-		},
-		{
-		 "id": "limite zone naturelle - Parc naturel 13",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "limite_lin",
-		 "minzoom": 12,
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "LIM_PARC_NATUREL",
-		  "LIM_PARC_NATUREL_ILE"
-		 ],
-		 "paint": {
-		  "line-color": "#42A266",
-		  "line-width": {
-		   "stops": [
-			[
-			 13,
-			 2
-			],
-			[
-			 17,
-			 4
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   2,
-		   4
-		  ]
-		 }
-		},
-		{
-		 "id": "limite zone naturelle - Parc naturel 14",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "limite_lin",
-		 "minzoom": 13,
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "LIM_PARC_NATUREL",
-		  "LIM_PARC_NATUREL_ILE"
-		 ],
-		 "paint": {
-		  "line-color": "rgba(66, 162, 102, 0.7)",
-		  "line-width": {
-		   "stops": [
-			[
-			 13,
-			 2
-			],
-			[
-			 17,
-			 4
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   2,
-		   5
-		  ]
-		 }
-		},
-		{
-		 "id": "limite zone naturelle - Parc marin",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "limite_lin",
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "LIM_PARC_NATUREL_MARIN"
-		 ],
-		 "paint": {
-		  "line-color": "#2A81A2",
-		  "line-width": {
-		   "stops": [
-			[
-			 13,
-			 2
-			],
-			[
-			 17,
-			 4
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   2,
-		   1
-		  ]
-		 }
-		},
-		
-		{
-		 "id": "limite admin - limite de commune",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "limite_lin",
-		 "minzoom": 13,
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "LIM_COMMUNE",
-		  "LIM_CANTON",
-		  "LIM_ARRONDISSEMENT"
-		 ],
-		 "paint": {
-		  "line-color": "rgba(126, 119, 184, 0.5)",
-		  "line-width": {
-		   "stops": [
-			[
-			 13,
-			 3
-			],
-			[
-			 17,
-			 5.5
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   4,
-		   2,
-		   1,
-		   1,
-		   1,
-		   1,
-		   1,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "limite admin - limite de département bandeau",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "limite_lin",
-		 "minzoom": 8,
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "LIM_DEPARTEMENT"
-		 ],
-		 "paint": {
-		  "line-color": "rgba(178, 175, 219, 0.4)",
-		  "line-width": {
-		   "stops": [
-			[
-			 9,
-			 4.1
-			],
-			[
-			 12,
-			 6
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "limite admin - limite de département tiret",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "limite_lin",
-		 "minzoom": 13,
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "LIM_DEPARTEMENT"
-		 ],
-		 "paint": {
-		  "line-color": "rgba(126, 119, 184, 0.5)",
-		  "line-width": {
-		   "stops": [
-			[
-			 13,
-			 3
-			],
-			[
-			 17,
-			 5.5
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   4,
-		   2,
-		   1,
-		   1,
-		   1,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "limite admin - limite de région bandeau",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "limite_lin",
-		 "minzoom": 7,
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "LIM_REGION"
-		 ],
-		 "paint": {
-		  "line-color": "rgba(178, 175, 219, 0.5)",
-		  "line-width": {
-		   "stops": [
-			[
-			 9,
-			 4.5
-			],
-			[
-			 12,
-			 6.7
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "limite admin - limite de région tiret",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "limite_lin",
-		 "minzoom": 13,
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "LIM_REGION"
-		 ],
-		 "paint": {
-		  "line-color": "rgba(126, 119, 184, 0.5)",
-		  "line-width": {
-		   "stops": [
-			[
-			 13,
-			 3
-			],
-			[
-			 17,
-			 5.5
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   4,
-		   2,
-		   1,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "limite etat 1",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "limite_lin",
-		 "minzoom": 2,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "LIM_ETAT",
-		  "LIM_ETAT_ETRANGER"
-		 ],
-		 "paint": {
-		  "line-color": "rgba(178, 175, 219, 0.6)",
-		  "line-width": {
-		   "stops": [
-			[
-			 2,
-			 2
-			],
-			[
-			 3,
-			 3.5
-			],
-			[
-			 9,
-			 5
-			],
-			[
-			 14,
-			 13
-			],
-			[
-			 15,
-			 20
-			],
-			[
-			 16,
-			 24
-			],
-			[
-			 17,
-			 42
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "limite etat 2",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "limite_lin",
-		 "minzoom": 7,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "LIM_ETAT",
-		  "LIM_ETAT_ETRANGER"
-		 ],
-		 "paint": {
-		  "line-color": "#9F9CB8",
-		  "line-width": {
-		   "stops": [
-			[
-			 9,
-			 1.5
-			],
-			[
-			 14,
-			 3.5
-			],
-			[
-			 15,
-			 5.5
-			],
-			[
-			 16,
-			 6.5
-			],
-			[
-			 17,
-			 11
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   4,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "limite cote",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "limite_lin",
-		 "minzoom": 7,
-		 "maxzoom": 10,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "LIM_COTE"
-		 ],
-		 "paint": {
-		  "line-color": "#82A3B2",
-		  "line-width": 1
-		 }
-		},
-		{
-		 "id": "ligne electrique",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "bati_lin",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "LIGNE_ELECTRIQUE"
-		 ],
-		 "paint": {
-		  "line-color": "#808080",
-		  "line-width": {
-		   "stops": [
-			[
-			 13,
-			 1
-			],
-			[
-			 17,
-			 2
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "autre construction linéaire",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "bati_lin",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "CABLE",
-		  "REMONTEE_MEC",
-		  "HYDROCARBURES",
-		  "CONDUITE_MATIERES_P",
-		  "SPORT_MONTAGNE_LIN",
-		  "PISTE_BOBSLEIGH",
-		  "PISTE_LUGE",
-		  "PISTE_AERO_LIN"
-		 ],
-		 "paint": {
-		  "line-color": "#808080",
-		  "line-width": 1
-		 }
-		},
-		{
-		 "id": "autre construction linéaire - trait perpend cable",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "bati_lin",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "CABLE"
-		 ],
-		 "paint": {
-		  "line-color": "#808080",
-		  "line-width": 5,
-		  "line-dasharray": [
-		   0.5,
-		   10
-		  ]
-		 }
-		},
-		{
-		 "id": "autre construction linéaire - trait perpend 1 remont",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "bati_lin",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "REMONTEE_MEC"
-		 ],
-		 "paint": {
-		  "line-color": "#808080",
-		  "line-width": 6,
-		  "line-dasharray": [
-		   1,
-		   10
-		  ]
-		 }
-		},
-		{
-		 "id": "autre construction linéaire - trait perpend 2 remont",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "bati_lin",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "REMONTEE_MEC"
-		 ],
-		 "paint": {
-		  "line-color": "#BEBEBE",
-		  "line-width": 6,
-		  "line-dasharray": [
-		   0.3,
-		   0.4,
-		   0.3,
-		   10
-		  ]
-		 }
-		},
-		{
-		 "id": "autre construction linéaire - trait perpend carbur",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "bati_lin",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "HYDROCARBURES",
-		  "CONDUITE_MATIERES_P"
-		 ],
-		 "paint": {
-		  "line-color": "#808080",
-		  "line-width": 5,
-		  "line-dasharray": [
-		   1,
-		   10
-		  ]
-		 }
-		},
-		{
-		 "id": "routier ponctuel - peage ponctuel",
-		 "type": "circle",
-		 "source": "plan_ign",
-		 "source-layer": "routier_ponc",
-		 "minzoom": 8,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "PEAGE_PONC"
-		 ],
-		 "paint": {
-		  "circle-radius": {
-		   "stops": [
-			[
-			 9,
-			 3.5
-			],
-			[
-			 12,
-			 6.5
-			]
-		   ]
-		  },
-		  "circle-color": "#E2A52A",
-		  "circle-stroke-width": 1,
-		  "circle-stroke-color": "#808080"
-		 }
-		},
-		{
-		 "id": "routier ponctuel - barriere",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "routier_ponc",
-		 "minzoom": 12,
-		 "layout": {
-		  "visibility": "visible",
-		  "icon-image": "Barriere",
-		  "icon-size": {
-		   "stops": [
-			[
-			 13,
-			 0.25
-			],
-			[
-			 16,
-			 0.45
-			],
-			[
-			 17,
-			 0.7
-			]
-		   ]
-		  },
-		  "icon-allow-overlap": true,
-		  "icon-rotate": [
-		   "get",
-		   "rotation"
-		  ]
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "BARRIERE"
-		 ],
-		 "paint": {
-		  "icon-color": "#969696"
-		 }
-		},
-		{
-		 "id": "hydro ponctuel",
-		 "type": "circle",
-		 "source": "plan_ign",
-		 "source-layer": "hydro_ponc",
-		 "minzoom": 13,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "FONTAINE",
-		  "POINT_D_EAU",
-		  "SOURCE",
-		  "SOURCE_CAPTEE",
-		  "PERTE",
-		  "RESURGENCE",
-		  "CASCADE",
-		  "AUTRE_HYDRO_PONC"
-		 ],
-		 "paint": {
-		  "circle-radius": {
-		   "stops": [
-			[
-			 14,
-			 3
-			],
-			[
-			 17,
-			 7
-			]
-		   ]
-		  },
-		  "circle-color": "#FFFFFF",
-		  "circle-opacity": 1,
-		  "circle-stroke-width": {
-		   "stops": [
-			[
-			 14,
-			 2
-			],
-			[
-			 17,
-			 5
-			]
-		   ]
-		  },
-		  "circle-stroke-color": "#1466B2"
-		 }
-		},
-		{
-		 "id": "point coté",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "oro_ponc",
-		 "minzoom": 11,
-		 "maxzoom": 21,
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "POINT_COTE",
-		  "POINT_COTE_TOPO",
-		  "POINT_COTE_RESEAU",
-		  "POINT_RBF"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "icon-image": "Localite",
-		  "icon-size": 0.1,
-		  "text-field": "{texte}",
-		  "text-size": 10,
-		  "text-allow-overlap": false,
-		  "text-anchor": "bottom-left",
-		  "text-offset": [
-		   0.2,
-		   0.4
-		  ],
-		  "text-padding": 2,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#505050"
-		 }
-		},
-		{
-		 "id": "bati ponctuel : Hopital",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "bati_ponc",
-		 "layout": {
-		  "visibility": "visible",
-		  "icon-image": "Hopital",
-		  "icon-size": 0.33
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "HOPITAL_PONC"
-		 ],
-		 "paint": {
-		  "icon-color": "#646464"
-		 }
-		},
-		{
-		 "id": "bati ponctuel hydrographique",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "bati_ponc",
-		 "minzoom": 14,
-		 "layout": {
-		  "visibility": "visible",
-		  "icon-image": "Pompage",
-		  "icon-size": {
-		   "stops": [
-			[
-			 13,
-			 0.2
-			],
-			[
-			 17,
-			 0.6
-			]
-		   ]
-		  },
-		  "icon-allow-overlap": true
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "CITERNE",
-		  "LAVOIR",
-		  "STATION_EPURATION",
-		  "STATION_DE_POMPAGE",
-		  "USINE_PRODUCTION_EAU",
-		  "USINE_ELEVATRICE"
-		 ],
-		 "paint": {
-		  "icon-color": "#1C62A6"
-		 }
-		},
-		{
-		 "id": "bati ponctuel hydrographique - Puits-Abreuvoir",
-		 "type": "circle",
-		 "source": "plan_ign",
-		 "source-layer": "bati_ponc",
-		 "minzoom": 13,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "PUITS",
-		  "ABREUVOIR"
-		 ],
-		 "paint": {
-		  "circle-radius": {
-		   "stops": [
-			[
-			 14,
-			 3
-			],
-			[
-			 17,
-			 7
-			]
-		   ]
-		  },
-		  "circle-color": "#FFFFFF",
-		  "circle-opacity": 1,
-		  "circle-stroke-width": {
-		   "stops": [
-			[
-			 14,
-			 2
-			],
-			[
-			 17,
-			 5
-			]
-		   ]
-		  },
-		  "circle-stroke-color": "#1466B2"
-		 }
-		},
-		{
-		 "id": "bati ponctuel hydrographique - Phare",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "bati_ponc",
-		 "minzoom": 13,
-		 "layout": {
-		  "visibility": "visible",
-		  "icon-image": "Phare",
-		  "icon-size": {
-		   "stops": [
-			[
-			 13,
-			 0.7
-			],
-			[
-			 17,
-			 1.3
-			]
-		   ]
-		  }
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "PHARE"
-		 ],
-		 "paint": {
-		  "icon-color": "#646464"
-		 }
-		},
-		{
-		 "id": "bati ponctuel hydrographique - Amer-Feu",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "bati_ponc",
-		 "minzoom": 13,
-		 "layout": {
-		  "visibility": "visible",
-		  "icon-image": "Feu",
-		  "icon-size": {
-		   "stops": [
-			[
-			 13,
-			 0.7
-			],
-			[
-			 17,
-			 1.3
-			]
-		   ]
-		  }
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "AMER",
-		  "FEU",
-		  "FEU_PONC",
-		  "TOURELLE_LUMINEUSE"
-		 ],
-		 "paint": {
-		  "icon-color": "#646464"
-		 }
-		},
-		{
-		 "id": "bati ponctuel hydrographique - Balise",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "bati_ponc",
-		 "minzoom": 13,
-		 "layout": {
-		  "visibility": "visible",
-		  "icon-image": "Balise",
-		  "icon-size": {
-		   "stops": [
-			[
-			 13,
-			 0.7
-			],
-			[
-			 17,
-			 1.3
-			]
-		   ]
-		  }
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BALISE",
-		  "TOURELLE"
-		 ],
-		 "paint": {
-		  "icon-color": "#646464"
-		 }
-		},
-		{
-		 "id": "bati ponctuel hydrographique - Ecluse",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "bati_ponc",
-		 "minzoom": 12,
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "icon-image": "Ecluse",
-		  "icon-size": 0.2
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "ECLUSE_PONC"
-		 ],
-		 "paint": {
-		  "icon-color": "#1C62A6"
-		 }
-		},
-		{
-		 "id": "bati ponctuel hydrographique - Barrage",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "bati_ponc",
-		 "minzoom": 12,
-		 "maxzoom": 14,
-		 "layout": {
-		  "visibility": "visible",
-		  "icon-image": "Barrage",
-		  "icon-size": 0.25
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "BARRAGE_PONC"
-		 ],
-		 "paint": {
-		  "icon-color": "#1C62A6"
-		 }
-		},
-		{
-		 "id": "bati ponctuel hydrographique - Chateau d'eau",
-		 "type": "circle",
-		 "source": "plan_ign",
-		 "source-layer": "bati_ponc",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "CHATEAU_EAU_PONC"
-		 ],
-		 "paint": {
-		  "circle-radius": {
-		   "stops": [
-			[
-			 14,
-			 3
-			],
-			[
-			 17,
-			 8
-			]
-		   ]
-		  },
-		  "circle-color": "#1466B2"
-		 }
-		},
-		{
-		 "id": "bati ponctuel hydrographique - Réservoir d'eau",
-		 "type": "circle",
-		 "source": "plan_ign",
-		 "source-layer": "bati_ponc",
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "RESERVOIR_EAU_PONC"
-		 ],
-		 "paint": {
-		  "circle-radius": {
-		   "stops": [
-			[
-			 14,
-			 3
-			],
-			[
-			 17,
-			 8
-			]
-		   ]
-		  },
-		  "circle-color": "#AAD5E9",
-		  "circle-opacity": 1,
-		  "circle-stroke-width": {
-		   "stops": [
-			[
-			 14,
-			 1
-			],
-			[
-			 17,
-			 2.5
-			]
-		   ]
-		  },
-		  "circle-stroke-color": "#1466B2"
-		 }
-		},
-		{
-		 "id": "bati ponctuel infrastructure - Constr spé",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "bati_ponc",
-		 "layout": {
-		  "visibility": "visible",
-		  "icon-image": "ConstrSpeciale",
-		  "icon-size": {
-		   "stops": [
-			[
-			 13,
-			 0.22
-			],
-			[
-			 17,
-			 0.5
-			]
-		   ]
-		  }
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "ANTENNE",
-		  "CONSTR_SPE_TECHNIQUE",
-		  "CONSTR_INDIF_PONC",
-		  "CHEMINEE",
-		  "CHEVALEMENT",
-		  "PUITS_GAZ",
-		  "PUITS_PETROLE",
-		  "PYLONE_METEO",
-		  "TORCHERE",
-		  "TOUR_GUET",
-		  "TOUR_HERTZIENNE"
-		 ],
-		 "paint": {
-		  "icon-color": "#646464"
-		 }
-		},
-		{
-		 "id": "bati ponctuel infrastructure - Silo",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "bati_ponc",
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "icon-image": "Silo",
-		  "icon-size": {
-		   "stops": [
-			[
-			 13,
-			 0.22
-			],
-			[
-			 17,
-			 0.5
-			]
-		   ]
-		  }
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "SILO_PONC"
-		 ],
-		 "paint": {
-		  "icon-color": "#646464"
-		 }
-		},
-		{
-		 "id": "bati ponctuel infrastructure - Eolienne",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "bati_ponc",
-		 "layout": {
-		  "visibility": "visible",
-		  "icon-image": "Eolienne",
-		  "icon-size": {
-		   "stops": [
-			[
-			 13,
-			 0.4
-			],
-			[
-			 17,
-			 1
-			],
-			[
-			 18,
-			 0.8
-			]
-		   ]
-		  }
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "EOLIENNE"
-		 ],
-		 "paint": {
-		  "icon-color": "#646464"
-		 }
-		},
-		{
-		 "id": "bati ponctuel infrastructure - Reservoir",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "bati_ponc",
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "icon-image": "Reservoir",
-		  "icon-size": {
-		   "stops": [
-			[
-			 13,
-			 0.26
-			],
-			[
-			 17,
-			 0.5
-			]
-		   ]
-		  }
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "RESERVOIR_PONC"
-		 ],
-		 "paint": {
-		  "icon-color": "#646464"
-		 }
-		},
-		{
-		 "id": "bati ponctuel infrastructure - pylone électrique",
-		 "type": "circle",
-		 "source": "plan_ign",
-		 "source-layer": "bati_ponc",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "PYLONE_ELEC"
-		 ],
-		 "paint": {
-		  "circle-radius": {
-		   "stops": [
-			[
-			 13,
-			 1
-			],
-			[
-			 17,
-			 2
-			]
-		   ]
-		  },
-		  "circle-color": "#000000"
-		 }
-		},
-		{
-		 "id": "bati ponctuel montagne - Abri",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "bati_ponc",
-		 "layout": {
-		  "visibility": "visible",
-		  "icon-image": "Abri",
-		  "icon-size": {
-		   "stops": [
-			[
-			 13,
-			 0.4
-			],
-			[
-			 15,
-			 0.6
-			],
-			[
-			 17,
-			 0.9
-			]
-		   ]
-		  }
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "ABRI"
-		 ],
-		 "paint": {
-		  "icon-color": "#246138"
-		 }
-		},
-		{
-		 "id": "bati ponctuel montagne - Refuge Garde",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "bati_ponc",
-		 "layout": {
-		  "visibility": "visible",
-		  "icon-image": "Refugegard",
-		  "icon-size": {
-		   "stops": [
-			[
-			 13,
-			 0.4
-			],
-			[
-			 15,
-			 0.6
-			],
-			[
-			 17,
-			 0.9
-			]
-		   ]
-		  }
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "REFUGE_GARDE"
-		 ],
-		 "paint": {
-		  "icon-color": "#246138"
-		 }
-		},
-		{
-		 "id": "bati ponctuel montagne - Refuge Non Garde",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "bati_ponc",
-		 "layout": {
-		  "visibility": "visible",
-		  "icon-image": "Refugenongard",
-		  "icon-size": {
-		   "stops": [
-			[
-			 13,
-			 0.4
-			],
-			[
-			 15,
-			 0.6
-			],
-			[
-			 17,
-			 0.9
-			]
-		   ]
-		  }
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "REFUGE"
-		 ],
-		 "paint": {
-		  "icon-color": "#246138"
-		 }
-		},
-		{
-		 "id": "bati ponctuel transport aerien - Aeroport FXX",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "bati_ponc",
-		 "layout": {
-		  "visibility": "visible",
-		  "icon-image": "Aeroport",
-		  "icon-size": 0.5
-		 },
-		 "filter": [
-		  "all",
-		  [
-		   "==",
-		   "symbo",
-		   "AEROPORT_PONC"
-		  ],
-		  [
-		   "==",
-		   "territoire",
-		   "FXX"
-		  ]
-		 ],
-		 "paint": {
-		  "icon-color": "#646464"
-		 }
-		},
-		{
-		 "id": "bati ponctuel transport aerien - Aerodrome FXX",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "bati_ponc",
-		 "layout": {
-		  "visibility": "visible",
-		  "icon-image": "Aerodrome",
-		  "icon-size": 0.4
-		 },
-		 "filter": [
-		  "all",
-		  [
-		   "==",
-		   "symbo",
-		   "AERODROME_PONC"
-		  ],
-		  [
-		   "==",
-		   "territoire",
-		   "FXX"
-		  ]
-		 ],
-		 "paint": {
-		  "icon-color": "#646464"
-		 }
-		},
-		{
-		 "id": "bati ponctuel transport aerien - Aeroport DOM",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "bati_ponc",
-		 "minzoom": 8,
-		 "layout": {
-		  "visibility": "visible",
-		  "icon-image": "Aeroport",
-		  "icon-size": 0.5
-		 },
-		 "filter": [
-		  "all",
-		  [
-		   "==",
-		   "symbo",
-		   "AEROPORT_PONC"
-		  ],
-		  [
-		   "!=",
-		   "territoire",
-		   "FXX"
-		  ]
-		 ],
-		 "paint": {
-		  "icon-color": "#646464"
-		 }
-		},
-		{
-		 "id": "bati ponctuel transport aerien - Aerodrome DOM",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "bati_ponc",
-		 "minzoom": 8,
-		 "layout": {
-		  "visibility": "visible",
-		  "icon-image": "Aerodrome",
-		  "icon-size": 0.4
-		 },
-		 "filter": [
-		  "all",
-		  [
-		   "==",
-		   "symbo",
-		   "AERODROME_PONC"
-		  ],
-		  [
-		   "!=",
-		   "territoire",
-		   "FXX"
-		  ]
-		 ],
-		 "paint": {
-		  "icon-color": "#646464"
-		 }
-		},
-		{
-		 "id": "bati ponctuel transport ferroviaire",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "bati_ponc",
-		 "layout": {
-		  "visibility": "visible",
-		  "icon-image": "Gare",
-		  "icon-size": 0.33
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "GARE_VOYAGEURS"
-		 ],
-		 "paint": {
-		  "icon-color": "#787878"
-		 }
-		},
-		{
-		 "id": "toponyme - bornes postales haute - chemins",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_routier_borne",
-		 "minzoom": 17,
-		 "maxzoom": 22,
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "CHEMIN",
-		  "CHEMIN_SOU",
-		  "CHEMIN_SUP",
-		  "PISTE_CYCLABLE",
-		  "PISTE_CYCLABLE_SOU",
-		  "PISTE_CYCLABLE_SUP",
-		  "RUE_PIETONNE",
-		  "RUE_PIETONNE_SOU",
-		  "RUE_PIETONNE_SUP",
-		  "SENTIER",
-		  "SENTIER_SOU",
-		  "SENTIER_SUP",
-		  "ESCALIER",
-		  "ESCALIER_SUP"
-		 ],
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{borne_sur}",
-		  "text-size": 11,
-		  "text-anchor": "center",
-		  "text-allow-overlap": true,
-		  "text-offset": [
-		   0,
-		   -1
-		  ],
-		  "text-font": [
-		   "Open Sans Regular"
-		  ],
-		  "visibility": "none"
-		 },
-		 "paint": {
-		  "text-color": "#79654F",
-		  "text-halo-width": 1,
-		  "text-halo-color": "#FFFFFF"
-		 }
-		},
-		{
-		 "id": "toponyme - bornes postales haute - non revetue, non classee",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_routier_borne",
-		 "minzoom": 17,
-		 "maxzoom": 22,
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "NON_CLASSEE",
-		  "NON_CLASSEE_4",
-		  "NON_CLASSEE_4_SUP",
-		  "NON_CLASSEE_RESTREINT",
-		  "NON_CLASSEE_RESTREINT_SUP",
-		  "NON_CLASSEE_SOU",
-		  "NON_CLASSEE_SUP",
-		  "NON_REVETUE_CARRO",
-		  "NON_REVETUE_CARRO_SUP"
-		 ],
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{borne_sur}",
-		  "text-size": 11,
-		  "text-anchor": "center",
-		  "text-allow-overlap": true,
-		  "text-offset": [
-		   0,
-		   -1.3
-		  ],
-		  "text-font": [
-		   "Open Sans Regular"
-		  ],
-		  "visibility": "none"
-		 },
-		 "paint": {
-		  "text-color": "#79654F",
-		  "text-halo-width": 1,
-		  "text-halo-color": "#FFFFFF"
-		 }
-		},
-		{
-		 "id": "toponyme - bornes postales haute - locales",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_routier_borne",
-		 "minzoom": 17,
-		 "maxzoom": 22,
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "LOCALE_1",
-		  "LOCALE_1_SOU",
-		  "LOCALE_1_SUP",
-		  "LOCALE_2",
-		  "LOCALE_2_SOU",
-		  "LOCALE_2_SUP",
-		  "LOCALE_3",
-		  "LOCALE_3_SOU",
-		  "LOCALE_3_SUP",
-		  "LOCALE_4",
-		  "LOCALE_4_SOU",
-		  "LOCALE_4_SUP",
-		  "LOCALE_CONSTR",
-		  "LOCALE_CONSTR_SUP"
-		 ],
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{borne_sur}",
-		  "text-size": 11,
-		  "text-anchor": "center",
-		  "text-allow-overlap": true,
-		  "text-offset": [
-		   0,
-		   -1.4
-		  ],
-		  "text-font": [
-		   "Open Sans Regular"
-		  ],
-		  "visibility": "none"
-		 },
-		 "paint": {
-		  "text-color": "#79654F",
-		  "text-halo-width": 1,
-		  "text-halo-color": "#FFFFFF"
-		 }
-		},
-		{
-		 "id": "toponyme - bornes postales haute - regionales",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_routier_borne",
-		 "minzoom": 17,
-		 "maxzoom": 22,
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "REGIONALE_1",
-		  "REGIONALE_1_SOU",
-		  "REGIONALE_1_SUP",
-		  "REGIONALE_2",
-		  "REGIONALE_2_SOU",
-		  "REGIONALE_2_SUP",
-		  "REGIONALE_3",
-		  "REGIONALE_3_SOU",
-		  "REGIONALE_3_SUP",
-		  "REGIONALE_4",
-		  "REGIONALE_4_SUP",
-		  "REGIONALE_CONSTR"
-		 ],
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{borne_sur}",
-		  "text-size": 11,
-		  "text-anchor": "center",
-		  "text-allow-overlap": true,
-		  "text-offset": [
-		   0,
-		   -1.5
-		  ],
-		  "text-font": [
-		   "Open Sans Regular"
-		  ],
-		  "visibility": "none"
-		 },
-		 "paint": {
-		  "text-color": "#79654F",
-		  "text-halo-width": 1,
-		  "text-halo-color": "#FFFFFF"
-		 }
-		},
-		{
-		 "id": "toponyme - bornes postales haute - principales",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_routier_borne",
-		 "minzoom": 17,
-		 "maxzoom": 22,
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "PRINCIPALE_1",
-		  "PRINCIPALE_1_SOU",
-		  "PRINCIPALE_1_SUP",
-		  "PRINCIPALE_2",
-		  "PRINCIPALE_2_SOU",
-		  "PRINCIPALE_2_SUP",
-		  "PRINCIPALE_3",
-		  "PRINCIPALE_3_SOU",
-		  "PRINCIPALE_3_SUP",
-		  "PRINCIPALE_4",
-		  "PRINCIPALE_4_SOU",
-		  "PRINCIPALE_4_SUP",
-		  "PRINCIPALE_CONSTR"
-		 ],
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{borne_sur}",
-		  "text-size": 11,
-		  "text-anchor": "center",
-		  "text-allow-overlap": true,
-		  "text-offset": [
-		   0,
-		   -1.6
-		  ],
-		  "text-font": [
-		   "Open Sans Regular"
-		  ],
-		  "visibility": "none"
-		 },
-		 "paint": {
-		  "text-color": "#79654F",
-		  "text-halo-width": 1,
-		  "text-halo-color": "#FFFFFF"
-		 }
-		},
-		{
-		 "id": "toponyme - bornes postales bas - chemins",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_routier_borne",
-		 "minzoom": 17,
-		 "maxzoom": 22,
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "CHEMIN",
-		  "CHEMIN_SOU",
-		  "CHEMIN_SUP",
-		  "PISTE_CYCLABLE",
-		  "PISTE_CYCLABLE_SOU",
-		  "PISTE_CYCLABLE_SUP",
-		  "RUE_PIETONNE",
-		  "RUE_PIETONNE_SOU",
-		  "RUE_PIETONNE_SUP",
-		  "SENTIER",
-		  "SENTIER_SOU",
-		  "SENTIER_SUP",
-		  "ESCALIER",
-		  "ESCALIER_SUP"
-		 ],
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{borne_sous}",
-		  "text-size": 11,
-		  "text-anchor": "center",
-		  "text-allow-overlap": true,
-		  "text-offset": [
-		   0,
-		   1
-		  ],
-		  "text-font": [
-		   "Open Sans Regular"
-		  ],
-		  "visibility": "none"
-		 },
-		 "paint": {
-		  "text-color": "#79654F",
-		  "text-halo-width": 1,
-		  "text-halo-color": "#FFFFFF"
-		 }
-		},
-		{
-		 "id": "toponyme - bornes postales bas - non revetue, non classee",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_routier_borne",
-		 "minzoom": 17,
-		 "maxzoom": 22,
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "NON_CLASSEE",
-		  "NON_CLASSEE_4",
-		  "NON_CLASSEE_4_SUP",
-		  "NON_CLASSEE_RESTREINT",
-		  "NON_CLASSEE_RESTREINT_SUP",
-		  "NON_CLASSEE_SOU",
-		  "NON_CLASSEE_SUP",
-		  "NON_REVETUE_CARRO",
-		  "NON_REVETUE_CARRO_SUP"
-		 ],
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{borne_sous}",
-		  "text-size": 11,
-		  "text-anchor": "center",
-		  "text-allow-overlap": true,
-		  "text-offset": [
-		   0,
-		   1.3
-		  ],
-		  "text-font": [
-		   "Open Sans Regular"
-		  ],
-		  "visibility": "none"
-		 },
-		 "paint": {
-		  "text-color": "#79654F",
-		  "text-halo-width": 1,
-		  "text-halo-color": "#FFFFFF"
-		 }
-		},
-		{
-		 "id": "toponyme - bornes postales bas - locales",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_routier_borne",
-		 "minzoom": 17,
-		 "maxzoom": 22,
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "LOCALE_1",
-		  "LOCALE_1_SOU",
-		  "LOCALE_1_SUP",
-		  "LOCALE_2",
-		  "LOCALE_2_SOU",
-		  "LOCALE_2_SUP",
-		  "LOCALE_3",
-		  "LOCALE_3_SOU",
-		  "LOCALE_3_SUP",
-		  "LOCALE_4",
-		  "LOCALE_4_SOU",
-		  "LOCALE_4_SUP",
-		  "LOCALE_CONSTR",
-		  "LOCALE_CONSTR_SUP"
-		 ],
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{borne_sous}",
-		  "text-size": 11,
-		  "text-anchor": "center",
-		  "text-allow-overlap": true,
-		  "text-offset": [
-		   0,
-		   1.4
-		  ],
-		  "text-font": [
-		   "Open Sans Regular"
-		  ],
-		  "visibility": "none"
-		 },
-		 "paint": {
-		  "text-color": "#79654F",
-		  "text-halo-width": 1,
-		  "text-halo-color": "#FFFFFF"
-		 }
-		},
-		{
-		 "id": "toponyme - bornes postales bas - regionales",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_routier_borne",
-		 "minzoom": 17,
-		 "maxzoom": 22,
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "REGIONALE_1",
-		  "REGIONALE_1_SOU",
-		  "REGIONALE_1_SUP",
-		  "REGIONALE_2",
-		  "REGIONALE_2_SOU",
-		  "REGIONALE_2_SUP",
-		  "REGIONALE_3",
-		  "REGIONALE_3_SOU",
-		  "REGIONALE_3_SUP",
-		  "REGIONALE_4",
-		  "REGIONALE_4_SUP",
-		  "REGIONALE_CONSTR"
-		 ],
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{borne_sous}",
-		  "text-size": 11,
-		  "text-anchor": "center",
-		  "text-allow-overlap": true,
-		  "text-offset": [
-		   0,
-		   1.5
-		  ],
-		  "text-font": [
-		   "Open Sans Regular"
-		  ],
-		  "visibility": "none"
-		 },
-		 "paint": {
-		  "text-color": "#79654F",
-		  "text-halo-width": 1,
-		  "text-halo-color": "#FFFFFF"
-		 }
-		},
-		{
-		 "id": "toponyme - bornes postales bas - principales",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_routier_borne",
-		 "minzoom": 17,
-		 "maxzoom": 22,
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "PRINCIPALE_1",
-		  "PRINCIPALE_1_SOU",
-		  "PRINCIPALE_1_SUP",
-		  "PRINCIPALE_2",
-		  "PRINCIPALE_2_SOU",
-		  "PRINCIPALE_2_SUP",
-		  "PRINCIPALE_3",
-		  "PRINCIPALE_3_SOU",
-		  "PRINCIPALE_3_SUP",
-		  "PRINCIPALE_4",
-		  "PRINCIPALE_4_SOU",
-		  "PRINCIPALE_4_SUP",
-		  "PRINCIPALE_CONSTR"
-		 ],
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{borne_sous}",
-		  "text-size": 11,
-		  "text-anchor": "center",
-		  "text-allow-overlap": true,
-		  "text-offset": [
-		   0,
-		   1.6
-		  ],
-		  "text-font": [
-		   "Open Sans Regular"
-		  ],
-		  "visibility": "none"
-		 },
-		 "paint": {
-		  "text-color": "#79654F",
-		  "text-halo-width": 1,
-		  "text-halo-color": "#FFFFFF"
-		 }
-		},
-		{
-		 "id": "toponyme - courbe rocher maitresse",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_oro_ponc",
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "ORO_COURBE_ROCHER"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 10,
-		  "text-allow-overlap": false,
-		  "text-padding": 30,
-		  "text-rotate": {
-		   "type": "identity",
-		   "property": "rotation"
-		  },
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#333333",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 1
-		 }
-		},
-		{
-		 "id": "toponyme - courbe glacier maitresse",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_oro_ponc",
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "ORO_COURBE_GLACIER"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 10,
-		  "text-allow-overlap": false,
-		  "text-padding": 30,
-		  "text-rotate": {
-		   "type": "identity",
-		   "property": "rotation"
-		  },
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#629FD9",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 1
-		 }
-		},
-		{
-		 "id": "toponyme - courbe maitresse",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_oro_ponc",
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "ORO_COURBE"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 10,
-		  "text-allow-overlap": false,
-		  "text-padding": 30,
-		  "text-rotate": {
-		   "type": "identity",
-		   "property": "rotation"
-		  },
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#604A2F",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 1
-		 }
-		},
-		{
-		 "id": "toponyme - liaison maritime",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_routier_liaison_lin",
-		 "minzoom": 8,
-		 "maxzoom": 22,
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "LIAISON_MARITIME"
-		 ],
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{texte}",
-		  "text-size": 15,
-		  "text-anchor": "center",
-		  "text-keep-upright": true,
-		  "text-max-angle": 45,
-		  "text-padding": 10,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ],
-		  "visibility": "visible"
-		 },
-		 "paint": {
-		  "text-color": "#5792C2",
-		  "text-halo-width": 5,
-		  "text-halo-color": "#AAD5E9"
-		 }
-		},
-		{
-		 "id": "toponyme bati station de métro + bati ponctuel metro",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_bati_ponc",
-		 "minzoom": 14,
-		 "filter": [
-		  "all",
-		  [
-		   "==",
-		   "txt_typo",
-		   "TYPO_E_1"
-		  ],
-		  [
-		   "==",
-		   "symbo",
-		   "STATION_METRO"
-		  ]
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 11,
-		  "text-allow-overlap": false,
-		  "text-offset": [
-		   0.3,
-		   -0.25
-		  ],
-		  "text-padding": 3,
-		  "text-anchor": "bottom-left",
-		  "text-font": [
-		   "Open Sans Regular"
-		  ],
-		  "icon-image": "Metro",
-		  "icon-size": {
-		   "stops": [
-			[
-			 15,
-			 0.33
-			],
-			[
-			 17,
-			 0.6
-			]
-		   ]
-		  }
-		 },
-		 "paint": {
-		  "text-color": "#3C3C3C",
-		  "icon-color": "#646464"
-		 }
-		},
-		{
-		 "id": "toponyme ferre lineaire",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_ferre_lin",
-		 "minzoom": 12,
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "FER_NOM",
-		  "FER_OUVRAGE"
-		 ],
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{texte}",
-		  "text-size": 10,
-		  "text-anchor": "center",
-		  "text-offset": [
-		   0,
-		   -1
-		  ],
-		  "text-font": [
-		   "Open Sans Regular"
-		  ],
-		  "visibility": "visible"
-		 },
-		 "paint": {
-		  "text-color": "#000000",
-		  "text-halo-width": 1,
-		  "text-halo-color": "rgba(255, 255, 255, 1)"
-		 }
-		},
-		{
-		 "id": "toponyme station epuration, de pompage, usine de production eau",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_bati_ponc",
-		 "minzoom": 14,
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "station"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{designation}",
-		  "text-anchor": "left",
-		  "text-offset": [
-		   0.8,
-		   0
-		  ],
-		  "text-size": 11,
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#447FB3"
-		 }
-		},
-		{
-		 "id": "toponyme bati ponc gare",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_bati_ponc",
-		 "minzoom": 15,
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "gore"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{designation}",
-		  "text-size": 11,
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#000000"
-		 }
-		},
-		{
-		 "id": "toponyme bati ponc barrage",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_bati_ponc",
-		 "minzoom": 12,
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "BARRAGE_PONC"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-anchor": "left",
-		  "text-offset": [
-		   0.8,
-		   0
-		  ],
-		  "text-size": 11,
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#447FB3"
-		 }
-		},
-		{
-		 "id": "toponyme bati ponc phare - niveau 13",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_bati_ponc",
-		 "maxzoom": 21,
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "PHARE"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-anchor": "right",
-		  "text-size": 11,
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#532A2A"
-		 }
-		},
-		{
-		 "id": "toponyme bati ponc phare - niveau 14à19",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_bati_ponc",
-		 "minzoom": 13,
-		 "filter": [
-		  "all",
-		  [
-		   "==",
-		   "symbo",
-		   "PHARE"
-		  ],
-		  [
-		   "in",
-		   "txt_typo",
-		   "TYPO_C_6",
-		   "TYPO_C_7",
-		   "TYPO_C_8",
-		   "TYPO_E_GE"
-		  ]
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-anchor": "right",
-		  "text-size": {
-		   "stops": [
-			[
-			 13,
-			 12
-			],
-			[
-			 18,
-			 18
-			]
-		   ]
-		  },
-		  "text-allow-overlap": false,
-		  "text-offset": [
-		   -2,
-		   0
-		  ],
-		  "text-padding": 3,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#532A2A"
-		 }
-		},
-		{
-		 "id": "toponyme bati ponc autre",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_bati_ponc",
-		 "minzoom": 12,
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "BAT_ACTIVITE",
-		  "BAT_FORTIF",
-		  "BAT_VILLAGE_DETRUIT"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-anchor": "center",
-		  "text-size": 11,
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#532A2A"
-		 }
-		},
-		{
-		 "id": "toponyme bati ponc aerogare",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_bati_ponc",
-		 "minzoom": 14,
-		 "maxzoom": 21,
-		 "filter": [
-		  "all",
-		  [
-		   "==",
-		   "txt_typo",
-		   "TYPO_E_GE"
-		  ],
-		  [
-		   "==",
-		   "symbo",
-		   "AEROGARE"
-		  ]
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-anchor": "center",
-		  "text-size": {
-		   "stops": [
-			[
-			 12,
-			 9
-			],
-			[
-			 16,
-			 11
-			]
-		   ]
-		  },
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#120049",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 1
-		 }
-		},
-		{
-		 "id": "toponyme bati ponc aeroport 12",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_bati_ponc",
-		 "minzoom": 11,
-		 "maxzoom": 21,
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "AEROPORT_PONC"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-anchor": "bottom",
-		  "text-offset": [
-		   0,
-		   -1.3
-		  ],
-		  "text-size": 10.5,
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#120049",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme bati ponc aeroport 13",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_bati_ponc",
-		 "minzoom": 12,
-		 "maxzoom": 21,
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "AEROPORT_PONC"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-anchor": "bottom",
-		  "text-offset": [
-		   0,
-		   -2
-		  ],
-		  "text-size": 11,
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#120049",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme bati ponc aeroport",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_bati_ponc",
-		 "minzoom": 13,
-		 "maxzoom": 21,
-		 "filter": [
-		  "all",
-		  [
-		   "==",
-		   "txt_typo",
-		   "TYPO_A_5"
-		  ],
-		  [
-		   "==",
-		   "symbo",
-		   "AEROPORT"
-		  ]
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-anchor": "center",
-		  "text-size": {
-		   "stops": [
-			[
-			 12,
-			 11
-			],
-			[
-			 16,
-			 13
-			]
-		   ]
-		  },
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#120049",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme bati ponc aerodrome 12",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_bati_ponc",
-		 "minzoom": 11,
-		 "maxzoom": 21,
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "AERODROME_PONC"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-anchor": "bottom",
-		  "text-offset": [
-		   0,
-		   -1.3
-		  ],
-		  "text-size": 9.5,
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#120049",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme bati ponc aerodrome 13",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_bati_ponc",
-		 "minzoom": 12,
-		 "maxzoom": 21,
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "AERODROME_PONC"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-anchor": "bottom",
-		  "text-offset": [
-		   0,
-		   -2
-		  ],
-		  "text-size": 10,
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#120049",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme bati ponc aerodrome",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_bati_ponc",
-		 "minzoom": 13,
-		 "maxzoom": 21,
-		 "filter": [
-		  "all",
-		  [
-		   "==",
-		   "txt_typo",
-		   "TYPO_A_7"
-		  ],
-		  [
-		   "==",
-		   "symbo",
-		   "AERODROME"
-		  ]
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-anchor": "center",
-		  "text-size": {
-		   "stops": [
-			[
-			 12,
-			 10
-			],
-			[
-			 16,
-			 12
-			]
-		   ]
-		  },
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#120049",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme - hydro ponc 5",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_hydro_ponc",
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "TYPO_D_9",
-		  "TYPO_D_10",
-		  "TYPO_E_1_cyan"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 15,
-			 11
-			],
-			[
-			 17,
-			 14
-			]
-		   ]
-		  },
-		  "text-allow-overlap": true,
-		  "text-padding": 5,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#447FB3",
-		  "text-halo-color": "#FFFFFF",
-		  "text-halo-width": 1
-		 }
-		},
-		{
-		 "id": "toponyme - hydro ponc glacier",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_hydro_ponc",
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "ORO_GLACIER_2"
-		 ],
-		 "layout": {
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 14,
-		  "text-anchor": "center",
-		  "text-allow-overlap": true,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ],
-		  "visibility": "visible"
-		 },
-		 "paint": {
-		  "text-color": "#447FB3",
-		  "text-halo-width": 2,
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)"
-		 }
-		},
-		{
-		 "id": "toponyme - limite militaire ponc 3 et 4",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_limite_ponc",
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "LIM_MILI_3",
-		  "LIM_MILI_4"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 12,
-		  "text-allow-overlap": false,
-		  "text-padding": 2,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#0D2000",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 1
-		 }
-		},
-		{
-		 "id": "toponyme - limite parc ponc 3 et 4",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_limite_ponc",
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "LIM_PARC_3",
-		  "LIM_PARC_4",
-		  "RESERVE_NATURELLE_PONC"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 13,
-		  "text-allow-overlap": false,
-		  "text-padding": 2,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#287B00",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 1
-		 }
-		},
-		{
-		 "id": "toponyme numéro de route - départementale",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_routier_numero_lin",
-		 "minzoom": 11,
-		 "maxzoom": 22,
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "Départementale"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "line",
-		  "text-field": "{texte}",
-		  "text-size": 10.5,
-		  "text-allow-overlap": false,
-		  "text-padding": 2,
-		  "text-anchor": "center",
-		  "text-font": [
-		   "Open Sans Regular"
-		  ],
-		  "text-rotation-alignment": "viewport"
-		 },
-		 "paint": {
-		  "text-color": "#4D4D4D",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 4
-		 }
-		},
-		{
-		 "id": "toponyme numéro de route - nationale",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_routier_numero_lin",
-		 "minzoom": 7,
-		 "maxzoom": 22,
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "Nationale"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "line",
-		  "text-field": "{texte}",
-		  "text-size": 12,
-		  "text-allow-overlap": false,
-		  "text-padding": 0,
-		  "text-anchor": "center",
-		  "text-font": [
-		   "Open Sans Regular"
-		  ],
-		  "icon-image": "Ecluse",
-		  "icon-rotation-alignment": "viewport",
-		  "text-rotation-alignment": "viewport",
-		  "icon-text-fit": "both",
-		  "icon-size": 0
-		 },
-		 "paint": {
-		  "text-color": "#F0F0F0",
-		  "icon-color": "#646464",
-		  "text-halo-color": "rgba(80, 80, 80, 0.5)",
-		  "text-halo-width": 4
-		 }
-		},
-		{
-		 "id": "toponyme numéro de route - autoroute",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_routier_numero_lin",
-		 "minzoom": 7,
-		 "maxzoom": 22,
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "Autoroute"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "line",
-		  "text-field": "{texte}",
-		  "text-size": 15,
-		  "text-allow-overlap": false,
-		  "text-padding": 0,
-		  "text-anchor": "center",
-		  "text-font": [
-		   "Open Sans Regular"
-		  ],
-		  "icon-image": "Ecluse",
-		  "icon-rotation-alignment": "viewport",
-		  "text-rotation-alignment": "viewport",
-		  "icon-text-fit": "both",
-		  "icon-size": 0
-		 },
-		 "paint": {
-		  "text-color": "#F0F0F0",
-		  "icon-color": "#646464",
-		  "text-halo-color": "rgba(80, 80, 80, 0.5)",
-		  "text-halo-width": 5
-		 }
-		},
-		{
-		 "id": "toponyme - odonyme abrégé",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_routier_odonyme_lin",
-		 "minzoom": 15,
-		 "maxzoom": 22,
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{nom_gauche}",
-		  "text-size": 10,
-		  "text-anchor": "center",
-		  "text-max-angle": 30,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ],
-		  "visibility": "none"
-		 },
-		 "paint": {
-		  "text-color": "#000000",
-		  "text-halo-width": 2,
-		  "text-halo-color": "rgba(255, 255, 255, 1)"
-		 }
-		},
-		{
-		 "id": "toponyme - odonyme desabrégé",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_routier_odonyme_lin",
-		 "minzoom": 17,
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{nom_desabrege}",
-		  "text-size": 11,
-		  "text-anchor": "center",
-		  "text-max-angle": 30,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ],
-		  "visibility": "none"
-		 },
-		 "paint": {
-		  "text-color": "#000000",
-		  "text-halo-width": 2,
-		  "text-halo-color": "rgba(255, 255, 255, 1)"
-		 }
-		},
-		{
-		 "id": "toponyme - lieu dit non habité 3",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_ocs_ponc",
-		 "filter": [
-		  "all",
-		  [
-		   "==",
-		   "symbo",
-		   "LIEU-DIT_NON_HABITE"
-		  ],
-		  [
-		   "in",
-		   "txt_typo",
-		   "TYPO_B_10",
-		   "TYPO_B_11"
-		  ]
-		 ],
-		 "layout": {
-		  "visibility": "none",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 11,
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#000000",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 1
-		 }
-		},
-		{
-		 "id": "toponyme - bois",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_ocs_ponc",
-		 "filter": [
-		  "all",
-		  [
-		   "==",
-		   "symbo",
-		   "BOIS"
-		  ],
-		  [
-		   "in",
-		   "txt_typo",
-		   "TYPO_F_10",
-		   "TYPO_F_11"
-		  ]
-		 ],
-		 "layout": {
-		  "visibility": "none",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 13,
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#287B00",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 1
-		 }
-		},
-		{
-		 "id": "toponyme - oro lineaire 4",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_oro_lin",
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "ORO_SOMMET_3",
-		  "ORO_GORGE_2"
-		 ],
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{texte}",
-		  "text-size": 11,
-		  "text-anchor": "center",
-		  "text-keep-upright": true,
-		  "text-max-angle": 45,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ],
-		  "visibility": "visible"
-		 },
-		 "paint": {
-		  "text-color": "#863831",
-		  "text-halo-width": 1.5,
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)"
-		 }
-		},
-		{
-		 "id": "toponyme - oro ponc 4",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_oro_ponc",
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "ORO_SOMMET_3",
-		  "ORO_GORGE_2",
-		  "GROTTE",
-		  "GORGE",
-		  "TYPO_G_9",
-		  "TYPO_G_10"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 13,
-			 11
-			],
-			[
-			 16,
-			 16
-			]
-		   ]
-		  },
-		  "text-allow-overlap": true,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#863831",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 1.5
-		 }
-		},
-		{
-		 "id": "toponyme - hydro ponc 4",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_hydro_ponc",
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "lac - étang - bassin",
-		  "HYD_SURF_4",
-		  "HYD_SURF_4_T",
-		  "HYD_SURF_5",
-		  "HYD_SURF_5_T",
-		  "TYPO_D_8",
-		  "SOURCE"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 14,
-			 13
-			],
-			[
-			 17,
-			 16
-			]
-		   ]
-		  },
-		  "text-allow-overlap": true,
-		  "text-padding": 5,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#447FB3",
-		  "text-halo-color": "#FFFFFF",
-		  "text-halo-width": 1
-		 }
-		},
-		{
-		 "id": "toponyme - lieu dit non habité",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_ocs_ponc",
-		 "filter": [
-		  "all",
-		  [
-		   "==",
-		   "symbo",
-		   "LIEU-DIT_NON_HABITE"
-		  ],
-		  [
-		   "in",
-		   "txt_typo",
-		   "TYPO_B_7",
-		   "TYPO_B_8",
-		   "TYPO_B_9"
-		  ]
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 12,
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#000000",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 1
-		 }
-		},
-		{
-		 "id": "toponyme - bois 2",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_ocs_ponc",
-		 "filter": [
-		  "all",
-		  [
-		   "==",
-		   "symbo",
-		   "BOIS"
-		  ],
-		  [
-		   "in",
-		   "txt_typo",
-		   "TYPO_F_7",
-		   "TYPO_F_8",
-		   "TYPO_F_9"
-		  ]
-		 ],
-		 "layout": {
-		  "visibility": "none",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 16,
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#287B00",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme localite importance 5",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_localite_ponc",
-		 "minzoom": 9,
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "commune 5",
-		  "BAT_COMMUNE_5",
-		  "BAT_COMMUNE_5_T",
-		  "BAT_CHEF_LIEU_COM",
-		  "BAT_CHEF_LIEU_COM_T",
-		  "BAT_CHEF_LIEU_COM-T",
-		  "BAT_ANCIENNE_COM",
-		  "BAT_ANCIENNE_COM_T",
-		  "BAT_COMMUNE_ASSOCIEE",
-		  "BAT_COMMUNE_ASSOCIEE_T",
-		  "Commune très petite"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "icon-image": "Localite",
-		  "icon-size": 0.21,
-		  "text-field": "{texte}",
-		  "text-size": 11.5,
-		  "text-allow-overlap": false,
-		  "text-anchor": "bottom-left",
-		  "text-offset": [
-		   0.3,
-		   0.1
-		  ],
-		  "text-padding": 1,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#000000",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme - ocs lineaire 3",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_ocs_lin",
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "OCS_FORET_3"
-		 ],
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 10,
-			 12
-			],
-			[
-			 12,
-			 15
-			]
-		   ]
-		  },
-		  "text-anchor": "center",
-		  "text-keep-upright": true,
-		  "text-max-angle": 45,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ],
-		  "visibility": "visible"
-		 },
-		 "paint": {
-		  "text-color": "#287B00",
-		  "text-halo-width": 1,
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)"
-		 }
-		},
-		{
-		 "id": "toponyme - lieu dit non habité 1",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_ocs_ponc",
-		 "filter": [
-		  "all",
-		  [
-		   "==",
-		   "symbo",
-		   "LIEU-DIT_NON_HABITE"
-		  ],
-		  [
-		   "in",
-		   "txt_typo",
-		   "TYPO_B_5",
-		   "TYPO_B_4"
-		  ]
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 15,
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#000000",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 1
-		 }
-		},
-		{
-		 "id": "toponyme - bois 1",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_ocs_ponc",
-		 "filter": [
-		  "all",
-		  [
-		   "==",
-		   "symbo",
-		   "BOIS"
-		  ],
-		  [
-		   "in",
-		   "txt_typo",
-		   "TYPO_F_5",
-		   "TYPO_F_4"
-		  ]
-		 ],
-		 "layout": {
-		  "visibility": "none",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 19,
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#287B00",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme - bois 0",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_ocs_ponc",
-		 "filter": [
-		  "all",
-		  [
-		   "==",
-		   "symbo",
-		   "BOIS"
-		  ],
-		  [
-		   "in",
-		   "txt_typo",
-		   "TYPO_F_3",
-		   "TYPO_F_2"
-		  ]
-		 ],
-		 "layout": {
-		  "visibility": "none",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 22,
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#287B00",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme - ocs ponc 3",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_ocs_ponc",
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "OCS_FORET_3"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 10,
-			 12
-			],
-			[
-			 12,
-			 15
-			]
-		   ]
-		  },
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-anchor": "center",
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#287B00",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 1
-		 }
-		},
-		{
-		 "id": "toponyme - oro lineaire 3",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_oro_lin",
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "ORO_ILE_3",
-		  "ORO_RELIEF_3",
-		  "ORO_RELIEF_3_T",
-		  "ORO_RELIEF_4",
-		  "ORO_RELIEF_4_T",
-		  "ORO_CAP_2",
-		  "ORO_CAP_3",
-		  "ORO_SOMMET_2",
-		  "ORO_COL_2",
-		  "ORO_GORGE_1",
-		  "ORO_GORGE-1"
-		 ],
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{texte}",
-		  "text-size": 12,
-		  "text-anchor": "center",
-		  "text-keep-upright": true,
-		  "text-max-angle": 45,
-		  "text-padding": 10,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ],
-		  "visibility": "visible"
-		 },
-		 "paint": {
-		  "text-color": "#863831",
-		  "text-halo-width": 1.5,
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)"
-		 }
-		},
-		{
-		 "id": "toponyme - oro ponc 3",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_oro_ponc",
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "ORO_ILE_3",
-		  "ORO_RELIEF_3",
-		  "ORO_RELIEF_3_T",
-		  "ORO_RELIEF_4",
-		  "ORO_RELIEF_4_T",
-		  "ORO_CAP_2",
-		  "ORO_CAP_3",
-		  "ORO_SOMMET_2",
-		  "ORO_COL_2",
-		  "ORO_GORGE_1",
-		  "ORO_GORGE-1",
-		  "TYPO_G_7",
-		  "TYPO_G_8"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 13,
-			 12
-			],
-			[
-			 16,
-			 17
-			]
-		   ]
-		  },
-		  "text-allow-overlap": true,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#863831",
-		  "text-halo-color": "#FFFFFF",
-		  "text-halo-width": 1.5
-		 }
-		},
-		{
-		 "id": "toponyme - hydro lineaire 3",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_hydro_lin",
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "HYD_LIN_3",
-		  "HYD_LIN_4",
-		  "HYD_LIN_5",
-		  "petite rivière",
-		  "canal",
-		  "HYD_SURF_3",
-		  "HYD_SURF_3_T",
-		  "HYD_SURF_4",
-		  "HYD_SURF_4_T",
-		  "HYD_SURF_5",
-		  "HYD_SURF_5_T",
-		  "TYPO_D_5"
-		 ],
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 14,
-			 12
-			],
-			[
-			 18,
-			 19
-			]
-		   ]
-		  },
-		  "text-anchor": "center",
-		  "text-keep-upright": true,
-		  "text-max-angle": 45,
-		  "text-padding": 10,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ],
-		  "visibility": "visible"
-		 },
-		 "paint": {
-		  "text-color": "#447FB3",
-		  "text-halo-width": 1.5,
-		  "text-halo-color": "rgba(255, 255, 255, 0.7)"
-		 }
-		},
-		{
-		 "id": "toponyme - hydro lineaire 4",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_hydro_lin",
-		 "minzoom": 14,
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "TYPO_D_6",
-		  "TYPO_D_8",
-		  "TYPO_D_9",
-		  "TYPO_D_10"
-		 ],
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 14,
-			 10
-			],
-			[
-			 18,
-			 16
-			]
-		   ]
-		  },
-		  "text-anchor": "center",
-		  "text-keep-upright": true,
-		  "text-max-angle": 45,
-		  "text-padding": 10,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ],
-		  "visibility": "visible"
-		 },
-		 "paint": {
-		  "text-color": "#447FB3",
-		  "text-halo-width": 1.5,
-		  "text-halo-color": "rgba(255, 255, 255, 0.7)"
-		 }
-		},
-		{
-		 "id": "toponyme - hydro ponc 3",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_hydro_ponc",
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "petit golfe",
-		  "grande baie",
-		  "baie",
-		  "HYD_SURF_3",
-		  "TYPO_D_5",
-		  "TYPO_D_6",
-		  "TYPO_D_7"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 15,
-			 15
-			],
-			[
-			 17,
-			 18
-			]
-		   ]
-		  },
-		  "text-allow-overlap": true,
-		  "text-padding": 10,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#447FB3",
-		  "text-halo-color": "#FFFFFF",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme bati ponc zai zoom 16",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_bati_ponc",
-		 "minzoom": 15,
-		 "maxzoom": 21,
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "zai"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{designation}",
-		  "text-size": 11,
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#000000"
-		 }
-		},
-		{
-		 "id": "toponyme bati ponc zai zoom 17 et 18",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_bati_ponc",
-		 "minzoom": 16,
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "zai"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 11,
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#000000"
-		 }
-		},
-		{
-		 "id": "toponyme localite importance 4",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_localite_ponc",
-		 "minzoom": 7,
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "commune 4",
-		  "BAT_COMMUNE_4",
-		  "BAT_COMMUNE_4_T"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "icon-image": "Localite",
-		  "icon-size": 0.21,
-		  "text-field": "{texte}",
-		  "text-size": 13,
-		  "text-allow-overlap": false,
-		  "text-anchor": "bottom-left",
-		  "text-offset": [
-		   0.3,
-		   0.1
-		  ],
-		  "text-padding": 1,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#000000",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme - limite militaire ponc 1 et 2",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_limite_ponc",
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "LIM_MILI_1",
-		  "LIM_MILI_2"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 15,
-		  "text-allow-overlap": false,
-		  "text-padding": 5,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#0D2000",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme - limite parc marin",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_limite_ponc",
-		 "minzoom": 8,
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "LIM_PARC_NATUREL_MARIN"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 15,
-		  "text-allow-overlap": false,
-		  "text-padding": 10,
-		  "text-transform": "uppercase",
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#2A81A2",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme - limite parc ponc 1 et 2",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_limite_ponc",
-		 "minzoom": 8,
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "LIM_PARC_1",
-		  "LIM_PARC_2",
-		  "LIM_PARC_NATUREL"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 15,
-		  "text-allow-overlap": false,
-		  "text-padding": 10,
-		  "text-transform": "uppercase",
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#287B00",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme - ocs lineaire 2",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_ocs_lin",
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "OCS_FORET_2"
-		 ],
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 10,
-			 15
-			],
-			[
-			 12,
-			 18
-			]
-		   ]
-		  },
-		  "text-anchor": "center",
-		  "text-keep-upright": true,
-		  "text-max-angle": 45,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ],
-		  "visibility": "visible"
-		 },
-		 "paint": {
-		  "text-color": "#287B00",
-		  "text-halo-width": 2,
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)"
-		 }
-		},
-		{
-		 "id": "toponyme - ocs ponc 2",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_ocs_ponc",
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "OCS_FORET_2"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 10,
-			 15
-			],
-			[
-			 12,
-			 18
-			]
-		   ]
-		  },
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-anchor": "center",
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#287B00",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme - oro lineaire 2",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_oro_lin",
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "ORO_ILE_2",
-		  "ORO_RELIEF_2",
-		  "ORO_RELIEF_2_T",
-		  "ORO_CAP_1",
-		  "ORO_SOMMET_1"
-		 ],
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{texte}",
-		  "text-size": 15,
-		  "text-anchor": "center",
-		  "text-keep-upright": true,
-		  "text-padding": 10,
-		  "text-max-angle": 45,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ],
-		  "visibility": "visible"
-		 },
-		 "paint": {
-		  "text-color": "#863831",
-		  "text-halo-width": 2,
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)"
-		 }
-		},
-		{
-		 "id": "toponyme - oro ponc 2",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_oro_ponc",
-		 "minzoom": 9,
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "ORO_ILE_2",
-		  "ORO_RELIEF_2",
-		  "ORO_RELIEF_2_T",
-		  "ORO_CAP_1",
-		  "ORO_COL_1",
-		  "sommet ou col",
-		  "ORO_SOMMET_1",
-		  "TYPO_G_4",
-		  "TYPO_G_6"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 9,
-			 13
-			],
-			[
-			 10,
-			 15
-			],
-			[
-			 13,
-			 15
-			],
-			[
-			 16,
-			 19
-			]
-		   ]
-		  },
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#863831",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme - oro ponc 2B",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_oro_ponc",
-		 "minzoom": 8,
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "île",
-		  "cap ou pointe"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 15,
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#863831",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme - hydro lineaire 2",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_hydro_lin",
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "HYD_LIN_2",
-		  "rivière moyenne",
-		  "HYD_SURF_2",
-		  "HYD_SURF_2_T",
-		  "TYPO_D_3"
-		 ],
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 14,
-			 15
-			],
-			[
-			 18,
-			 21
-			]
-		   ]
-		  },
-		  "text-anchor": "center",
-		  "text-keep-upright": true,
-		  "text-max-angle": 45,
-		  "text-padding": 10,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ],
-		  "visibility": "visible"
-		 },
-		 "paint": {
-		  "text-color": "#447FB3",
-		  "text-halo-width": 2,
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)"
-		 }
-		},
-		{
-		 "id": "toponyme - hydro ponc 2",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_hydro_ponc",
-		 "minzoom": 5,
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "moyen",
-		  "golfe moyen",
-		  "HYD_SURF_2",
-		  "TYPO_D_2",
-		  "TYPO_D_3",
-		  "TYPO_D_4"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 5,
-			 12
-			],
-			[
-			 6,
-			 18
-			],
-			[
-			 10,
-			 17
-			],
-			[
-			 18,
-			 21
-			]
-		   ]
-		  },
-		  "text-allow-overlap": false,
-		  "text-padding": 10,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#447FB3",
-		  "text-halo-color": "#FFFFFF",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme localite importance 3",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_localite_ponc",
-		 "minzoom": 5,
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "commune 3",
-		  "BAT_COMMUNE_3",
-		  "BAT_COMMUNE_3_T"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "icon-image": "Localite",
-		  "icon-size": 0.21,
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 5,
-			 10
-			],
-			[
-			 6,
-			 15
-			]
-		   ]
-		  },
-		  "text-allow-overlap": false,
-		  "text-anchor": "bottom-left",
-		  "text-offset": [
-		   0.3,
-		   0.1
-		  ],
-		  "text-padding": 1,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#000000",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme localite n0 typoA7 non commune",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_localite_ponc",
-		 "maxzoom": 21,
-		 "filter": [
-		  "all",
-		  [
-		   "!=",
-		   "symbo",
-		   "COMMUNE_FUSIONNEE"
-		  ],
-		  [
-		   "!=",
-		   "symbo",
-		   "COMMUNE_CHEF_LIEU"
-		  ],
-		  [
-		   "==",
-		   "txt_typo",
-		   "TYPO_A_7"
-		  ]
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 15,
-			 13
-			],
-			[
-			 17,
-			 16
-			]
-		   ]
-		  },
-		  "text-allow-overlap": true,
-		  "text-anchor": "center",
-		  "text-padding": 1,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#000000",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme localite n0 typoA6 non commune",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_localite_ponc",
-		 "maxzoom": 21,
-		 "filter": [
-		  "all",
-		  [
-		   "!=",
-		   "symbo",
-		   "COMMUNE_FUSIONNEE"
-		  ],
-		  [
-		   "!=",
-		   "symbo",
-		   "COMMUNE_CHEF_LIEU"
-		  ],
-		  [
-		   "==",
-		   "txt_typo",
-		   "TYPO_A_6"
-		  ]
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 15,
-			 15
-			],
-			[
-			 17,
-			 18
-			]
-		   ]
-		  },
-		  "text-allow-overlap": true,
-		  "text-anchor": "center",
-		  "text-padding": 1,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#000000",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme - oro lineaire 1",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_oro_lin",
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "ORO_ILE_1",
-		  "ORO_RELIEF_1",
-		  "ORO_RELIEF_1_T"
-		 ],
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{texte}",
-		  "text-size": 20,
-		  "text-anchor": "center",
-		  "text-keep-upright": true,
-		  "text-padding": 5,
-		  "text-max-angle": 45,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ],
-		  "visibility": "visible"
-		 },
-		 "paint": {
-		  "text-color": "#863831",
-		  "text-halo-width": 2,
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)"
-		 }
-		},
-		{
-		 "id": "toponyme - oro ponc monde",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_oro_ponc",
-		 "minzoom": 5,
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "Basin",
-		  "Depression",
-		  "Desert",
-		  "Geoarea",
-		  "Gorge",
-		  "Isthmus",
-		  "Lake",
-		  "Lowland",
-		  "Pen/cape",
-		  "Plain",
-		  "Plateau",
-		  "Range/mtn",
-		  "Tundra",
-		  "Valley",
-		  "Island",
-		  "Island group"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 11,
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#863831",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme localite n0 typoA4 non commune",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_localite_ponc",
-		 "maxzoom": 21,
-		 "filter": [
-		  "all",
-		  [
-		   "!=",
-		   "symbo",
-		   "COMMUNE_FUSIONNEE"
-		  ],
-		  [
-		   "!=",
-		   "symbo",
-		   "COMMUNE_CHEF_LIEU"
-		  ],
-		  [
-		   "==",
-		   "txt_typo",
-		   "TYPO_A_4"
-		  ]
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 17,
-		  "text-allow-overlap": true,
-		  "text-anchor": "center",
-		  "text-padding": 1,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#000000",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 3
-		 }
-		},
-		{
-		 "id": "toponyme - ocs lineaire 1",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_ocs_lin",
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "OCS_FORET_1"
-		 ],
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 10,
-			 18
-			],
-			[
-			 12,
-			 22
-			]
-		   ]
-		  },
-		  "text-anchor": "center",
-		  "text-keep-upright": true,
-		  "text-padding": 1,
-		  "text-max-angle": 45,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ],
-		  "visibility": "visible"
-		 },
-		 "paint": {
-		  "text-color": "#287B00",
-		  "text-halo-width": 2,
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)"
-		 }
-		},
-		{
-		 "id": "toponyme - ocs ponc 1",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_ocs_ponc",
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "OCS_FORET_1"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 10,
-			 18
-			],
-			[
-			 12,
-			 22
-			]
-		   ]
-		  },
-		  "text-allow-overlap": true,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#287B00",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme - oro ponc 1",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_oro_ponc",
-		 "minzoom": 8,
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "grande île",
-		  "ORO_ILE_1",
-		  "ORO_RELIEF_1",
-		  "ORO_RELIEF_1_T",
-		  "TYPO_G_3",
-		  "TYPO_G_2",
-		  "TYPO_G_1"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 21,
-		  "text-allow-overlap": true,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#863831",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme - hydro lineaire glacier",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_hydro_lin",
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "ORO_GLACIER_1",
-		  "ORO_GLACIER_2"
-		 ],
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{texte}",
-		  "text-size": 15,
-		  "text-anchor": "center",
-		  "text-keep-upright": true,
-		  "text-max-angle": 45,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ],
-		  "visibility": "visible"
-		 },
-		 "paint": {
-		  "text-color": "#447FB3",
-		  "text-halo-width": 2,
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)"
-		 }
-		},
-		{
-		 "id": "toponyme - hydro lineaire 1",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_hydro_lin",
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "HYD_LIN_1",
-		  "HYD-LIN-1",
-		  "grande rivière",
-		  "HYD_SURF_1",
-		  "HYD_SURF_1_T",
-		  "TYPO_D_1",
-		  "TYPO_D_2"
-		 ],
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{texte}",
-		  "text-size": 18,
-		  "text-anchor": "center",
-		  "text-keep-upright": true,
-		  "text-max-angle": 45,
-		  "text-padding": 10,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ],
-		  "visibility": "visible"
-		 },
-		 "paint": {
-		  "text-color": "#447FB3",
-		  "text-halo-width": 2,
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)"
-		 }
-		},
-		{
-		 "id": "toponyme - hydro lineaire ocean",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_hydro_lin",
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "mer et océan"
-		 ],
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{texte}",
-		  "text-size": 30,
-		  "text-anchor": "center",
-		  "text-keep-upright": true,
-		  "text-max-angle": 45,
-		  "text-padding": 10,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ],
-		  "visibility": "visible"
-		 },
-		 "paint": {
-		  "text-color": "#447FB3",
-		  "text-halo-width": 4,
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)"
-		 }
-		},
-		{
-		 "id": "toponyme - hydro ponc 1",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_hydro_ponc",
-		 "minzoom": 4,
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "mer",
-		  "grand",
-		  "grand golfe",
-		  "HYD_SURF_1",
-		  "TYPO_D_1"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 4,
-			 16
-			],
-			[
-			 6,
-			 30
-			],
-			[
-			 10,
-			 25
-			]
-		   ]
-		  },
-		  "text-allow-overlap": true,
-		  "text-padding": 10,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#447FB3",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 4
-		 }
-		},
-		{
-		 "id": "toponyme localite importance 2",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_localite_ponc",
-		 "minzoom": 4,
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "commune 2",
-		  "BAT_COMMUNE_2",
-		  "BAT_COMMUNE-2",
-		  "BAT_COMMUNE_2_T"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "icon-image": "Localite",
-		  "icon-size": 0.25,
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 4,
-			 10
-			],
-			[
-			 6,
-			 17
-			]
-		   ]
-		  },
-		  "text-allow-overlap": true,
-		  "text-anchor": "bottom-left",
-		  "text-offset": [
-		   0.3,
-		   0.2
-		  ],
-		  "text-padding": 1,
-		  "text-transform": "uppercase",
-		  "text-font": {
-		   "stops": [
-			[
-			 1,
-			 [
-			  "Open Sans Regular"
-			 ]
-			],
-			[
-			 7,
-			 [
-			  "Open Sans Regular"
-			 ]
-			],
-			[
-			 10,
-			 [
-			  "Open Sans Regular"
-			 ]
-			]
-		   ]
-		  }
-		 },
-		 "paint": {
-		  "text-color": "#000000",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 3
-		 }
-		},
-		{
-		 "id": "toponyme localite n0 typoA3 non commune",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_localite_ponc",
-		 "maxzoom": 21,
-		 "filter": [
-		  "all",
-		  [
-		   "!=",
-		   "symbo",
-		   "COMMUNE_FUSIONNEE"
-		  ],
-		  [
-		   "!=",
-		   "symbo",
-		   "COMMUNE_CHEF_LIEU"
-		  ],
-		  [
-		   "==",
-		   "txt_typo",
-		   "TYPO_A_3"
-		  ]
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 19,
-		  "text-allow-overlap": true,
-		  "text-anchor": "center",
-		  "text-padding": 1,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#000000",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 3
-		 }
-		},
-		{
-		 "id": "toponyme localite n0 typoA2 non commune",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_localite_ponc",
-		 "maxzoom": 21,
-		 "filter": [
-		  "all",
-		  [
-		   "!=",
-		   "symbo",
-		   "COMMUNE_FUSIONNEE"
-		  ],
-		  [
-		   "!=",
-		   "symbo",
-		   "COMMUNE_CHEF_LIEU"
-		  ],
-		  [
-		   "==",
-		   "txt_typo",
-		   "TYPO_A_2"
-		  ]
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 21,
-		  "text-allow-overlap": true,
-		  "text-anchor": "center",
-		  "text-padding": 1,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#000000",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 4
-		 }
-		},
-		{
-		 "id": "toponyme localite n0 typoA7 commune",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_localite_ponc",
-		 "maxzoom": 21,
-		 "filter": [
-		  "all",
-		  [
-		   "in",
-		   "symbo",
-		   "COMMUNE_FUSIONNEE",
-		   "COMMUNE_CHEF_LIEU"
-		  ],
-		  [
-		   "==",
-		   "txt_typo",
-		   "TYPO_A_7"
-		  ]
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 15,
-			 13
-			],
-			[
-			 17,
-			 16
-			]
-		   ]
-		  },
-		  "text-allow-overlap": true,
-		  "text-anchor": "center",
-		  "text-padding": 1,
-		  "text-transform": "uppercase",
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#000000",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme localite n0 typoA6 commune",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_localite_ponc",
-		 "maxzoom": 21,
-		 "filter": [
-		  "all",
-		  [
-		   "in",
-		   "symbo",
-		   "COMMUNE_FUSIONNEE",
-		   "COMMUNE_CHEF_LIEU"
-		  ],
-		  [
-		   "==",
-		   "txt_typo",
-		   "TYPO_A_6"
-		  ]
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 15,
-			 15
-			],
-			[
-			 17,
-			 18
-			]
-		   ]
-		  },
-		  "text-allow-overlap": true,
-		  "text-anchor": "center",
-		  "text-padding": 1,
-		  "text-transform": "uppercase",
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#000000",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme localite n0 typoA1 non commune",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_localite_ponc",
-		 "maxzoom": 21,
-		 "filter": [
-		  "all",
-		  [
-		   "!=",
-		   "symbo",
-		   "COMMUNE_FUSIONNEE"
-		  ],
-		  [
-		   "!=",
-		   "symbo",
-		   "COMMUNE_CHEF_LIEU"
-		  ],
-		  [
-		   "==",
-		   "txt_typo",
-		   "TYPO_A_1"
-		  ]
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 23,
-		  "text-allow-overlap": true,
-		  "text-anchor": "center",
-		  "text-padding": 1,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#000000",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 4
-		 }
-		},
-		{
-		 "id": "toponyme localite n0 typoA4 commune",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_localite_ponc",
-		 "maxzoom": 21,
-		 "filter": [
-		  "all",
-		  [
-		   "in",
-		   "symbo",
-		   "COMMUNE_FUSIONNEE",
-		   "COMMUNE_CHEF_LIEU"
-		  ],
-		  [
-		   "==",
-		   "txt_typo",
-		   "TYPO_A_4"
-		  ]
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 17,
-		  "text-allow-overlap": true,
-		  "text-anchor": "center",
-		  "text-padding": 1,
-		  "text-transform": "uppercase",
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#000000",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 3
-		 }
-		},
-		{
-		 "id": "toponyme localite n0 typoA3 commune",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_localite_ponc",
-		 "maxzoom": 21,
-		 "filter": [
-		  "all",
-		  [
-		   "in",
-		   "symbo",
-		   "COMMUNE_FUSIONNEE",
-		   "COMMUNE_CHEF_LIEU"
-		  ],
-		  [
-		   "==",
-		   "txt_typo",
-		   "TYPO_A_3"
-		  ]
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 19,
-		  "text-allow-overlap": true,
-		  "text-anchor": "center",
-		  "text-padding": 1,
-		  "text-transform": "uppercase",
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#000000",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 3
-		 }
-		},
-		{
-		 "id": "toponyme localite n0 typoA2 commune",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_localite_ponc",
-		 "maxzoom": 21,
-		 "filter": [
-		  "all",
-		  [
-		   "in",
-		   "symbo",
-		   "COMMUNE_FUSIONNEE",
-		   "COMMUNE_CHEF_LIEU"
-		  ],
-		  [
-		   "==",
-		   "txt_typo",
-		   "TYPO_A_2"
-		  ]
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 21,
-		  "text-allow-overlap": true,
-		  "text-anchor": "center",
-		  "text-padding": 1,
-		  "text-transform": "uppercase",
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#000000",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 4
-		 }
-		},
-		{
-		 "id": "toponyme localite importance 1",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_localite_ponc",
-		 "minzoom": 3,
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "commune 1",
-		  "BAT_COMMUNE_1",
-		  "BAT_COMMUNE_1_T"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "icon-image": "Localite",
-		  "icon-size": 0.3,
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 3,
-			 10
-			],
-			[
-			 6,
-			 20
-			]
-		   ]
-		  },
-		  "text-allow-overlap": false,
-		  "text-anchor": "bottom-left",
-		  "text-offset": [
-		   0.25,
-		   -0.1
-		  ],
-		  "text-padding": 1,
-		  "text-transform": "uppercase",
-		  "text-font": {
-		   "stops": [
-			[
-			 1,
-			 [
-			  "Open Sans Regular"
-			 ]
-			],
-			[
-			 7,
-			 [
-			  "Open Sans Regular"
-			 ]
-			],
-			[
-			 10,
-			 [
-			  "Open Sans Regular"
-			 ]
-			]
-		   ]
-		  }
-		 },
-		 "paint": {
-		  "text-color": "#000000",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 4
-		 }
-		},
-		{
-		 "id": "toponyme localite n0 typoA1 commune",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_localite_ponc",
-		 "maxzoom": 21,
-		 "filter": [
-		  "all",
-		  [
-		   "in",
-		   "symbo",
-		   "COMMUNE_FUSIONNEE",
-		   "COMMUNE_CHEF_LIEU"
-		  ],
-		  [
-		   "==",
-		   "txt_typo",
-		   "TYPO_A_1"
-		  ]
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 23,
-		  "text-allow-overlap": true,
-		  "text-anchor": "center",
-		  "text-padding": 1,
-		  "text-transform": "uppercase",
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#000000",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 4
-		 }
-		},
-		{
-		 "id": "toponyme - hydro ponc ocean",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_hydro_ponc",
-		 "minzoom": 1,
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "ocean"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 1,
-			 16
-			],
-			[
-			 6,
-			 30
-			]
-		   ]
-		  },
-		  "text-allow-overlap": true,
-		  "text-anchor": "center",
-		  "text-padding": 10,
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#447FB3",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 4
-		 }
-		},
-		{
-		 "id": "toponyme pays 3",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_localite_ponc",
-		 "minzoom": 4,
-		 "maxzoom": 5,
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "pays 3"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "text-field": "{texte}",
-		  "text-size": 9,
-		  "text-allow-overlap": true,
-		  "text-anchor": "center",
-		  "text-padding": 1,
-		  "text-transform": "uppercase",
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#787878",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 4
-		 }
-		},
-		{
-		 "id": "toponyme pays 2",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_localite_ponc",
-		 "minzoom": 2,
-		 "maxzoom": 5,
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "pays 2"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "text-field": "{texte}",
-		  "text-size": 13,
-		  "text-allow-overlap": true,
-		  "text-anchor": "center",
-		  "text-padding": 2,
-		  "text-transform": "uppercase",
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#787878",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 4
-		 }
-		},
-		{
-		 "id": "toponyme pays 1",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_localite_ponc",
-		 "minzoom": 2,
-		 "maxzoom": 5,
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "pays 1"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "text-field": "{texte}",
-		  "text-size": 13,
-		  "text-allow-overlap": true,
-		  "text-anchor": "center",
-		  "text-padding": 2,
-		  "text-transform": "uppercase",
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#787878",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 4
-		 }
-		},
-		{
-		 "id": "toponyme continent",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_localite_ponc",
-		 "maxzoom": 3,
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "continent"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "text-field": "{texte}",
-		  "text-size": 15,
-		  "text-allow-overlap": true,
-		  "text-anchor": "center",
-		  "text-padding": 1,
-		  "text-transform": "uppercase",
-		  "text-font": [
-		   "Open Sans Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#787878",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 4
-		 }
-		}
-	   ]
-	  }
+    "delay": 0
+  },
+  "layers": [
+    {
+     "id": "bckgrd",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "fond_opaque",
+     "minzoom": 0,
+     "layout": {
+      "visibility": "visible"
+     },
+     "paint": {
+      "fill-color": "#FFFFFF",
+      "fill-opacity": 0.1
+     }
+    },
+    {
+     "id": "orographie : relief - 0m",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "oro_relief",
+     "minzoom": 0,
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "HYPSO_0"
+     ],
+     "paint": {
+      "fill-color": "#D6E5BA",
+      "fill-opacity": 1
+     }
+    },
+    {
+     "id": "orographie : relief - 100m",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "oro_relief",
+     "minzoom": 0,
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "HYPSO_100"
+     ],
+     "paint": {
+      "fill-color": "#F7F2DA",
+      "fill-opacity": 1
+     }
+    },
+    {
+     "id": "orographie : relief - 200m",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "oro_relief",
+     "minzoom": 0,
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "HYPSO_200"
+     ],
+     "paint": {
+      "fill-color": "#EBDEBF",
+      "fill-opacity": 1
+     }
+    },
+    {
+     "id": "orographie : relief - 1000m",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "oro_relief",
+     "minzoom": 0,
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "HYPSO_1000"
+     ],
+     "paint": {
+      "fill-color": "#DABE97",
+      "fill-opacity": 1
+     }
+    },
+    {
+     "id": "orographie : relief - 3000m",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "oro_relief",
+     "minzoom": 0,
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "HYPSO_3000"
+     ],
+     "paint": {
+      "fill-color": "#B28773",
+      "fill-opacity": 1
+     }
+    },
+    {
+     "id": "orographie : relief - 4000m",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "oro_relief",
+     "minzoom": 0,
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "HYPSO_4000"
+     ],
+     "paint": {
+      "fill-color": "#9E6A54",
+      "fill-opacity": 1
+     }
+    },
+    {
+     "id": "orographie : relief - 5000m",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "oro_relief",
+     "minzoom": 0,
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "HYPSO_5000"
+     ],
+     "paint": {
+      "fill-color": "#773A2B",
+      "fill-opacity": 1
+     }
+    },
+    {
+     "id": "orographie : relief - glacier",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "oro_relief",
+     "minzoom": 0,
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "GLACIER"
+     ],
+     "paint": {
+      "fill-color": "#FFFFFF",
+      "fill-opacity": 0.7
+     }
+    },
+    {
+     "id": "ocs - vegetation - zone boiséee, foret fermee, peupleraie",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "ocs_vegetation_surf",
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "ZONE_BOISEE",
+      "ZONE_FORET_FERMEE_FEUIL",
+      "ZONE_FORET_FERMEE_CONI",
+      "ZONE_FORET_FERMEE_MIXTE",
+      "ZONE_PEUPLERAIE"
+     ],
+     "paint": {
+      "fill-color": "#DFE8D5",
+      "fill-outline-color": "#DFE8D5"
+     }
+    },
+    {
+     "id": "ocs - vegetation - forêt ouverte",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "ocs_vegetation_surf",
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "ZONE_FORET_OUVERTE"
+     ],
+     "paint": {
+      "fill-color": "#EDF2D9",
+      "fill-outline-color": "#EDF2D9"
+     }
+    },
+    {
+     "id": "ocs - vegetation - lande ligneuse",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "ocs_vegetation_surf",
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "ZONE_LANDE_LIGNEUSE"
+     ],
+     "paint": {
+      "fill-color": "#F2EECD"
+     }
+    },
+    {
+     "id": "ocs - vegetation - vigne",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "ocs_vegetation_surf",
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "ZONE_VIGNE"
+     ],
+     "paint": {
+      "fill-color": "#FFEDD9"
+     }
+    },
+    {
+     "id": "ocs - vegetation - verger",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "ocs_vegetation_surf",
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "ZONE_VERGER"
+     ],
+     "paint": {
+      "fill-color": "#FAE2C5"
+     }
+    },
+    {
+     "id": "ocs - vegetation - canne à sucre, bananeraie",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "ocs_vegetation_surf",
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "ZONE_CANNE_BANANE"
+     ],
+     "paint": {
+      "fill-color": "#FAEDFA"
+     }
+    },
+    {
+     "id": "hydro surfacique - Estran",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "hydro_surf",
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "ZONE_D_ESTRAN"
+     ],
+     "paint": {
+      "fill-color": "#C3DDE9",
+      "fill-outline-color": "#C3DDE9"
+     }
+    },
+    {
+     "id": "ocs - vegetation - mangrovre",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "ocs_vegetation_surf",
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "ZONE_MANGROVE"
+     ],
+     "paint": {
+      "fill-color": {
+       "stops": [
+      [
+       9,
+       "#85CCCB"
+      ],
+      [
+       10,
+       "#90CCCB"
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "ocs - vegetation - marais",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "ocs_vegetation_surf",
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "ZONE_MARAIS"
+     ],
+     "paint": {
+      "fill-pattern": "Marais"
+     }
+    },
+    {
+     "id": "ocs - vegetation - marais salant",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "ocs_vegetation_surf",
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "ZONE_MARAIS_SALANT"
+     ],
+     "paint": {
+      "fill-pattern": "MaraisSalant"
+     }
+    },
+    {
+     "id": "ocs - Zone",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "ocs_nature_sol_surf",
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "ZONE_ROCHEUSE"
+     ],
+     "paint": {
+      "fill-color": "#D0D0D0",
+      "fill-opacity": 0.3
+     }
+    },
+    {
+     "id": "ocs - Zone sable sec",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "ocs_nature_sol_surf",
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "ZONE_SABLE_SEC"
+     ],
+     "paint": {
+      "fill-pattern": "Sable"
+     }
+    },
+    {
+     "id": "ocs - Zone sable humide",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "ocs_nature_sol_surf",
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "ZONE_SABLE_HUMIDE",
+      "FOND_CUVETTE_HUMIDE"
+     ],
+     "paint": {
+      "fill-pattern": "SableHumide"
+     }
+    },
+    {
+     "id": "ocs - Zone graviers galets secs",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "ocs_nature_sol_surf",
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "GRAVIERS_GALETS_SEC"
+     ],
+     "paint": {
+      "fill-pattern": "GravierSec"
+     }
+    },
+    {
+     "id": "ocs - Zone graviers galets humides",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "ocs_nature_sol_surf",
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "GRAVIERS_GALETS_HUM"
+     ],
+     "paint": {
+      "fill-pattern": "Gravier"
+     }
+    },
+    {
+     "id": "ocs - Zone rocher hydro",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "ocs_nature_sol_surf",
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "ZONE_ROCHER_HYDRO"
+     ],
+     "paint": {
+      "fill-pattern": "RocherHydro"
+     }
+    },
+    {
+     "id": "ocs - Zone glacier",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "ocs_nature_sol_surf",
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "ZONE_GLACIER"
+     ],
+     "paint": {
+      "fill-pattern": "Glacier",
+      "fill-opacity": {
+       "stops": [
+      [
+       10,
+       0.5
+      ],
+      [
+       12,
+       0.3
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "zone batie",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "bati_zone_surf",
+     "minzoom": 7,
+     "maxzoom": 21,
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "ZONE_BATI"
+     ],
+     "paint": {
+      "fill-color": "#E8E2D1",
+      "fill-opacity": {
+       "stops": [
+      [
+       12,
+       1
+      ],
+      [
+       13,
+       0.9
+      ],
+      [
+       14,
+       0.5
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "zone d'activité",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "bati_zone_surf",
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "ZONE_INDUS_ACTI"
+     ],
+     "paint": {
+      "fill-color": "#D9D9D9"
+     }
+    },
+    {
+     "id": "oro - courbe et cuvette maitresse",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "oro_courbe",
+     "maxzoom": 21,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "CNV_MAITRESSE",
+      "CUVETTE_MAITRESSE"
+     ],
+     "paint": {
+      "line-color": "#D9C8A9",
+      "line-width": {
+       "stops": [
+      [
+       13,
+       1.7
+      ],
+      [
+       15,
+       2
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "oro - courbe et cuvette normale",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "oro_courbe",
+     "maxzoom": 21,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "CNV_NORMALE",
+      "CUVETTE_NORMALE"
+     ],
+     "paint": {
+      "line-color": "#D9C8A9",
+      "line-width": {
+       "stops": [
+      [
+       13,
+       1
+      ],
+      [
+       15,
+       1.2
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "oro - courbe et cuvette intercalaire",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "oro_courbe",
+     "maxzoom": 21,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "CNV_INTERCALAIRE",
+      "CUVETTE_INTERCAL",
+      "CNV_SS_INTERCALAIRE"
+     ],
+     "paint": {
+      "line-color": "#D9C8A9",
+      "line-width": 0.7,
+      "line-dasharray": [
+       20,
+       7
+      ]
+     }
+    },
+    {
+     "id": "oro - courbe et cuvette glacier maitresse",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "oro_courbe",
+     "maxzoom": 21,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "CNV_GLACIER_MAITRESSE",
+      "CUV_GLACIER_MAITRESSE"
+     ],
+     "paint": {
+      "line-color": "#A4BFD9",
+      "line-width": {
+       "stops": [
+      [
+       13,
+       1.7
+      ],
+      [
+       15,
+       2
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "oro - courbe et cuvette glacier normale",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "oro_courbe",
+     "maxzoom": 21,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "CNV_GLACIER_NORMALE",
+      "CUV_GLACIER_NORMALE"
+     ],
+     "paint": {
+      "line-color": "#A4BFD9",
+      "line-width": {
+       "stops": [
+      [
+       13,
+       1
+      ],
+      [
+       15,
+       1.2
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "oro - courbe et cuvette glacier intercalaire",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "oro_courbe",
+     "maxzoom": 21,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "CNV_GLACIER_INTERCAL",
+      "CUV_GLACIER_INTERCAL"
+     ],
+     "paint": {
+      "line-color": "#A4BFD9",
+      "line-width": {
+       "stops": [
+      [
+       13,
+       0.7
+      ],
+      [
+       15,
+       0.9
+      ]
+       ]
+      },
+      "line-dasharray": [
+       20,
+       7
+      ]
+     }
+    },
+    {
+     "id": "oro - courbe et cuvette rocher maitresse",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "oro_courbe",
+     "maxzoom": 21,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "CNV_ROCHER_MAITRESSE",
+      "CUV_ROCHER_MAITRESSE"
+     ],
+     "paint": {
+      "line-color": "#AAAAAA",
+      "line-width": 1.7
+     }
+    },
+    {
+     "id": "oro - courbe et cuvette rocher normale",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "oro_courbe",
+     "maxzoom": 21,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "CNV_ROCHER_NORMALE",
+      "CUV_ROCHER_NORMALE"
+     ],
+     "paint": {
+      "line-color": "#AAAAAA",
+      "line-width": 1
+     }
+    },
+    {
+     "id": "oro - courbe et cuvette rocher intercalaire",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "oro_courbe",
+     "maxzoom": 21,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "CNV_ROCHER_INTERCAL",
+      "CUV_ROCHER_INTERCAL"
+     ],
+     "paint": {
+      "line-color": "#AAAAAA",
+      "line-width": {
+       "stops": [
+      [
+       13,
+       0.7
+      ],
+      [
+       15,
+       0.9
+      ]
+       ]
+      },
+      "line-dasharray": [
+       20,
+       7
+      ]
+     }
+    },
+    {
+     "id": "oro - courbe et cuvette bathymetrique",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "oro_courbe",
+     "maxzoom": 21,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "CNV_BATHYMETRIQUE",
+      "CUV_BATHYMETRIQUE"
+     ],
+     "paint": {
+      "line-color": "#0000FF",
+      "line-width": 1
+     }
+    },
+    {
+     "id": "oro lin - talus",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "oro_lin",
+     "minzoom": 14,
+     "maxzoom": 21,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "TALUS"
+     ],
+     "paint": {
+      "line-color": "#D9C8A9",
+      "line-width": 1
+     }
+    },
+    {
+     "id": "oro lin - talus - trait perpendiculaire",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "oro_lin",
+     "minzoom": 14,
+     "maxzoom": 21,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "TALUS"
+     ],
+     "paint": {
+      "line-color": "#D9C8A9",
+      "line-width": {
+       "stops": [
+      [
+       14,
+       7
+      ],
+      [
+       16,
+       9
+      ]
+       ]
+      },
+      "line-dasharray": [
+       0.1,
+       1
+      ],
+      "line-translate": [
+       0,
+       4
+      ]
+     }
+    },
+    {
+     "id": "toponyme - cote de courbe normale",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "oro_courbe",
+     "minzoom": 13,
+     "maxzoom": 21,
+     "layout": {
+      "symbol-placement": "line",
+      "text-field": "{texte}",
+      "text-size": {
+       "stops": [
+      [
+       13,
+       10
+      ],
+      [
+       15,
+       13
+      ]
+       ]
+      },
+      "text-anchor": "center",
+      "text-rotation-alignment": "map",
+      "text-pitch-alignment": "viewport",
+      "text-keep-upright": false,
+      "text-max-angle": 20,
+      "text-max-width": 100,
+      "text-font": [
+       "Open Sans Regular"
+      ],
+      "visibility": "visible"
+     },
+     "filter": [
+      "all",
+      [
+       "!=",
+       "texte",
+       "0"
+      ],
+      [
+       "==",
+       "hors_zone",
+       "true"
+      ],
+      [
+       "in",
+       "symbo",
+       "CNV_MAITRESSE",
+       "CUVETTE_MAITRESSE"
+      ]
+     ],
+     "paint": {
+      "text-color": "#604A2F",
+      "text-halo-width": 0.5,
+      "text-halo-color": "#FFFFFF"
+     }
+    },
+    {
+     "id": "toponyme - cote de courbe rocher",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "oro_courbe",
+     "minzoom": 13,
+     "maxzoom": 21,
+     "layout": {
+      "symbol-placement": "line",
+      "text-field": "{texte}",
+      "text-size": {
+       "stops": [
+      [
+       13,
+       10
+      ],
+      [
+       15,
+       13
+      ]
+       ]
+      },
+      "text-anchor": "center",
+      "text-rotation-alignment": "map",
+      "text-pitch-alignment": "viewport",
+      "text-keep-upright": false,
+      "text-max-angle": 20,
+      "text-max-width": 100,
+      "text-font": [
+       "Open Sans Regular"
+      ],
+      "visibility": "visible"
+     },
+     "filter": [
+      "all",
+      [
+       "!=",
+       "texte",
+       "0"
+      ],
+      [
+       "==",
+       "hors_zone",
+       "true"
+      ],
+      [
+       "in",
+       "symbo",
+       "CNV_ROCHER_MAITRESSE",
+       "CUV_ROCHER_MAITRESSE"
+      ]
+     ],
+     "paint": {
+      "text-color": "#333333",
+      "text-halo-width": 0.5,
+      "text-halo-color": "#FFFFFF"
+     }
+    },
+    {
+     "id": "toponyme - cote de courbe glacier",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "oro_courbe",
+     "minzoom": 13,
+     "maxzoom": 21,
+     "layout": {
+      "symbol-placement": "line",
+      "text-field": "{texte}",
+      "text-size": {
+       "stops": [
+      [
+       13,
+       10
+      ],
+      [
+       15,
+       13
+      ]
+       ]
+      },
+      "text-anchor": "center",
+      "text-rotation-alignment": "map",
+      "text-pitch-alignment": "viewport",
+      "text-keep-upright": false,
+      "text-max-angle": 20,
+      "text-max-width": 100,
+      "text-font": [
+       "Open Sans Regular"
+      ],
+      "visibility": "visible"
+     },
+     "filter": [
+      "all",
+      [
+       "!=",
+       "texte",
+       "0"
+      ],
+      [
+       "==",
+       "hors_zone",
+       "true"
+      ],
+      [
+       "in",
+       "symbo",
+       "CNV_GLACIER_MAITRESSE",
+       "CUV_GLACIER_MAITRESSE"
+      ]
+     ],
+     "paint": {
+      "text-color": "#629FD9",
+      "text-halo-width": 0.5,
+      "text-halo-color": "#FFFFFF"
+     }
+    },
+    {
+     "id": "hydro surfacique",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "hydro_surf",
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "SURFACE_D_EAU",
+      "BASSIN",
+      "ZONE_MARINE"
+     ],
+     "paint": {
+      "fill-color": "#AAD5E9",
+      "fill-outline-color": "#AAD5E9"
+     }
+    },
+    {
+     "id": "hydro surfacique temporaire",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "hydro_surf",
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "SURFACE_D_EAU_TEMP"
+     ],
+     "paint": {
+      "fill-color": "rgba(168, 203, 220, 0.5)"
+     }
+    },
+    {
+     "id": "réseau hydro  - cours d'eau souterrain",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "hydro_reseau_sou",
+     "maxzoom": 21,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "COURS_D_EAU_SOU",
+      "COURS_D_EAU_MOY_SOU"
+     ],
+     "paint": {
+      "line-color": "#AAD5E9",
+      "line-width": {
+       "stops": [
+      [
+       12,
+       1.5
+      ],
+      [
+       17,
+       6.5
+      ]
+       ]
+      },
+      "line-dasharray": [
+       2,
+       2
+      ]
+     }
+    },
+    {
+     "id": "réseau hydro - filet interieur - aqueduc souterrain",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "hydro_reseau_sou",
+     "minzoom": 12,
+     "maxzoom": 21,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "AQUEDUC_SOU"
+     ],
+     "paint": {
+      "line-color": "#AAD5E9",
+      "line-width": {
+       "stops": [
+      [
+       12,
+       1.4
+      ],
+      [
+       16,
+       3.5
+      ],
+      [
+       17,
+       5.9
+      ]
+       ]
+      },
+      "line-dasharray": [
+       2,
+       2
+      ]
+     }
+    },
+    {
+     "id": "réseau hydro - carre - aqueduc souterrain",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "hydro_reseau_sou",
+     "minzoom": 12,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "AQUEDUC_SOU"
+     ],
+     "paint": {
+      "line-color": "#AAD5E9",
+      "line-width": {
+       "stops": [
+      [
+       12,
+       3.5
+      ],
+      [
+       16,
+       8.7
+      ],
+      [
+       17,
+       14.7
+      ]
+       ]
+      },
+      "line-dasharray": [
+       1,
+       5
+      ]
+     }
+    },
+    {
+     "id": "Ferre souterrain - voie normale",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "ferre_sou",
+     "minzoom": 10,
+     "maxzoom": 21,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "VF_1_SOU",
+      "VF_2_SOU",
+      "VF_ELEC_1_SOU",
+      "VF_FERRO_ROUTIER_SOU"
+     ],
+     "paint": {
+      "line-color": "#B4B4B4",
+      "line-width": {
+       "stops": [
+      [
+       10,
+       0.8
+      ],
+      [
+       17,
+       2.5
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Ferre souterrain - trait perpendic épais",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "ferre_sou",
+     "minzoom": 10,
+     "maxzoom": 21,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "VF_1_SOU",
+      "VF_2_SOU",
+      "VF_ELEC_1_SOU",
+      "VF_FERRO_ROUTIER_SOU"
+     ],
+     "paint": {
+      "line-color": "#B4B4B4",
+      "line-width": {
+       "stops": [
+      [
+       10,
+       3.5
+      ],
+      [
+       17,
+       14.7
+      ]
+       ]
+      },
+      "line-dasharray": [
+       0.1,
+       10
+      ]
+     }
+    },
+    {
+     "id": "Ferre souterrain - voie etroite",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "ferre_sou",
+     "minzoom": 10,
+     "maxzoom": 21,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "VF_ETROITE_1_SOU",
+      "VF_ETROITE_SOU"
+     ],
+     "paint": {
+      "line-color": "#B4B4B4",
+      "line-width": {
+       "stops": [
+      [
+       10,
+       0.3
+      ],
+      [
+       17,
+       1.8
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Ferre souterrain - trait perpendic fin",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "ferre_sou",
+     "minzoom": 10,
+     "maxzoom": 21,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "VF_ETROITE_1_SOU",
+      "VF_ETROITE_SOU"
+     ],
+     "paint": {
+      "line-color": "#B4B4B4",
+      "line-width": {
+       "stops": [
+      [
+       10,
+       3.5
+      ],
+      [
+       17,
+       14.7
+      ]
+       ]
+      },
+      "line-dasharray": [
+       0.1,
+       10
+      ]
+     }
+    },
+    {
+     "id": "Ferre souterrain - voie service",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "ferre_sou",
+     "minzoom": 14,
+     "maxzoom": 21,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "VF_SERVICE_SOU",
+      "VF_NON_EXPLOITEE_SOU"
+     ],
+     "paint": {
+      "line-color": "#B4B4B4",
+      "line-width": {
+       "stops": [
+      [
+       10,
+       0.3
+      ],
+      [
+       17,
+       1.8
+      ]
+       ]
+      },
+      "line-dasharray": [
+       5,
+       2,
+       1,
+       2
+      ]
+     }
+    },
+    {
+     "id": "Ferre souterrain - funic/urbain",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "ferre_sou",
+     "maxzoom": 21,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "FUNI_CREMAILLERE_SOU",
+      "TRANSPORT_URBAIN_SOU"
+     ],
+     "paint": {
+      "line-color": "#B4B4B4",
+      "line-width": {
+       "stops": [
+      [
+       10,
+       0.3
+      ],
+      [
+       17,
+       1.8
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Ferre souterrain - 2 trait perpendic - funic/urbain",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "ferre_sou",
+     "maxzoom": 21,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "FUNI_CREMAILLERE_SOU",
+      "TRANSPORT_URBAIN_SOU"
+     ],
+     "paint": {
+      "line-color": "#B4B4B4",
+      "line-width": {
+       "stops": [
+      [
+       10,
+       3.5
+      ],
+      [
+       17,
+       17
+      ]
+       ]
+      },
+      "line-dasharray": [
+       0.1,
+       0.2,
+       0.1,
+       10
+      ]
+     }
+    },
+    {
+     "id": "Chemin souterrain - piste cyclable",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_chemin_sou",
+     "minzoom": 13,
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "PISTE_CYCLABLE_SOU"
+     ],
+     "paint": {
+      "line-color": "#AB81CC",
+      "line-width": {
+       "stops": [
+      [
+       14,
+       1.1
+      ],
+      [
+       15,
+       1.7
+      ],
+      [
+       16,
+       2
+      ],
+      [
+       17,
+       3.5
+      ]
+       ]
+      },
+      "line-dasharray": [
+       6,
+       2
+      ]
+     }
+    },
+    {
+     "id": "Chemin souterrain - filet exterieur - escalier",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_chemin_sou",
+     "minzoom": 14,
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "ESCALIER_SOU"
+     ],
+     "paint": {
+      "line-color": "#B3989A",
+      "line-width": {
+       "stops": [
+      [
+       14,
+       1.75
+      ],
+      [
+       15,
+       3
+      ],
+      [
+       16,
+       4.2
+      ],
+      [
+       17,
+       9.5
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Chemin souterrain - filet interieur - escalier",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_chemin_sou",
+     "minzoom": 14,
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "ESCALIER_SOU"
+     ],
+     "paint": {
+      "line-color": "#EDF1FF",
+      "line-width": {
+       "stops": [
+      [
+       14,
+       1
+      ],
+      [
+       15,
+       1.9
+      ],
+      [
+       16,
+       2.7
+      ],
+      [
+       17,
+       5.8
+      ]
+       ]
+      },
+      "line-dasharray": [
+       1,
+       0.2
+      ]
+     }
+    },
+    {
+     "id": "Chemin souterrain - Rue pietonne",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_chemin_sou",
+     "minzoom": 14,
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "RUE_PIETONNE_SOU"
+     ],
+     "paint": {
+      "line-color": "#B3989A",
+      "line-width": {
+       "stops": [
+      [
+       14,
+       1
+      ],
+      [
+       15,
+       1.2
+      ],
+      [
+       16,
+       1.4
+      ],
+      [
+       17,
+       2
+      ]
+       ]
+      },
+      "line-dasharray": [
+       1,
+       3
+      ]
+     }
+    },
+    {
+     "id": "Chemin souterrain - sentier",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_chemin_sou",
+     "minzoom": 13,
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "SENTIER_SOU"
+     ],
+     "paint": {
+      "line-color": "#B3989A",
+      "line-width": {
+       "stops": [
+      [
+       14,
+       1
+      ],
+      [
+       15,
+       1.2
+      ],
+      [
+       16,
+       1.4
+      ],
+      [
+       17,
+       2
+      ]
+       ]
+      },
+      "line-dasharray": [
+       4,
+       3
+      ]
+     }
+    },
+    {
+     "id": "Chemin souterrain - chemin",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_chemin_sou",
+     "minzoom": 12,
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "CHEMIN_SOU"
+     ],
+     "paint": {
+      "line-color": "#B3989A",
+      "line-width": {
+       "stops": [
+      [
+       14,
+       1
+      ],
+      [
+       15,
+       1.2
+      ],
+      [
+       16,
+       1.4
+      ],
+      [
+       17,
+       2
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier souterrain - filet extérieur - route non revetu carrosable",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route_sou",
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "NON_REVETUE_CARRO_SOU"
+     ],
+     "paint": {
+      "line-color": "#AFAFAF",
+      "line-width": {
+       "stops": [
+      [
+       14,
+       3.2
+      ],
+      [
+       15,
+       5.4
+      ],
+      [
+       16,
+       7.7
+      ],
+      [
+       17,
+       16.8
+      ]
+       ]
+      },
+      "line-dasharray": [
+       2,
+       2
+      ]
+     }
+    },
+    {
+     "id": "Routier souterrain - filet extérieur - bretelle autoroute",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route_sou",
+     "minzoom": 12,
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "BRET_AUTO_PEAGE_3_SOU",
+      "BRET_AUTO_PEAGE_2_SOU",
+      "BRET_AUTO_PEAGE_1_SOU",
+      "BRET_AUTO_LIBRE_3_SOU",
+      "BRET_AUTO_LIBRE_2_SOU",
+      "BRET_AUTO_LIBRE_1_SOU"
+     ],
+     "paint": {
+      "line-color": "rgba(222, 70, 14, 0.5)",
+      "line-width": {
+       "stops": [
+      [
+       12,
+       2.5
+      ],
+      [
+       14,
+       3.7
+      ],
+      [
+       15,
+       6.8
+      ],
+      [
+       16,
+       8.4
+      ],
+      [
+       17,
+       14
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier souterrain - filet extérieur - route non classee restreint",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route_sou",
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "NON_CLASSEE_RESTREINT_SOU"
+     ],
+     "paint": {
+      "line-color": "#AFAFAF",
+      "line-width": {
+       "stops": [
+      [
+       14,
+       3.2
+      ],
+      [
+       15,
+       5.4
+      ],
+      [
+       16,
+       7.7
+      ],
+      [
+       17,
+       16.8
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier souterrain - filet extérieur - route non classee",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route_sou",
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "NON_CLASSEE_4_SOU",
+      "NON_CLASSEE_SOU"
+     ],
+     "paint": {
+      "line-color": "#AFAFAF",
+      "line-width": {
+       "stops": [
+      [
+       14,
+       3.2
+      ],
+      [
+       15,
+       5.4
+      ],
+      [
+       16,
+       7.7
+      ],
+      [
+       17,
+       16.8
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier souterrain - filet extérieur - route locale",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route_sou",
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "BRET_LOCALE_SOU",
+      "LOCALE_4_SOU",
+      "LOCALE_3_SOU",
+      "LOCALE_2_SOU",
+      "LOCALE_1_SOU"
+     ],
+     "paint": {
+      "line-color": "rgba(130, 130, 130, 0.5)",
+      "line-width": {
+       "stops": [
+      [
+       9,
+       2
+      ],
+      [
+       14,
+       3.5
+      ],
+      [
+       15,
+       6
+      ],
+      [
+       16,
+       8.4
+      ],
+      [
+       17,
+       18.3
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier souterrain - filet extérieur - route locale en construction",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route_sou",
+     "minzoom": 11,
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "LOCALE_CONSTR_SOU"
+     ],
+     "paint": {
+      "line-color": "#C8C8C8",
+      "line-width": {
+       "stops": [
+      [
+       9,
+       2
+      ],
+      [
+       14,
+       3.5
+      ],
+      [
+       15,
+       6
+      ],
+      [
+       16,
+       8.4
+      ],
+      [
+       17,
+       18.3
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier souterrain - filet extérieur - route regionale",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route_sou",
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "BRET_REGIONALE_SOU",
+      "REGIONALE_4_SOU",
+      "REGIONALE_3_SOU",
+      "REGIONALE_2_SOU",
+      "REGIONALE_1_SOU"
+     ],
+     "paint": {
+      "line-color": "rgba(130, 130, 130, 0.5)",
+      "line-width": {
+       "stops": [
+      [
+       6,
+       1.5
+      ],
+      [
+       9,
+       2.3
+      ],
+      [
+       14,
+       5
+      ],
+      [
+       15,
+       8.1
+      ],
+      [
+       16,
+       11.2
+      ],
+      [
+       17,
+       22
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier souterrain - filet extérieur - route regionale en construction",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route_sou",
+     "minzoom": 10,
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "REGIONALE_CONSTR_SOU"
+     ],
+     "paint": {
+      "line-color": "#C8C8C8",
+      "line-width": {
+       "stops": [
+      [
+       6,
+       1.5
+      ],
+      [
+       9,
+       2.3
+      ],
+      [
+       14,
+       5
+      ],
+      [
+       15,
+       8.1
+      ],
+      [
+       16,
+       11.2
+      ],
+      [
+       17,
+       22
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier souterrain - filet extérieur - route principale",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route_sou",
+     "minzoom": 7,
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "BRET_PRINCIPALE_SOU",
+      "PRINCIPALE_4_SOU",
+      "PRINCIPALE_3_SOU",
+      "PRINCIPALE_2_SOU",
+      "PRINCIPALE_1_SOU"
+     ],
+     "paint": {
+      "line-color": "rgba(222, 70, 14, 0.5)",
+      "line-width": {
+       "stops": [
+      [
+       6,
+       1.8
+      ],
+      [
+       9,
+       2.7
+      ],
+      [
+       14,
+       5.9
+      ],
+      [
+       15,
+       9
+      ],
+      [
+       16,
+       12.2
+      ],
+      [
+       17,
+       22.5
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier souterrain - filet extérieur - route principale en construction",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route_sou",
+     "minzoom": 10,
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "PRINCIPALE_CONSTR_SOU"
+     ],
+     "paint": {
+      "line-color": "#C8C8C8",
+      "line-width": {
+       "stops": [
+      [
+       6,
+       1.8
+      ],
+      [
+       9,
+       2.7
+      ],
+      [
+       14,
+       5.9
+      ],
+      [
+       15,
+       9
+      ],
+      [
+       16,
+       12.2
+      ],
+      [
+       17,
+       22.5
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier souterrain - filet extérieur - autoroute",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route_sou",
+     "minzoom": 7,
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "AUTOROU_PEAGE_SOU",
+      "AUTOROU_LIBRE_SOU"
+     ],
+     "paint": {
+      "line-color": "rgba(222, 70, 14, 0.5)",
+      "line-width": {
+       "stops": [
+      [
+       6,
+       2.5
+      ],
+      [
+       9,
+       3.5
+      ],
+      [
+       14,
+       7.5
+      ],
+      [
+       15,
+       11
+      ],
+      [
+       16,
+       15
+      ],
+      [
+       17,
+       26
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier souterrain - filet extérieur - autoroute en construction",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route_sou",
+     "minzoom": 10,
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "AUTOROU_CONSTR_SOU"
+     ],
+     "paint": {
+      "line-color": "#C8C8C8",
+      "line-width": {
+       "stops": [
+      [
+       6,
+       2.5
+      ],
+      [
+       9,
+       3.5
+      ],
+      [
+       14,
+       7.5
+      ],
+      [
+       15,
+       11
+      ],
+      [
+       16,
+       15
+      ],
+      [
+       17,
+       26
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier souterrain - filet interieur - route non revetu carrosable",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route_sou",
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "NON_REVETUE_CARRO_SOU"
+     ],
+     "paint": {
+      "line-color": "#DCDCDC",
+      "line-width": {
+       "stops": [
+      [
+       14,
+       2.3
+      ],
+      [
+       15,
+       4.1
+      ],
+      [
+       16,
+       6.3
+      ],
+      [
+       17,
+       13.5
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier souterrain - filet interieur - bretelle autoroute",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route_sou",
+     "minzoom": 12,
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "BRET_AUTO_PEAGE_3_SOU",
+      "BRET_AUTO_PEAGE_2_SOU",
+      "BRET_AUTO_PEAGE_1_SOU",
+      "BRET_AUTO_LIBRE_3_SOU",
+      "BRET_AUTO_LIBRE_2_SOU",
+      "BRET_AUTO_LIBRE_1_SOU"
+     ],
+     "paint": {
+      "line-color": "rgba(255, 255, 255, 0.5)",
+      "line-width": {
+       "stops": [
+      [
+       12,
+       1.5
+      ],
+      [
+       14,
+       2.6
+      ],
+      [
+       15,
+       5.2
+      ],
+      [
+       16,
+       6.7
+      ],
+      [
+       17,
+       10.8
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier souterrain - filet interieur - route non classee restreint",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route_sou",
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "NON_CLASSEE_RESTREINT_SOU"
+     ],
+     "paint": {
+      "line-color": "#F2F5FF",
+      "line-width": {
+       "stops": [
+      [
+       14,
+       2.3
+      ],
+      [
+       15,
+       4.1
+      ],
+      [
+       16,
+       6.3
+      ],
+      [
+       17,
+       13.5
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier souterrain - filet interieur - route non classee",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route_sou",
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "NON_CLASSEE_4_SOU",
+      "NON_CLASSEE_SOU"
+     ],
+     "paint": {
+      "line-color": "#DCDCDC",
+      "line-width": {
+       "stops": [
+      [
+       14,
+       2.3
+      ],
+      [
+       15,
+       4.1
+      ],
+      [
+       16,
+       6.3
+      ],
+      [
+       17,
+       13.5
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier souterrain - filet interieur - route locale",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route_sou",
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "BRET_LOCALE_SOU",
+      "LOCALE_4_SOU",
+      "LOCALE_3_SOU",
+      "LOCALE_2_SOU",
+      "LOCALE_1_SOU"
+     ],
+     "paint": {
+      "line-color": "rgba(255, 255, 255, 0.5)",
+      "line-width": {
+       "stops": [
+      [
+       9,
+       1.3
+      ],
+      [
+       14,
+       2.3
+      ],
+      [
+       15,
+       4.1
+      ],
+      [
+       16,
+       6.1
+      ],
+      [
+       17,
+       13.1
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier souterrain - filet interieur - route locale en construction",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route_sou",
+     "minzoom": 11,
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "LOCALE_CONSTR_SOU"
+     ],
+     "paint": {
+      "line-color": {
+       "stops": [
+      [
+       12,
+       "#EDF1FF"
+      ],
+      [
+       13,
+       "#FCF4A8"
+      ],
+      [
+       17,
+       "#FCF7C1"
+      ]
+       ]
+      },
+      "line-width": {
+       "stops": [
+      [
+       9,
+       2
+      ],
+      [
+       14,
+       3.5
+      ],
+      [
+       15,
+       6
+      ],
+      [
+       16,
+       8.4
+      ],
+      [
+       17,
+       18.3
+      ]
+       ]
+      },
+      "line-dasharray": [
+       2,
+       2
+      ]
+     }
+    },
+    {
+     "id": "Routier souterrain - filet interieur - route regionale",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route_sou",
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "BRET_REGIONALE_SOU",
+      "REGIONALE_4_SOU",
+      "REGIONALE_3_SOU",
+      "REGIONALE_2_SOU",
+      "REGIONALE_1_SOU"
+     ],
+     "paint": {
+      "line-color": "rgba(255, 255, 255, 0.5)",
+      "line-width": {
+       "stops": [
+      [
+       6,
+       1.4
+      ],
+      [
+       9,
+       1.5
+      ],
+      [
+       14,
+       3.2
+      ],
+      [
+       15,
+       5.8
+      ],
+      [
+       16,
+       8.3
+      ],
+      [
+       17,
+       16.2
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier souterrain - filet interieur - route regionale en construction",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route_sou",
+     "minzoom": 10,
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "REGIONALE_CONSTR_SOU"
+     ],
+     "paint": {
+      "line-color": {
+       "stops": [
+      [
+       9,
+       "#EDF1FF"
+      ],
+      [
+       10,
+       "#FDF28B"
+      ],
+      [
+       17,
+       "#FCF6BD"
+      ]
+       ]
+      },
+      "line-width": {
+       "stops": [
+      [
+       4,
+       0.4
+      ],
+      [
+       6,
+       1.5
+      ],
+      [
+       9,
+       2.3
+      ],
+      [
+       14,
+       5
+      ],
+      [
+       15,
+       8.1
+      ],
+      [
+       16,
+       11.2
+      ],
+      [
+       17,
+       22
+      ]
+       ]
+      },
+      "line-dasharray": [
+       2,
+       2
+      ]
+     }
+    },
+    {
+     "id": "Routier souterrain - filet interieur - route principale",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route_sou",
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "BRET_PRINCIPALE_SOU",
+      "PRINCIPALE_4_SOU",
+      "PRINCIPALE_3_SOU",
+      "PRINCIPALE_2_SOU",
+      "PRINCIPALE_1_SOU"
+     ],
+     "paint": {
+      "line-color": "rgba(255, 255, 255, 0.5)",
+      "line-width": {
+       "stops": [
+      [
+       4,
+       0.5
+      ],
+      [
+       6,
+       1.8
+      ],
+      [
+       9,
+       2.1
+      ],
+      [
+       14,
+       4.4
+      ],
+      [
+       15,
+       7.3
+      ],
+      [
+       16,
+       10
+      ],
+      [
+       17,
+       18.5
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier souterrain - filet interieur - route principale en construction",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route_sou",
+     "minzoom": 10,
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "PRINCIPALE_CONSTR_SOU"
+     ],
+     "paint": {
+      "line-color": {
+       "stops": [
+      [
+       9,
+       "#F3C66D"
+      ],
+      [
+       17,
+       "#F2DDB3"
+      ]
+       ]
+      },
+      "line-width": {
+       "stops": [
+      [
+       4,
+       0.5
+      ],
+      [
+       6,
+       1.8
+      ],
+      [
+       9,
+       2.7
+      ],
+      [
+       14,
+       5.9
+      ],
+      [
+       15,
+       9
+      ],
+      [
+       16,
+       12.2
+      ],
+      [
+       17,
+       22.5
+      ]
+       ]
+      },
+      "line-dasharray": [
+       2,
+       2
+      ]
+     }
+    },
+    {
+     "id": "Routier souterrain - filet interieur - autoroute",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route_sou",
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "AUTOROU_PEAGE_SOU",
+      "AUTOROU_LIBRE_SOU"
+     ],
+     "paint": {
+      "line-color": "rgba(255, 255, 255, 0.5)",
+      "line-width": {
+       "stops": [
+      [
+       4,
+       0.7
+      ],
+      [
+       6,
+       2.5
+      ],
+      [
+       9,
+       2.7
+      ],
+      [
+       14,
+       5.8
+      ],
+      [
+       15,
+       9
+      ],
+      [
+       16,
+       12
+      ],
+      [
+       17,
+       20.8
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier souterrain - axe central - autoroute",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route_sou",
+     "minzoom": 13,
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "AUTOROU_PEAGE_SOU",
+      "AUTOROU_LIBRE_SOU"
+     ],
+     "paint": {
+      "line-color": "#EDF1FF",
+      "line-width": {
+       "stops": [
+      [
+       9,
+       0.6
+      ],
+      [
+       14,
+       0.7
+      ],
+      [
+       15,
+       1
+      ],
+      [
+       16,
+       1.2
+      ],
+      [
+       17,
+       2.1
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier souterrain - filet interieur - autoroute en construction",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route_sou",
+     "minzoom": 10,
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "AUTOROU_CONSTR_SOU"
+     ],
+     "paint": {
+      "line-color": {
+       "stops": [
+      [
+       9,
+       "#F2BA59"
+      ],
+      [
+       17,
+       "#F2C261"
+      ]
+       ]
+      },
+      "line-width": {
+       "stops": [
+      [
+       4,
+       0.7
+      ],
+      [
+       6,
+       2.5
+      ],
+      [
+       9,
+       3.5
+      ],
+      [
+       14,
+       7.5
+      ],
+      [
+       15,
+       11
+      ],
+      [
+       16,
+       15
+      ],
+      [
+       17,
+       26
+      ]
+       ]
+      },
+      "line-dasharray": [
+       2,
+       2
+      ]
+     }
+    },
+    {
+     "id": "Routier souterrain - axe central - autoroute en construction",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route_sou",
+     "minzoom": 13,
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "AUTOROU_CONSTR_SOU"
+     ],
+     "paint": {
+      "line-color": "#808080",
+      "line-width": {
+       "stops": [
+      [
+       9,
+       0.6
+      ],
+      [
+       14,
+       0.7
+      ],
+      [
+       15,
+       1
+      ],
+      [
+       16,
+       1.2
+      ],
+      [
+       17,
+       2.1
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "réseau hydro - cours d'eau temporaire",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "hydro_reseau",
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "COURS_D_EAU_TEMP",
+      "COURS_D_EAU_TEMP_MOY"
+     ],
+     "paint": {
+      "line-color": "#AAD5E9",
+      "line-width": {
+       "stops": [
+      [
+       12,
+       1.5
+      ],
+      [
+       17,
+       4
+      ]
+       ]
+      },
+      "line-dasharray": [
+       6,
+       2
+      ]
+     }
+    },
+    {
+     "id": "réseau hydro - cours d'eau",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "hydro_reseau",
+     "minzoom": 3,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "COURS_D_EAU"
+     ],
+     "paint": {
+      "line-color": "#AAD5E9",
+      "line-width": {
+       "stops": [
+      [
+       4,
+       0.3
+      ],
+      [
+       7,
+       1.5
+      ],
+      [
+       12,
+       1.5
+      ],
+      [
+       17,
+       6.5
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "réseau hydro - canal",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "hydro_reseau",
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "CANAL"
+     ],
+     "paint": {
+      "line-color": "#AAD5E9",
+      "line-width": {
+       "stops": [
+      [
+       12,
+       1.4
+      ],
+      [
+       17,
+       5.9
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "réseau hydro - filet interieur - aqueduc",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "hydro_reseau",
+     "minzoom": 12,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "AQUEDUC_AU_SOL"
+     ],
+     "paint": {
+      "line-color": "#AAD5E9",
+      "line-width": {
+       "stops": [
+      [
+       12,
+       1.4
+      ],
+      [
+       16,
+       3.5
+      ],
+      [
+       17,
+       5.9
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "réseau hydro - carre - aqueduc",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "hydro_reseau",
+     "minzoom": 12,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "AQUEDUC_AU_SOL"
+     ],
+     "paint": {
+      "line-color": "#AAD5E9",
+      "line-width": {
+       "stops": [
+      [
+       12,
+       3.5
+      ],
+      [
+       16,
+       8.7
+      ],
+      [
+       17,
+       14.7
+      ]
+       ]
+      },
+      "line-dasharray": [
+       1,
+       5
+      ]
+     }
+    },
+    {
+     "id": "réseau hydro - cours d'eau moyen ",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "hydro_reseau",
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "COURS_D_EAU_MOY"
+     ],
+     "paint": {
+      "line-color": "#AAD5E9",
+      "line-width": {
+       "stops": [
+      [
+       7,
+       2
+      ],
+      [
+       12,
+       2.5
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "réseau hydro - cours d'eau large ",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "hydro_reseau",
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "COURS_D_EAU_LAR"
+     ],
+     "paint": {
+      "line-color": "#AAD5E9",
+      "line-width": {
+       "stops": [
+      [
+       7,
+       3
+      ],
+      [
+       11,
+       5
+      ]
+       ]
+      }
+     }
+    },
+
+    {
+     "id": "bati surfacique mairie - Zoom 14",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "bati_surf",
+     "maxzoom": 14,
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "MAIRIE",
+      "MAIRIE_ANNEXE"
+     ],
+     "paint": {
+      "fill-color": "#FFA6A6"
+     }
+    },
+    {
+     "id": "bati surfacique mairie - Zoom 15,16,17,18",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "bati_surf",
+     "minzoom": 14,
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "MAIRIE",
+      "MAIRIE_ANNEXE"
+     ],
+     "paint": {
+      "fill-color": {
+       "stops": [
+      [
+       14,
+       "#FFA6A6"
+      ],
+      [
+       15,
+       "#FFAEAE"
+      ]
+       ]
+      },
+      "fill-outline-color": "#FF7C7C"
+     }
+    },
+    {
+     "id": "bati surfacique fonctionnel industriel ou commercial - Zoom 14,15",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "bati_surf",
+     "maxzoom": 21,
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "BATI_COMMERCIAL",
+      "BATI_INDUSTRIEL",
+      "HANGAR",
+      "HANGAR_COMMERCIAL",
+      "HANGAR_INDUSTRIEL"
+     ],
+     "paint": {
+      "fill-color": "#C8C8C8"
+     }
+    },
+    {
+     "id": "bati surfacique fonctionnel industriel ou commercial - Zoom 16,17,18",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "bati_surf",
+     "minzoom": 15,
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "BATI_COMMERCIAL",
+      "BATI_INDUSTRIEL",
+      "HANGAR",
+      "HANGAR_COMMERCIAL",
+      "HANGAR_INDUSTRIEL"
+     ],
+     "paint": {
+      "fill-color": {
+       "stops": [
+      [
+       15,
+       "#D1D1D1"
+      ],
+      [
+       16,
+       "#E6E6E6"
+      ]
+       ]
+      },
+      "fill-outline-color": "#B8B8B8"
+     }
+    },
+    {
+     "id": "bati surfacique fonctionnel public - Zoom 14,15",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "bati_surf",
+     "maxzoom": 21,
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "BATI_PUBLIC",
+      "HANGAR_PUBLIC"
+     ],
+     "paint": {
+      "fill-color": "#B9B6D6"
+     }
+    },
+    {
+     "id": "bati surfacique fonctionnel public - Zoom 16,17,18",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "bati_surf",
+     "minzoom": 21,
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "BATI_PUBLIC",
+      "HANGAR_PUBLIC"
+     ],
+     "paint": {
+      "fill-color": {
+       "stops": [
+      [
+       15,
+       "#CFC5DE"
+      ],
+      [
+       16,
+       "#E4DAF3"
+      ]
+       ]
+      },
+      "fill-outline-color": "#A6A1D6"
+     }
+    },
+    {
+     "id": "bati surfacique fonctionnel sportif - bordure",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "bati_surf",
+     "minzoom": 15,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "BATI_SPORTIF"
+     ],
+     "paint": {
+      "line-color": "#BCD9AB",
+      "line-width": 4
+     }
+    },
+    {
+     "id": "bati surfacique fonctionnel sportif",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "bati_surf",
+     "minzoom": 13,
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "BATI_SPORTIF"
+     ],
+     "paint": {
+      "fill-color": {
+       "stops": [
+      [
+       14,
+       "#C9E1DD"
+      ],
+      [
+       15,
+       "#DCE6E4"
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "bati surfacique fonctionnel gare - Zoom 14,15",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "bati_surf",
+     "maxzoom": 21,
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "BATI_GARE"
+     ],
+     "paint": {
+      "fill-color": "#B3B5F5"
+     }
+    },
+    {
+     "id": "bati surfacique fonctionnel gare - Zoom 16,17,18",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "bati_surf",
+     "minzoom": 15,
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "BATI_GARE"
+     ],
+     "paint": {
+      "fill-color": {
+       "stops": [
+      [
+       15,
+       "#BFC1F5"
+      ],
+      [
+       16,
+       "#CBCDF5"
+      ]
+       ]
+      },
+      "fill-outline-color": "#9B9EF6"
+     }
+    },
+    {
+     "id": "bati surfacique quelconque - Zoom 15",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "bati_surf",
+     "minzoom": 14,
+     "maxzoom": 21,
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "BATI_QQUE"
+     ],
+     "paint": {
+      "fill-color": "#D6C6B8"
+     }
+    },
+    {
+     "id": "bati surfacique quelconque - Zoom 16,17,18",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "bati_surf",
+     "minzoom": 15,
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "BATI_QQUE"
+     ],
+     "paint": {
+      "fill-color": {
+       "stops": [
+      [
+       15,
+       "#E6E0CF"
+      ],
+      [
+       16,
+       "#F1EBD9"
+      ]
+       ]
+      },
+      "fill-outline-color": "#C3AA8E"
+     }
+    },
+    {
+     "id": "cimetiere surfacique 1",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "bati_surf",
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "CIMETIERE_SURF",
+      "CIMETIERE_MILI_SURF",
+      "NECROPOLE_NATIONALE"
+     ],
+     "paint": {
+      "fill-color": "#F0F0F0",
+      "fill-opacity": 0.5,
+      "fill-outline-color": "#818181"
+     }
+    },
+    {
+     "id": "cimetiere surfacique 2",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "bati_surf",
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "CIMETIERE_SURF",
+      "CIMETIERE_MILI_SURF",
+      "NECROPOLE_NATIONALE"
+     ],
+     "paint": {
+      "fill-pattern": "Cimetiere"
+     }
+    },
+    {
+     "id": "bati hydro surfacique - Autre",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "bati_surf",
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "ECLUSE_SURF",
+      "RESERVOIR_EAU_SURF"
+     ],
+     "paint": {
+      "fill-color": "#ADCCD9",
+      "fill-outline-color": "#336699"
+     }
+    },
+    {
+     "id": "bati hydro surfacique - Pecherie",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "bati_surf",
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "PECHERIE_SURF"
+     ],
+     "paint": {
+      "fill-color": "#BFE2F0",
+      "fill-outline-color": "#509FEF"
+     }
+    },
+    {
+     "id": "bati hydro surfacique - Barrage",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "bati_surf",
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "BARRAGE_SURF"
+     ],
+     "paint": {
+      "fill-color": "#FFFFFF",
+      "fill-outline-color": "#464646"
+     }
+    },
+    {
+     "id": "bati hydro surfacique - Chateau d'eau",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "bati_surf",
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "CHATEAU_EAU_SURF"
+     ],
+     "paint": {
+      "fill-color": "#1466B2"
+     }
+    },
+    {
+     "id": "bati infra surfacique - Silo",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "bati_surf",
+     "minzoom": 15,
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "SILO_SURF"
+     ],
+     "paint": {
+      "fill-color": "#C7A9AA",
+      "fill-outline-color": "#696969"
+     }
+    },
+    {
+     "id": "bati infra surfacique - Reservoir indus",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "bati_surf",
+     "minzoom": 14,
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "RESERVOIR_INDUS_SURF"
+     ],
+     "paint": {
+      "fill-color": "#8D9DAA",
+      "fill-outline-color": "#464646"
+     }
+    },
+    {
+     "id": "bati infra surfacique - Serre",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "bati_surf",
+     "minzoom": 13,
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "SERRE_SURF"
+     ],
+     "paint": {
+      "fill-color": "#CAD6D9",
+      "fill-outline-color": "#8C8C8C"
+     }
+    },
+    {
+     "id": "bati infra surfacique - poste electrique",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "bati_surf",
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "POSTE_ELEC_SURF"
+     ],
+     "paint": {
+      "fill-color": "#7993B6",
+      "fill-opacity": 0.3
+     }
+    },
+    {
+     "id": "bati infra surfacique - poste electrique bord",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "bati_surf",
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "POSTE_ELEC_SURF"
+     ],
+     "paint": {
+      "line-color": "#000000",
+      "line-width": {
+       "stops": [
+      [
+       12,
+       0.3
+      ],
+      [
+       17,
+       1.2
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "bati religieux surfacique - Zoom 14",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "bati_surf",
+     "maxzoom": 14,
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "CHAPELLE_SURF",
+      "EGLISE_SURF",
+      "CHRETIEN_SURF",
+      "SYNAGOGUE_SURF",
+      "MOSQUEE_SURF",
+      "AUTRE_CULTE_SURF"
+     ],
+     "paint": {
+      "fill-color": "#F7CBCB"
+     }
+    },
+    {
+     "id": "bati religieux surfacique - Zoom 15,16,17,18",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "bati_surf",
+     "minzoom": 14,
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "CHAPELLE_SURF",
+      "EGLISE_SURF",
+      "CHRETIEN_SURF",
+      "SYNAGOGUE_SURF",
+      "MOSQUEE_SURF",
+      "AUTRE_CULTE_SURF"
+     ],
+     "paint": {
+      "fill-color": {
+       "stops": [
+      [
+       14,
+       "#F7CBCB"
+      ],
+      [
+       15,
+       "#F7E1E1"
+      ]
+       ]
+      },
+      "fill-outline-color": {
+       "stops": [
+      [
+       14,
+       "#F7A8A8"
+      ],
+      [
+       15,
+       "#F7B7B7"
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "bati remarquable surfacique",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "bati_surf",
+     "minzoom": 13,
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "FORTIF_SURF",
+      "CHATEAU_SURF",
+      "TOUR_MOULIN_SURF",
+      "ARENE_THEATRE",
+      "ARC_TRIOMPHE_SURF",
+      "MONUMENT_SURF"
+     ],
+     "paint": {
+      "fill-color": "#9B9B9B",
+      "fill-outline-color": "#6E6E6E"
+     }
+    },
+    {
+     "id": "bati sportif surfacique fond",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "bati_surf",
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "TENNIS_SURF",
+      "SPORT_INDIF_SURF",
+      "FOOT_SURF",
+      "MULTI_SPORT_SURF",
+      "PISTE_SPORT_SURF",
+      "NATATION_SURF"
+     ],
+     "paint": {
+      "fill-color": "#FFFFFF",
+      "fill-outline-color": "#FFFFFF"
+     }
+    },
+    {
+     "id": "bati sportif surfacique",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "bati_surf",
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "TENNIS_SURF",
+      "SPORT_INDIF_SURF",
+      "FOOT_SURF",
+      "MULTI_SPORT_SURF",
+      "PISTE_SPORT_SURF",
+      "NATATION_SURF"
+     ],
+     "paint": {
+      "line-color": "#BCD9AB",
+      "line-width": 2
+     }
+    },
+    {
+     "id": "bati transport surfacique - piste",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "bati_surf",
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "PISTE_DUR",
+      "PISTE_HERBE"
+     ],
+     "paint": {
+      "fill-color": "#DBDBDB",
+      "fill-outline-color": "#808080"
+     }
+    },
+    {
+     "id": "bati ZAI - Autres",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "bati_zai",
+     "minzoom": 15,
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "in",
+      "nature",
+      "Lycée",
+      "Université",
+      "Capitainerie",
+      "Gendarmerie",
+      "Siège d'EPCI",
+      "Musée",
+      "Collège",
+      "Maison de retraite",
+      "Etablissement thermal",
+      "Autre service déconcentré de l'Etat",
+      "Etablissement pénitentiaire",
+      "Divers public ou administratif",
+      "Autre établissement d'enseignement",
+      "Maison du parc",
+      "Palais de justice",
+      "Enseignement primaire",
+      "Office de tourisme",
+      "Hôpital",
+      "Police",
+      "Piscine",
+      "Enseignement supérieur",
+      "Poste",
+      "Caserne",
+      "Etablissement hospitalier",
+      "Etablissement extraterritorial",
+      "Science",
+      "Structure d'accueil pour personnes handicapées",
+      "Administration centrale de l'Etat",
+      "Caserne de pompiers"
+     ],
+     "paint": {
+      "fill-color": "#E3BFE2",
+      "fill-opacity": 0.5,
+      "fill-outline-color": "#E39FE1"
+     }
+    },
+    {
+     "id": "bati ZAI - Commandement",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "bati_zai",
+     "minzoom": 15,
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "in",
+      "nature",
+      "Hôtel de département",
+      "Hôtel de région",
+      "Préfecture de région",
+      "Préfecture",
+      "Sous-préfecture"
+     ],
+     "paint": {
+      "fill-color": "#FF0000",
+      "fill-opacity": 0.3,
+      "fill-outline-color": "#B40000"
+     }
+    },
+    {
+     "id": "construction linéaire - mur",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "bati_lin",
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "MUR"
+     ],
+     "paint": {
+      "line-color": "#8C8C8C",
+      "line-width": 0.3
+     }
+    },
+    {
+     "id": "construction linéaire - autre",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "bati_lin",
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "RUINE_LIN",
+      "MUR_SOUTENEMENT",
+      "FORTIF_LIN"
+     ],
+     "paint": {
+      "line-color": "#646464",
+      "line-width": 0.5
+     }
+    },
+    {
+     "id": "construction hydrographique linéaire - Barrage",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "bati_lin",
+     "minzoom": 13,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "BARRAGE_LIN"
+     ],
+     "paint": {
+      "line-color": "#646464",
+      "line-width": {
+       "stops": [
+      [
+       13,
+       1.5
+      ],
+      [
+       17,
+       5
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "construction hydrographique linéaire - Quai",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "bati_lin",
+     "minzoom": 12,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "QUAI",
+      "DIGUE"
+     ],
+     "paint": {
+      "line-color": "#828282",
+      "line-width": {
+       "stops": [
+      [
+       14,
+       1
+      ],
+      [
+       17,
+       2.5
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "construction hydrographique linéaire - Pecherie",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "bati_lin",
+     "minzoom": 12,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "PECHERIE_LIN"
+     ],
+     "paint": {
+      "line-color": "#0066CC",
+      "line-width": {
+       "stops": [
+      [
+       14,
+       1
+      ],
+      [
+       17,
+       2.5
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Chemin a niveau - piste cyclable",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_chemin",
+     "minzoom": 13,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "PISTE_CYCLABLE"
+     ],
+     "paint": {
+      "line-color": {
+       "stops": [
+      [
+       17,
+       "#9B5CCC"
+      ],
+      [
+       18,
+       "#EDF1FF"
+      ]
+       ]
+      },
+      "line-width": {
+       "stops": [
+      [
+       14,
+       1.1
+      ],
+      [
+       15,
+       1.7
+      ],
+      [
+       16,
+       2
+      ],
+      [
+       17,
+       3.5
+      ],
+      [
+       18,
+       6
+      ]
+       ]
+      },
+      "line-dasharray": [
+       6,
+       2
+      ]
+     }
+    },
+    {
+     "id": "Chemin a niveau - filet exterieur - escalier",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_chemin",
+     "minzoom": 14,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "ESCALIER"
+     ],
+     "paint": {
+      "line-color": {
+       "stops": [
+      [
+       17,
+       "#8C7274"
+      ],
+      [
+       18,
+       "#C8C8C8"
+      ]
+       ]
+      },
+      "line-width": {
+       "stops": [
+      [
+       14,
+       1.75
+      ],
+      [
+       15,
+       3
+      ],
+      [
+       16,
+       4.2
+      ],
+      [
+       17,
+       9.5
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Chemin a niveau - filet interieur - escalier",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_chemin",
+     "minzoom": 14,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "ESCALIER"
+     ],
+     "paint": {
+      "line-color": "#EDF1FF",
+      "line-width": {
+       "stops": [
+      [
+       14,
+       1
+      ],
+      [
+       15,
+       1.9
+      ],
+      [
+       16,
+       2.7
+      ],
+      [
+       17,
+       5.8
+      ]
+       ]
+      },
+      "line-dasharray": [
+       1,
+       0.2
+      ]
+     }
+    },
+    {
+     "id": "Chemin a niveau - Rue pietonne",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_chemin",
+     "minzoom": 14,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "RUE_PIETONNE"
+     ],
+     "paint": {
+      "line-color": {
+       "stops": [
+      [
+       17,
+       "#8C7274"
+      ],
+      [
+       18,
+       "#F8E5D5"
+      ]
+       ]
+      },
+      "line-width": {
+       "stops": [
+      [
+       14,
+       1
+      ],
+      [
+       15,
+       1.2
+      ],
+      [
+       16,
+       1.4
+      ],
+      [
+       17,
+       2
+      ],
+      [
+       18,
+       5
+      ]
+       ]
+      },
+      "line-dasharray": [
+       1,
+       3
+      ]
+     }
+    },
+    {
+     "id": "Chemin a niveau - sentier",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_chemin",
+     "minzoom": 13,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "SENTIER"
+     ],
+     "paint": {
+      "line-color": {
+       "stops": [
+      [
+       17,
+       "#8C7274"
+      ],
+      [
+       18,
+       "#EDF1FF"
+      ]
+       ]
+      },
+      "line-width": {
+       "stops": [
+      [
+       14,
+       1
+      ],
+      [
+       15,
+       1.2
+      ],
+      [
+       16,
+       1.4
+      ],
+      [
+       17,
+       2
+      ],
+      [
+       18,
+       6
+      ]
+       ]
+      },
+      "line-dasharray": [
+       4,
+       3
+      ]
+     }
+    },
+    {
+     "id": "Chemin a niveau - chemin",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_chemin",
+     "minzoom": 12,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "CHEMIN"
+     ],
+     "paint": {
+      "line-color": {
+       "stops": [
+      [
+       17,
+       "#8C7274"
+      ],
+      [
+       18,
+       "#EDF1FF"
+      ]
+       ]
+      },
+      "line-width": {
+       "stops": [
+      [
+       14,
+       1
+      ],
+      [
+       15,
+       1.2
+      ],
+      [
+       16,
+       1.4
+      ],
+      [
+       17,
+       2
+      ],
+      [
+       18,
+       7
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier a niveau - filet extérieur - route non revetu carrosable",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route",
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "NON_REVETUE_CARRO"
+     ],
+     "paint": {
+      "line-color": {
+       "stops": [
+      [
+       12,
+       "#646464"
+      ],
+      [
+       17,
+       "#8C8C8C"
+      ]
+       ]
+      },
+      "line-width": {
+       "stops": [
+      [
+       14,
+       3.2
+      ],
+      [
+       15,
+       5.4
+      ],
+      [
+       16,
+       7.7
+      ],
+      [
+       17,
+       16.8
+      ]
+       ]
+      },
+      "line-dasharray": [
+       2,
+       2
+      ]
+     }
+    },
+    {
+     "id": "Routier a niveau - filet interieur - route non revetu carrosable",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route",
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "NON_REVETUE_CARRO"
+     ],
+     "paint": {
+      "line-color": "#EDF1FF",
+      "line-width": {
+       "stops": [
+      [
+       14,
+       2.3
+      ],
+      [
+       15,
+       4.1
+      ],
+      [
+       16,
+       6.3
+      ],
+      [
+       17,
+       13.5
+      ],
+      [
+       18,
+       16.8
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier a niveau - filet extérieur - bretelle autoroute",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route",
+     "minzoom": 12,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "BRET_AUTO_PEAGE_3",
+      "BRET_AUTO_PEAGE_2",
+      "BRET_AUTO_PEAGE_1",
+      "BRET_AUTO_LIBRE_3",
+      "BRET_AUTO_LIBRE_2",
+      "BRET_AUTO_LIBRE_1"
+     ],
+     "paint": {
+      "line-color": {
+       "stops": [
+      [
+       9,
+       "#DE460E"
+      ],
+      [
+       17,
+       "#F18800"
+      ],
+      [
+       18,
+       "#EDF1FF"
+      ]
+       ]
+      },
+      "line-width": {
+       "stops": [
+      [
+       12,
+       2.5
+      ],
+      [
+       14,
+       3.7
+      ],
+      [
+       15,
+       6.8
+      ],
+      [
+       16,
+       8.4
+      ],
+      [
+       17,
+       14
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier a niveau - filet extérieur - route non classee restreint",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route",
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "NON_CLASSEE_RESTREINT"
+     ],
+     "paint": {
+      "line-color": {
+       "stops": [
+      [
+       17,
+       "#969696"
+      ],
+      [
+       18,
+       "#EDF1FF"
+      ]
+       ]
+      },
+      "line-width": {
+       "stops": [
+      [
+       14,
+       3.2
+      ],
+      [
+       15,
+       5.4
+      ],
+      [
+       16,
+       7.7
+      ],
+      [
+       17,
+       16.8
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier a niveau - filet extérieur - route non classee",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route",
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "NON_CLASSEE_4",
+      "NON_CLASSEE"
+     ],
+     "paint": {
+      "line-color": {
+       "stops": [
+      [
+       17,
+       "#969696"
+      ],
+      [
+       18,
+       "#EDF1FF"
+      ]
+       ]
+      },
+      "line-width": {
+       "stops": [
+      [
+       14,
+       3.2
+      ],
+      [
+       15,
+       5.4
+      ],
+      [
+       16,
+       7.7
+      ],
+      [
+       17,
+       16.8
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier a niveau - filet extérieur - route locale",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route",
+     "minzoom": 7,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "BRET_LOCALE",
+      "LOCALE_4",
+      "LOCALE_3",
+      "LOCALE_2",
+      "LOCALE_1"
+     ],
+     "paint": {
+      "line-color": {
+       "stops": [
+      [
+       12,
+       "#8C8C8C"
+      ],
+      [
+       13,
+       "#B4B4B4"
+      ],
+      [
+       17,
+       "#B4B4B4"
+      ],
+      [
+       18,
+       "#EDF1FF"
+      ]
+       ]
+      },
+      "line-width": {
+       "stops": [
+      [
+       9,
+       2
+      ],
+      [
+       14,
+       3.5
+      ],
+      [
+       15,
+       6
+      ],
+      [
+       16,
+       8.4
+      ],
+      [
+       17,
+       18.3
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier a niveau - filet extérieur - route locale en construction",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route",
+     "minzoom": 11,
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "LOCALE_CONSTR"
+     ],
+     "paint": {
+      "line-color": "#C8C8C8",
+      "line-width": {
+       "stops": [
+      [
+       9,
+       2
+      ],
+      [
+       14,
+       3.5
+      ],
+      [
+       15,
+       6
+      ],
+      [
+       16,
+       8.4
+      ],
+      [
+       17,
+       18.3
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier a niveau - filet extérieur - route regionale",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route",
+     "minzoom": 8,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "BRET_REGIONALE",
+      "REGIONALE_4",
+      "REGIONALE_3",
+      "REGIONALE_2",
+      "REGIONALE_1"
+     ],
+     "paint": {
+      "line-color": {
+       "stops": [
+      [
+       9,
+       "#828282"
+      ],
+      [
+       10,
+       "#B4B4B4"
+      ],
+      [
+       17,
+       "#B4B4B4"
+      ],
+      [
+       18,
+       "#EDF1FF"
+      ]
+       ]
+      },
+      "line-width": {
+       "stops": [
+      [
+       6,
+       1.5
+      ],
+      [
+       9,
+       2.3
+      ],
+      [
+       14,
+       5
+      ],
+      [
+       15,
+       8.1
+      ],
+      [
+       16,
+       11.2
+      ],
+      [
+       17,
+       22
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier a niveau - filet extérieur - route regionale en construction",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route",
+     "minzoom": 10,
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "REGIONALE_CONSTR"
+     ],
+     "paint": {
+      "line-color": "#C8C8C8",
+      "line-width": {
+       "stops": [
+      [
+       6,
+       1.5
+      ],
+      [
+       9,
+       2.3
+      ],
+      [
+       14,
+       5
+      ],
+      [
+       15,
+       8.1
+      ],
+      [
+       16,
+       11.2
+      ],
+      [
+       17,
+       22
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier a niveau - filet extérieur - route principale",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route",
+     "minzoom": 8,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "BRET_PRINCIPALE",
+      "PRINCIPALE_4",
+      "PRINCIPALE_3",
+      "PRINCIPALE_2",
+      "PRINCIPALE_1"
+     ],
+     "paint": {
+      "line-color": {
+       "stops": [
+      [
+       17,
+       "#E2A52A"
+      ],
+      [
+       18,
+       "#EDF1FF"
+      ]
+       ]
+      },
+      "line-width": {
+       "stops": [
+      [
+       6,
+       1.8
+      ],
+      [
+       9,
+       2.7
+      ],
+      [
+       14,
+       5.9
+      ],
+      [
+       15,
+       9
+      ],
+      [
+       16,
+       12.2
+      ],
+      [
+       17,
+       22.5
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier a niveau - filet extérieur - route principale en construction",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route",
+     "minzoom": 10,
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "PRINCIPALE_CONSTR"
+     ],
+     "paint": {
+      "line-color": "#C8C8C8",
+      "line-width": {
+       "stops": [
+      [
+       6,
+       1.8
+      ],
+      [
+       9,
+       2.7
+      ],
+      [
+       14,
+       5.9
+      ],
+      [
+       15,
+       9
+      ],
+      [
+       16,
+       12.2
+      ],
+      [
+       17,
+       22.5
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier a niveau - filet extérieur - autoroute",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route",
+     "minzoom": 8,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "AUTOROU_PEAGE",
+      "AUTOROU_LIBRE"
+     ],
+     "paint": {
+      "line-color": {
+       "stops": [
+      [
+       9,
+       "#DE460E"
+      ],
+      [
+       17,
+       "#F18800"
+      ],
+      [
+       18,
+       "#EDF1FF"
+      ]
+       ]
+      },
+      "line-width": {
+       "stops": [
+      [
+       6,
+       2.5
+      ],
+      [
+       9,
+       3.5
+      ],
+      [
+       14,
+       7.5
+      ],
+      [
+       15,
+       11
+      ],
+      [
+       16,
+       15
+      ],
+      [
+       17,
+       26
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier a niveau - filet extérieur - autoroute en construction",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route",
+     "minzoom": 8,
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "AUTOROU_CONSTR"
+     ],
+     "paint": {
+      "line-color": "#C8C8C8",
+      "line-width": {
+       "stops": [
+      [
+       6,
+       2.5
+      ],
+      [
+       9,
+       3.5
+      ],
+      [
+       14,
+       7.5
+      ],
+      [
+       15,
+       11
+      ],
+      [
+       16,
+       15
+      ],
+      [
+       17,
+       26
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier a niveau - filet interieur - bretelle autoroute",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route",
+     "minzoom": 12,
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "BRET_AUTO_PEAGE_3",
+      "BRET_AUTO_PEAGE_2",
+      "BRET_AUTO_PEAGE_1",
+      "BRET_AUTO_LIBRE_3",
+      "BRET_AUTO_LIBRE_2",
+      "BRET_AUTO_LIBRE_1"
+     ],
+     "paint": {
+      "line-color": {
+       "stops": [
+      [
+       9,
+       "#F18800"
+      ],
+      [
+       17,
+       "#F2B230"
+      ]
+       ]
+      },
+      "line-width": {
+       "stops": [
+      [
+       12,
+       1.5
+      ],
+      [
+       14,
+       2.6
+      ],
+      [
+       15,
+       5.2
+      ],
+      [
+       16,
+       6.7
+      ],
+      [
+       17,
+       10.8
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier a niveau - filet interieur - route non classee restreint",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route",
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "NON_CLASSEE_RESTREINT"
+     ],
+     "paint": {
+      "line-color": "#EDF1FF",
+      "line-width": {
+       "stops": [
+      [
+       14,
+       2.3
+      ],
+      [
+       15,
+       4.1
+      ],
+      [
+       16,
+       6.3
+      ],
+      [
+       17,
+       13.5
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier a niveau - filet interieur - route non classee",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route",
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "NON_CLASSEE_4",
+      "NON_CLASSEE"
+     ],
+     "paint": {
+      "line-color": "#EDF1FF",
+      "line-width": {
+       "stops": [
+      [
+       14,
+       2.3
+      ],
+      [
+       15,
+       4.1
+      ],
+      [
+       16,
+       6.3
+      ],
+      [
+       17,
+       13.5
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier a niveau - filet interieur - route locale",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route",
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "BRET_LOCALE",
+      "LOCALE_4",
+      "LOCALE_3",
+      "LOCALE_2",
+      "LOCALE_1"
+     ],
+     "paint": {
+      "line-color": {
+       "stops": [
+      [
+       6,
+       "#F2B361"
+      ],
+      [
+       7,
+       "#EDF1FF"
+      ],
+      [
+       12,
+       "#EDF1FF"
+      ],
+      [
+       13,
+       "#FCF4A8"
+      ],
+      [
+       17,
+       "#FCF7C1"
+      ]
+       ]
+      },
+      "line-width": {
+       "stops": [
+      [
+       9,
+       1.3
+      ],
+      [
+       14,
+       2.3
+      ],
+      [
+       15,
+       4.1
+      ],
+      [
+       16,
+       6.1
+      ],
+      [
+       17,
+       13.1
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier a niveau - filet interieur - route locale en construction",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route",
+     "minzoom": 11,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "LOCALE_CONSTR"
+     ],
+     "paint": {
+      "line-color": {
+       "stops": [
+      [
+       12,
+       "#EDF1FF"
+      ],
+      [
+       13,
+       "#FCF4A8"
+      ],
+      [
+       17,
+       "#FCF7C1"
+      ],
+      [
+       18,
+       "#EDEDED"
+      ]
+       ]
+      },
+      "line-width": {
+       "stops": [
+      [
+       9,
+       2
+      ],
+      [
+       14,
+       3.5
+      ],
+      [
+       15,
+       6
+      ],
+      [
+       16,
+       8.4
+      ],
+      [
+       17,
+       18.3
+      ]
+       ]
+      },
+      "line-dasharray": [
+       2,
+       2
+      ]
+     }
+    },
+    {
+     "id": "Routier a niveau - filet interieur - route regionale",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route",
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "BRET_REGIONALE",
+      "REGIONALE_4",
+      "REGIONALE_3",
+      "REGIONALE_2",
+      "REGIONALE_1"
+     ],
+     "paint": {
+      "line-color": {
+       "stops": [
+      [
+       6,
+       "#F2A949"
+      ],
+      [
+       7,
+       "#EDF1FF"
+      ],
+      [
+       9,
+       "#EDF1FF"
+      ],
+      [
+       10,
+       "#FDF28B"
+      ],
+      [
+       17,
+       "#FCF6BD"
+      ]
+       ]
+      },
+      "line-width": {
+       "stops": [
+      [
+       4,
+       1.1
+      ],
+      [
+       6,
+       1.4
+      ],
+      [
+       9,
+       1.5
+      ],
+      [
+       14,
+       3.2
+      ],
+      [
+       15,
+       5.8
+      ],
+      [
+       16,
+       8.3
+      ],
+      [
+       17,
+       16.2
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier a niveau - filet interieur - route regionale en construction",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route",
+     "minzoom": 10,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "REGIONALE_CONSTR"
+     ],
+     "paint": {
+      "line-color": {
+       "stops": [
+      [
+       9,
+       "#EDF1FF"
+      ],
+      [
+       10,
+       "#FDF28B"
+      ],
+      [
+       17,
+       "#FCF6BD"
+      ],
+      [
+       18,
+       "#EDEDED"
+      ]
+       ]
+      },
+      "line-width": {
+       "stops": [
+      [
+       4,
+       0.4
+      ],
+      [
+       6,
+       1.5
+      ],
+      [
+       9,
+       2.3
+      ],
+      [
+       14,
+       5
+      ],
+      [
+       15,
+       8.1
+      ],
+      [
+       16,
+       11.2
+      ],
+      [
+       17,
+       22
+      ]
+       ]
+      },
+      "line-dasharray": [
+       2,
+       2
+      ]
+     }
+    },
+    {
+     "id": "Routier a niveau - filet interieur - route principale",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route",
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "BRET_PRINCIPALE",
+      "PRINCIPALE_4",
+      "PRINCIPALE_3",
+      "PRINCIPALE_2",
+      "PRINCIPALE_1"
+     ],
+     "paint": {
+      "line-color": {
+       "stops": [
+      [
+       6,
+       "#F29924"
+      ],
+      [
+       7,
+       "#F3C66D"
+      ],
+      [
+       9,
+       "#F3C66D"
+      ],
+      [
+       17,
+       "#F2DDB3"
+      ]
+       ]
+      },
+      "line-width": {
+       "stops": [
+      [
+       4,
+       0.6
+      ],
+      [
+       6,
+       1.8
+      ],
+      [
+       9,
+       2.1
+      ],
+      [
+       14,
+       4.4
+      ],
+      [
+       15,
+       7.3
+      ],
+      [
+       16,
+       10
+      ],
+      [
+       17,
+       18.5
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier a niveau - filet interieur - route principale en construction",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route",
+     "minzoom": 10,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "PRINCIPALE_CONSTR"
+     ],
+     "paint": {
+      "line-color": {
+       "stops": [
+      [
+       9,
+       "#F3C66D"
+      ],
+      [
+       17,
+       "#F2DDB3"
+      ],
+      [
+       18,
+       "#EDEDED"
+      ]
+       ]
+      },
+      "line-width": {
+       "stops": [
+      [
+       4,
+       0.5
+      ],
+      [
+       6,
+       1.8
+      ],
+      [
+       9,
+       2.7
+      ],
+      [
+       14,
+       5.9
+      ],
+      [
+       15,
+       9
+      ],
+      [
+       16,
+       12.2
+      ],
+      [
+       17,
+       22.5
+      ]
+       ]
+      },
+      "line-dasharray": [
+       2,
+       2
+      ]
+     }
+    },
+    {
+     "id": "Routier a niveau - filet interieur - autoroute",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route",
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "AUTOROU_PEAGE",
+      "AUTOROU_LIBRE"
+     ],
+     "paint": {
+      "line-color": {
+       "stops": [
+      [
+       9,
+       "#F18800"
+      ],
+      [
+       17,
+       "#F2B230"
+      ]
+       ]
+      },
+      "line-width": {
+       "stops": [
+      [
+       4,
+       0.7
+      ],
+      [
+       6,
+       2.5
+      ],
+      [
+       9,
+       2.7
+      ],
+      [
+       14,
+       5.8
+      ],
+      [
+       15,
+       9
+      ],
+      [
+       16,
+       12
+      ],
+      [
+       17,
+       20.8
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier a niveau - axe central - autoroute",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route",
+     "minzoom": 13,
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "AUTOROU_PEAGE",
+      "AUTOROU_LIBRE"
+     ],
+     "paint": {
+      "line-color": "#EDF1FF",
+      "line-width": {
+       "stops": [
+      [
+       9,
+       0.6
+      ],
+      [
+       14,
+       0.7
+      ],
+      [
+       15,
+       1
+      ],
+      [
+       16,
+       1.2
+      ],
+      [
+       17,
+       2.1
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier a niveau - filet interieur - autoroute en construction",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route",
+     "minzoom": 8,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "AUTOROU_CONSTR"
+     ],
+     "paint": {
+      "line-color": {
+       "stops": [
+      [
+       9,
+       "#F18800"
+      ],
+      [
+       17,
+       "#F2B230"
+      ],
+      [
+       18,
+       "#EDEDED"
+      ]
+       ]
+      },
+      "line-width": {
+       "stops": [
+      [
+       4,
+       0.7
+      ],
+      [
+       6,
+       2.5
+      ],
+      [
+       9,
+       3.5
+      ],
+      [
+       14,
+       7.5
+      ],
+      [
+       15,
+       11
+      ],
+      [
+       16,
+       15
+      ],
+      [
+       17,
+       26
+      ]
+       ]
+      },
+      "line-dasharray": [
+       2,
+       2
+      ]
+     }
+    },
+    {
+     "id": "Routier a niveau - axe centrale - autoroute en construction",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route",
+     "minzoom": 13,
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "AUTOROU_CONSTR"
+     ],
+     "paint": {
+      "line-color": "#808080",
+      "line-width": {
+       "stops": [
+      [
+       9,
+       0.6
+      ],
+      [
+       14,
+       0.7
+      ],
+      [
+       15,
+       1
+      ],
+      [
+       16,
+       1.2
+      ],
+      [
+       17,
+       2.1
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Ferre a niveau - voie normale",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "ferre",
+     "minzoom": 10,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "VF_1",
+      "VF_2",
+      "VF_3",
+      "VF_4",
+      "VF_ELEC_1",
+      "VF_ELEC_2",
+      "VF_ELEC_3",
+      "VF_ELEC_4"
+     ],
+     "paint": {
+      "line-color": "#787878",
+      "line-width": {
+       "stops": [
+      [
+       10,
+       0.8
+      ],
+      [
+       17,
+       2.5
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Ferre a niveau - voie normale trait perpendic",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "ferre",
+     "minzoom": 10,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "VF_1",
+      "VF_2",
+      "VF_3",
+      "VF_4",
+      "VF_ELEC_1",
+      "VF_ELEC_2",
+      "VF_ELEC_3",
+      "VF_ELEC_4"
+     ],
+     "paint": {
+      "line-color": "#787878",
+      "line-width": {
+       "stops": [
+      [
+       10,
+       3.5
+      ],
+      [
+       17,
+       14.7
+      ]
+       ]
+      },
+      "line-dasharray": [
+       0.1,
+       10
+      ]
+     }
+    },
+    {
+     "id": "Ferre a niveau - voie etroite",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "ferre",
+     "minzoom": 10,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "VF_ETROITE_1",
+      "VF_ETROITE_2",
+      "VF_ETROITE"
+     ],
+     "paint": {
+      "line-color": "#787878",
+      "line-width": {
+       "stops": [
+      [
+       10,
+       0.3
+      ],
+      [
+       17,
+       1.8
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Ferre a niveau - voie etroite trait perpendic",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "ferre",
+     "minzoom": 10,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "VF_ETROITE_1",
+      "VF_ETROITE_2",
+      "VF_ETROITE"
+     ],
+     "paint": {
+      "line-color": "#787878",
+      "line-width": {
+       "stops": [
+      [
+       10,
+       3.5
+      ],
+      [
+       17,
+       14.7
+      ]
+       ]
+      },
+      "line-dasharray": [
+       0.1,
+       10
+      ]
+     }
+    },
+    {
+     "id": "Ferre a niveau - voie service",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "ferre",
+     "minzoom": 14,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "VF_SERVICE",
+      "VF_NON_EXPLOITEE"
+     ],
+     "paint": {
+      "line-color": "#787878",
+      "line-width": {
+       "stops": [
+      [
+       10,
+       0.3
+      ],
+      [
+       17,
+       1.8
+      ]
+       ]
+      },
+      "line-dasharray": [
+       5,
+       2,
+       1,
+       2
+      ]
+     }
+    },
+    {
+     "id": "Ferre a niveau - voie en construction",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "ferre",
+     "minzoom": 10,
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "VF_EN_CONSTR"
+     ],
+     "paint": {
+      "line-color": "#787878",
+      "line-width": {
+       "stops": [
+      [
+       10,
+       0.3
+      ],
+      [
+       17,
+       1.8
+      ]
+       ]
+      },
+      "line-dasharray": [
+       2,
+       2
+      ]
+     }
+    },
+    {
+     "id": "Ferre a niveau - voie en construction trait perpendic",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "ferre",
+     "minzoom": 10,
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "VF_EN_CONSTR"
+     ],
+     "paint": {
+      "line-color": "#787878",
+      "line-width": {
+       "stops": [
+      [
+       10,
+       3.5
+      ],
+      [
+       17,
+       14.7
+      ]
+       ]
+      },
+      "line-dasharray": [
+       0.1,
+       10
+      ]
+     }
+    },
+    {
+     "id": "Ferre a niveau - funic/urbain",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "ferre",
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "FUNI_CREMAILLERE",
+      "TRANSPORT_URBAIN"
+     ],
+     "paint": {
+      "line-color": "#787878",
+      "line-width": {
+       "stops": [
+      [
+       10,
+       0.3
+      ],
+      [
+       17,
+       1.8
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Ferre a niveau - 2 trait perpendic - funic/urbain",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "ferre",
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "FUNI_CREMAILLERE",
+      "TRANSPORT_URBAIN"
+     ],
+     "paint": {
+      "line-color": "#787878",
+      "line-width": {
+       "stops": [
+      [
+       10,
+       3.5
+      ],
+      [
+       17,
+       17
+      ]
+       ]
+      },
+      "line-dasharray": [
+       0.1,
+       0.2,
+       0.1,
+       10
+      ]
+     }
+    },
+    {
+     "id": "liaison routiere - Bac Liaison Maritime",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_liaison",
+     "minzoom": 8,
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "BAC_AUTO",
+      "LIAISON_MARITIME",
+      "BAC_LIAISON_MARITIME"
+     ],
+     "paint": {
+      "line-color": "#5792C2",
+      "line-width": {
+       "stops": [
+      [
+       8,
+       1
+      ],
+      [
+       13,
+       2.5
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "liaison routiere - Gue route",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_liaison",
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "GUE_ROUTE"
+     ],
+     "paint": {
+      "line-color": {
+       "stops": [
+      [
+       13,
+       "#BEBEBE"
+      ],
+      [
+       17,
+       "#646464"
+      ],
+      [
+       18,
+       "#EDF1FF"
+      ]
+       ]
+      },
+      "line-width": {
+       "stops": [
+      [
+       14,
+       2.3
+      ],
+      [
+       15,
+       4.1
+      ],
+      [
+       16,
+       6.3
+      ],
+      [
+       17,
+       13.5
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "liaison routiere - Gue chemin",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_liaison",
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "GUE_CHEMIN"
+     ],
+     "paint": {
+      "line-color": {
+       "stops": [
+      [
+       13,
+       "#BEBEBE"
+      ],
+      [
+       17,
+       "#646464"
+      ]
+       ]
+      },
+      "line-width": {
+       "stops": [
+      [
+       14,
+       1.6
+      ],
+      [
+       15,
+       2.9
+      ],
+      [
+       16,
+       4.4
+      ],
+      [
+       17,
+       6.5
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "liaison routiere - filet extérieur - Pont passerelle",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_liaison",
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "PONT_PASSERELLE",
+      "PONT_LIN",
+      "PONT_MOBILE_LIN"
+     ],
+     "paint": {
+      "line-color": {
+       "stops": [
+      [
+       17,
+       "#C8C8C8"
+      ],
+      [
+       18,
+       "#EDF1FF"
+      ]
+       ]
+      },
+      "line-width": {
+       "stops": [
+      [
+       14,
+       2.2
+      ],
+      [
+       15,
+       3.8
+      ],
+      [
+       16,
+       5.4
+      ],
+      [
+       17,
+       11.8
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "liaison routiere - filet intérieur - Pont passerelle",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_liaison",
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "PONT_PASSERELLE",
+      "PONT_LIN",
+      "PONT_MOBILE_LIN"
+     ],
+     "paint": {
+      "line-color": "#EDF1FF",
+      "line-width": {
+       "stops": [
+      [
+       14,
+       0.7
+      ],
+      [
+       15,
+       1.1
+      ],
+      [
+       16,
+       1.7
+      ],
+      [
+       17,
+       3.8
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier surfacique",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "routier_surf",
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "SURF_ROUT_PRINC",
+      "SURF_ROUT_REG",
+      "SURF_ROUT_LOC",
+      "SURF_ROUT_NON_CLA"
+     ],
+     "paint": {
+      "fill-color": "#EDF1FF",
+      "fill-outline-color": "#000000"
+     }
+    },
+    {
+     "id": "Routier surfacique - Dalle de protection",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "routier_surf",
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "DALLE_DE_PROTECTION"
+     ],
+     "paint": {
+      "fill-opacity": 0.5,
+      "fill-color": "#FFFFFF",
+      "fill-outline-color": "#000000"
+     }
+    },
+    {
+     "id": "Routier surfacique - Escalier surfacique",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "routier_surf",
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "ESCALIER_SURF"
+     ],
+     "paint": {
+      "fill-opacity": 0.8,
+      "fill-color": "#FFFFFF",
+      "fill-outline-color": "#918091"
+     }
+    },
+    {
+     "id": "Routier surfacique - Péage surfacique",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "routier_surf",
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "SURF_PEAGE"
+     ],
+     "paint": {
+      "fill-color": "#F2DAAA",
+      "fill-outline-color": "#E2A52A"
+     }
+    },
+    {
+     "id": "bati transport surfacique - bati peage",
+     "type": "fill",
+     "source": "plan_ign",
+     "source-layer": "bati_surf",
+     "minzoom": 13,
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "BATI_PEAGE"
+     ],
+     "paint": {
+      "fill-color": "#DCDCDC",
+      "fill-outline-color": "#808080"
+     }
+    },
+    {
+     "id": "réseau hydro  - cours d'eau superieur",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "hydro_reseau_sup",
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "COURS_D_EAU_SUP",
+      "COURS_D_EAU_MOY_SUP"
+     ],
+     "paint": {
+      "line-color": "#AAD5E9",
+      "line-width": {
+       "stops": [
+      [
+       12,
+       1.5
+      ],
+      [
+       17,
+       6.5
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "réseau hydro - canal superieur",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "hydro_reseau_sup",
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "CANAL_SUP"
+     ],
+     "paint": {
+      "line-color": "#AAD5E9",
+      "line-width": {
+       "stops": [
+      [
+       12,
+       1.4
+      ],
+      [
+       17,
+       5.9
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "réseau hydro - filet interieur - aqueduc superieur",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "hydro_reseau_sup",
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "AQUEDUC_SUP"
+     ],
+     "paint": {
+      "line-color": "#AAD5E9",
+      "line-width": {
+       "stops": [
+      [
+       12,
+       1.4
+      ],
+      [
+       16,
+       3.5
+      ],
+      [
+       17,
+       5.9
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "réseau hydro - carre - aqueduc superieur",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "hydro_reseau_sup",
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "AQUEDUC_SUP"
+     ],
+     "paint": {
+      "line-color": "#AAD5E9",
+      "line-width": {
+       "stops": [
+      [
+       12,
+       3.5
+      ],
+      [
+       16,
+       8.7
+      ],
+      [
+       17,
+       14.7
+      ]
+       ]
+      },
+      "line-dasharray": [
+       1,
+       5
+      ]
+     }
+    },
+    {
+     "id": "Chemin superieur - piste cyclable",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_chemin_sup",
+     "minzoom": 13,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "PISTE_CYCLABLE_SUP"
+     ],
+     "paint": {
+      "line-color": {
+       "stops": [
+      [
+       17,
+       "#9B5CCC"
+      ],
+      [
+       18,
+       "#EDF1FF"
+      ]
+       ]
+      },
+      "line-width": {
+       "stops": [
+      [
+       14,
+       1.1
+      ],
+      [
+       15,
+       1.7
+      ],
+      [
+       16,
+       2
+      ],
+      [
+       17,
+       3.5
+      ],
+      [
+       18,
+       6
+      ]
+       ]
+      },
+      "line-dasharray": [
+       6,
+       2
+      ]
+     }
+    },
+    {
+     "id": "Chemin superieur - filet exterieur - escalier",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_chemin_sup",
+     "minzoom": 14,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "ESCALIER_SUP"
+     ],
+     "paint": {
+      "line-color": {
+       "stops": [
+      [
+       17,
+       "#8C7274"
+      ],
+      [
+       18,
+       "#C8C8C8"
+      ]
+       ]
+      },
+      "line-width": {
+       "stops": [
+      [
+       14,
+       1.75
+      ],
+      [
+       15,
+       3
+      ],
+      [
+       16,
+       4.2
+      ],
+      [
+       17,
+       9.5
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Chemin superieur - filet interieur - escalier",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_chemin_sup",
+     "minzoom": 14,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "ESCALIER_SUP"
+     ],
+     "paint": {
+      "line-color": "#FFFFFF",
+      "line-width": {
+       "stops": [
+      [
+       14,
+       1
+      ],
+      [
+       15,
+       1.9
+      ],
+      [
+       16,
+       2.7
+      ],
+      [
+       17,
+       5.8
+      ]
+       ]
+      },
+      "line-dasharray": [
+       1,
+       0.2
+      ]
+     }
+    },
+    {
+     "id": "Chemin superieur - Rue pietonne",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_chemin_sup",
+     "minzoom": 14,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "RUE_PIETONNE_SUP"
+     ],
+     "paint": {
+      "line-color": {
+       "stops": [
+      [
+       17,
+       "#8C7274"
+      ],
+      [
+       18,
+       "#EBEBEB"
+      ]
+       ]
+      },
+      "line-width": {
+       "stops": [
+      [
+       14,
+       1
+      ],
+      [
+       15,
+       1.2
+      ],
+      [
+       16,
+       1.4
+      ],
+      [
+       17,
+       2
+      ],
+      [
+       18,
+       5
+      ]
+       ]
+      },
+      "line-dasharray": [
+       1,
+       3
+      ]
+     }
+    },
+    {
+     "id": "Chemin superieur - sentier",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_chemin_sup",
+     "minzoom": 13,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "SENTIER_SUP"
+     ],
+     "paint": {
+      "line-color": {
+       "stops": [
+      [
+       17,
+       "#8C7274"
+      ],
+      [
+       18,
+       "#FFFFFF"
+      ]
+       ]
+      },
+      "line-width": {
+       "stops": [
+      [
+       14,
+       1
+      ],
+      [
+       15,
+       1.2
+      ],
+      [
+       16,
+       1.4
+      ],
+      [
+       17,
+       2
+      ],
+      [
+       18,
+       6
+      ]
+       ]
+      },
+      "line-dasharray": [
+       4,
+       3
+      ]
+     }
+    },
+    {
+     "id": "Chemin superieur - chemin",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_chemin_sup",
+     "minzoom": 12,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "CHEMIN_SUP"
+     ],
+     "paint": {
+      "line-color": {
+       "stops": [
+      [
+       17,
+       "#8C7274"
+      ],
+      [
+       18,
+       "#EDF1FF"
+      ]
+       ]
+      },
+      "line-width": {
+       "stops": [
+      [
+       14,
+       1
+      ],
+      [
+       15,
+       1.2
+      ],
+      [
+       16,
+       1.4
+      ],
+      [
+       17,
+       2
+      ],
+      [
+       18,
+       7
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier superieur - filet extérieur - route non revetu carrosable",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route_sup",
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "NON_REVETUE_CARRO_SUP"
+     ],
+     "paint": {
+      "line-color": {
+       "stops": [
+      [
+       12,
+       "#646464"
+      ],
+      [
+       17,
+       "#8C8C8C"
+      ]
+       ]
+      },
+      "line-width": {
+       "stops": [
+      [
+       14,
+       3.2
+      ],
+      [
+       15,
+       5.4
+      ],
+      [
+       16,
+       7.7
+      ],
+      [
+       17,
+       16.8
+      ]
+       ]
+      },
+      "line-dasharray": [
+       2,
+       2
+      ]
+     }
+    },
+    {
+     "id": "Routier superieur - filet extérieur - bretelle autoroute",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route_sup",
+     "minzoom": 12,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "BRET_AUTO_PEAGE_3_SUP",
+      "BRET_AUTO_PEAGE_2_SUP",
+      "BRET_AUTO_PEAGE_1_SUP",
+      "BRET_AUTO_LIBRE_3_SUP",
+      "BRET_AUTO_LIBRE_2_SUP",
+      "BRET_AUTO_LIBRE_1_SUP"
+     ],
+     "paint": {
+      "line-color": {
+       "stops": [
+      [
+       9,
+       "#DE460E"
+      ],
+      [
+       17,
+       "#F18800"
+      ],
+      [
+       18,
+       "#EDF1FF"
+      ]
+       ]
+      },
+      "line-width": {
+       "stops": [
+      [
+       12,
+       2.5
+      ],
+      [
+       14,
+       3.7
+      ],
+      [
+       15,
+       6.8
+      ],
+      [
+       16,
+       8.4
+      ],
+      [
+       17,
+       14
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier superieur - filet extérieur - route non classee restreint",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route_sup",
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "NON_CLASSEE_RESTREINT_SUP"
+     ],
+     "paint": {
+      "line-color": {
+       "stops": [
+      [
+       17,
+       "#969696"
+      ],
+      [
+       18,
+       "#EDF1FF"
+      ]
+       ]
+      },
+      "line-width": {
+       "stops": [
+      [
+       14,
+       3.2
+      ],
+      [
+       15,
+       5.4
+      ],
+      [
+       16,
+       7.7
+      ],
+      [
+       17,
+       16.8
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier superieur - filet extérieur - route non classee",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route_sup",
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "NON_CLASSEE_4_SUP",
+      "NON_CLASSEE_SUP"
+     ],
+     "paint": {
+      "line-color": {
+       "stops": [
+      [
+       17,
+       "#969696"
+      ],
+      [
+       18,
+       "#EDF1FF"
+      ]
+       ]
+      },
+      "line-width": {
+       "stops": [
+      [
+       14,
+       3.2
+      ],
+      [
+       15,
+       5.4
+      ],
+      [
+       16,
+       7.7
+      ],
+      [
+       17,
+       16.8
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier superieur - filet extérieur - route locale",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route_sup",
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "BRET_LOCALE_SUP",
+      "LOCALE_4_SUP",
+      "LOCALE_3_SUP",
+      "LOCALE_2_SUP",
+      "LOCALE_1_SUP"
+     ],
+     "paint": {
+      "line-color": {
+       "stops": [
+      [
+       12,
+       "#8C8C8C"
+      ],
+      [
+       13,
+       "#B4B4B4"
+      ],
+      [
+       17,
+       "#B4B4B4"
+      ],
+      [
+       18,
+       "#EDF1FF"
+      ]
+       ]
+      },
+      "line-width": {
+       "stops": [
+      [
+       9,
+       2
+      ],
+      [
+       14,
+       3.5
+      ],
+      [
+       15,
+       6
+      ],
+      [
+       16,
+       8.4
+      ],
+      [
+       17,
+       18.3
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier superieur - filet extérieur - route locale en construction",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route_sup",
+     "minzoom": 11,
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "LOCALE_CONSTR_SUP"
+     ],
+     "paint": {
+      "line-color": "#C8C8C8",
+      "line-width": {
+       "stops": [
+      [
+       9,
+       2
+      ],
+      [
+       14,
+       3.5
+      ],
+      [
+       15,
+       6
+      ],
+      [
+       16,
+       8.4
+      ],
+      [
+       17,
+       18.3
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier superieur - filet extérieur - route regionale",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route_sup",
+     "minzoom": 8,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "BRET_REGIONALE_SUP",
+      "REGIONALE_4_SUP",
+      "REGIONALE_3_SUP",
+      "REGIONALE_2_SUP",
+      "REGIONALE_1_SUP"
+     ],
+     "paint": {
+      "line-color": {
+       "stops": [
+      [
+       9,
+       "#828282"
+      ],
+      [
+       10,
+       "#B4B4B4"
+      ],
+      [
+       17,
+       "#B4B4B4"
+      ],
+      [
+       18,
+       "#EDF1FF"
+      ]
+       ]
+      },
+      "line-width": {
+       "stops": [
+      [
+       6,
+       1.5
+      ],
+      [
+       9,
+       2.3
+      ],
+      [
+       14,
+       5
+      ],
+      [
+       15,
+       8.1
+      ],
+      [
+       16,
+       11.2
+      ],
+      [
+       17,
+       22
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier superieur - filet extérieur - route regionale en construction",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route_sup",
+     "minzoom": 10,
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "REGIONALE_CONSTR_SUP"
+     ],
+     "paint": {
+      "line-color": "#C8C8C8",
+      "line-width": {
+       "stops": [
+      [
+       6,
+       1.5
+      ],
+      [
+       9,
+       2.3
+      ],
+      [
+       14,
+       5
+      ],
+      [
+       15,
+       8.1
+      ],
+      [
+       16,
+       11.2
+      ],
+      [
+       17,
+       22
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier superieur - filet extérieur - route principale",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route_sup",
+     "minzoom": 8,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "BRET_PRINCIPALE_SUP",
+      "PRINCIPALE_4_SUP",
+      "PRINCIPALE_3_SUP",
+      "PRINCIPALE_2_SUP",
+      "PRINCIPALE_1_SUP"
+     ],
+     "paint": {
+      "line-color": {
+       "stops": [
+      [
+       17,
+       "#E2A52A"
+      ],
+      [
+       18,
+       "#EDF1FF"
+      ]
+       ]
+      },
+      "line-width": {
+       "stops": [
+      [
+       6,
+       1.8
+      ],
+      [
+       9,
+       2.7
+      ],
+      [
+       14,
+       5.9
+      ],
+      [
+       15,
+       9
+      ],
+      [
+       16,
+       12.2
+      ],
+      [
+       17,
+       22.5
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier superieur - filet extérieur - route principale en construction",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route_sup",
+     "minzoom": 10,
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "PRINCIPALE_CONSTR_SUP"
+     ],
+     "paint": {
+      "line-color": "#C8C8C8",
+      "line-width": {
+       "stops": [
+      [
+       6,
+       1.8
+      ],
+      [
+       9,
+       2.7
+      ],
+      [
+       14,
+       5.9
+      ],
+      [
+       15,
+       9
+      ],
+      [
+       16,
+       12.2
+      ],
+      [
+       17,
+       22.5
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier superieur - filet extérieur - autoroute",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route_sup",
+     "minzoom": 8,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "AUTOROU_PEAGE_SUP",
+      "AUTOROU_LIBRE_SUP"
+     ],
+     "paint": {
+      "line-color": {
+       "stops": [
+      [
+       9,
+       "#DE460E"
+      ],
+      [
+       17,
+       "#F18800"
+      ],
+      [
+       18,
+       "#EDF1FF"
+      ]
+       ]
+      },
+      "line-width": {
+       "stops": [
+      [
+       6,
+       2.5
+      ],
+      [
+       9,
+       3.5
+      ],
+      [
+       14,
+       7.5
+      ],
+      [
+       15,
+       11
+      ],
+      [
+       16,
+       15
+      ],
+      [
+       17,
+       26
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier superieur - filet extérieur - autoroute en construction",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route_sup",
+     "minzoom": 10,
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "AUTOROU_CONSTR_SUP"
+     ],
+     "paint": {
+      "line-color": "#C8C8C8",
+      "line-width": {
+       "stops": [
+      [
+       6,
+       2.5
+      ],
+      [
+       9,
+       3.5
+      ],
+      [
+       14,
+       7.5
+      ],
+      [
+       15,
+       11
+      ],
+      [
+       16,
+       15
+      ],
+      [
+       17,
+       26
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier superieur - filet interieur - route non revetu carrosable",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route_sup",
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "NON_REVETUE_CARRO_SUP"
+     ],
+     "paint": {
+      "line-color": "#EDF1FF",
+      "line-width": {
+       "stops": [
+      [
+       14,
+       2.3
+      ],
+      [
+       15,
+       4.1
+      ],
+      [
+       16,
+       6.3
+      ],
+      [
+       17,
+       13.5
+      ],
+      [
+       18,
+       16.8
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier superieur - filet interieur - bretelle autoroute",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route_sup",
+     "minzoom": 12,
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "BRET_AUTO_PEAGE_3_SUP",
+      "BRET_AUTO_PEAGE_2_SUP",
+      "BRET_AUTO_PEAGE_1_SUP",
+      "BRET_AUTO_LIBRE_3_SUP",
+      "BRET_AUTO_LIBRE_2_SUP",
+      "BRET_AUTO_LIBRE_1_SUP"
+     ],
+     "paint": {
+      "line-color": {
+       "stops": [
+      [
+       9,
+       "#F18800"
+      ],
+      [
+       17,
+       "#F2B230"
+      ]
+       ]
+      },
+      "line-width": {
+       "stops": [
+      [
+       12,
+       1.5
+      ],
+      [
+       14,
+       2.6
+      ],
+      [
+       15,
+       5.2
+      ],
+      [
+       16,
+       6.7
+      ],
+      [
+       17,
+       10.8
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier superieur - filet interieur - route non classee restreint",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route_sup",
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "NON_CLASSEE_RESTREINT_SUP"
+     ],
+     "paint": {
+      "line-color": "#EDF1FF",
+      "line-width": {
+       "stops": [
+      [
+       14,
+       2.3
+      ],
+      [
+       15,
+       4.1
+      ],
+      [
+       16,
+       6.3
+      ],
+      [
+       17,
+       13.5
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier superieur - filet interieur - route non classee",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route_sup",
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "NON_CLASSEE_4_SUP",
+      "NON_CLASSEE_SUP"
+     ],
+     "paint": {
+      "line-color": "#EDF1FF",
+      "line-width": {
+       "stops": [
+      [
+       14,
+       2.3
+      ],
+      [
+       15,
+       4.1
+      ],
+      [
+       16,
+       6.3
+      ],
+      [
+       17,
+       13.5
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier superieur - filet interieur - route locale",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route_sup",
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "BRET_LOCALE_SUP",
+      "LOCALE_4_SUP",
+      "LOCALE_3_SUP",
+      "LOCALE_2_SUP",
+      "LOCALE_1_SUP"
+     ],
+     "paint": {
+      "line-color": {
+       "stops": [
+      [
+       12,
+       "#EDF1FF"
+      ],
+      [
+       13,
+       "#FCF4A8"
+      ],
+      [
+       17,
+       "#FCF7C1"
+      ]
+       ]
+      },
+      "line-width": {
+       "stops": [
+      [
+       9,
+       1.3
+      ],
+      [
+       14,
+       2.3
+      ],
+      [
+       15,
+       4.1
+      ],
+      [
+       16,
+       6.1
+      ],
+      [
+       17,
+       13.1
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier superieur - filet interieur - route locale en construction",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route_sup",
+     "minzoom": 11,
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "LOCALE_CONSTR_SUP"
+     ],
+     "paint": {
+      "line-color": {
+       "stops": [
+      [
+       12,
+       "#EDF1FF"
+      ],
+      [
+       13,
+       "#FCF4A8"
+      ],
+      [
+       17,
+       "#FCF7C1"
+      ]
+       ]
+      },
+      "line-width": {
+       "stops": [
+      [
+       9,
+       2
+      ],
+      [
+       14,
+       3.5
+      ],
+      [
+       15,
+       6
+      ],
+      [
+       16,
+       8.4
+      ],
+      [
+       17,
+       18.3
+      ]
+       ]
+      },
+      "line-dasharray": [
+       2,
+       2
+      ]
+     }
+    },
+    {
+     "id": "Routier superieur - filet interieur - route regionale",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route_sup",
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "BRET_REGIONALE_SUP",
+      "REGIONALE_4_SUP",
+      "REGIONALE_3_SUP",
+      "REGIONALE_2_SUP",
+      "REGIONALE_1_SUP"
+     ],
+     "paint": {
+      "line-color": {
+       "stops": [
+      [
+       9,
+       "#EDF1FF"
+      ],
+      [
+       10,
+       "#FDF28B"
+      ],
+      [
+       17,
+       "#FCF6BD"
+      ]
+       ]
+      },
+      "line-width": {
+       "stops": [
+      [
+       6,
+       1.4
+      ],
+      [
+       9,
+       1.5
+      ],
+      [
+       14,
+       3.2
+      ],
+      [
+       15,
+       5.8
+      ],
+      [
+       16,
+       8.3
+      ],
+      [
+       17,
+       16.2
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier superieur - filet interieur - route regionale en construction",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route_sup",
+     "minzoom": 10,
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "REGIONALE_CONSTR_SUP"
+     ],
+     "paint": {
+      "line-color": {
+       "stops": [
+      [
+       9,
+       "#EDF1FF"
+      ],
+      [
+       10,
+       "#FDF28B"
+      ],
+      [
+       17,
+       "#FCF6BD"
+      ]
+       ]
+      },
+      "line-width": {
+       "stops": [
+      [
+       6,
+       1.5
+      ],
+      [
+       9,
+       2.3
+      ],
+      [
+       14,
+       5
+      ],
+      [
+       15,
+       8.1
+      ],
+      [
+       16,
+       11.2
+      ],
+      [
+       17,
+       22
+      ]
+       ]
+      },
+      "line-dasharray": [
+       2,
+       2
+      ]
+     }
+    },
+    {
+     "id": "Routier superieur - filet interieur - route principale",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route_sup",
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "BRET_PRINCIPALE_SUP",
+      "PRINCIPALE_4_SUP",
+      "PRINCIPALE_3_SUP",
+      "PRINCIPALE_2_SUP",
+      "PRINCIPALE_1_SUP"
+     ],
+     "paint": {
+      "line-color": {
+       "stops": [
+      [
+       9,
+       "#F3C66D"
+      ],
+      [
+       17,
+       "#F2DDB3"
+      ]
+       ]
+      },
+      "line-width": {
+       "stops": [
+      [
+       4,
+       0.5
+      ],
+      [
+       6,
+       1.8
+      ],
+      [
+       9,
+       2.1
+      ],
+      [
+       14,
+       4.4
+      ],
+      [
+       15,
+       7.3
+      ],
+      [
+       16,
+       10
+      ],
+      [
+       17,
+       18.5
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier superieur - filet interieur - route principale en construction",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route_sup",
+     "minzoom": 10,
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "PRINCIPALE_CONSTR_SUP"
+     ],
+     "paint": {
+      "line-color": {
+       "stops": [
+      [
+       9,
+       "#F3C66D"
+      ],
+      [
+       17,
+       "#F2DDB3"
+      ]
+       ]
+      },
+      "line-width": {
+       "stops": [
+      [
+       6,
+       1.8
+      ],
+      [
+       9,
+       2.7
+      ],
+      [
+       14,
+       5.9
+      ],
+      [
+       15,
+       9
+      ],
+      [
+       16,
+       12.2
+      ],
+      [
+       17,
+       22.5
+      ]
+       ]
+      },
+      "line-dasharray": [
+       2,
+       2
+      ]
+     }
+    },
+    {
+     "id": "Routier superieur - filet interieur - autoroute",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route_sup",
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "AUTOROU_PEAGE_SUP",
+      "AUTOROU_LIBRE_SUP"
+     ],
+     "paint": {
+      "line-color": {
+       "stops": [
+      [
+       9,
+       "#F18800"
+      ],
+      [
+       17,
+       "#F2B230"
+      ]
+       ]
+      },
+      "line-width": {
+       "stops": [
+      [
+       4,
+       0.7
+      ],
+      [
+       6,
+       2.5
+      ],
+      [
+       9,
+       2.7
+      ],
+      [
+       14,
+       5.8
+      ],
+      [
+       15,
+       9
+      ],
+      [
+       16,
+       12
+      ],
+      [
+       17,
+       20.8
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier superieur - axe central - autoroute",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route_sup",
+     "minzoom": 13,
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "AUTOROU_PEAGE_SUP",
+      "AUTOROU_LIBRE_SUP"
+     ],
+     "paint": {
+      "line-color": "#EDF1FF",
+      "line-width": {
+       "stops": [
+      [
+       9,
+       0.6
+      ],
+      [
+       14,
+       0.7
+      ],
+      [
+       15,
+       1
+      ],
+      [
+       16,
+       1.2
+      ],
+      [
+       17,
+       2.1
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Routier superieur - filet interieur - autoroute en construction",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route_sup",
+     "minzoom": 10,
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "AUTOROU_CONSTR_SUP"
+     ],
+     "paint": {
+      "line-color": {
+       "stops": [
+      [
+       9,
+       "#F18800"
+      ],
+      [
+       17,
+       "#F2B230"
+      ]
+       ]
+      },
+      "line-width": {
+       "stops": [
+      [
+       4,
+       0.7
+      ],
+      [
+       6,
+       2.5
+      ],
+      [
+       9,
+       3.5
+      ],
+      [
+       14,
+       7.5
+      ],
+      [
+       15,
+       11
+      ],
+      [
+       16,
+       15
+      ],
+      [
+       17,
+       26
+      ]
+       ]
+      },
+      "line-dasharray": [
+       2,
+       2
+      ]
+     }
+    },
+    {
+     "id": "Routier superieur - axe centrale - autoroute en construction",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "routier_route_sup",
+     "minzoom": 13,
+     "maxzoom": 22,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "AUTOROU_CONSTR_SUP"
+     ],
+     "paint": {
+      "line-color": "#808080",
+      "line-width": {
+       "stops": [
+      [
+       9,
+       0.6
+      ],
+      [
+       14,
+       0.7
+      ],
+      [
+       15,
+       1
+      ],
+      [
+       16,
+       1.2
+      ],
+      [
+       17,
+       2.1
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Ferre superieur - voie normale",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "ferre_sup",
+     "minzoom": 10,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "VF_1_SUP",
+      "VF_2_SUP",
+      "VF_ELEC_1_SUP"
+     ],
+     "paint": {
+      "line-color": "#787878",
+      "line-width": {
+       "stops": [
+      [
+       10,
+       0.8
+      ],
+      [
+       17,
+       2.5
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Ferre superieur - voie normale trait perpendic",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "ferre_sup",
+     "minzoom": 10,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "VF_1_SUP",
+      "VF_2_SUP",
+      "VF_ELEC_1_SUP"
+     ],
+     "paint": {
+      "line-color": "#787878",
+      "line-width": {
+       "stops": [
+      [
+       10,
+       3.5
+      ],
+      [
+       17,
+       14.7
+      ]
+       ]
+      },
+      "line-dasharray": [
+       0.1,
+       10
+      ]
+     }
+    },
+    {
+     "id": "Ferre superieur - voie etroite",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "ferre_sup",
+     "minzoom": 10,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "VF_ETROITE_1_SUP",
+      "VF_ETROITE_SUP"
+     ],
+     "paint": {
+      "line-color": "#787878",
+      "line-width": {
+       "stops": [
+      [
+       10,
+       0.3
+      ],
+      [
+       17,
+       1.8
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Ferre superieur - voie etroite trait perpendic",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "ferre_sup",
+     "minzoom": 10,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "VF_ETROITE_1_SUP",
+      "VF_ETROITE_SUP"
+     ],
+     "paint": {
+      "line-color": "#787878",
+      "line-width": {
+       "stops": [
+      [
+       10,
+       3.5
+      ],
+      [
+       17,
+       14.7
+      ]
+       ]
+      },
+      "line-dasharray": [
+       0.1,
+       10
+      ]
+     }
+    },
+    {
+     "id": "Ferre superieur - voie service",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "ferre_sup",
+     "minzoom": 14,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "VF_SERVICE_SUP",
+      "VF_NON_EXPLOITEE_SUP"
+     ],
+     "paint": {
+      "line-color": "#787878",
+      "line-width": {
+       "stops": [
+      [
+       10,
+       0.3
+      ],
+      [
+       17,
+       1.8
+      ]
+       ]
+      },
+      "line-dasharray": [
+       5,
+       2,
+       1,
+       2
+      ]
+     }
+    },
+    {
+     "id": "Ferre superieur - voie en construction",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "ferre_sup",
+     "minzoom": 10,
+     "maxzoom": 21,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "VF_EN_CONSTR_SUP"
+     ],
+     "paint": {
+      "line-color": "#787878",
+      "line-width": {
+       "stops": [
+      [
+       10,
+       0.3
+      ],
+      [
+       17,
+       1.8
+      ]
+       ]
+      },
+      "line-dasharray": [
+       2,
+       2
+      ]
+     }
+    },
+    {
+     "id": "Ferre superieur - voie en construction trait perpendic",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "ferre_sup",
+     "minzoom": 10,
+     "maxzoom": 21,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "VF_EN_CONSTR_SUP"
+     ],
+     "paint": {
+      "line-color": "#787878",
+      "line-width": {
+       "stops": [
+      [
+       10,
+       3.5
+      ],
+      [
+       17,
+       14.7
+      ]
+       ]
+      },
+      "line-dasharray": [
+       0.1,
+       10
+      ]
+     }
+    },
+    {
+     "id": "Ferre superieur - funic/urbain",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "ferre_sup",
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "FUNI_CREMAILLERE_SUP",
+      "TRANSPORT_URBAIN_SUP"
+     ],
+     "paint": {
+      "line-color": "#787878",
+      "line-width": {
+       "stops": [
+      [
+       10,
+       0.3
+      ],
+      [
+       17,
+       1.8
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "Ferre superieur - 2 trait perpendic - funic/urbain",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "ferre_sup",
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "FUNI_CREMAILLERE_SUP",
+      "TRANSPORT_URBAIN_SUP"
+     ],
+     "paint": {
+      "line-color": "#787878",
+      "line-width": {
+       "stops": [
+      [
+       10,
+       3.5
+      ],
+      [
+       17,
+       17
+      ]
+       ]
+      },
+      "line-dasharray": [
+       0.1,
+       0.2,
+       0.1,
+       10
+      ]
+     }
+    },
+    {
+     "id": "Limite - cloture",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "limite_lin",
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "CLOTURE"
+     ],
+     "paint": {
+      "line-color": "#000000",
+      "line-width": {
+       "stops": [
+      [
+       13,
+       0.6
+      ],
+      [
+       17,
+       1
+      ]
+       ]
+      },
+      "line-dasharray": [
+       1.5,
+       4
+      ]
+     }
+    },
+    {
+     "id": "Limite - layon",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "limite_lin",
+     "minzoom": 14,
+     "maxzoom": 21,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "LAYON"
+     ],
+     "paint": {
+      "line-color": "#B3989A",
+      "line-width": {
+       "stops": [
+      [
+       14,
+       1
+      ],
+      [
+       15,
+       1.2
+      ],
+      [
+       16,
+       1.4
+      ],
+      [
+       17,
+       2
+      ]
+       ]
+      },
+      "line-dasharray": [
+       4,
+       7
+      ]
+     }
+    },
+    {
+     "id": "Zone Règlementee - Enceinte militaire",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "limite_lin",
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "LIM_ZONE_REGLEMENTEE",
+      "LIM_ENCEINTE_MILITAIRE",
+      "LIM_ENCEINTE_MILI",
+      "LIM_CHAMP_TIR"
+     ],
+     "paint": {
+      "line-color": "rgba(226, 130, 92, 0.8)",
+      "line-width": {
+       "stops": [
+      [
+       13,
+       1.7
+      ],
+      [
+       17,
+       3.1
+      ]
+       ]
+      },
+      "line-dasharray": [
+       4,
+       1,
+       2,
+       5
+      ]
+     }
+    },
+    {
+     "id": "limite zone naturelle",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "limite_lin",
+     "maxzoom": 21,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "LIM_ZONE_NATURELLE",
+      "LIM_ZONE_NATURELLE_ILE",
+      "LIM_RESERVE_NATURELLE"
+     ],
+     "paint": {
+      "line-color": "#FFC2CB",
+      "line-width": {
+       "stops": [
+      [
+       13,
+       2
+      ],
+      [
+       17,
+       4
+      ]
+       ]
+      },
+      "line-dasharray": [
+       2,
+       1
+      ]
+     }
+    },
+    {
+     "id": "limite zone naturelle - Parc naturel 10",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "limite_lin",
+     "maxzoom": 10,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "LIM_PARC_NATUREL",
+      "LIM_PARC_NATUREL_ILE"
+     ],
+     "paint": {
+      "line-color": "#42A266",
+      "line-width": {
+       "stops": [
+      [
+       13,
+       2
+      ],
+      [
+       17,
+       4
+      ]
+       ]
+      },
+      "line-dasharray": [
+       2,
+       1
+      ]
+     }
+    },
+    {
+     "id": "limite zone naturelle - Parc naturel 11",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "limite_lin",
+     "minzoom": 10,
+     "maxzoom": 21,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "LIM_PARC_NATUREL",
+      "LIM_PARC_NATUREL_ILE"
+     ],
+     "paint": {
+      "line-color": "#42A266",
+      "line-width": {
+       "stops": [
+      [
+       13,
+       2
+      ],
+      [
+       17,
+       4
+      ]
+       ]
+      },
+      "line-dasharray": [
+       2,
+       2
+      ]
+     }
+    },
+    {
+     "id": "limite zone naturelle - Parc naturel 12",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "limite_lin",
+     "minzoom": 11,
+     "maxzoom": 21,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "LIM_PARC_NATUREL",
+      "LIM_PARC_NATUREL_ILE"
+     ],
+     "paint": {
+      "line-color": "#42A266",
+      "line-width": {
+       "stops": [
+      [
+       13,
+       2
+      ],
+      [
+       17,
+       4
+      ]
+       ]
+      },
+      "line-dasharray": [
+       2,
+       3
+      ]
+     }
+    },
+    {
+     "id": "limite zone naturelle - Parc naturel 13",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "limite_lin",
+     "minzoom": 12,
+     "maxzoom": 21,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "LIM_PARC_NATUREL",
+      "LIM_PARC_NATUREL_ILE"
+     ],
+     "paint": {
+      "line-color": "#42A266",
+      "line-width": {
+       "stops": [
+      [
+       13,
+       2
+      ],
+      [
+       17,
+       4
+      ]
+       ]
+      },
+      "line-dasharray": [
+       2,
+       4
+      ]
+     }
+    },
+    {
+     "id": "limite zone naturelle - Parc naturel 14",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "limite_lin",
+     "minzoom": 13,
+     "maxzoom": 21,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "LIM_PARC_NATUREL",
+      "LIM_PARC_NATUREL_ILE"
+     ],
+     "paint": {
+      "line-color": "rgba(66, 162, 102, 0.7)",
+      "line-width": {
+       "stops": [
+      [
+       13,
+       2
+      ],
+      [
+       17,
+       4
+      ]
+       ]
+      },
+      "line-dasharray": [
+       2,
+       5
+      ]
+     }
+    },
+    {
+     "id": "limite zone naturelle - Parc marin",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "limite_lin",
+     "maxzoom": 21,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "LIM_PARC_NATUREL_MARIN"
+     ],
+     "paint": {
+      "line-color": "#2A81A2",
+      "line-width": {
+       "stops": [
+      [
+       13,
+       2
+      ],
+      [
+       17,
+       4
+      ]
+       ]
+      },
+      "line-dasharray": [
+       2,
+       1
+      ]
+     }
+    },
+
+    {
+     "id": "limite admin - limite de commune",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "limite_lin",
+     "minzoom": 13,
+     "maxzoom": 21,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "LIM_COMMUNE",
+      "LIM_CANTON",
+      "LIM_ARRONDISSEMENT"
+     ],
+     "paint": {
+      "line-color": "rgba(126, 119, 184, 0.5)",
+      "line-width": {
+       "stops": [
+      [
+       13,
+       3
+      ],
+      [
+       17,
+       5.5
+      ]
+       ]
+      },
+      "line-dasharray": [
+       4,
+       2,
+       1,
+       1,
+       1,
+       1,
+       1,
+       2
+      ]
+     }
+    },
+    {
+     "id": "limite admin - limite de département bandeau",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "limite_lin",
+     "minzoom": 8,
+     "maxzoom": 21,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "LIM_DEPARTEMENT"
+     ],
+     "paint": {
+      "line-color": "rgba(178, 175, 219, 0.4)",
+      "line-width": {
+       "stops": [
+      [
+       9,
+       4.1
+      ],
+      [
+       12,
+       6
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "limite admin - limite de département tiret",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "limite_lin",
+     "minzoom": 13,
+     "maxzoom": 21,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "LIM_DEPARTEMENT"
+     ],
+     "paint": {
+      "line-color": "rgba(126, 119, 184, 0.5)",
+      "line-width": {
+       "stops": [
+      [
+       13,
+       3
+      ],
+      [
+       17,
+       5.5
+      ]
+       ]
+      },
+      "line-dasharray": [
+       4,
+       2,
+       1,
+       1,
+       1,
+       2
+      ]
+     }
+    },
+    {
+     "id": "limite admin - limite de région bandeau",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "limite_lin",
+     "minzoom": 7,
+     "maxzoom": 21,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "LIM_REGION"
+     ],
+     "paint": {
+      "line-color": "rgba(178, 175, 219, 0.5)",
+      "line-width": {
+       "stops": [
+      [
+       9,
+       4.5
+      ],
+      [
+       12,
+       6.7
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "limite admin - limite de région tiret",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "limite_lin",
+     "minzoom": 13,
+     "maxzoom": 21,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "LIM_REGION"
+     ],
+     "paint": {
+      "line-color": "rgba(126, 119, 184, 0.5)",
+      "line-width": {
+       "stops": [
+      [
+       13,
+       3
+      ],
+      [
+       17,
+       5.5
+      ]
+       ]
+      },
+      "line-dasharray": [
+       4,
+       2,
+       1,
+       2
+      ]
+     }
+    },
+    {
+     "id": "limite etat 1",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "limite_lin",
+     "minzoom": 2,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "LIM_ETAT",
+      "LIM_ETAT_ETRANGER"
+     ],
+     "paint": {
+      "line-color": "rgba(178, 175, 219, 0.6)",
+      "line-width": {
+       "stops": [
+      [
+       2,
+       2
+      ],
+      [
+       3,
+       3.5
+      ],
+      [
+       9,
+       5
+      ],
+      [
+       14,
+       13
+      ],
+      [
+       15,
+       20
+      ],
+      [
+       16,
+       24
+      ],
+      [
+       17,
+       42
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "limite etat 2",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "limite_lin",
+     "minzoom": 7,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "LIM_ETAT",
+      "LIM_ETAT_ETRANGER"
+     ],
+     "paint": {
+      "line-color": "#9F9CB8",
+      "line-width": {
+       "stops": [
+      [
+       9,
+       1.5
+      ],
+      [
+       14,
+       3.5
+      ],
+      [
+       15,
+       5.5
+      ],
+      [
+       16,
+       6.5
+      ],
+      [
+       17,
+       11
+      ]
+       ]
+      },
+      "line-dasharray": [
+       4,
+       2
+      ]
+     }
+    },
+    {
+     "id": "limite cote",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "limite_lin",
+     "minzoom": 7,
+     "maxzoom": 10,
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "LIM_COTE"
+     ],
+     "paint": {
+      "line-color": "#82A3B2",
+      "line-width": 1
+     }
+    },
+    {
+     "id": "ligne electrique",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "bati_lin",
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "LIGNE_ELECTRIQUE"
+     ],
+     "paint": {
+      "line-color": "#808080",
+      "line-width": {
+       "stops": [
+      [
+       13,
+       1
+      ],
+      [
+       17,
+       2
+      ]
+       ]
+      }
+     }
+    },
+    {
+     "id": "autre construction linéaire",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "bati_lin",
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "round",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "CABLE",
+      "REMONTEE_MEC",
+      "HYDROCARBURES",
+      "CONDUITE_MATIERES_P",
+      "SPORT_MONTAGNE_LIN",
+      "PISTE_BOBSLEIGH",
+      "PISTE_LUGE",
+      "PISTE_AERO_LIN"
+     ],
+     "paint": {
+      "line-color": "#808080",
+      "line-width": 1
+     }
+    },
+    {
+     "id": "autre construction linéaire - trait perpend cable",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "bati_lin",
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "CABLE"
+     ],
+     "paint": {
+      "line-color": "#808080",
+      "line-width": 5,
+      "line-dasharray": [
+       0.5,
+       10
+      ]
+     }
+    },
+    {
+     "id": "autre construction linéaire - trait perpend 1 remont",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "bati_lin",
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "REMONTEE_MEC"
+     ],
+     "paint": {
+      "line-color": "#808080",
+      "line-width": 6,
+      "line-dasharray": [
+       1,
+       10
+      ]
+     }
+    },
+    {
+     "id": "autre construction linéaire - trait perpend 2 remont",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "bati_lin",
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "REMONTEE_MEC"
+     ],
+     "paint": {
+      "line-color": "#BEBEBE",
+      "line-width": 6,
+      "line-dasharray": [
+       0.3,
+       0.4,
+       0.3,
+       10
+      ]
+     }
+    },
+    {
+     "id": "autre construction linéaire - trait perpend carbur",
+     "type": "line",
+     "source": "plan_ign",
+     "source-layer": "bati_lin",
+     "layout": {
+      "visibility": "visible",
+      "line-cap": "butt",
+      "line-join": "round"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "HYDROCARBURES",
+      "CONDUITE_MATIERES_P"
+     ],
+     "paint": {
+      "line-color": "#808080",
+      "line-width": 5,
+      "line-dasharray": [
+       1,
+       10
+      ]
+     }
+    },
+    {
+     "id": "routier ponctuel - peage ponctuel",
+     "type": "circle",
+     "source": "plan_ign",
+     "source-layer": "routier_ponc",
+     "minzoom": 8,
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "PEAGE_PONC"
+     ],
+     "paint": {
+      "circle-radius": {
+       "stops": [
+      [
+       9,
+       3.5
+      ],
+      [
+       12,
+       6.5
+      ]
+       ]
+      },
+      "circle-color": "#E2A52A",
+      "circle-stroke-width": 1,
+      "circle-stroke-color": "#808080"
+     }
+    },
+    {
+     "id": "routier ponctuel - barriere",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "routier_ponc",
+     "minzoom": 12,
+     "layout": {
+      "visibility": "visible",
+      "icon-image": "Barriere",
+      "icon-size": {
+       "stops": [
+      [
+       13,
+       0.25
+      ],
+      [
+       16,
+       0.45
+      ],
+      [
+       17,
+       0.7
+      ]
+       ]
+      },
+      "icon-allow-overlap": true,
+      "icon-rotate": [
+       "get",
+       "rotation"
+      ]
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "BARRIERE"
+     ],
+     "paint": {
+      "icon-color": "#969696"
+     }
+    },
+    {
+     "id": "hydro ponctuel",
+     "type": "circle",
+     "source": "plan_ign",
+     "source-layer": "hydro_ponc",
+     "minzoom": 13,
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "FONTAINE",
+      "POINT_D_EAU",
+      "SOURCE",
+      "SOURCE_CAPTEE",
+      "PERTE",
+      "RESURGENCE",
+      "CASCADE",
+      "AUTRE_HYDRO_PONC"
+     ],
+     "paint": {
+      "circle-radius": {
+       "stops": [
+      [
+       14,
+       3
+      ],
+      [
+       17,
+       7
+      ]
+       ]
+      },
+      "circle-color": "#FFFFFF",
+      "circle-opacity": 1,
+      "circle-stroke-width": {
+       "stops": [
+      [
+       14,
+       2
+      ],
+      [
+       17,
+       5
+      ]
+       ]
+      },
+      "circle-stroke-color": "#1466B2"
+     }
+    },
+    {
+     "id": "point coté",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "oro_ponc",
+     "minzoom": 11,
+     "maxzoom": 21,
+     "filter": [
+      "in",
+      "symbo",
+      "POINT_COTE",
+      "POINT_COTE_TOPO",
+      "POINT_COTE_RESEAU",
+      "POINT_RBF"
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "icon-image": "Localite",
+      "icon-size": 0.1,
+      "text-field": "{texte}",
+      "text-size": 10,
+      "text-allow-overlap": false,
+      "text-anchor": "bottom-left",
+      "text-offset": [
+       0.2,
+       0.4
+      ],
+      "text-padding": 2,
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#505050"
+     }
+    },
+    {
+     "id": "bati ponctuel : Hopital",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "bati_ponc",
+     "layout": {
+      "visibility": "visible",
+      "icon-image": "Hopital",
+      "icon-size": 0.33
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "HOPITAL_PONC"
+     ],
+     "paint": {
+      "icon-color": "#646464"
+     }
+    },
+    {
+     "id": "bati ponctuel hydrographique",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "bati_ponc",
+     "minzoom": 14,
+     "layout": {
+      "visibility": "visible",
+      "icon-image": "Pompage",
+      "icon-size": {
+       "stops": [
+      [
+       13,
+       0.2
+      ],
+      [
+       17,
+       0.6
+      ]
+       ]
+      },
+      "icon-allow-overlap": true
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "CITERNE",
+      "LAVOIR",
+      "STATION_EPURATION",
+      "STATION_DE_POMPAGE",
+      "USINE_PRODUCTION_EAU",
+      "USINE_ELEVATRICE"
+     ],
+     "paint": {
+      "icon-color": "#1C62A6"
+     }
+    },
+    {
+     "id": "bati ponctuel hydrographique - Puits-Abreuvoir",
+     "type": "circle",
+     "source": "plan_ign",
+     "source-layer": "bati_ponc",
+     "minzoom": 13,
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "PUITS",
+      "ABREUVOIR"
+     ],
+     "paint": {
+      "circle-radius": {
+       "stops": [
+      [
+       14,
+       3
+      ],
+      [
+       17,
+       7
+      ]
+       ]
+      },
+      "circle-color": "#FFFFFF",
+      "circle-opacity": 1,
+      "circle-stroke-width": {
+       "stops": [
+      [
+       14,
+       2
+      ],
+      [
+       17,
+       5
+      ]
+       ]
+      },
+      "circle-stroke-color": "#1466B2"
+     }
+    },
+    {
+     "id": "bati ponctuel hydrographique - Phare",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "bati_ponc",
+     "minzoom": 13,
+     "layout": {
+      "visibility": "visible",
+      "icon-image": "Phare",
+      "icon-size": {
+       "stops": [
+      [
+       13,
+       0.7
+      ],
+      [
+       17,
+       1.3
+      ]
+       ]
+      }
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "PHARE"
+     ],
+     "paint": {
+      "icon-color": "#646464"
+     }
+    },
+    {
+     "id": "bati ponctuel hydrographique - Amer-Feu",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "bati_ponc",
+     "minzoom": 13,
+     "layout": {
+      "visibility": "visible",
+      "icon-image": "Feu",
+      "icon-size": {
+       "stops": [
+      [
+       13,
+       0.7
+      ],
+      [
+       17,
+       1.3
+      ]
+       ]
+      }
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "AMER",
+      "FEU",
+      "FEU_PONC",
+      "TOURELLE_LUMINEUSE"
+     ],
+     "paint": {
+      "icon-color": "#646464"
+     }
+    },
+    {
+     "id": "bati ponctuel hydrographique - Balise",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "bati_ponc",
+     "minzoom": 13,
+     "layout": {
+      "visibility": "visible",
+      "icon-image": "Balise",
+      "icon-size": {
+       "stops": [
+      [
+       13,
+       0.7
+      ],
+      [
+       17,
+       1.3
+      ]
+       ]
+      }
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "BALISE",
+      "TOURELLE"
+     ],
+     "paint": {
+      "icon-color": "#646464"
+     }
+    },
+    {
+     "id": "bati ponctuel hydrographique - Ecluse",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "bati_ponc",
+     "minzoom": 12,
+     "maxzoom": 21,
+     "layout": {
+      "visibility": "visible",
+      "icon-image": "Ecluse",
+      "icon-size": 0.2
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "ECLUSE_PONC"
+     ],
+     "paint": {
+      "icon-color": "#1C62A6"
+     }
+    },
+    {
+     "id": "bati ponctuel hydrographique - Barrage",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "bati_ponc",
+     "minzoom": 12,
+     "maxzoom": 14,
+     "layout": {
+      "visibility": "visible",
+      "icon-image": "Barrage",
+      "icon-size": 0.25
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "BARRAGE_PONC"
+     ],
+     "paint": {
+      "icon-color": "#1C62A6"
+     }
+    },
+    {
+     "id": "bati ponctuel hydrographique - Chateau d'eau",
+     "type": "circle",
+     "source": "plan_ign",
+     "source-layer": "bati_ponc",
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "CHATEAU_EAU_PONC"
+     ],
+     "paint": {
+      "circle-radius": {
+       "stops": [
+      [
+       14,
+       3
+      ],
+      [
+       17,
+       8
+      ]
+       ]
+      },
+      "circle-color": "#1466B2"
+     }
+    },
+    {
+     "id": "bati ponctuel hydrographique - Réservoir d'eau",
+     "type": "circle",
+     "source": "plan_ign",
+     "source-layer": "bati_ponc",
+     "maxzoom": 21,
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "RESERVOIR_EAU_PONC"
+     ],
+     "paint": {
+      "circle-radius": {
+       "stops": [
+      [
+       14,
+       3
+      ],
+      [
+       17,
+       8
+      ]
+       ]
+      },
+      "circle-color": "#AAD5E9",
+      "circle-opacity": 1,
+      "circle-stroke-width": {
+       "stops": [
+      [
+       14,
+       1
+      ],
+      [
+       17,
+       2.5
+      ]
+       ]
+      },
+      "circle-stroke-color": "#1466B2"
+     }
+    },
+    {
+     "id": "bati ponctuel infrastructure - Constr spé",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "bati_ponc",
+     "layout": {
+      "visibility": "visible",
+      "icon-image": "ConstrSpeciale",
+      "icon-size": {
+       "stops": [
+      [
+       13,
+       0.22
+      ],
+      [
+       17,
+       0.5
+      ]
+       ]
+      }
+     },
+     "filter": [
+      "in",
+      "symbo",
+      "ANTENNE",
+      "CONSTR_SPE_TECHNIQUE",
+      "CONSTR_INDIF_PONC",
+      "CHEMINEE",
+      "CHEVALEMENT",
+      "PUITS_GAZ",
+      "PUITS_PETROLE",
+      "PYLONE_METEO",
+      "TORCHERE",
+      "TOUR_GUET",
+      "TOUR_HERTZIENNE"
+     ],
+     "paint": {
+      "icon-color": "#646464"
+     }
+    },
+    {
+     "id": "bati ponctuel infrastructure - Silo",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "bati_ponc",
+     "maxzoom": 21,
+     "layout": {
+      "visibility": "visible",
+      "icon-image": "Silo",
+      "icon-size": {
+       "stops": [
+      [
+       13,
+       0.22
+      ],
+      [
+       17,
+       0.5
+      ]
+       ]
+      }
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "SILO_PONC"
+     ],
+     "paint": {
+      "icon-color": "#646464"
+     }
+    },
+    {
+     "id": "bati ponctuel infrastructure - Eolienne",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "bati_ponc",
+     "layout": {
+      "visibility": "visible",
+      "icon-image": "Eolienne",
+      "icon-size": {
+       "stops": [
+      [
+       13,
+       0.4
+      ],
+      [
+       17,
+       1
+      ],
+      [
+       18,
+       0.8
+      ]
+       ]
+      }
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "EOLIENNE"
+     ],
+     "paint": {
+      "icon-color": "#646464"
+     }
+    },
+    {
+     "id": "bati ponctuel infrastructure - Reservoir",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "bati_ponc",
+     "maxzoom": 21,
+     "layout": {
+      "visibility": "visible",
+      "icon-image": "Reservoir",
+      "icon-size": {
+       "stops": [
+      [
+       13,
+       0.26
+      ],
+      [
+       17,
+       0.5
+      ]
+       ]
+      }
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "RESERVOIR_PONC"
+     ],
+     "paint": {
+      "icon-color": "#646464"
+     }
+    },
+    {
+     "id": "bati ponctuel infrastructure - pylone électrique",
+     "type": "circle",
+     "source": "plan_ign",
+     "source-layer": "bati_ponc",
+     "layout": {
+      "visibility": "visible"
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "PYLONE_ELEC"
+     ],
+     "paint": {
+      "circle-radius": {
+       "stops": [
+      [
+       13,
+       1
+      ],
+      [
+       17,
+       2
+      ]
+       ]
+      },
+      "circle-color": "#000000"
+     }
+    },
+    {
+     "id": "bati ponctuel montagne - Abri",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "bati_ponc",
+     "layout": {
+      "visibility": "visible",
+      "icon-image": "Abri",
+      "icon-size": {
+       "stops": [
+      [
+       13,
+       0.4
+      ],
+      [
+       15,
+       0.6
+      ],
+      [
+       17,
+       0.9
+      ]
+       ]
+      }
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "ABRI"
+     ],
+     "paint": {
+      "icon-color": "#246138"
+     }
+    },
+    {
+     "id": "bati ponctuel montagne - Refuge Garde",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "bati_ponc",
+     "layout": {
+      "visibility": "visible",
+      "icon-image": "Refugegard",
+      "icon-size": {
+       "stops": [
+      [
+       13,
+       0.4
+      ],
+      [
+       15,
+       0.6
+      ],
+      [
+       17,
+       0.9
+      ]
+       ]
+      }
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "REFUGE_GARDE"
+     ],
+     "paint": {
+      "icon-color": "#246138"
+     }
+    },
+    {
+     "id": "bati ponctuel montagne - Refuge Non Garde",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "bati_ponc",
+     "layout": {
+      "visibility": "visible",
+      "icon-image": "Refugenongard",
+      "icon-size": {
+       "stops": [
+      [
+       13,
+       0.4
+      ],
+      [
+       15,
+       0.6
+      ],
+      [
+       17,
+       0.9
+      ]
+       ]
+      }
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "REFUGE"
+     ],
+     "paint": {
+      "icon-color": "#246138"
+     }
+    },
+    {
+     "id": "bati ponctuel transport aerien - Aeroport FXX",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "bati_ponc",
+     "layout": {
+      "visibility": "visible",
+      "icon-image": "Aeroport",
+      "icon-size": 0.5
+     },
+     "filter": [
+      "all",
+      [
+       "==",
+       "symbo",
+       "AEROPORT_PONC"
+      ],
+      [
+       "==",
+       "territoire",
+       "FXX"
+      ]
+     ],
+     "paint": {
+      "icon-color": "#646464"
+     }
+    },
+    {
+     "id": "bati ponctuel transport aerien - Aerodrome FXX",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "bati_ponc",
+     "layout": {
+      "visibility": "visible",
+      "icon-image": "Aerodrome",
+      "icon-size": 0.4
+     },
+     "filter": [
+      "all",
+      [
+       "==",
+       "symbo",
+       "AERODROME_PONC"
+      ],
+      [
+       "==",
+       "territoire",
+       "FXX"
+      ]
+     ],
+     "paint": {
+      "icon-color": "#646464"
+     }
+    },
+    {
+     "id": "bati ponctuel transport aerien - Aeroport DOM",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "bati_ponc",
+     "minzoom": 8,
+     "layout": {
+      "visibility": "visible",
+      "icon-image": "Aeroport",
+      "icon-size": 0.5
+     },
+     "filter": [
+      "all",
+      [
+       "==",
+       "symbo",
+       "AEROPORT_PONC"
+      ],
+      [
+       "!=",
+       "territoire",
+       "FXX"
+      ]
+     ],
+     "paint": {
+      "icon-color": "#646464"
+     }
+    },
+    {
+     "id": "bati ponctuel transport aerien - Aerodrome DOM",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "bati_ponc",
+     "minzoom": 8,
+     "layout": {
+      "visibility": "visible",
+      "icon-image": "Aerodrome",
+      "icon-size": 0.4
+     },
+     "filter": [
+      "all",
+      [
+       "==",
+       "symbo",
+       "AERODROME_PONC"
+      ],
+      [
+       "!=",
+       "territoire",
+       "FXX"
+      ]
+     ],
+     "paint": {
+      "icon-color": "#646464"
+     }
+    },
+    {
+     "id": "bati ponctuel transport ferroviaire",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "bati_ponc",
+     "layout": {
+      "visibility": "visible",
+      "icon-image": "Gare",
+      "icon-size": 0.33
+     },
+     "filter": [
+      "==",
+      "symbo",
+      "GARE_VOYAGEURS"
+     ],
+     "paint": {
+      "icon-color": "#787878"
+     }
+    },
+    {
+     "id": "toponyme - bornes postales haute - chemins",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_routier_borne",
+     "minzoom": 17,
+     "maxzoom": 22,
+     "filter": [
+      "in",
+      "symbo",
+      "CHEMIN",
+      "CHEMIN_SOU",
+      "CHEMIN_SUP",
+      "PISTE_CYCLABLE",
+      "PISTE_CYCLABLE_SOU",
+      "PISTE_CYCLABLE_SUP",
+      "RUE_PIETONNE",
+      "RUE_PIETONNE_SOU",
+      "RUE_PIETONNE_SUP",
+      "SENTIER",
+      "SENTIER_SOU",
+      "SENTIER_SUP",
+      "ESCALIER",
+      "ESCALIER_SUP"
+     ],
+     "layout": {
+      "symbol-placement": "line",
+      "text-field": "{borne_sur}",
+      "text-size": 11,
+      "text-anchor": "center",
+      "text-allow-overlap": true,
+      "text-offset": [
+       0,
+       -1
+      ],
+      "text-font": [
+       "Open Sans Regular"
+      ],
+      "visibility": "none"
+     },
+     "paint": {
+      "text-color": "#79654F",
+      "text-halo-width": 1,
+      "text-halo-color": "#FFFFFF"
+     }
+    },
+    {
+     "id": "toponyme - bornes postales haute - non revetue, non classee",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_routier_borne",
+     "minzoom": 17,
+     "maxzoom": 22,
+     "filter": [
+      "in",
+      "symbo",
+      "NON_CLASSEE",
+      "NON_CLASSEE_4",
+      "NON_CLASSEE_4_SUP",
+      "NON_CLASSEE_RESTREINT",
+      "NON_CLASSEE_RESTREINT_SUP",
+      "NON_CLASSEE_SOU",
+      "NON_CLASSEE_SUP",
+      "NON_REVETUE_CARRO",
+      "NON_REVETUE_CARRO_SUP"
+     ],
+     "layout": {
+      "symbol-placement": "line",
+      "text-field": "{borne_sur}",
+      "text-size": 11,
+      "text-anchor": "center",
+      "text-allow-overlap": true,
+      "text-offset": [
+       0,
+       -1.3
+      ],
+      "text-font": [
+       "Open Sans Regular"
+      ],
+      "visibility": "none"
+     },
+     "paint": {
+      "text-color": "#79654F",
+      "text-halo-width": 1,
+      "text-halo-color": "#FFFFFF"
+     }
+    },
+    {
+     "id": "toponyme - bornes postales haute - locales",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_routier_borne",
+     "minzoom": 17,
+     "maxzoom": 22,
+     "filter": [
+      "in",
+      "symbo",
+      "LOCALE_1",
+      "LOCALE_1_SOU",
+      "LOCALE_1_SUP",
+      "LOCALE_2",
+      "LOCALE_2_SOU",
+      "LOCALE_2_SUP",
+      "LOCALE_3",
+      "LOCALE_3_SOU",
+      "LOCALE_3_SUP",
+      "LOCALE_4",
+      "LOCALE_4_SOU",
+      "LOCALE_4_SUP",
+      "LOCALE_CONSTR",
+      "LOCALE_CONSTR_SUP"
+     ],
+     "layout": {
+      "symbol-placement": "line",
+      "text-field": "{borne_sur}",
+      "text-size": 11,
+      "text-anchor": "center",
+      "text-allow-overlap": true,
+      "text-offset": [
+       0,
+       -1.4
+      ],
+      "text-font": [
+       "Open Sans Regular"
+      ],
+      "visibility": "none"
+     },
+     "paint": {
+      "text-color": "#79654F",
+      "text-halo-width": 1,
+      "text-halo-color": "#FFFFFF"
+     }
+    },
+    {
+     "id": "toponyme - bornes postales haute - regionales",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_routier_borne",
+     "minzoom": 17,
+     "maxzoom": 22,
+     "filter": [
+      "in",
+      "symbo",
+      "REGIONALE_1",
+      "REGIONALE_1_SOU",
+      "REGIONALE_1_SUP",
+      "REGIONALE_2",
+      "REGIONALE_2_SOU",
+      "REGIONALE_2_SUP",
+      "REGIONALE_3",
+      "REGIONALE_3_SOU",
+      "REGIONALE_3_SUP",
+      "REGIONALE_4",
+      "REGIONALE_4_SUP",
+      "REGIONALE_CONSTR"
+     ],
+     "layout": {
+      "symbol-placement": "line",
+      "text-field": "{borne_sur}",
+      "text-size": 11,
+      "text-anchor": "center",
+      "text-allow-overlap": true,
+      "text-offset": [
+       0,
+       -1.5
+      ],
+      "text-font": [
+       "Open Sans Regular"
+      ],
+      "visibility": "none"
+     },
+     "paint": {
+      "text-color": "#79654F",
+      "text-halo-width": 1,
+      "text-halo-color": "#FFFFFF"
+     }
+    },
+    {
+     "id": "toponyme - bornes postales haute - principales",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_routier_borne",
+     "minzoom": 17,
+     "maxzoom": 22,
+     "filter": [
+      "in",
+      "symbo",
+      "PRINCIPALE_1",
+      "PRINCIPALE_1_SOU",
+      "PRINCIPALE_1_SUP",
+      "PRINCIPALE_2",
+      "PRINCIPALE_2_SOU",
+      "PRINCIPALE_2_SUP",
+      "PRINCIPALE_3",
+      "PRINCIPALE_3_SOU",
+      "PRINCIPALE_3_SUP",
+      "PRINCIPALE_4",
+      "PRINCIPALE_4_SOU",
+      "PRINCIPALE_4_SUP",
+      "PRINCIPALE_CONSTR"
+     ],
+     "layout": {
+      "symbol-placement": "line",
+      "text-field": "{borne_sur}",
+      "text-size": 11,
+      "text-anchor": "center",
+      "text-allow-overlap": true,
+      "text-offset": [
+       0,
+       -1.6
+      ],
+      "text-font": [
+       "Open Sans Regular"
+      ],
+      "visibility": "none"
+     },
+     "paint": {
+      "text-color": "#79654F",
+      "text-halo-width": 1,
+      "text-halo-color": "#FFFFFF"
+     }
+    },
+    {
+     "id": "toponyme - bornes postales bas - chemins",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_routier_borne",
+     "minzoom": 17,
+     "maxzoom": 22,
+     "filter": [
+      "in",
+      "symbo",
+      "CHEMIN",
+      "CHEMIN_SOU",
+      "CHEMIN_SUP",
+      "PISTE_CYCLABLE",
+      "PISTE_CYCLABLE_SOU",
+      "PISTE_CYCLABLE_SUP",
+      "RUE_PIETONNE",
+      "RUE_PIETONNE_SOU",
+      "RUE_PIETONNE_SUP",
+      "SENTIER",
+      "SENTIER_SOU",
+      "SENTIER_SUP",
+      "ESCALIER",
+      "ESCALIER_SUP"
+     ],
+     "layout": {
+      "symbol-placement": "line",
+      "text-field": "{borne_sous}",
+      "text-size": 11,
+      "text-anchor": "center",
+      "text-allow-overlap": true,
+      "text-offset": [
+       0,
+       1
+      ],
+      "text-font": [
+       "Open Sans Regular"
+      ],
+      "visibility": "none"
+     },
+     "paint": {
+      "text-color": "#79654F",
+      "text-halo-width": 1,
+      "text-halo-color": "#FFFFFF"
+     }
+    },
+    {
+     "id": "toponyme - bornes postales bas - non revetue, non classee",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_routier_borne",
+     "minzoom": 17,
+     "maxzoom": 22,
+     "filter": [
+      "in",
+      "symbo",
+      "NON_CLASSEE",
+      "NON_CLASSEE_4",
+      "NON_CLASSEE_4_SUP",
+      "NON_CLASSEE_RESTREINT",
+      "NON_CLASSEE_RESTREINT_SUP",
+      "NON_CLASSEE_SOU",
+      "NON_CLASSEE_SUP",
+      "NON_REVETUE_CARRO",
+      "NON_REVETUE_CARRO_SUP"
+     ],
+     "layout": {
+      "symbol-placement": "line",
+      "text-field": "{borne_sous}",
+      "text-size": 11,
+      "text-anchor": "center",
+      "text-allow-overlap": true,
+      "text-offset": [
+       0,
+       1.3
+      ],
+      "text-font": [
+       "Open Sans Regular"
+      ],
+      "visibility": "none"
+     },
+     "paint": {
+      "text-color": "#79654F",
+      "text-halo-width": 1,
+      "text-halo-color": "#FFFFFF"
+     }
+    },
+    {
+     "id": "toponyme - bornes postales bas - locales",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_routier_borne",
+     "minzoom": 17,
+     "maxzoom": 22,
+     "filter": [
+      "in",
+      "symbo",
+      "LOCALE_1",
+      "LOCALE_1_SOU",
+      "LOCALE_1_SUP",
+      "LOCALE_2",
+      "LOCALE_2_SOU",
+      "LOCALE_2_SUP",
+      "LOCALE_3",
+      "LOCALE_3_SOU",
+      "LOCALE_3_SUP",
+      "LOCALE_4",
+      "LOCALE_4_SOU",
+      "LOCALE_4_SUP",
+      "LOCALE_CONSTR",
+      "LOCALE_CONSTR_SUP"
+     ],
+     "layout": {
+      "symbol-placement": "line",
+      "text-field": "{borne_sous}",
+      "text-size": 11,
+      "text-anchor": "center",
+      "text-allow-overlap": true,
+      "text-offset": [
+       0,
+       1.4
+      ],
+      "text-font": [
+       "Open Sans Regular"
+      ],
+      "visibility": "none"
+     },
+     "paint": {
+      "text-color": "#79654F",
+      "text-halo-width": 1,
+      "text-halo-color": "#FFFFFF"
+     }
+    },
+    {
+     "id": "toponyme - bornes postales bas - regionales",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_routier_borne",
+     "minzoom": 17,
+     "maxzoom": 22,
+     "filter": [
+      "in",
+      "symbo",
+      "REGIONALE_1",
+      "REGIONALE_1_SOU",
+      "REGIONALE_1_SUP",
+      "REGIONALE_2",
+      "REGIONALE_2_SOU",
+      "REGIONALE_2_SUP",
+      "REGIONALE_3",
+      "REGIONALE_3_SOU",
+      "REGIONALE_3_SUP",
+      "REGIONALE_4",
+      "REGIONALE_4_SUP",
+      "REGIONALE_CONSTR"
+     ],
+     "layout": {
+      "symbol-placement": "line",
+      "text-field": "{borne_sous}",
+      "text-size": 11,
+      "text-anchor": "center",
+      "text-allow-overlap": true,
+      "text-offset": [
+       0,
+       1.5
+      ],
+      "text-font": [
+       "Open Sans Regular"
+      ],
+      "visibility": "none"
+     },
+     "paint": {
+      "text-color": "#79654F",
+      "text-halo-width": 1,
+      "text-halo-color": "#FFFFFF"
+     }
+    },
+    {
+     "id": "toponyme - bornes postales bas - principales",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_routier_borne",
+     "minzoom": 17,
+     "maxzoom": 22,
+     "filter": [
+      "in",
+      "symbo",
+      "PRINCIPALE_1",
+      "PRINCIPALE_1_SOU",
+      "PRINCIPALE_1_SUP",
+      "PRINCIPALE_2",
+      "PRINCIPALE_2_SOU",
+      "PRINCIPALE_2_SUP",
+      "PRINCIPALE_3",
+      "PRINCIPALE_3_SOU",
+      "PRINCIPALE_3_SUP",
+      "PRINCIPALE_4",
+      "PRINCIPALE_4_SOU",
+      "PRINCIPALE_4_SUP",
+      "PRINCIPALE_CONSTR"
+     ],
+     "layout": {
+      "symbol-placement": "line",
+      "text-field": "{borne_sous}",
+      "text-size": 11,
+      "text-anchor": "center",
+      "text-allow-overlap": true,
+      "text-offset": [
+       0,
+       1.6
+      ],
+      "text-font": [
+       "Open Sans Regular"
+      ],
+      "visibility": "none"
+     },
+     "paint": {
+      "text-color": "#79654F",
+      "text-halo-width": 1,
+      "text-halo-color": "#FFFFFF"
+     }
+    },
+    {
+     "id": "toponyme - courbe rocher maitresse",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_oro_ponc",
+     "filter": [
+      "==",
+      "txt_typo",
+      "ORO_COURBE_ROCHER"
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-size": 10,
+      "text-allow-overlap": false,
+      "text-padding": 30,
+      "text-rotate": {
+       "type": "identity",
+       "property": "rotation"
+      },
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#333333",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 1
+     }
+    },
+    {
+     "id": "toponyme - courbe glacier maitresse",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_oro_ponc",
+     "filter": [
+      "==",
+      "txt_typo",
+      "ORO_COURBE_GLACIER"
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-size": 10,
+      "text-allow-overlap": false,
+      "text-padding": 30,
+      "text-rotate": {
+       "type": "identity",
+       "property": "rotation"
+      },
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#629FD9",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 1
+     }
+    },
+    {
+     "id": "toponyme - courbe maitresse",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_oro_ponc",
+     "filter": [
+      "==",
+      "txt_typo",
+      "ORO_COURBE"
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-size": 10,
+      "text-allow-overlap": false,
+      "text-padding": 30,
+      "text-rotate": {
+       "type": "identity",
+       "property": "rotation"
+      },
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#604A2F",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 1
+     }
+    },
+    {
+     "id": "toponyme - liaison maritime",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_routier_liaison_lin",
+     "minzoom": 8,
+     "maxzoom": 22,
+     "filter": [
+      "==",
+      "txt_typo",
+      "LIAISON_MARITIME"
+     ],
+     "layout": {
+      "symbol-placement": "line",
+      "text-field": "{texte}",
+      "text-size": 15,
+      "text-anchor": "center",
+      "text-keep-upright": true,
+      "text-max-angle": 45,
+      "text-padding": 10,
+      "text-font": [
+       "Open Sans Regular"
+      ],
+      "visibility": "visible"
+     },
+     "paint": {
+      "text-color": "#5792C2",
+      "text-halo-width": 5,
+      "text-halo-color": "#AAD5E9"
+     }
+    },
+    {
+     "id": "toponyme bati station de métro + bati ponctuel metro",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_bati_ponc",
+     "minzoom": 14,
+     "filter": [
+      "all",
+      [
+       "==",
+       "txt_typo",
+       "TYPO_E_1"
+      ],
+      [
+       "==",
+       "symbo",
+       "STATION_METRO"
+      ]
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-size": 11,
+      "text-allow-overlap": false,
+      "text-offset": [
+       0.3,
+       -0.25
+      ],
+      "text-padding": 3,
+      "text-anchor": "bottom-left",
+      "text-font": [
+       "Open Sans Regular"
+      ],
+      "icon-image": "Metro",
+      "icon-size": {
+       "stops": [
+      [
+       15,
+       0.33
+      ],
+      [
+       17,
+       0.6
+      ]
+       ]
+      }
+     },
+     "paint": {
+      "text-color": "#3C3C3C",
+      "icon-color": "#646464"
+     }
+    },
+    {
+     "id": "toponyme ferre lineaire",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_ferre_lin",
+     "minzoom": 12,
+     "filter": [
+      "in",
+      "txt_typo",
+      "FER_NOM",
+      "FER_OUVRAGE"
+     ],
+     "layout": {
+      "symbol-placement": "line",
+      "text-field": "{texte}",
+      "text-size": 10,
+      "text-anchor": "center",
+      "text-offset": [
+       0,
+       -1
+      ],
+      "text-font": [
+       "Open Sans Regular"
+      ],
+      "visibility": "visible"
+     },
+     "paint": {
+      "text-color": "#000000",
+      "text-halo-width": 1,
+      "text-halo-color": "rgba(255, 255, 255, 1)"
+     }
+    },
+    {
+     "id": "toponyme station epuration, de pompage, usine de production eau",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_bati_ponc",
+     "minzoom": 14,
+     "filter": [
+      "==",
+      "txt_typo",
+      "station"
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{designation}",
+      "text-anchor": "left",
+      "text-offset": [
+       0.8,
+       0
+      ],
+      "text-size": 11,
+      "text-allow-overlap": false,
+      "text-padding": 1,
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#447FB3"
+     }
+    },
+    {
+     "id": "toponyme bati ponc gare",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_bati_ponc",
+     "minzoom": 15,
+     "filter": [
+      "==",
+      "txt_typo",
+      "gore"
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{designation}",
+      "text-size": 11,
+      "text-allow-overlap": false,
+      "text-padding": 1,
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#000000"
+     }
+    },
+    {
+     "id": "toponyme bati ponc barrage",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_bati_ponc",
+     "minzoom": 12,
+     "filter": [
+      "==",
+      "txt_typo",
+      "BARRAGE_PONC"
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-anchor": "left",
+      "text-offset": [
+       0.8,
+       0
+      ],
+      "text-size": 11,
+      "text-allow-overlap": false,
+      "text-padding": 1,
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#447FB3"
+     }
+    },
+    {
+     "id": "toponyme bati ponc phare - niveau 13",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_bati_ponc",
+     "maxzoom": 21,
+     "filter": [
+      "==",
+      "txt_typo",
+      "PHARE"
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-anchor": "right",
+      "text-size": 11,
+      "text-allow-overlap": false,
+      "text-padding": 1,
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#532A2A"
+     }
+    },
+    {
+     "id": "toponyme bati ponc phare - niveau 14à19",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_bati_ponc",
+     "minzoom": 13,
+     "filter": [
+      "all",
+      [
+       "==",
+       "symbo",
+       "PHARE"
+      ],
+      [
+       "in",
+       "txt_typo",
+       "TYPO_C_6",
+       "TYPO_C_7",
+       "TYPO_C_8",
+       "TYPO_E_GE"
+      ]
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-anchor": "right",
+      "text-size": {
+       "stops": [
+      [
+       13,
+       12
+      ],
+      [
+       18,
+       18
+      ]
+       ]
+      },
+      "text-allow-overlap": false,
+      "text-offset": [
+       -2,
+       0
+      ],
+      "text-padding": 3,
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#532A2A"
+     }
+    },
+    {
+     "id": "toponyme bati ponc autre",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_bati_ponc",
+     "minzoom": 12,
+     "filter": [
+      "in",
+      "txt_typo",
+      "BAT_ACTIVITE",
+      "BAT_FORTIF",
+      "BAT_VILLAGE_DETRUIT"
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-anchor": "center",
+      "text-size": 11,
+      "text-allow-overlap": false,
+      "text-padding": 1,
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#532A2A"
+     }
+    },
+    {
+     "id": "toponyme bati ponc aerogare",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_bati_ponc",
+     "minzoom": 14,
+     "maxzoom": 21,
+     "filter": [
+      "all",
+      [
+       "==",
+       "txt_typo",
+       "TYPO_E_GE"
+      ],
+      [
+       "==",
+       "symbo",
+       "AEROGARE"
+      ]
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-anchor": "center",
+      "text-size": {
+       "stops": [
+      [
+       12,
+       9
+      ],
+      [
+       16,
+       11
+      ]
+       ]
+      },
+      "text-allow-overlap": false,
+      "text-padding": 1,
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#120049",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 1
+     }
+    },
+    {
+     "id": "toponyme bati ponc aeroport 12",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_bati_ponc",
+     "minzoom": 11,
+     "maxzoom": 21,
+     "filter": [
+      "==",
+      "txt_typo",
+      "AEROPORT_PONC"
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-anchor": "bottom",
+      "text-offset": [
+       0,
+       -1.3
+      ],
+      "text-size": 10.5,
+      "text-allow-overlap": false,
+      "text-padding": 1,
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#120049",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 2
+     }
+    },
+    {
+     "id": "toponyme bati ponc aeroport 13",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_bati_ponc",
+     "minzoom": 12,
+     "maxzoom": 21,
+     "filter": [
+      "==",
+      "txt_typo",
+      "AEROPORT_PONC"
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-anchor": "bottom",
+      "text-offset": [
+       0,
+       -2
+      ],
+      "text-size": 11,
+      "text-allow-overlap": false,
+      "text-padding": 1,
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#120049",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 2
+     }
+    },
+    {
+     "id": "toponyme bati ponc aeroport",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_bati_ponc",
+     "minzoom": 13,
+     "maxzoom": 21,
+     "filter": [
+      "all",
+      [
+       "==",
+       "txt_typo",
+       "TYPO_A_5"
+      ],
+      [
+       "==",
+       "symbo",
+       "AEROPORT"
+      ]
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-anchor": "center",
+      "text-size": {
+       "stops": [
+      [
+       12,
+       11
+      ],
+      [
+       16,
+       13
+      ]
+       ]
+      },
+      "text-allow-overlap": false,
+      "text-padding": 1,
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#120049",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 2
+     }
+    },
+    {
+     "id": "toponyme bati ponc aerodrome 12",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_bati_ponc",
+     "minzoom": 11,
+     "maxzoom": 21,
+     "filter": [
+      "==",
+      "txt_typo",
+      "AERODROME_PONC"
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-anchor": "bottom",
+      "text-offset": [
+       0,
+       -1.3
+      ],
+      "text-size": 9.5,
+      "text-allow-overlap": false,
+      "text-padding": 1,
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#120049",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 2
+     }
+    },
+    {
+     "id": "toponyme bati ponc aerodrome 13",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_bati_ponc",
+     "minzoom": 12,
+     "maxzoom": 21,
+     "filter": [
+      "==",
+      "txt_typo",
+      "AERODROME_PONC"
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-anchor": "bottom",
+      "text-offset": [
+       0,
+       -2
+      ],
+      "text-size": 10,
+      "text-allow-overlap": false,
+      "text-padding": 1,
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#120049",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 2
+     }
+    },
+    {
+     "id": "toponyme bati ponc aerodrome",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_bati_ponc",
+     "minzoom": 13,
+     "maxzoom": 21,
+     "filter": [
+      "all",
+      [
+       "==",
+       "txt_typo",
+       "TYPO_A_7"
+      ],
+      [
+       "==",
+       "symbo",
+       "AERODROME"
+      ]
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-anchor": "center",
+      "text-size": {
+       "stops": [
+      [
+       12,
+       10
+      ],
+      [
+       16,
+       12
+      ]
+       ]
+      },
+      "text-allow-overlap": false,
+      "text-padding": 1,
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#120049",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 2
+     }
+    },
+    {
+     "id": "toponyme - hydro ponc 5",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_hydro_ponc",
+     "filter": [
+      "in",
+      "txt_typo",
+      "TYPO_D_9",
+      "TYPO_D_10",
+      "TYPO_E_1_cyan"
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-size": {
+       "stops": [
+      [
+       15,
+       11
+      ],
+      [
+       17,
+       14
+      ]
+       ]
+      },
+      "text-allow-overlap": true,
+      "text-padding": 5,
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#447FB3",
+      "text-halo-color": "#FFFFFF",
+      "text-halo-width": 1
+     }
+    },
+    {
+     "id": "toponyme - hydro ponc glacier",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_hydro_ponc",
+     "filter": [
+      "==",
+      "txt_typo",
+      "ORO_GLACIER_2"
+     ],
+     "layout": {
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-size": 14,
+      "text-anchor": "center",
+      "text-allow-overlap": true,
+      "text-padding": 1,
+      "text-font": [
+       "Open Sans Regular"
+      ],
+      "visibility": "visible"
+     },
+     "paint": {
+      "text-color": "#447FB3",
+      "text-halo-width": 2,
+      "text-halo-color": "rgba(255, 255, 255, 0.5)"
+     }
+    },
+    {
+     "id": "toponyme - limite militaire ponc 3 et 4",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_limite_ponc",
+     "filter": [
+      "in",
+      "txt_typo",
+      "LIM_MILI_3",
+      "LIM_MILI_4"
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-size": 12,
+      "text-allow-overlap": false,
+      "text-padding": 2,
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#0D2000",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 1
+     }
+    },
+    {
+     "id": "toponyme - limite parc ponc 3 et 4",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_limite_ponc",
+     "filter": [
+      "in",
+      "txt_typo",
+      "LIM_PARC_3",
+      "LIM_PARC_4",
+      "RESERVE_NATURELLE_PONC"
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-size": 13,
+      "text-allow-overlap": false,
+      "text-padding": 2,
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#287B00",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 1
+     }
+    },
+    {
+     "id": "toponyme numéro de route - départementale",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_routier_numero_lin",
+     "minzoom": 11,
+     "maxzoom": 22,
+     "filter": [
+      "==",
+      "txt_typo",
+      "Départementale"
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "line",
+      "text-field": "{texte}",
+      "text-size": 10.5,
+      "text-allow-overlap": false,
+      "text-padding": 2,
+      "text-anchor": "center",
+      "text-font": [
+       "Open Sans Regular"
+      ],
+      "text-rotation-alignment": "viewport"
+     },
+     "paint": {
+      "text-color": "#4D4D4D",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 4
+     }
+    },
+    {
+     "id": "toponyme numéro de route - nationale",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_routier_numero_lin",
+     "minzoom": 7,
+     "maxzoom": 22,
+     "filter": [
+      "==",
+      "txt_typo",
+      "Nationale"
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "line",
+      "text-field": "{texte}",
+      "text-size": 12,
+      "text-allow-overlap": false,
+      "text-padding": 0,
+      "text-anchor": "center",
+      "text-font": [
+       "Open Sans Regular"
+      ],
+      "icon-image": "Ecluse",
+      "icon-rotation-alignment": "viewport",
+      "text-rotation-alignment": "viewport",
+      "icon-text-fit": "both",
+      "icon-size": 0
+     },
+     "paint": {
+      "text-color": "#F0F0F0",
+      "icon-color": "#646464",
+      "text-halo-color": "rgba(80, 80, 80, 0.5)",
+      "text-halo-width": 4
+     }
+    },
+    {
+     "id": "toponyme numéro de route - autoroute",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_routier_numero_lin",
+     "minzoom": 7,
+     "maxzoom": 22,
+     "filter": [
+      "==",
+      "txt_typo",
+      "Autoroute"
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "line",
+      "text-field": "{texte}",
+      "text-size": 15,
+      "text-allow-overlap": false,
+      "text-padding": 0,
+      "text-anchor": "center",
+      "text-font": [
+       "Open Sans Regular"
+      ],
+      "icon-image": "Ecluse",
+      "icon-rotation-alignment": "viewport",
+      "text-rotation-alignment": "viewport",
+      "icon-text-fit": "both",
+      "icon-size": 0
+     },
+     "paint": {
+      "text-color": "#F0F0F0",
+      "icon-color": "#646464",
+      "text-halo-color": "rgba(80, 80, 80, 0.5)",
+      "text-halo-width": 5
+     }
+    },
+    {
+     "id": "toponyme - odonyme abrégé",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_routier_odonyme_lin",
+     "minzoom": 15,
+     "maxzoom": 22,
+     "layout": {
+      "symbol-placement": "line",
+      "text-field": "{nom_gauche}",
+      "text-size": 10,
+      "text-anchor": "center",
+      "text-max-angle": 30,
+      "text-font": [
+       "Open Sans Regular"
+      ],
+      "visibility": "none"
+     },
+     "paint": {
+      "text-color": "#000000",
+      "text-halo-width": 2,
+      "text-halo-color": "rgba(255, 255, 255, 1)"
+     }
+    },
+    {
+     "id": "toponyme - odonyme desabrégé",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_routier_odonyme_lin",
+     "minzoom": 17,
+     "layout": {
+      "symbol-placement": "line",
+      "text-field": "{nom_desabrege}",
+      "text-size": 11,
+      "text-anchor": "center",
+      "text-max-angle": 30,
+      "text-font": [
+       "Open Sans Regular"
+      ],
+      "visibility": "none"
+     },
+     "paint": {
+      "text-color": "#000000",
+      "text-halo-width": 2,
+      "text-halo-color": "rgba(255, 255, 255, 1)"
+     }
+    },
+    {
+     "id": "toponyme - lieu dit non habité 3",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_ocs_ponc",
+     "filter": [
+      "all",
+      [
+       "==",
+       "symbo",
+       "LIEU-DIT_NON_HABITE"
+      ],
+      [
+       "in",
+       "txt_typo",
+       "TYPO_B_10",
+       "TYPO_B_11"
+      ]
+     ],
+     "layout": {
+      "visibility": "none",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-size": 11,
+      "text-allow-overlap": false,
+      "text-padding": 1,
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#000000",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 1
+     }
+    },
+    {
+     "id": "toponyme - bois",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_ocs_ponc",
+     "filter": [
+      "all",
+      [
+       "==",
+       "symbo",
+       "BOIS"
+      ],
+      [
+       "in",
+       "txt_typo",
+       "TYPO_F_10",
+       "TYPO_F_11"
+      ]
+     ],
+     "layout": {
+      "visibility": "none",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-size": 13,
+      "text-allow-overlap": false,
+      "text-padding": 1,
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#287B00",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 1
+     }
+    },
+    {
+     "id": "toponyme - oro lineaire 4",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_oro_lin",
+     "filter": [
+      "in",
+      "txt_typo",
+      "ORO_SOMMET_3",
+      "ORO_GORGE_2"
+     ],
+     "layout": {
+      "symbol-placement": "line",
+      "text-field": "{texte}",
+      "text-size": 11,
+      "text-anchor": "center",
+      "text-keep-upright": true,
+      "text-max-angle": 45,
+      "text-padding": 1,
+      "text-font": [
+       "Open Sans Regular"
+      ],
+      "visibility": "visible"
+     },
+     "paint": {
+      "text-color": "#863831",
+      "text-halo-width": 1.5,
+      "text-halo-color": "rgba(255, 255, 255, 0.5)"
+     }
+    },
+    {
+     "id": "toponyme - oro ponc 4",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_oro_ponc",
+     "filter": [
+      "in",
+      "txt_typo",
+      "ORO_SOMMET_3",
+      "ORO_GORGE_2",
+      "GROTTE",
+      "GORGE",
+      "TYPO_G_9",
+      "TYPO_G_10"
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-size": {
+       "stops": [
+      [
+       13,
+       11
+      ],
+      [
+       16,
+       16
+      ]
+       ]
+      },
+      "text-allow-overlap": true,
+      "text-padding": 1,
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#863831",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 1.5
+     }
+    },
+    {
+     "id": "toponyme - hydro ponc 4",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_hydro_ponc",
+     "filter": [
+      "in",
+      "txt_typo",
+      "lac - étang - bassin",
+      "HYD_SURF_4",
+      "HYD_SURF_4_T",
+      "HYD_SURF_5",
+      "HYD_SURF_5_T",
+      "TYPO_D_8",
+      "SOURCE"
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-size": {
+       "stops": [
+      [
+       14,
+       13
+      ],
+      [
+       17,
+       16
+      ]
+       ]
+      },
+      "text-allow-overlap": true,
+      "text-padding": 5,
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#447FB3",
+      "text-halo-color": "#FFFFFF",
+      "text-halo-width": 1
+     }
+    },
+    {
+     "id": "toponyme - lieu dit non habité",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_ocs_ponc",
+     "filter": [
+      "all",
+      [
+       "==",
+       "symbo",
+       "LIEU-DIT_NON_HABITE"
+      ],
+      [
+       "in",
+       "txt_typo",
+       "TYPO_B_7",
+       "TYPO_B_8",
+       "TYPO_B_9"
+      ]
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-size": 12,
+      "text-allow-overlap": false,
+      "text-padding": 1,
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#000000",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 1
+     }
+    },
+    {
+     "id": "toponyme - bois 2",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_ocs_ponc",
+     "filter": [
+      "all",
+      [
+       "==",
+       "symbo",
+       "BOIS"
+      ],
+      [
+       "in",
+       "txt_typo",
+       "TYPO_F_7",
+       "TYPO_F_8",
+       "TYPO_F_9"
+      ]
+     ],
+     "layout": {
+      "visibility": "none",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-size": 16,
+      "text-allow-overlap": false,
+      "text-padding": 1,
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#287B00",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 2
+     }
+    },
+    {
+     "id": "toponyme localite importance 5",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_localite_ponc",
+     "minzoom": 9,
+     "filter": [
+      "in",
+      "txt_typo",
+      "commune 5",
+      "BAT_COMMUNE_5",
+      "BAT_COMMUNE_5_T",
+      "BAT_CHEF_LIEU_COM",
+      "BAT_CHEF_LIEU_COM_T",
+      "BAT_CHEF_LIEU_COM-T",
+      "BAT_ANCIENNE_COM",
+      "BAT_ANCIENNE_COM_T",
+      "BAT_COMMUNE_ASSOCIEE",
+      "BAT_COMMUNE_ASSOCIEE_T",
+      "Commune très petite"
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "icon-image": "Localite",
+      "icon-size": 0.21,
+      "text-field": "{texte}",
+      "text-size": 11.5,
+      "text-allow-overlap": false,
+      "text-anchor": "bottom-left",
+      "text-offset": [
+       0.3,
+       0.1
+      ],
+      "text-padding": 1,
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#000000",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 2
+     }
+    },
+    {
+     "id": "toponyme - ocs lineaire 3",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_ocs_lin",
+     "filter": [
+      "==",
+      "txt_typo",
+      "OCS_FORET_3"
+     ],
+     "layout": {
+      "symbol-placement": "line",
+      "text-field": "{texte}",
+      "text-size": {
+       "stops": [
+      [
+       10,
+       12
+      ],
+      [
+       12,
+       15
+      ]
+       ]
+      },
+      "text-anchor": "center",
+      "text-keep-upright": true,
+      "text-max-angle": 45,
+      "text-padding": 1,
+      "text-font": [
+       "Open Sans Regular"
+      ],
+      "visibility": "visible"
+     },
+     "paint": {
+      "text-color": "#287B00",
+      "text-halo-width": 1,
+      "text-halo-color": "rgba(255, 255, 255, 0.5)"
+     }
+    },
+    {
+     "id": "toponyme - lieu dit non habité 1",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_ocs_ponc",
+     "filter": [
+      "all",
+      [
+       "==",
+       "symbo",
+       "LIEU-DIT_NON_HABITE"
+      ],
+      [
+       "in",
+       "txt_typo",
+       "TYPO_B_5",
+       "TYPO_B_4"
+      ]
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-size": 15,
+      "text-allow-overlap": false,
+      "text-padding": 1,
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#000000",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 1
+     }
+    },
+    {
+     "id": "toponyme - bois 1",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_ocs_ponc",
+     "filter": [
+      "all",
+      [
+       "==",
+       "symbo",
+       "BOIS"
+      ],
+      [
+       "in",
+       "txt_typo",
+       "TYPO_F_5",
+       "TYPO_F_4"
+      ]
+     ],
+     "layout": {
+      "visibility": "none",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-size": 19,
+      "text-allow-overlap": false,
+      "text-padding": 1,
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#287B00",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 2
+     }
+    },
+    {
+     "id": "toponyme - bois 0",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_ocs_ponc",
+     "filter": [
+      "all",
+      [
+       "==",
+       "symbo",
+       "BOIS"
+      ],
+      [
+       "in",
+       "txt_typo",
+       "TYPO_F_3",
+       "TYPO_F_2"
+      ]
+     ],
+     "layout": {
+      "visibility": "none",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-size": 22,
+      "text-allow-overlap": false,
+      "text-padding": 1,
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#287B00",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 2
+     }
+    },
+    {
+     "id": "toponyme - ocs ponc 3",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_ocs_ponc",
+     "filter": [
+      "==",
+      "txt_typo",
+      "OCS_FORET_3"
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-size": {
+       "stops": [
+      [
+       10,
+       12
+      ],
+      [
+       12,
+       15
+      ]
+       ]
+      },
+      "text-allow-overlap": false,
+      "text-padding": 1,
+      "text-anchor": "center",
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#287B00",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 1
+     }
+    },
+    {
+     "id": "toponyme - oro lineaire 3",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_oro_lin",
+     "filter": [
+      "in",
+      "txt_typo",
+      "ORO_ILE_3",
+      "ORO_RELIEF_3",
+      "ORO_RELIEF_3_T",
+      "ORO_RELIEF_4",
+      "ORO_RELIEF_4_T",
+      "ORO_CAP_2",
+      "ORO_CAP_3",
+      "ORO_SOMMET_2",
+      "ORO_COL_2",
+      "ORO_GORGE_1",
+      "ORO_GORGE-1"
+     ],
+     "layout": {
+      "symbol-placement": "line",
+      "text-field": "{texte}",
+      "text-size": 12,
+      "text-anchor": "center",
+      "text-keep-upright": true,
+      "text-max-angle": 45,
+      "text-padding": 10,
+      "text-font": [
+       "Open Sans Regular"
+      ],
+      "visibility": "visible"
+     },
+     "paint": {
+      "text-color": "#863831",
+      "text-halo-width": 1.5,
+      "text-halo-color": "rgba(255, 255, 255, 0.5)"
+     }
+    },
+    {
+     "id": "toponyme - oro ponc 3",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_oro_ponc",
+     "filter": [
+      "in",
+      "txt_typo",
+      "ORO_ILE_3",
+      "ORO_RELIEF_3",
+      "ORO_RELIEF_3_T",
+      "ORO_RELIEF_4",
+      "ORO_RELIEF_4_T",
+      "ORO_CAP_2",
+      "ORO_CAP_3",
+      "ORO_SOMMET_2",
+      "ORO_COL_2",
+      "ORO_GORGE_1",
+      "ORO_GORGE-1",
+      "TYPO_G_7",
+      "TYPO_G_8"
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-size": {
+       "stops": [
+      [
+       13,
+       12
+      ],
+      [
+       16,
+       17
+      ]
+       ]
+      },
+      "text-allow-overlap": true,
+      "text-padding": 1,
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#863831",
+      "text-halo-color": "#FFFFFF",
+      "text-halo-width": 1.5
+     }
+    },
+    {
+     "id": "toponyme - hydro lineaire 3",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_hydro_lin",
+     "filter": [
+      "in",
+      "txt_typo",
+      "HYD_LIN_3",
+      "HYD_LIN_4",
+      "HYD_LIN_5",
+      "petite rivière",
+      "canal",
+      "HYD_SURF_3",
+      "HYD_SURF_3_T",
+      "HYD_SURF_4",
+      "HYD_SURF_4_T",
+      "HYD_SURF_5",
+      "HYD_SURF_5_T",
+      "TYPO_D_5"
+     ],
+     "layout": {
+      "symbol-placement": "line",
+      "text-field": "{texte}",
+      "text-size": {
+       "stops": [
+      [
+       14,
+       12
+      ],
+      [
+       18,
+       19
+      ]
+       ]
+      },
+      "text-anchor": "center",
+      "text-keep-upright": true,
+      "text-max-angle": 45,
+      "text-padding": 10,
+      "text-font": [
+       "Open Sans Regular"
+      ],
+      "visibility": "visible"
+     },
+     "paint": {
+      "text-color": "#447FB3",
+      "text-halo-width": 1.5,
+      "text-halo-color": "rgba(255, 255, 255, 0.7)"
+     }
+    },
+    {
+     "id": "toponyme - hydro lineaire 4",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_hydro_lin",
+     "minzoom": 14,
+     "filter": [
+      "in",
+      "txt_typo",
+      "TYPO_D_6",
+      "TYPO_D_8",
+      "TYPO_D_9",
+      "TYPO_D_10"
+     ],
+     "layout": {
+      "symbol-placement": "line",
+      "text-field": "{texte}",
+      "text-size": {
+       "stops": [
+      [
+       14,
+       10
+      ],
+      [
+       18,
+       16
+      ]
+       ]
+      },
+      "text-anchor": "center",
+      "text-keep-upright": true,
+      "text-max-angle": 45,
+      "text-padding": 10,
+      "text-font": [
+       "Open Sans Regular"
+      ],
+      "visibility": "visible"
+     },
+     "paint": {
+      "text-color": "#447FB3",
+      "text-halo-width": 1.5,
+      "text-halo-color": "rgba(255, 255, 255, 0.7)"
+     }
+    },
+    {
+     "id": "toponyme - hydro ponc 3",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_hydro_ponc",
+     "filter": [
+      "in",
+      "txt_typo",
+      "petit golfe",
+      "grande baie",
+      "baie",
+      "HYD_SURF_3",
+      "TYPO_D_5",
+      "TYPO_D_6",
+      "TYPO_D_7"
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-size": {
+       "stops": [
+      [
+       15,
+       15
+      ],
+      [
+       17,
+       18
+      ]
+       ]
+      },
+      "text-allow-overlap": true,
+      "text-padding": 10,
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#447FB3",
+      "text-halo-color": "#FFFFFF",
+      "text-halo-width": 2
+     }
+    },
+    {
+     "id": "toponyme bati ponc zai zoom 16",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_bati_ponc",
+     "minzoom": 15,
+     "maxzoom": 21,
+     "filter": [
+      "==",
+      "txt_typo",
+      "zai"
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{designation}",
+      "text-size": 11,
+      "text-allow-overlap": false,
+      "text-padding": 1,
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#000000"
+     }
+    },
+    {
+     "id": "toponyme bati ponc zai zoom 17 et 18",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_bati_ponc",
+     "minzoom": 16,
+     "filter": [
+      "==",
+      "txt_typo",
+      "zai"
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-size": 11,
+      "text-allow-overlap": false,
+      "text-padding": 1,
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#000000"
+     }
+    },
+    {
+     "id": "toponyme localite importance 4",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_localite_ponc",
+     "minzoom": 7,
+     "filter": [
+      "in",
+      "txt_typo",
+      "commune 4",
+      "BAT_COMMUNE_4",
+      "BAT_COMMUNE_4_T"
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "icon-image": "Localite",
+      "icon-size": 0.21,
+      "text-field": "{texte}",
+      "text-size": 13,
+      "text-allow-overlap": false,
+      "text-anchor": "bottom-left",
+      "text-offset": [
+       0.3,
+       0.1
+      ],
+      "text-padding": 1,
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#000000",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 2
+     }
+    },
+    {
+     "id": "toponyme - limite militaire ponc 1 et 2",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_limite_ponc",
+     "filter": [
+      "in",
+      "txt_typo",
+      "LIM_MILI_1",
+      "LIM_MILI_2"
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-size": 15,
+      "text-allow-overlap": false,
+      "text-padding": 5,
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#0D2000",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 2
+     }
+    },
+    {
+     "id": "toponyme - limite parc marin",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_limite_ponc",
+     "minzoom": 8,
+     "filter": [
+      "==",
+      "txt_typo",
+      "LIM_PARC_NATUREL_MARIN"
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-size": 15,
+      "text-allow-overlap": false,
+      "text-padding": 10,
+      "text-transform": "uppercase",
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#2A81A2",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 2
+     }
+    },
+    {
+     "id": "toponyme - limite parc ponc 1 et 2",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_limite_ponc",
+     "minzoom": 8,
+     "filter": [
+      "in",
+      "txt_typo",
+      "LIM_PARC_1",
+      "LIM_PARC_2",
+      "LIM_PARC_NATUREL"
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-size": 15,
+      "text-allow-overlap": false,
+      "text-padding": 10,
+      "text-transform": "uppercase",
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#287B00",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 2
+     }
+    },
+    {
+     "id": "toponyme - ocs lineaire 2",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_ocs_lin",
+     "filter": [
+      "==",
+      "txt_typo",
+      "OCS_FORET_2"
+     ],
+     "layout": {
+      "symbol-placement": "line",
+      "text-field": "{texte}",
+      "text-size": {
+       "stops": [
+      [
+       10,
+       15
+      ],
+      [
+       12,
+       18
+      ]
+       ]
+      },
+      "text-anchor": "center",
+      "text-keep-upright": true,
+      "text-max-angle": 45,
+      "text-padding": 1,
+      "text-font": [
+       "Open Sans Regular"
+      ],
+      "visibility": "visible"
+     },
+     "paint": {
+      "text-color": "#287B00",
+      "text-halo-width": 2,
+      "text-halo-color": "rgba(255, 255, 255, 0.5)"
+     }
+    },
+    {
+     "id": "toponyme - ocs ponc 2",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_ocs_ponc",
+     "filter": [
+      "==",
+      "txt_typo",
+      "OCS_FORET_2"
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-size": {
+       "stops": [
+      [
+       10,
+       15
+      ],
+      [
+       12,
+       18
+      ]
+       ]
+      },
+      "text-allow-overlap": false,
+      "text-padding": 1,
+      "text-anchor": "center",
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#287B00",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 2
+     }
+    },
+    {
+     "id": "toponyme - oro lineaire 2",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_oro_lin",
+     "filter": [
+      "in",
+      "txt_typo",
+      "ORO_ILE_2",
+      "ORO_RELIEF_2",
+      "ORO_RELIEF_2_T",
+      "ORO_CAP_1",
+      "ORO_SOMMET_1"
+     ],
+     "layout": {
+      "symbol-placement": "line",
+      "text-field": "{texte}",
+      "text-size": 15,
+      "text-anchor": "center",
+      "text-keep-upright": true,
+      "text-padding": 10,
+      "text-max-angle": 45,
+      "text-font": [
+       "Open Sans Regular"
+      ],
+      "visibility": "visible"
+     },
+     "paint": {
+      "text-color": "#863831",
+      "text-halo-width": 2,
+      "text-halo-color": "rgba(255, 255, 255, 0.5)"
+     }
+    },
+    {
+     "id": "toponyme - oro ponc 2",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_oro_ponc",
+     "minzoom": 9,
+     "filter": [
+      "in",
+      "txt_typo",
+      "ORO_ILE_2",
+      "ORO_RELIEF_2",
+      "ORO_RELIEF_2_T",
+      "ORO_CAP_1",
+      "ORO_COL_1",
+      "sommet ou col",
+      "ORO_SOMMET_1",
+      "TYPO_G_4",
+      "TYPO_G_6"
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-size": {
+       "stops": [
+      [
+       9,
+       13
+      ],
+      [
+       10,
+       15
+      ],
+      [
+       13,
+       15
+      ],
+      [
+       16,
+       19
+      ]
+       ]
+      },
+      "text-allow-overlap": false,
+      "text-padding": 1,
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#863831",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 2
+     }
+    },
+    {
+     "id": "toponyme - oro ponc 2B",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_oro_ponc",
+     "minzoom": 8,
+     "filter": [
+      "in",
+      "txt_typo",
+      "île",
+      "cap ou pointe"
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-size": 15,
+      "text-allow-overlap": false,
+      "text-padding": 1,
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#863831",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 2
+     }
+    },
+    {
+     "id": "toponyme - hydro lineaire 2",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_hydro_lin",
+     "filter": [
+      "in",
+      "txt_typo",
+      "HYD_LIN_2",
+      "rivière moyenne",
+      "HYD_SURF_2",
+      "HYD_SURF_2_T",
+      "TYPO_D_3"
+     ],
+     "layout": {
+      "symbol-placement": "line",
+      "text-field": "{texte}",
+      "text-size": {
+       "stops": [
+      [
+       14,
+       15
+      ],
+      [
+       18,
+       21
+      ]
+       ]
+      },
+      "text-anchor": "center",
+      "text-keep-upright": true,
+      "text-max-angle": 45,
+      "text-padding": 10,
+      "text-font": [
+       "Open Sans Regular"
+      ],
+      "visibility": "visible"
+     },
+     "paint": {
+      "text-color": "#447FB3",
+      "text-halo-width": 2,
+      "text-halo-color": "rgba(255, 255, 255, 0.5)"
+     }
+    },
+    {
+     "id": "toponyme - hydro ponc 2",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_hydro_ponc",
+     "minzoom": 5,
+     "filter": [
+      "in",
+      "txt_typo",
+      "moyen",
+      "golfe moyen",
+      "HYD_SURF_2",
+      "TYPO_D_2",
+      "TYPO_D_3",
+      "TYPO_D_4"
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-size": {
+       "stops": [
+      [
+       5,
+       12
+      ],
+      [
+       6,
+       18
+      ],
+      [
+       10,
+       17
+      ],
+      [
+       18,
+       21
+      ]
+       ]
+      },
+      "text-allow-overlap": false,
+      "text-padding": 10,
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#447FB3",
+      "text-halo-color": "#FFFFFF",
+      "text-halo-width": 2
+     }
+    },
+    {
+     "id": "toponyme localite importance 3",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_localite_ponc",
+     "minzoom": 5,
+     "filter": [
+      "in",
+      "txt_typo",
+      "commune 3",
+      "BAT_COMMUNE_3",
+      "BAT_COMMUNE_3_T"
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "icon-image": "Localite",
+      "icon-size": 0.21,
+      "text-field": "{texte}",
+      "text-size": {
+       "stops": [
+      [
+       5,
+       10
+      ],
+      [
+       6,
+       15
+      ]
+       ]
+      },
+      "text-allow-overlap": false,
+      "text-anchor": "bottom-left",
+      "text-offset": [
+       0.3,
+       0.1
+      ],
+      "text-padding": 1,
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#000000",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 2
+     }
+    },
+    {
+     "id": "toponyme localite n0 typoA7 non commune",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_localite_ponc",
+     "maxzoom": 21,
+     "filter": [
+      "all",
+      [
+       "!=",
+       "symbo",
+       "COMMUNE_FUSIONNEE"
+      ],
+      [
+       "!=",
+       "symbo",
+       "COMMUNE_CHEF_LIEU"
+      ],
+      [
+       "==",
+       "txt_typo",
+       "TYPO_A_7"
+      ]
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-size": {
+       "stops": [
+      [
+       15,
+       13
+      ],
+      [
+       17,
+       16
+      ]
+       ]
+      },
+      "text-allow-overlap": true,
+      "text-anchor": "center",
+      "text-padding": 1,
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#000000",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 2
+     }
+    },
+    {
+     "id": "toponyme localite n0 typoA6 non commune",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_localite_ponc",
+     "maxzoom": 21,
+     "filter": [
+      "all",
+      [
+       "!=",
+       "symbo",
+       "COMMUNE_FUSIONNEE"
+      ],
+      [
+       "!=",
+       "symbo",
+       "COMMUNE_CHEF_LIEU"
+      ],
+      [
+       "==",
+       "txt_typo",
+       "TYPO_A_6"
+      ]
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-size": {
+       "stops": [
+      [
+       15,
+       15
+      ],
+      [
+       17,
+       18
+      ]
+       ]
+      },
+      "text-allow-overlap": true,
+      "text-anchor": "center",
+      "text-padding": 1,
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#000000",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 2
+     }
+    },
+    {
+     "id": "toponyme - oro lineaire 1",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_oro_lin",
+     "filter": [
+      "in",
+      "txt_typo",
+      "ORO_ILE_1",
+      "ORO_RELIEF_1",
+      "ORO_RELIEF_1_T"
+     ],
+     "layout": {
+      "symbol-placement": "line",
+      "text-field": "{texte}",
+      "text-size": 20,
+      "text-anchor": "center",
+      "text-keep-upright": true,
+      "text-padding": 5,
+      "text-max-angle": 45,
+      "text-font": [
+       "Open Sans Regular"
+      ],
+      "visibility": "visible"
+     },
+     "paint": {
+      "text-color": "#863831",
+      "text-halo-width": 2,
+      "text-halo-color": "rgba(255, 255, 255, 0.5)"
+     }
+    },
+    {
+     "id": "toponyme - oro ponc monde",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_oro_ponc",
+     "minzoom": 5,
+     "filter": [
+      "in",
+      "txt_typo",
+      "Basin",
+      "Depression",
+      "Desert",
+      "Geoarea",
+      "Gorge",
+      "Isthmus",
+      "Lake",
+      "Lowland",
+      "Pen/cape",
+      "Plain",
+      "Plateau",
+      "Range/mtn",
+      "Tundra",
+      "Valley",
+      "Island",
+      "Island group"
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-size": 11,
+      "text-allow-overlap": false,
+      "text-padding": 1,
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#863831",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 2
+     }
+    },
+    {
+     "id": "toponyme localite n0 typoA4 non commune",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_localite_ponc",
+     "maxzoom": 21,
+     "filter": [
+      "all",
+      [
+       "!=",
+       "symbo",
+       "COMMUNE_FUSIONNEE"
+      ],
+      [
+       "!=",
+       "symbo",
+       "COMMUNE_CHEF_LIEU"
+      ],
+      [
+       "==",
+       "txt_typo",
+       "TYPO_A_4"
+      ]
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-size": 17,
+      "text-allow-overlap": true,
+      "text-anchor": "center",
+      "text-padding": 1,
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#000000",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 3
+     }
+    },
+    {
+     "id": "toponyme - ocs lineaire 1",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_ocs_lin",
+     "filter": [
+      "==",
+      "txt_typo",
+      "OCS_FORET_1"
+     ],
+     "layout": {
+      "symbol-placement": "line",
+      "text-field": "{texte}",
+      "text-size": {
+       "stops": [
+      [
+       10,
+       18
+      ],
+      [
+       12,
+       22
+      ]
+       ]
+      },
+      "text-anchor": "center",
+      "text-keep-upright": true,
+      "text-padding": 1,
+      "text-max-angle": 45,
+      "text-font": [
+       "Open Sans Regular"
+      ],
+      "visibility": "visible"
+     },
+     "paint": {
+      "text-color": "#287B00",
+      "text-halo-width": 2,
+      "text-halo-color": "rgba(255, 255, 255, 0.5)"
+     }
+    },
+    {
+     "id": "toponyme - ocs ponc 1",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_ocs_ponc",
+     "filter": [
+      "==",
+      "txt_typo",
+      "OCS_FORET_1"
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-size": {
+       "stops": [
+      [
+       10,
+       18
+      ],
+      [
+       12,
+       22
+      ]
+       ]
+      },
+      "text-allow-overlap": true,
+      "text-padding": 1,
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#287B00",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 2
+     }
+    },
+    {
+     "id": "toponyme - oro ponc 1",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_oro_ponc",
+     "minzoom": 8,
+     "filter": [
+      "in",
+      "txt_typo",
+      "grande île",
+      "ORO_ILE_1",
+      "ORO_RELIEF_1",
+      "ORO_RELIEF_1_T",
+      "TYPO_G_3",
+      "TYPO_G_2",
+      "TYPO_G_1"
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-size": 21,
+      "text-allow-overlap": true,
+      "text-padding": 1,
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#863831",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 2
+     }
+    },
+    {
+     "id": "toponyme - hydro lineaire glacier",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_hydro_lin",
+     "filter": [
+      "in",
+      "txt_typo",
+      "ORO_GLACIER_1",
+      "ORO_GLACIER_2"
+     ],
+     "layout": {
+      "symbol-placement": "line",
+      "text-field": "{texte}",
+      "text-size": 15,
+      "text-anchor": "center",
+      "text-keep-upright": true,
+      "text-max-angle": 45,
+      "text-font": [
+       "Open Sans Regular"
+      ],
+      "visibility": "visible"
+     },
+     "paint": {
+      "text-color": "#447FB3",
+      "text-halo-width": 2,
+      "text-halo-color": "rgba(255, 255, 255, 0.5)"
+     }
+    },
+    {
+     "id": "toponyme - hydro lineaire 1",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_hydro_lin",
+     "filter": [
+      "in",
+      "txt_typo",
+      "HYD_LIN_1",
+      "HYD-LIN-1",
+      "grande rivière",
+      "HYD_SURF_1",
+      "HYD_SURF_1_T",
+      "TYPO_D_1",
+      "TYPO_D_2"
+     ],
+     "layout": {
+      "symbol-placement": "line",
+      "text-field": "{texte}",
+      "text-size": 18,
+      "text-anchor": "center",
+      "text-keep-upright": true,
+      "text-max-angle": 45,
+      "text-padding": 10,
+      "text-font": [
+       "Open Sans Regular"
+      ],
+      "visibility": "visible"
+     },
+     "paint": {
+      "text-color": "#447FB3",
+      "text-halo-width": 2,
+      "text-halo-color": "rgba(255, 255, 255, 0.5)"
+     }
+    },
+    {
+     "id": "toponyme - hydro lineaire ocean",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_hydro_lin",
+     "filter": [
+      "==",
+      "txt_typo",
+      "mer et océan"
+     ],
+     "layout": {
+      "symbol-placement": "line",
+      "text-field": "{texte}",
+      "text-size": 30,
+      "text-anchor": "center",
+      "text-keep-upright": true,
+      "text-max-angle": 45,
+      "text-padding": 10,
+      "text-font": [
+       "Open Sans Regular"
+      ],
+      "visibility": "visible"
+     },
+     "paint": {
+      "text-color": "#447FB3",
+      "text-halo-width": 4,
+      "text-halo-color": "rgba(255, 255, 255, 0.5)"
+     }
+    },
+    {
+     "id": "toponyme - hydro ponc 1",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_hydro_ponc",
+     "minzoom": 4,
+     "filter": [
+      "in",
+      "txt_typo",
+      "mer",
+      "grand",
+      "grand golfe",
+      "HYD_SURF_1",
+      "TYPO_D_1"
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-size": {
+       "stops": [
+      [
+       4,
+       16
+      ],
+      [
+       6,
+       30
+      ],
+      [
+       10,
+       25
+      ]
+       ]
+      },
+      "text-allow-overlap": true,
+      "text-padding": 10,
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#447FB3",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 4
+     }
+    },
+    {
+     "id": "toponyme localite importance 2",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_localite_ponc",
+     "minzoom": 4,
+     "filter": [
+      "in",
+      "txt_typo",
+      "commune 2",
+      "BAT_COMMUNE_2",
+      "BAT_COMMUNE-2",
+      "BAT_COMMUNE_2_T"
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "icon-image": "Localite",
+      "icon-size": 0.25,
+      "text-field": "{texte}",
+      "text-size": {
+       "stops": [
+      [
+       4,
+       10
+      ],
+      [
+       6,
+       17
+      ]
+       ]
+      },
+      "text-allow-overlap": true,
+      "text-anchor": "bottom-left",
+      "text-offset": [
+       0.3,
+       0.2
+      ],
+      "text-padding": 1,
+      "text-transform": "uppercase",
+      "text-font": {
+       "stops": [
+      [
+       1,
+       [
+        "Open Sans Regular"
+       ]
+      ],
+      [
+       7,
+       [
+        "Open Sans Regular"
+       ]
+      ],
+      [
+       10,
+       [
+        "Open Sans Regular"
+       ]
+      ]
+       ]
+      }
+     },
+     "paint": {
+      "text-color": "#000000",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 3
+     }
+    },
+    {
+     "id": "toponyme localite n0 typoA3 non commune",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_localite_ponc",
+     "maxzoom": 21,
+     "filter": [
+      "all",
+      [
+       "!=",
+       "symbo",
+       "COMMUNE_FUSIONNEE"
+      ],
+      [
+       "!=",
+       "symbo",
+       "COMMUNE_CHEF_LIEU"
+      ],
+      [
+       "==",
+       "txt_typo",
+       "TYPO_A_3"
+      ]
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-size": 19,
+      "text-allow-overlap": true,
+      "text-anchor": "center",
+      "text-padding": 1,
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#000000",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 3
+     }
+    },
+    {
+     "id": "toponyme localite n0 typoA2 non commune",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_localite_ponc",
+     "maxzoom": 21,
+     "filter": [
+      "all",
+      [
+       "!=",
+       "symbo",
+       "COMMUNE_FUSIONNEE"
+      ],
+      [
+       "!=",
+       "symbo",
+       "COMMUNE_CHEF_LIEU"
+      ],
+      [
+       "==",
+       "txt_typo",
+       "TYPO_A_2"
+      ]
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-size": 21,
+      "text-allow-overlap": true,
+      "text-anchor": "center",
+      "text-padding": 1,
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#000000",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 4
+     }
+    },
+    {
+     "id": "toponyme localite n0 typoA7 commune",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_localite_ponc",
+     "maxzoom": 21,
+     "filter": [
+      "all",
+      [
+       "in",
+       "symbo",
+       "COMMUNE_FUSIONNEE",
+       "COMMUNE_CHEF_LIEU"
+      ],
+      [
+       "==",
+       "txt_typo",
+       "TYPO_A_7"
+      ]
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-size": {
+       "stops": [
+      [
+       15,
+       13
+      ],
+      [
+       17,
+       16
+      ]
+       ]
+      },
+      "text-allow-overlap": true,
+      "text-anchor": "center",
+      "text-padding": 1,
+      "text-transform": "uppercase",
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#000000",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 2
+     }
+    },
+    {
+     "id": "toponyme localite n0 typoA6 commune",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_localite_ponc",
+     "maxzoom": 21,
+     "filter": [
+      "all",
+      [
+       "in",
+       "symbo",
+       "COMMUNE_FUSIONNEE",
+       "COMMUNE_CHEF_LIEU"
+      ],
+      [
+       "==",
+       "txt_typo",
+       "TYPO_A_6"
+      ]
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-size": {
+       "stops": [
+      [
+       15,
+       15
+      ],
+      [
+       17,
+       18
+      ]
+       ]
+      },
+      "text-allow-overlap": true,
+      "text-anchor": "center",
+      "text-padding": 1,
+      "text-transform": "uppercase",
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#000000",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 2
+     }
+    },
+    {
+     "id": "toponyme localite n0 typoA1 non commune",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_localite_ponc",
+     "maxzoom": 21,
+     "filter": [
+      "all",
+      [
+       "!=",
+       "symbo",
+       "COMMUNE_FUSIONNEE"
+      ],
+      [
+       "!=",
+       "symbo",
+       "COMMUNE_CHEF_LIEU"
+      ],
+      [
+       "==",
+       "txt_typo",
+       "TYPO_A_1"
+      ]
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-size": 23,
+      "text-allow-overlap": true,
+      "text-anchor": "center",
+      "text-padding": 1,
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#000000",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 4
+     }
+    },
+    {
+     "id": "toponyme localite n0 typoA4 commune",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_localite_ponc",
+     "maxzoom": 21,
+     "filter": [
+      "all",
+      [
+       "in",
+       "symbo",
+       "COMMUNE_FUSIONNEE",
+       "COMMUNE_CHEF_LIEU"
+      ],
+      [
+       "==",
+       "txt_typo",
+       "TYPO_A_4"
+      ]
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-size": 17,
+      "text-allow-overlap": true,
+      "text-anchor": "center",
+      "text-padding": 1,
+      "text-transform": "uppercase",
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#000000",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 3
+     }
+    },
+    {
+     "id": "toponyme localite n0 typoA3 commune",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_localite_ponc",
+     "maxzoom": 21,
+     "filter": [
+      "all",
+      [
+       "in",
+       "symbo",
+       "COMMUNE_FUSIONNEE",
+       "COMMUNE_CHEF_LIEU"
+      ],
+      [
+       "==",
+       "txt_typo",
+       "TYPO_A_3"
+      ]
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-size": 19,
+      "text-allow-overlap": true,
+      "text-anchor": "center",
+      "text-padding": 1,
+      "text-transform": "uppercase",
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#000000",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 3
+     }
+    },
+    {
+     "id": "toponyme localite n0 typoA2 commune",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_localite_ponc",
+     "maxzoom": 21,
+     "filter": [
+      "all",
+      [
+       "in",
+       "symbo",
+       "COMMUNE_FUSIONNEE",
+       "COMMUNE_CHEF_LIEU"
+      ],
+      [
+       "==",
+       "txt_typo",
+       "TYPO_A_2"
+      ]
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-size": 21,
+      "text-allow-overlap": true,
+      "text-anchor": "center",
+      "text-padding": 1,
+      "text-transform": "uppercase",
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#000000",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 4
+     }
+    },
+    {
+     "id": "toponyme localite importance 1",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_localite_ponc",
+     "minzoom": 3,
+     "filter": [
+      "in",
+      "txt_typo",
+      "commune 1",
+      "BAT_COMMUNE_1",
+      "BAT_COMMUNE_1_T"
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "icon-image": "Localite",
+      "icon-size": 0.3,
+      "text-field": "{texte}",
+      "text-size": {
+       "stops": [
+      [
+       3,
+       10
+      ],
+      [
+       6,
+       20
+      ]
+       ]
+      },
+      "text-allow-overlap": false,
+      "text-anchor": "bottom-left",
+      "text-offset": [
+       0.25,
+       -0.1
+      ],
+      "text-padding": 1,
+      "text-transform": "uppercase",
+      "text-font": {
+       "stops": [
+      [
+       1,
+       [
+        "Open Sans Regular"
+       ]
+      ],
+      [
+       7,
+       [
+        "Open Sans Regular"
+       ]
+      ],
+      [
+       10,
+       [
+        "Open Sans Regular"
+       ]
+      ]
+       ]
+      }
+     },
+     "paint": {
+      "text-color": "#000000",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 4
+     }
+    },
+    {
+     "id": "toponyme localite n0 typoA1 commune",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_localite_ponc",
+     "maxzoom": 21,
+     "filter": [
+      "all",
+      [
+       "in",
+       "symbo",
+       "COMMUNE_FUSIONNEE",
+       "COMMUNE_CHEF_LIEU"
+      ],
+      [
+       "==",
+       "txt_typo",
+       "TYPO_A_1"
+      ]
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-size": 23,
+      "text-allow-overlap": true,
+      "text-anchor": "center",
+      "text-padding": 1,
+      "text-transform": "uppercase",
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#000000",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 4
+     }
+    },
+    {
+     "id": "toponyme - hydro ponc ocean",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_hydro_ponc",
+     "minzoom": 1,
+     "filter": [
+      "==",
+      "txt_typo",
+      "ocean"
+     ],
+     "layout": {
+      "visibility": "visible",
+      "symbol-placement": "point",
+      "text-field": "{texte}",
+      "text-size": {
+       "stops": [
+      [
+       1,
+       16
+      ],
+      [
+       6,
+       30
+      ]
+       ]
+      },
+      "text-allow-overlap": true,
+      "text-anchor": "center",
+      "text-padding": 10,
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#447FB3",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 4
+     }
+    },
+    {
+     "id": "toponyme pays 3",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_localite_ponc",
+     "minzoom": 4,
+     "maxzoom": 5,
+     "filter": [
+      "==",
+      "txt_typo",
+      "pays 3"
+     ],
+     "layout": {
+      "visibility": "visible",
+      "text-field": "{texte}",
+      "text-size": 9,
+      "text-allow-overlap": true,
+      "text-anchor": "center",
+      "text-padding": 1,
+      "text-transform": "uppercase",
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#787878",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 4
+     }
+    },
+    {
+     "id": "toponyme pays 2",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_localite_ponc",
+     "minzoom": 2,
+     "maxzoom": 5,
+     "filter": [
+      "==",
+      "txt_typo",
+      "pays 2"
+     ],
+     "layout": {
+      "visibility": "visible",
+      "text-field": "{texte}",
+      "text-size": 13,
+      "text-allow-overlap": true,
+      "text-anchor": "center",
+      "text-padding": 2,
+      "text-transform": "uppercase",
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#787878",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 4
+     }
+    },
+    {
+     "id": "toponyme pays 1",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_localite_ponc",
+     "minzoom": 2,
+     "maxzoom": 5,
+     "filter": [
+      "==",
+      "txt_typo",
+      "pays 1"
+     ],
+     "layout": {
+      "visibility": "visible",
+      "text-field": "{texte}",
+      "text-size": 13,
+      "text-allow-overlap": true,
+      "text-anchor": "center",
+      "text-padding": 2,
+      "text-transform": "uppercase",
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#787878",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 4
+     }
+    },
+    {
+     "id": "toponyme continent",
+     "type": "symbol",
+     "source": "plan_ign",
+     "source-layer": "toponyme_localite_ponc",
+     "maxzoom": 3,
+     "filter": [
+      "==",
+      "txt_typo",
+      "continent"
+     ],
+     "layout": {
+      "visibility": "visible",
+      "text-field": "{texte}",
+      "text-size": 15,
+      "text-allow-overlap": true,
+      "text-anchor": "center",
+      "text-padding": 1,
+      "text-transform": "uppercase",
+      "text-font": [
+       "Open Sans Regular"
+      ]
+     },
+     "paint": {
+      "text-color": "#787878",
+      "text-halo-color": "rgba(255, 255, 255, 0.5)",
+      "text-halo-width": 4
+     }
+    }
+     ]
+    }

--- a/components/map/styles/plan-ign.json
+++ b/components/map/styles/plan-ign.json
@@ -10,7 +10,7 @@
 		  "https://wxs.ign.fr/essentiels/geoportail/tms/1.0.0/PLAN.IGN/{z}/{x}/{y}.pbf"
 		],
 		"scheme": "xyz",
-		"attribution": "<a target='_blank' href='https://geoservices.ign.fr/'>© IGN</a>"
+		"attribution": "<a target='_blank' href='https://geoservices.ign.fr/documentation/donnees/cartes/planign'>© IGN</a>"
 	  },
 	  "cadastre": {
 		"type": "vector",
@@ -956,7 +956,7 @@
 		  "text-max-angle": 20,
 		  "text-max-width": 100,
 		  "text-font": [
-		   "Source Sans Pro Italic"
+		   "Open Sans Regular"
 		  ],
 		  "visibility": "visible"
 		 },
@@ -1014,7 +1014,7 @@
 		  "text-max-angle": 20,
 		  "text-max-width": 100,
 		  "text-font": [
-		   "Source Sans Pro Italic"
+		   "Open Sans Regular"
 		  ],
 		  "visibility": "visible"
 		 },
@@ -1072,7 +1072,7 @@
 		  "text-max-angle": 20,
 		  "text-max-width": 100,
 		  "text-font": [
-		   "Source Sans Pro Italic"
+		   "Open Sans Regular"
 		  ],
 		  "visibility": "visible"
 		 },
@@ -10028,7 +10028,7 @@
 		  ],
 		  "text-padding": 2,
 		  "text-font": [
-		   "Source Sans Pro Italic"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -10780,7 +10780,7 @@
 		   -1
 		  ],
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ],
 		  "visibility": "none"
 		 },
@@ -10821,7 +10821,7 @@
 		   -1.3
 		  ],
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ],
 		  "visibility": "none"
 		 },
@@ -10867,7 +10867,7 @@
 		   -1.4
 		  ],
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ],
 		  "visibility": "none"
 		 },
@@ -10911,7 +10911,7 @@
 		   -1.5
 		  ],
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ],
 		  "visibility": "none"
 		 },
@@ -10956,7 +10956,7 @@
 		   -1.6
 		  ],
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ],
 		  "visibility": "none"
 		 },
@@ -11002,7 +11002,7 @@
 		   1
 		  ],
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ],
 		  "visibility": "none"
 		 },
@@ -11043,7 +11043,7 @@
 		   1.3
 		  ],
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ],
 		  "visibility": "none"
 		 },
@@ -11089,7 +11089,7 @@
 		   1.4
 		  ],
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ],
 		  "visibility": "none"
 		 },
@@ -11133,7 +11133,7 @@
 		   1.5
 		  ],
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ],
 		  "visibility": "none"
 		 },
@@ -11178,7 +11178,7 @@
 		   1.6
 		  ],
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ],
 		  "visibility": "none"
 		 },
@@ -11210,7 +11210,7 @@
 		   "property": "rotation"
 		  },
 		  "text-font": [
-		   "Source Sans Pro Italic"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -11241,7 +11241,7 @@
 		   "property": "rotation"
 		  },
 		  "text-font": [
-		   "Source Sans Pro Italic"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -11272,7 +11272,7 @@
 		   "property": "rotation"
 		  },
 		  "text-font": [
-		   "Source Sans Pro Italic"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -11302,7 +11302,7 @@
 		  "text-max-angle": 45,
 		  "text-padding": 10,
 		  "text-font": [
-		   "Source Sans Pro Italic"
+		   "Open Sans Regular"
 		  ],
 		  "visibility": "visible"
 		 },
@@ -11344,7 +11344,7 @@
 		  "text-padding": 3,
 		  "text-anchor": "bottom-left",
 		  "text-font": [
-		   "Source Sans Pro"
+		   "Open Sans Regular"
 		  ],
 		  "icon-image": "Metro",
 		  "icon-size": {
@@ -11387,7 +11387,7 @@
 		   -1
 		  ],
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ],
 		  "visibility": "visible"
 		 },
@@ -11421,7 +11421,7 @@
 		  "text-allow-overlap": false,
 		  "text-padding": 1,
 		  "text-font": [
-		   "Source Sans Pro Italic"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -11447,7 +11447,7 @@
 		  "text-allow-overlap": false,
 		  "text-padding": 1,
 		  "text-font": [
-		   "Source Sans Pro Italic"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -11478,7 +11478,7 @@
 		  "text-allow-overlap": false,
 		  "text-padding": 1,
 		  "text-font": [
-		   "Source Sans Pro"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -11505,7 +11505,7 @@
 		  "text-allow-overlap": false,
 		  "text-padding": 1,
 		  "text-font": [
-		   "Source Sans Pro"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -11558,7 +11558,7 @@
 		  ],
 		  "text-padding": 3,
 		  "text-font": [
-		   "Source Sans Pro"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -11587,7 +11587,7 @@
 		  "text-allow-overlap": false,
 		  "text-padding": 1,
 		  "text-font": [
-		   "Source Sans Pro"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -11634,7 +11634,7 @@
 		  "text-allow-overlap": false,
 		  "text-padding": 1,
 		  "text-font": [
-		   "Source Sans Pro Italic"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -11668,7 +11668,7 @@
 		  "text-allow-overlap": false,
 		  "text-padding": 1,
 		  "text-font": [
-		   "Source Sans Pro"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -11702,7 +11702,7 @@
 		  "text-allow-overlap": false,
 		  "text-padding": 1,
 		  "text-font": [
-		   "Source Sans Pro"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -11751,7 +11751,7 @@
 		  "text-allow-overlap": false,
 		  "text-padding": 1,
 		  "text-font": [
-		   "Source Sans Pro"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -11785,7 +11785,7 @@
 		  "text-allow-overlap": false,
 		  "text-padding": 1,
 		  "text-font": [
-		   "Source Sans Pro"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -11819,7 +11819,7 @@
 		  "text-allow-overlap": false,
 		  "text-padding": 1,
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -11868,7 +11868,7 @@
 		  "text-allow-overlap": false,
 		  "text-padding": 1,
 		  "text-font": [
-		   "Source Sans Pro"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -11908,7 +11908,7 @@
 		  "text-allow-overlap": true,
 		  "text-padding": 5,
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -11935,7 +11935,7 @@
 		  "text-allow-overlap": true,
 		  "text-padding": 1,
 		  "text-font": [
-		   "Source Sans Pro Italic"
+		   "Open Sans Regular"
 		  ],
 		  "visibility": "visible"
 		 },
@@ -11964,7 +11964,7 @@
 		  "text-allow-overlap": false,
 		  "text-padding": 2,
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -11993,7 +11993,7 @@
 		  "text-allow-overlap": false,
 		  "text-padding": 2,
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -12023,7 +12023,7 @@
 		  "text-padding": 2,
 		  "text-anchor": "center",
 		  "text-font": [
-		   "Source Sans Pro Semibold"
+		   "Open Sans Regular"
 		  ],
 		  "text-rotation-alignment": "viewport"
 		 },
@@ -12054,7 +12054,7 @@
 		  "text-padding": 0,
 		  "text-anchor": "center",
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ],
 		  "icon-image": "Ecluse",
 		  "icon-rotation-alignment": "viewport",
@@ -12090,7 +12090,7 @@
 		  "text-padding": 0,
 		  "text-anchor": "center",
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ],
 		  "icon-image": "Ecluse",
 		  "icon-rotation-alignment": "viewport",
@@ -12119,7 +12119,7 @@
 		  "text-anchor": "center",
 		  "text-max-angle": 30,
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ],
 		  "visibility": "none"
 		 },
@@ -12142,7 +12142,7 @@
 		  "text-anchor": "center",
 		  "text-max-angle": 30,
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ],
 		  "visibility": "none"
 		 },
@@ -12179,7 +12179,7 @@
 		  "text-allow-overlap": false,
 		  "text-padding": 1,
 		  "text-font": [
-		   "Source Sans Pro Italic"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -12215,7 +12215,7 @@
 		  "text-allow-overlap": false,
 		  "text-padding": 1,
 		  "text-font": [
-		   "Source Sans Pro Italic"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -12244,7 +12244,7 @@
 		  "text-max-angle": 45,
 		  "text-padding": 1,
 		  "text-font": [
-		   "Source Sans Pro Italic"
+		   "Open Sans Regular"
 		  ],
 		  "visibility": "visible"
 		 },
@@ -12288,7 +12288,7 @@
 		  "text-allow-overlap": true,
 		  "text-padding": 1,
 		  "text-font": [
-		   "Source Sans Pro Italic"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -12332,7 +12332,7 @@
 		  "text-allow-overlap": true,
 		  "text-padding": 5,
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -12369,7 +12369,7 @@
 		  "text-allow-overlap": false,
 		  "text-padding": 1,
 		  "text-font": [
-		   "Source Sans Pro Italic"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -12406,7 +12406,7 @@
 		  "text-allow-overlap": false,
 		  "text-padding": 1,
 		  "text-font": [
-		   "Source Sans Pro Italic"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -12451,7 +12451,7 @@
 		  ],
 		  "text-padding": 1,
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -12490,7 +12490,7 @@
 		  "text-max-angle": 45,
 		  "text-padding": 1,
 		  "text-font": [
-		   "Source Sans Pro Italic"
+		   "Open Sans Regular"
 		  ],
 		  "visibility": "visible"
 		 },
@@ -12527,7 +12527,7 @@
 		  "text-allow-overlap": false,
 		  "text-padding": 1,
 		  "text-font": [
-		   "Source Sans Pro Italic"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -12563,7 +12563,7 @@
 		  "text-allow-overlap": false,
 		  "text-padding": 1,
 		  "text-font": [
-		   "Source Sans Pro Italic"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -12599,7 +12599,7 @@
 		  "text-allow-overlap": false,
 		  "text-padding": 1,
 		  "text-font": [
-		   "Source Sans Pro Italic"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -12638,7 +12638,7 @@
 		  "text-padding": 1,
 		  "text-anchor": "center",
 		  "text-font": [
-		   "Source Sans Pro Italic"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -12676,7 +12676,7 @@
 		  "text-max-angle": 45,
 		  "text-padding": 10,
 		  "text-font": [
-		   "Source Sans Pro Italic"
+		   "Open Sans Regular"
 		  ],
 		  "visibility": "visible"
 		 },
@@ -12727,7 +12727,7 @@
 		  "text-allow-overlap": true,
 		  "text-padding": 1,
 		  "text-font": [
-		   "Source Sans Pro Italic"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -12777,7 +12777,7 @@
 		  "text-max-angle": 45,
 		  "text-padding": 10,
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ],
 		  "visibility": "visible"
 		 },
@@ -12821,7 +12821,7 @@
 		  "text-max-angle": 45,
 		  "text-padding": 10,
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ],
 		  "visibility": "visible"
 		 },
@@ -12866,7 +12866,7 @@
 		  "text-allow-overlap": true,
 		  "text-padding": 10,
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -12895,7 +12895,7 @@
 		  "text-allow-overlap": false,
 		  "text-padding": 1,
 		  "text-font": [
-		   "Source Sans Pro Italic"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -12921,7 +12921,7 @@
 		  "text-allow-overlap": false,
 		  "text-padding": 1,
 		  "text-font": [
-		   "Source Sans Pro Italic"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -12956,7 +12956,7 @@
 		  ],
 		  "text-padding": 1,
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -12984,7 +12984,7 @@
 		  "text-allow-overlap": false,
 		  "text-padding": 5,
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -13013,7 +13013,7 @@
 		  "text-padding": 10,
 		  "text-transform": "uppercase",
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -13044,7 +13044,7 @@
 		  "text-padding": 10,
 		  "text-transform": "uppercase",
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -13083,7 +13083,7 @@
 		  "text-max-angle": 45,
 		  "text-padding": 1,
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ],
 		  "visibility": "visible"
 		 },
@@ -13123,7 +13123,7 @@
 		  "text-padding": 1,
 		  "text-anchor": "center",
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -13155,7 +13155,7 @@
 		  "text-padding": 10,
 		  "text-max-angle": 45,
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ],
 		  "visibility": "visible"
 		 },
@@ -13211,7 +13211,7 @@
 		  "text-allow-overlap": false,
 		  "text-padding": 1,
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -13240,7 +13240,7 @@
 		  "text-allow-overlap": false,
 		  "text-padding": 1,
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -13283,7 +13283,7 @@
 		  "text-max-angle": 45,
 		  "text-padding": 10,
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ],
 		  "visibility": "visible"
 		 },
@@ -13336,7 +13336,7 @@
 		  "text-allow-overlap": false,
 		  "text-padding": 10,
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -13384,7 +13384,7 @@
 		  ],
 		  "text-padding": 1,
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -13437,7 +13437,7 @@
 		  "text-anchor": "center",
 		  "text-padding": 1,
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -13490,7 +13490,7 @@
 		  "text-anchor": "center",
 		  "text-padding": 1,
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -13520,7 +13520,7 @@
 		  "text-padding": 5,
 		  "text-max-angle": 45,
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ],
 		  "visibility": "visible"
 		 },
@@ -13564,7 +13564,7 @@
 		  "text-allow-overlap": false,
 		  "text-padding": 1,
 		  "text-font": [
-		   "Source Sans Pro Italic"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -13606,7 +13606,7 @@
 		  "text-anchor": "center",
 		  "text-padding": 1,
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -13645,7 +13645,7 @@
 		  "text-padding": 1,
 		  "text-max-angle": 45,
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ],
 		  "visibility": "visible"
 		 },
@@ -13684,7 +13684,7 @@
 		  "text-allow-overlap": true,
 		  "text-padding": 1,
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -13718,7 +13718,7 @@
 		  "text-allow-overlap": true,
 		  "text-padding": 1,
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -13746,7 +13746,7 @@
 		  "text-keep-upright": true,
 		  "text-max-angle": 45,
 		  "text-font": [
-		   "Source Sans Pro Italic"
+		   "Open Sans Regular"
 		  ],
 		  "visibility": "visible"
 		 },
@@ -13781,7 +13781,7 @@
 		  "text-max-angle": 45,
 		  "text-padding": 10,
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ],
 		  "visibility": "visible"
 		 },
@@ -13810,7 +13810,7 @@
 		  "text-max-angle": 45,
 		  "text-padding": 10,
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ],
 		  "visibility": "visible"
 		 },
@@ -13858,7 +13858,7 @@
 		  "text-allow-overlap": true,
 		  "text-padding": 10,
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -13912,19 +13912,19 @@
 			[
 			 1,
 			 [
-			  "Source Sans Pro Regular"
+			  "Open Sans Regular"
 			 ]
 			],
 			[
 			 7,
 			 [
-			  "Source Sans Pro Bold"
+			  "Open Sans Regular"
 			 ]
 			],
 			[
 			 10,
 			 [
-			  "Source Sans Pro Regular"
+			  "Open Sans Regular"
 			 ]
 			]
 		   ]
@@ -13969,7 +13969,7 @@
 		  "text-anchor": "center",
 		  "text-padding": 1,
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -14011,7 +14011,7 @@
 		  "text-anchor": "center",
 		  "text-padding": 1,
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -14061,7 +14061,7 @@
 		  "text-padding": 1,
 		  "text-transform": "uppercase",
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -14111,7 +14111,7 @@
 		  "text-padding": 1,
 		  "text-transform": "uppercase",
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -14153,7 +14153,7 @@
 		  "text-anchor": "center",
 		  "text-padding": 1,
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -14192,7 +14192,7 @@
 		  "text-padding": 1,
 		  "text-transform": "uppercase",
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -14231,7 +14231,7 @@
 		  "text-padding": 1,
 		  "text-transform": "uppercase",
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -14270,7 +14270,7 @@
 		  "text-padding": 1,
 		  "text-transform": "uppercase",
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -14323,19 +14323,19 @@
 			[
 			 1,
 			 [
-			  "Source Sans Pro Regular"
+			  "Open Sans Regular"
 			 ]
 			],
 			[
 			 7,
 			 [
-			  "Source Sans Pro Bold"
+			  "Open Sans Regular"
 			 ]
 			],
 			[
 			 10,
 			 [
-			  "Source Sans Pro Regular"
+			  "Open Sans Regular"
 			 ]
 			]
 		   ]
@@ -14377,7 +14377,7 @@
 		  "text-padding": 1,
 		  "text-transform": "uppercase",
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -14417,7 +14417,7 @@
 		  "text-anchor": "center",
 		  "text-padding": 10,
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -14447,7 +14447,7 @@
 		  "text-padding": 1,
 		  "text-transform": "uppercase",
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -14477,7 +14477,7 @@
 		  "text-padding": 2,
 		  "text-transform": "uppercase",
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -14507,7 +14507,7 @@
 		  "text-padding": 2,
 		  "text-transform": "uppercase",
 		  "text-font": [
-		   "Source Sans Pro Regular"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {
@@ -14536,7 +14536,7 @@
 		  "text-padding": 1,
 		  "text-transform": "uppercase",
 		  "text-font": [
-		   "Source Sans Pro Bold"
+		   "Open Sans Regular"
 		  ]
 		 },
 		 "paint": {

--- a/components/map/styles/vector.json
+++ b/components/map/styles/vector.json
@@ -4,9 +4,12 @@
     "glyphs":"https://wxs.ign.fr/static/vectorTiles/fonts/{fontstack}/{range}.pbf",
 	"sprite": "https://wxs.ign.fr/static/vectorTiles/styles/PLAN.IGN/sprite/PlanIgn",
     "sources": {
-      "plan_ign": {
-        "type": "vector",
-        "url": "https://wxs.ign.fr/essentiels/geoportail/tms/1.0.0/PLAN.IGN/metadata.json/"
+		"plan_ign": {
+			"type": "vector",
+			"tiles": [
+			 "https://wxs.ign.fr/essentiels/geoportail/tms/1.0.0/PLAN.IGN/{z}/{x}/{y}.pbf"
+			],
+			"scheme": "xyz"
 		},
 		"cadastre": {
 			"type": "vector",
@@ -17,8561 +20,14865 @@
 			"url": "https://openmaptiles.geo.data.gouv.fr/data/decoupage-administratif.json"
 		  }
     },
-
 	"transition": {
-		"duration": 300,
-		"delay": 0
+	 "duration": 50,
+	 "delay": 0
 	},
 	"layers": [
-        {
-            "id": "bckgrd",
-             "type": "fill",
-             "source": "plan_ign",
-             "source-layer": "fond_opaque",
-             "minzoom": 0,
-             "layout": {
-                 "visibility": "visible"
-             },
-             "paint": {
-                 "fill-color": "#FFFFFF",
-                 "fill-opacity": 1
-             }
-        },
-        {
-			"id": "orographie : relief - 0m",
-			"type": "fill",
-			"source": "plan_ign",
-			"source-layer": "oro_relief",
-			"minzoom": 0,
-			"layout": {
-				"visibility": "visible"
-			},
-            "filter": ["==","symbo","HYPSO_0"],
-			"paint": {
-				"fill-color": "#D6E5BA",
-		        "fill-opacity": 1
-			}
-		},
-		{
-			"id": "orographie : relief - 100m",
-			"type": "fill",
-			"source": "plan_ign",
-			"source-layer": "oro_relief",
-			"minzoom": 0,
-			"layout": {
-				"visibility": "visible"
-			},
-            "filter": ["==","symbo","HYPSO_100"],
-			"paint": {
-				"fill-color": "#F7F2DA",
-		        "fill-opacity": 1
-			}
-		},
-		{
-			"id": "orographie : relief - 200m",
-			"type": "fill",
-			"source": "plan_ign",
-			"source-layer": "oro_relief",
-			"minzoom": 0,
-			"layout": {
-				"visibility": "visible"
-			},
-            "filter": ["==","symbo","HYPSO_200"],
-			"paint": {
-				"fill-color": "#EBDEBF",
-		        "fill-opacity": 1
-			}
-		},
-		{
-			"id": "orographie : relief - 1000m",
-			"type": "fill",
-			"source": "plan_ign",
-			"source-layer": "oro_relief",
-			"minzoom": 0,
-			"layout": {
-				"visibility": "visible"
-			},
-            "filter": ["==","symbo","HYPSO_1000"],
-			"paint": {
-				"fill-color": "#DABE97",
-		        "fill-opacity": 1
-			}
-		},
-		{
-			"id": "orographie : relief - 3000m",
-			"type": "fill",
-			"source": "plan_ign",
-			"source-layer": "oro_relief",
-			"minzoom": 0,
-			"layout": {
-				"visibility": "visible"
-			},
-            "filter": ["==","symbo","HYPSO_3000"],
-			"paint": {
-				"fill-color": "#B28773",
-		        "fill-opacity": 1
-			}
-		},
-		{
-			"id": "orographie : relief - 4000m",
-			"type": "fill",
-			"source": "plan_ign",
-			"source-layer": "oro_relief",
-			"minzoom": 0,
-			"layout": {
-				"visibility": "visible"
-			},
-            "filter": ["==","symbo","HYPSO_4000"],
-			"paint": {
-				"fill-color": "#9E6A54",
-		        "fill-opacity": 1
-			}
-		},
-		{
-			"id": "orographie : relief - 5000m",
-			"type": "fill",
-			"source": "plan_ign",
-			"source-layer": "oro_relief",
-			"minzoom": 0,
-			"layout": {
-				"visibility": "visible"
-			},
-            "filter": ["==","symbo","HYPSO_5000"],
-			"paint": {
-				"fill-color": "#773A2B",
-				"fill-opacity": 1
-			}
-		},
-		{
-			"id": "orographie : relief - glacier",
-			"type": "fill",
-			"source": "plan_ign",
-			"source-layer": "oro_relief",
-			"minzoom": 0,
-			"layout": {
-				"visibility": "visible"
-			},
-            "filter": ["==","symbo","GLACIER"],
-			"paint": {
-				"fill-color": "#FFFFFF",
-				"fill-opacity": 0.7
-			}
-		},
-        {
-            "id": "ocs - vegetation - zone boiséee, foret fermee, peupleraie",
-            "type": "fill",
-            "source": "plan_ign",
-            "source-layer": "ocs_vegetation_surf",
-            "layout": {
-                "visibility": "visible"
-            },
-            "filter": ["in","symbo",
-                                    "ZONE_BOISEE",
-                                    "ZONE_FORET_FERMEE_FEUIL",
-                                    "ZONE_FORET_FERMEE_CONI",
-                                    "ZONE_FORET_FERMEE_MIXTE",
-                                    "ZONE_PEUPLERAIE"
-            ],
-            "paint": {
-                "fill-color": "#DFE8D5",
-				"fill-outline-color": "#DFE8D5"
-            }
-        },
-        {
-            "id": "ocs - vegetation - forêt ouverte",
-            "type": "fill",
-            "source": "plan_ign",
-            "source-layer": "ocs_vegetation_surf",
-            "layout": {
-                "visibility": "visible"
-            },
-            "filter": ["in","symbo",
-									"ZONE_FORET_OUVERTE"
-            ],
-            "paint": {
-                "fill-color": "#EDF2D9",
-				"fill-outline-color": "#EDF2D9"
-            }
-        },
-        {
-            "id": "ocs - vegetation - lande ligneuse",
-            "type": "fill",
-            "source": "plan_ign",
-            "source-layer": "ocs_vegetation_surf",
-            "layout": {
-                "visibility": "visible"
-            },
-            "filter": ["==","symbo","ZONE_LANDE_LIGNEUSE"],
-            "paint": {
-                "fill-color": "#F2EECD"
-            }
-        },
-        {
-            "id": "ocs - vegetation - vigne",
-            "type": "fill",
-            "source": "plan_ign",
-            "source-layer": "ocs_vegetation_surf",
-            "layout": {
-                "visibility": "visible"
-            },
-            "filter": ["==","symbo","ZONE_VIGNE"],
-            "paint": {
-                "fill-color": "#FFEDD9"
-            }
-        },
-        {
-            "id": "ocs - vegetation - verger",
-            "type": "fill",
-            "source": "plan_ign",
-            "source-layer": "ocs_vegetation_surf",
-            "layout": {
-                "visibility": "visible"
-            },
-            "filter": ["==","symbo","ZONE_VERGER"],
-            "paint": {
-                "fill-color": "#FAE2C5"
-            }
-        },
-        {
-            "id": "ocs - vegetation - canne à sucre, bananeraie",
-            "type": "fill",
-            "source": "plan_ign",
-            "source-layer": "ocs_vegetation_surf",
-            "layout": {
-                "visibility": "visible"
-            },
-            "filter": ["==","symbo","ZONE_CANNE_BANANE"],
-            "paint": {
-                "fill-color": "#FAEDFA"
-            }
-        },
-        {
-			"id": "hydro surfacique - Estran",
-			"type": "fill",
-			"source": "plan_ign",
-			"source-layer": "hydro_surf",
-			"layout": {
-				"visibility": "visible"
-			},
-            "filter": ["==","symbo","ZONE_D_ESTRAN"],
-			"paint": {
-				"fill-color": "#C3DDE9",
-				"fill-outline-color": "#C3DDE9"
-			}
-		},
-        {
-            "id": "ocs - vegetation - mangrovre",
-            "type": "fill",
-            "source": "plan_ign",
-            "source-layer": "ocs_vegetation_surf",
-            "layout": {
-                "visibility": "visible"
-            },
-            "filter": ["==","symbo","ZONE_MANGROVE"],
-            "paint": {
-                "fill-color": {"stops": [[9, "#85CCCB"], [10, "#90CCCB"]]}
-            }
-        },
-        {
-            "id": "ocs - vegetation - marais",
-            "type": "fill",
-            "source": "plan_ign",
-            "source-layer": "ocs_vegetation_surf",
-            "layout": {
-                "visibility": "visible"
-            },
-            "filter": ["==","symbo","ZONE_MARAIS"],
-            "paint": {
-                "fill-pattern": "Marais"
-            }
-        },
-        {
-            "id": "ocs - vegetation - marais salant",
-            "type": "fill",
-            "source": "plan_ign",
-            "source-layer": "ocs_vegetation_surf",
-            "layout": {
-                "visibility": "visible"
-            },
-            "filter": ["==","symbo","ZONE_MARAIS_SALANT"],
-            "paint": {
-                "fill-pattern": "MaraisSalant"
-            }
-        },
-        {
-            "id": "ocs - Zone",
-            "type": "fill",
-            "source": "plan_ign",
-            "source-layer": "ocs_nature_sol_surf",
-            "layout": {
-                "visibility": "visible"
-            },
-            "filter": ["==","symbo","ZONE_ROCHEUSE"],
-            "paint": {
-                "fill-color": "#D0D0D0",
-				"fill-opacity": 0.3
-            }
-        },
-        {
-            "id": "ocs - Zone sable sec",
-            "type": "fill",
-            "source": "plan_ign",
-            "source-layer": "ocs_nature_sol_surf",
-            "layout": {
-                "visibility": "visible"
-            },
-            "filter": ["==","symbo","ZONE_SABLE_SEC"],
-            "paint": {
-				"fill-pattern": "Sable"
-            }
-        },
-        {
-            "id": "ocs - Zone sable humide",
-            "type": "fill",
-            "source": "plan_ign",
-            "source-layer": "ocs_nature_sol_surf",
-            "layout": {
-                "visibility": "visible"
-            },
-            "filter": ["in","symbo",
-                                    "ZONE_SABLE_HUMIDE",
-                                    "FOND_CUVETTE_HUMIDE"
-            ],
-            "paint": {
-				"fill-pattern": "SableHumide"
-            }
-        },
-        {
-            "id": "ocs - Zone graviers galets secs",
-            "type": "fill",
-            "source": "plan_ign",
-            "source-layer": "ocs_nature_sol_surf",
-            "layout": {
-                "visibility": "visible"
-            },
-            "filter": ["==","symbo","GRAVIERS_GALETS_SEC"],
-            "paint": {
-				"fill-pattern": "GravierSec"
-            }
-        },
-        {
-            "id": "ocs - Zone graviers galets humides",
-            "type": "fill",
-            "source": "plan_ign",
-            "source-layer": "ocs_nature_sol_surf",
-            "layout": {
-                "visibility": "visible"
-            },
-            "filter": ["==","symbo","GRAVIERS_GALETS_HUM"],
-            "paint": {
-				"fill-pattern": "Gravier"
-            }
-        },
-        {
-            "id": "ocs - Zone rocher hydro",
-            "type": "fill",
-            "source": "plan_ign",
-            "source-layer": "ocs_nature_sol_surf",
-            "layout": {
-                "visibility": "visible"
-            },
-            "filter": ["==","symbo","ZONE_ROCHER_HYDRO"],
-            "paint": {
-				"fill-pattern": "RocherHydro"
-            }
-        },
-        {
-            "id": "ocs - Zone glacier",
-            "type": "fill",
-            "source": "plan_ign",
-            "source-layer": "ocs_nature_sol_surf",
-            "layout": {
-                "visibility": "visible"
-            },
-            "filter": ["==","symbo","ZONE_GLACIER"],
-            "paint": {
-				"fill-pattern": "Glacier",
-				"fill-opacity": {"stops": [[10, 0.5], [12, 0.3]]}
-            }
-        },
-        {
-            "id": "zone batie",
-            "type": "fill",
-            "source": "plan_ign",
-            "source-layer": "bati_zone_surf",
-			"minzoom": 7,
-			"maxzoom": 15,
-            "layout": {
-                "visibility": "visible"
-            },
-            "filter": ["==","symbo","ZONE_BATI"],
-            "paint": {
-                "fill-color": "#E8E2D1",
-                "fill-opacity": {"stops": [[12, 1], [13, 0.9], [14, 0.5]]}
-            }
-        },
-        {
-            "id": "zone d'activité",
-            "type": "fill",
-            "source": "plan_ign",
-            "source-layer": "bati_zone_surf",
-            "layout": {
-                "visibility": "visible"
-            },
-            "filter": ["==","symbo","ZONE_INDUS_ACTI"],
-            "paint": {
-                "fill-color": "#D9D9D9"
-            }
-        },
-        {
-            "id": "oro - courbe et cuvette maitresse",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "oro_courbe",
-            "maxzoom":16,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "CNV_MAITRESSE",
-                                    "CUVETTE_MAITRESSE"
-            ],
-			"paint": {
-				"line-color": "#D9C8A9",
-                "line-width": {
-					"stops": [[13, 1.7], [15, 2]]
-				}
-			}
-        },
-        {
-            "id": "oro - courbe et cuvette normale",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "oro_courbe",
-            "maxzoom":16,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "CNV_NORMALE",
-                                    "CUVETTE_NORMALE"
-            ],
-			"paint": {
-				"line-color": "#D9C8A9",
-                "line-width": {
-					"stops": [[13, 1], [15, 1.2]]
-				}
-			}
-        },
-        {
-            "id": "oro - courbe et cuvette intercalaire",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "oro_courbe",
-            "maxzoom":16,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "CNV_INTERCALAIRE",
-                                    "CUVETTE_INTERCAL",
-                                    "CNV_SS_INTERCALAIRE"
-            ],
-			"paint": {
-				"line-color": "#D9C8A9",
-                "line-width": 0.7,
-				"line-dasharray": [20,7]
-			}
-        },
-        {
-            "id": "oro - courbe et cuvette glacier maitresse",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "oro_courbe",
-            "maxzoom":16,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "CNV_GLACIER_MAITRESSE",
-                                    "CUV_GLACIER_MAITRESSE"
-            ],
-			"paint": {
-				"line-color": "#A4BFD9",
-                "line-width": {
-					"stops": [[13, 1.7], [15, 2]]
-				}
-			}
-        },
-        {
-            "id": "oro - courbe et cuvette glacier normale",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "oro_courbe",
-            "maxzoom":16,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "CNV_GLACIER_NORMALE",
-                                    "CUV_GLACIER_NORMALE"
-            ],
-			"paint": {
-				"line-color": "#A4BFD9",
-                "line-width": {
-					"stops": [[13, 1], [15, 1.2]]
-				}
-			}
-        },
-        {
-            "id": "oro - courbe et cuvette glacier intercalaire",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "oro_courbe",
-            "maxzoom":16,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "CNV_GLACIER_INTERCAL",
-                                    "CUV_GLACIER_INTERCAL"
-            ],
-			"paint": {
-				"line-color": "#A4BFD9",
-                "line-width": {
-					"stops": [[13, 0.7], [15, 0.9]]
-				},
-				"line-dasharray": [20,7]
-			}
-        },
-        {
-            "id": "oro - courbe et cuvette rocher maitresse",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "oro_courbe",
-            "maxzoom":16,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "CNV_ROCHER_MAITRESSE",
-                                    "CUV_ROCHER_MAITRESSE"
-            ],
-			"paint": {
-				"line-color": "#AAAAAA",
-                "line-width": 1.7
-            }
-        },
-        {
-            "id": "oro - courbe et cuvette rocher normale",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "oro_courbe",
-            "maxzoom":16,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "CNV_ROCHER_NORMALE",
-                                    "CUV_ROCHER_NORMALE"
-            ],
-			"paint": {
-				"line-color": "#AAAAAA",
-                "line-width": 1
-			}
-        },
-        {
-            "id": "oro - courbe et cuvette rocher intercalaire",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "oro_courbe",
-            "maxzoom":16,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "CNV_ROCHER_INTERCAL",
-                                    "CUV_ROCHER_INTERCAL"
-            ],
-			"paint": {
-				"line-color": "#AAAAAA",
-                "line-width": {
-					"stops": [[13, 0.7], [15, 0.9]]
-				},
-				"line-dasharray": [20,7]
-			}
-        },
-        {
-            "id": "oro - courbe et cuvette bathymetrique",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "oro_courbe",
-            "maxzoom":16,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "CNV_BATHYMETRIQUE",
-                                    "CUV_BATHYMETRIQUE"
-            ],
-			"paint": {
-				"line-color": "#0000FF",
-                "line-width": 1
-			}
-        },
-        {
-            "id": "oro lin - talus",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "oro_lin",
-			"minzoom": 14,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","TALUS"],
-			"paint": {
-				"line-color": "#D9C8A9",
-                "line-width": 1
-			}
-        },
-        {
-            "id": "oro lin - talus - trait perpendiculaire",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "oro_lin",
-			"minzoom": 14,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","TALUS"],
-			"paint": {
-				"line-color": "#D9C8A9",
-		        "line-width": {
-					"stops": [[14, 7], [16, 9]]
-				},
-				"line-dasharray": [0.1,1],
-                "line-translate": [0,4]
-			}
-        },
-		{
-            "id": "toponyme - cote de courbe normale",
-            "type": "symbol",
-            "source": "plan_ign",
-            "source-layer": "oro_courbe",
-			"minzoom":13,
-            "maxzoom":16,
-            "layout": {
-                "symbol-placement": "line",
-                "text-field": "{texte}",
-                "text-size": {"stops": [[13, 10], [15, 13]]},
-                "text-anchor": "center",
-                "text-rotation-alignment":"map",
-                "text-pitch-alignment": "viewport",
-                "text-keep-upright": false,
-                "text-max-angle": 20,
-                "text-max-width": 100,
-                "text-font": ["Source Sans Pro Italic"]
-            },
-            "filter": ["all",
-                        ["!=","texte","0"],
-                        ["==","hors_zone","true"],
-                        ["in","symbo",
-                                    "CNV_MAITRESSE",
-                                    "CUVETTE_MAITRESSE"
-                        ]
-            ],
-            "paint": {
-                "text-color": "#604A2F",
-                "text-halo-width": 0.5,
-                "text-halo-color": "#FFFFFF"
-            }
-        },
-		{
-            "id": "toponyme - cote de courbe rocher",
-            "type": "symbol",
-            "source": "plan_ign",
-            "source-layer": "oro_courbe",
-			"minzoom":13,
-            "maxzoom":16,
-            "layout": {
-                "symbol-placement": "line",
-                "text-field": "{texte}",
-                "text-size": {"stops": [[13, 10], [15, 13]]},
-                "text-anchor": "center",
-                "text-rotation-alignment":"map",
-                "text-pitch-alignment": "viewport",
-                "text-keep-upright": false,
-                "text-max-angle": 20,
-                "text-max-width": 100,
-                "text-font": ["Source Sans Pro Italic"]
-            },
-            "filter": ["all",
-                        ["!=","texte","0"],
-                        ["==","hors_zone","true"],
-                        ["in","symbo",
-                                    "CNV_ROCHER_MAITRESSE",
-                                    "CUV_ROCHER_MAITRESSE"
-                        ]
-            ],
-            "paint": {
-                "text-color": "#333333",
-                "text-halo-width": 0.5,
-                "text-halo-color": "#FFFFFF"
-            }
-        },
-		{
-            "id": "toponyme - cote de courbe glacier",
-            "type": "symbol",
-            "source": "plan_ign",
-            "source-layer": "oro_courbe",
-			"minzoom":13,
-            "maxzoom":16,
-            "layout": {
-                "symbol-placement": "line",
-                "text-field": "{texte}",
-                "text-size": {"stops": [[13, 10], [15, 13]]},
-                "text-anchor": "center",
-                "text-rotation-alignment":"map",
-                "text-pitch-alignment": "viewport",
-                "text-keep-upright": false,
-                "text-max-angle": 20,
-                "text-max-width": 100,
-                "text-font": ["Source Sans Pro Italic"]
-            },
-            "filter": ["all",
-                        ["!=","texte","0"],
-                        ["==","hors_zone","true"],
-                        ["in","symbo",
-                                    "CNV_GLACIER_MAITRESSE",
-									"CUV_GLACIER_MAITRESSE"
-                        ]
-            ],
-            "paint": {
-                "text-color": "#629FD9",
-                "text-halo-width": 0.5,
-                "text-halo-color": "#FFFFFF"
-            }
-        },
-        {
-			"id": "hydro surfacique",
-			"type": "fill",
-			"source": "plan_ign",
-			"source-layer": "hydro_surf",
-			"layout": {
-				"visibility": "visible"
-			},
-            "filter": ["in","symbo",
-                                    "SURFACE_D_EAU",
-                                    "BASSIN",
-                                    "ZONE_MARINE"
-            ],
-			"paint": {
-				"fill-color": "#AAD5E9",
-				"fill-outline-color": "#AAD5E9"
-			}
-		},
-        {
-			"id": "hydro surfacique temporaire",
-			"type": "fill",
-			"source": "plan_ign",
-			"source-layer": "hydro_surf",
-			"layout": {
-				"visibility": "visible"
-			},
-            "filter": ["==","symbo","SURFACE_D_EAU_TEMP"],
-			"paint": {
-				"fill-color": "rgba(168, 203, 220, 0.5)"
-			}
-		},
-		{
-			"id": "réseau hydro  - cours d'eau souterrain",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "hydro_reseau_sou",
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-            },
-            "filter": ["in","symbo",
-									"COURS_D_EAU_SOU",
-									"COURS_D_EAU_MOY_SOU"
-			],
-			"paint": {
-				"line-color": "#AAD5E9",
-		        "line-width": {
-					"stops": [[12, 1.5], [17, 6.5]]
-                },
-                "line-dasharray": [2,2]	
-			}
-		},
-        {
-			"id": "réseau hydro - filet interieur - aqueduc souterrain",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "hydro_reseau_sou",
-			"minzoom": 12,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","AQUEDUC_SOU"],
-			"paint": {
-				"line-color": "#AAD5E9",
-		        "line-width": {
-					"stops": [[12, 1.4], [16, 3.5], [17, 5.9]]
-				},
-				"line-dasharray": [2,2]
-			}
-		},
-		{
-			"id": "réseau hydro - carre - aqueduc souterrain",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "hydro_reseau_sou",
-			"minzoom": 12,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","AQUEDUC_SOU"],
-			"paint": {
-				"line-color": "#AAD5E9",
-		        "line-width": {
-					"stops": [[12, 3.5], [16, 8.7], [17, 14.7]]
-				},
-				"line-dasharray": [1,5]
-			}
-		},
-        {
-			"id": "Ferre souterrain - voie normale",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "ferre_sou",
-            "minzoom": 10,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "VF_1_SOU",
-									"VF_2_SOU",
-                                    "VF_ELEC_1_SOU",
-                                    "VF_FERRO_ROUTIER_SOU"
-            ],
-			"paint": {
-				"line-color": "#B4B4B4",
-		        "line-width": {
-					"stops": [[10, 0.8], [17, 2.5]]
-				}
-			}
-		},
-        {
-			"id": "Ferre souterrain - trait perpendic épais",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "ferre_sou",
-			"minzoom": 10,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "VF_1_SOU",
-                                    "VF_2_SOU",
-                                    "VF_ELEC_1_SOU",
-                                    "VF_FERRO_ROUTIER_SOU"
-            ],
-			"paint": {
-				"line-color": "#B4B4B4",
-		        "line-width": {
-					"stops": [[10, 3.5], [17, 14.7]]
-				},
-				"line-dasharray": [0.1,10]
-			}
-		},
-        {
-			"id": "Ferre souterrain - voie etroite",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "ferre_sou",
-			"minzoom": 10,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "VF_ETROITE_1_SOU",
-									"VF_ETROITE_SOU"
-            ],
-			"paint": {
-				"line-color": "#B4B4B4",
-		        "line-width": {
-					"stops": [[10, 0.3], [17, 1.8]]
-				}
-			}
-		},
-        {
-			"id": "Ferre souterrain - trait perpendic fin",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "ferre_sou",
-			"minzoom": 10,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "VF_ETROITE_1_SOU",
-									"VF_ETROITE_SOU"
-            ],
-			"paint": {
-				"line-color": "#B4B4B4",
-		        "line-width": {
-					"stops": [[10, 3.5], [17, 14.7]]
-				},
-				"line-dasharray": [0.1,10]
-			}
-		},
-        {
-			"id": "Ferre souterrain - voie service",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "ferre_sou",
-			"minzoom": 14,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "VF_SERVICE_SOU",
-                                    "VF_NON_EXPLOITEE_SOU"
-            ],
-			"paint": {
-				"line-color": "#B4B4B4",
-		        "line-width": {
-					"stops": [[10, 0.3], [17, 1.8]]
-				},
-				"line-dasharray": [5,2,1,2]
-			}
-		},
-        {
-        	"id": "Ferre souterrain - funic/urbain",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "ferre_sou",
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "FUNI_CREMAILLERE_SOU",
-                                    "TRANSPORT_URBAIN_SOU"
-            ],
-			"paint": {
-				"line-color": "#B4B4B4",
-		        "line-width": {
-					"stops": [[10, 0.3], [17, 1.8]]
-				}
-			}
-		},
-        {
-			"id": "Ferre souterrain - 2 trait perpendic - funic/urbain",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "ferre_sou",
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "FUNI_CREMAILLERE_SOU",
-                                    "TRANSPORT_URBAIN_SOU"
-            ],
-			"paint": {
-				"line-color": "#B4B4B4",
-		        "line-width": {
-					"stops": [[10, 3.5], [17, 17]]
-				},
-				"line-dasharray": [0.1,0.2,0.1,10]
-			}
-		},
-        {
-			"id": "Chemin souterrain - piste cyclable",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_chemin_sou",
-			"minzoom": 13,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-			"filter": ["==","symbo","PISTE_CYCLABLE_SOU"],
-			"paint": {
-				"line-color": "#AB81CC",
-		        "line-width": {
-				"stops": [[14, 1.1], [15, 1.7], [16, 2], [17, 3.5]]
-                },
-				"line-dasharray": [6,2]
-			}
-		},
-        {
-			"id": "Chemin souterrain - filet exterieur - escalier",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_chemin_sou",
-			"minzoom": 14,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-			"filter": ["==","symbo","ESCALIER_SOU"],
-			"paint": {
-				"line-color": "#B3989A",
-		        "line-width": {
-				"stops": [[14, 1.75], [15, 3], [16, 4.2], [17, 9.5]]
-                }
-			}
-		},
-        {
-			"id": "Chemin souterrain - filet interieur - escalier",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_chemin_sou",
-			"minzoom": 14,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-			"filter": ["==","symbo","ESCALIER_SOU"],
-			"paint": {
-				"line-color": "#FFFFFF",
-		        "line-width": {
-				"stops": [[14, 1], [15, 1.9], [16, 2.7], [17, 5.8]]
-                },
-				"line-dasharray": [1,0.2]
-			}
-		},
-        {
-			"id": "Chemin souterrain - Rue pietonne",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_chemin_sou",
-			"minzoom": 14,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-			"filter": ["==","symbo","RUE_PIETONNE_SOU"],
-			"paint": {
-				"line-color": "#B3989A",
-		        "line-width": {
-				"stops": [[14, 1], [15, 1.2], [16, 1.4], [17, 2]]
-                },
-				"line-dasharray": [1,3]
-			}
-		},
-        {
-			"id": "Chemin souterrain - sentier",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_chemin_sou",
-			"minzoom": 13,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-			"filter": ["==","symbo","SENTIER_SOU"],
-			"paint": {
-				"line-color": "#B3989A",
-		        "line-width": {
-				"stops": [[14, 1], [15, 1.2], [16, 1.4], [17, 2]]
-                },
-				"line-dasharray": [4,3]
-			}
-		},
-        {
-			"id": "Chemin souterrain - chemin",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_chemin_sou",
-			"minzoom": 12,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-			"filter": ["==","symbo","CHEMIN_SOU"],
-			"paint": {
-				"line-color": "#B3989A",
-		        "line-width": {
-				"stops": [[14, 1], [15, 1.2], [16, 1.4], [17, 2]]
-                }
-			}
-		},
-        {
-			"id": "Routier souterrain - filet extérieur - route non revetu carrosable",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route_sou",
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-			"filter": ["==","symbo","NON_REVETUE_CARRO_SOU"],
-			"paint": {
-				"line-color": "#AFAFAF",
-		        "line-width": {
-				"stops": [[14, 3.2], [15, 5.4], [16, 7.7], [17, 16.8]]
-                },
-				"line-dasharray": [2,2]
-			}
-		},
-        {
-			"id": "Routier souterrain - filet extérieur - bretelle autoroute",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route_sou",
-			"minzoom": 12,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "BRET_AUTO_PEAGE_3_SOU",
-                                    "BRET_AUTO_PEAGE_2_SOU",
-                                    "BRET_AUTO_PEAGE_1_SOU",
-                                    "BRET_AUTO_LIBRE_3_SOU",
-                                    "BRET_AUTO_LIBRE_2_SOU",
-                                    "BRET_AUTO_LIBRE_1_SOU"
-            ],
-			"paint": {
-				"line-color": "rgba(222, 70, 14, 0.5)",
-				"line-width": {
-					"stops": [[12, 2.5], [14, 3.7], [15, 6.8], [16, 8.4], [17, 14]]
-                }
-			}
-		},
-        {
-			"id": "Routier souterrain - filet extérieur - route non classee restreint",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route_sou",
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","NON_CLASSEE_RESTREINT_SOU"],
-			"paint": {
-				"line-color": "#AFAFAF",
-		        "line-width": {
-				"stops": [[14, 3.2], [15, 5.4], [16, 7.7], [17, 16.8]]
-                }
-			}
-		},
-        {
-			"id": "Routier souterrain - filet extérieur - route non classee",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route_sou",
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "NON_CLASSEE_4_SOU",
-                                    "NON_CLASSEE_SOU"
-            ],
-			"paint": {
-				"line-color": "#AFAFAF",
-		        "line-width": {
-				"stops": [[14, 3.2], [15, 5.4], [16, 7.7], [17, 16.8]]
-                }
-			}
-		},
-        {
-			"id": "Routier souterrain - filet extérieur - route locale",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route_sou",
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "BRET_LOCALE_SOU",
-                                    "LOCALE_4_SOU",
-                                    "LOCALE_3_SOU",
-                                    "LOCALE_2_SOU",
-                                    "LOCALE_1_SOU"
-            ],
-			"paint": {
-				"line-color": "rgba(130, 130, 130, 0.5)",
-		        "line-width": {
-				"stops": [[9, 2], [14, 3.5], [15, 6], [16, 8.4], [17, 18.3]]
-                }
-			}
-		},
-        {
-			"id": "Routier souterrain - filet extérieur - route locale en construction",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route_sou",
-			"minzoom": 11,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","LOCALE_CONSTR_SOU"],
-			"paint": {
-				"line-color": "#C8C8C8",
-		        "line-width": {
-				"stops": [[9, 2], [14, 3.5], [15, 6], [16, 8.4], [17, 18.3]]
-                }
-			}
-		},
-        {
-			"id": "Routier souterrain - filet extérieur - route regionale",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route_sou",
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "BRET_REGIONALE_SOU",
-                                    "REGIONALE_4_SOU",
-                                    "REGIONALE_3_SOU",
-                                    "REGIONALE_2_SOU",
-                                    "REGIONALE_1_SOU"
-            ],
-			"paint": {
-				"line-color": "rgba(130, 130, 130, 0.5)",
-		        "line-width": {
-					"stops": [[6, 1.5], [9, 2.3], [14, 5], [15, 8.1], [16, 11.2], [17, 22]]
-                }					
-			}
-		},
-        {
-			"id": "Routier souterrain - filet extérieur - route regionale en construction",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route_sou",
-			"minzoom": 10,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","REGIONALE_CONSTR_SOU"],
-			"paint": {
-				"line-color": "#C8C8C8",
-		        "line-width": {
-					"stops": [[6, 1.5], [9, 2.3], [14, 5], [15, 8.1], [16, 11.2], [17, 22]]
-                }					
-			}
-		},
-        {
-			"id": "Routier souterrain - filet extérieur - route principale",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route_sou",
-			"minzoom": 7,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "BRET_PRINCIPALE_SOU",
-                                    "PRINCIPALE_4_SOU",
-                                    "PRINCIPALE_3_SOU",
-                                    "PRINCIPALE_2_SOU",
-                                    "PRINCIPALE_1_SOU"
-            ],
-			"paint": {
-				"line-color": "rgba(222, 70, 14, 0.5)",
-		        "line-width": {
-                    "stops": [[6, 1.8], [9, 2.7], [14, 5.9], [15, 9], [16, 12.2], [17, 22.5]]
-                }
-			}
-		},
-        {
-			"id": "Routier souterrain - filet extérieur - route principale en construction",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route_sou",
-			"minzoom": 10,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","PRINCIPALE_CONSTR_SOU"],
-			"paint": {
-				"line-color": "#C8C8C8",
-		        "line-width": {
-					"stops": [[6, 1.8], [9, 2.7], [14, 5.9], [15, 9], [16, 12.2], [17, 22.5]]
-                }
-			}
-		},
-        {
-			"id": "Routier souterrain - filet extérieur - autoroute",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route_sou",
-			"minzoom": 7,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "AUTOROU_PEAGE_SOU",
-                                    "AUTOROU_LIBRE_SOU"
-            ],
-			"paint": {
-				"line-color": "rgba(222, 70, 14, 0.5)",
-		        "line-width": {
-					"stops": [[6, 2.5], [9, 3.5], [14, 7.5], [15, 11], [16, 15], [17, 26]]
-                }
-			}
-		},
-        {
-			"id": "Routier souterrain - filet extérieur - autoroute en construction",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route_sou",
-			"minzoom": 10,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-			"filter": ["==","symbo","AUTOROU_CONSTR_SOU"],
-			"paint": {
-				"line-color": "#C8C8C8",
-		        "line-width": {
-					"stops": [[6, 2.5], [9, 3.5], [14, 7.5], [15, 11], [16, 15], [17, 26]]
-                }
-			}
-		},
-        {
-			"id": "Routier souterrain - filet interieur - route non revetu carrosable",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route_sou",
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-			"filter": ["==","symbo","NON_REVETUE_CARRO_SOU"],
-			"paint": {
-				"line-color": "#DCDCDC",
-		        "line-width": {
-				"stops": [[14, 2.3], [15, 4.1], [16, 6.3], [17, 13.5]]
-                }
-			}
-		},
-        {
-			"id": "Routier souterrain - filet interieur - bretelle autoroute",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route_sou",
-			"minzoom": 12,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "BRET_AUTO_PEAGE_3_SOU",
-                                    "BRET_AUTO_PEAGE_2_SOU",
-                                    "BRET_AUTO_PEAGE_1_SOU",
-                                    "BRET_AUTO_LIBRE_3_SOU",
-                                    "BRET_AUTO_LIBRE_2_SOU",
-                                    "BRET_AUTO_LIBRE_1_SOU"
-            ],
-			"paint": {
-				"line-color": "rgba(255, 255, 255, 0.5)",
-				"line-width": {
-					"stops": [[12, 1.5], [14, 2.6], [15, 5.2], [16, 6.7], [17, 10.8]]
-                }
-			}
-		},
-        {
-			"id": "Routier souterrain - filet interieur - route non classee restreint",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route_sou",
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","NON_CLASSEE_RESTREINT_SOU"],
-			"paint": {
-				"line-color": "#F2F5FF",
-		        "line-width": {
-				"stops": [[14, 2.3], [15, 4.1], [16, 6.3], [17, 13.5]]
-                }
-			}
-		},
-        {
-			"id": "Routier souterrain - filet interieur - route non classee",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route_sou",
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "NON_CLASSEE_4_SOU",
-                                    "NON_CLASSEE_SOU"
-            ],
-			"paint": {
-				"line-color": "#DCDCDC",
-		        "line-width": {
-				"stops": [[14, 2.3], [15, 4.1], [16, 6.3], [17, 13.5]]
-                }
-			}
-		},
-        {
-			"id": "Routier souterrain - filet interieur - route locale",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route_sou",
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "BRET_LOCALE_SOU",
-                                    "LOCALE_4_SOU",
-                                    "LOCALE_3_SOU",
-                                    "LOCALE_2_SOU",
-                                    "LOCALE_1_SOU"
-            ],
-			"paint": {
-				"line-color": "rgba(255, 255, 255, 0.5)",
-		        "line-width": {
-				"stops": [[9, 1.3], [14, 2.3], [15, 4.1], [16, 6.1], [17, 13.1]]
-                }
-			}
-		},
-        {
-			"id": "Routier souterrain - filet interieur - route locale en construction",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route_sou",
-			"minzoom": 11,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","LOCALE_CONSTR_SOU"],
-			"paint": {
-				"line-color": {
-                    "stops": [[12, "#FFFFFF"], [13, "#FCF4A8"], [17, "#FCF7C1"]]
-                },
-		        "line-width": {
-				"stops": [[9, 2], [14, 3.5], [15, 6], [16, 8.4], [17, 18.3]]
-                },
-				"line-dasharray": [2, 2]
-
-			}
-		},
-        {
-			"id": "Routier souterrain - filet interieur - route regionale",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route_sou",
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "BRET_REGIONALE_SOU",
-                                    "REGIONALE_4_SOU",
-                                    "REGIONALE_3_SOU",
-                                    "REGIONALE_2_SOU",
-                                    "REGIONALE_1_SOU"
-            ],
-			"paint": {
-				"line-color": "rgba(255, 255, 255, 0.5)",
-		        "line-width": {
-					"stops": [[6, 1.4], [9, 1.5], [14, 3.2], [15, 5.8], [16, 8.3], [17, 16.2]]
-                }
-			}
-		},
-        {
-			"id": "Routier souterrain - filet interieur - route regionale en construction",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route_sou",
-			"minzoom": 10,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","REGIONALE_CONSTR_SOU"],
-			"paint": {
-				"line-color": {
-                    "stops": [[9, "#FFFFFF"], [10, "#FDF28B"], [17, "#FCF6BD"]]
-                },
-		        "line-width": {
-					"stops": [[4, 0.4], [6, 1.5], [9, 2.3], [14, 5], [15, 8.1], [16, 11.2], [17, 22]]
-                },
-				"line-dasharray": [2,2]
-			}
-		},
-        {
-			"id": "Routier souterrain - filet interieur - route principale",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route_sou",
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "BRET_PRINCIPALE_SOU",
-                                    "PRINCIPALE_4_SOU",
-                                    "PRINCIPALE_3_SOU",
-                                    "PRINCIPALE_2_SOU",
-                                    "PRINCIPALE_1_SOU"
-            ],
-			"paint": {
-				"line-color": "rgba(255, 255, 255, 0.5)",
-		        "line-width": {
-					"stops": [[4, 0.5], [6, 1.8], [9, 2.1], [14, 4.4], [15, 7.3], [16, 10], [17, 18.5]]
-                }
-			}
-		},
-        {
-			"id": "Routier souterrain - filet interieur - route principale en construction",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route_sou",
-			"minzoom": 10,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-			"filter": ["==","symbo","PRINCIPALE_CONSTR_SOU"],
-			"paint": {
-				"line-color": {"stops": [[9, "#F3C66D"], [17, "#F2DDB3"]]},
-		        "line-width": {
-					"stops": [[4, 0.5], [6, 1.8], [9, 2.7], [14, 5.9], [15, 9], [16, 12.2], [17, 22.5]]
-                },
-				"line-dasharray": [2,2]
-			}
-		},
-        {
-			"id": "Routier souterrain - filet interieur - autoroute",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route_sou",
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "AUTOROU_PEAGE_SOU",
-                                    "AUTOROU_LIBRE_SOU"
-            ],
-			"paint": {
-				"line-color": "rgba(255, 255, 255, 0.5)",
-		        "line-width": {
-					"stops": [[4, 0.7], [6, 2.5], [9, 2.7], [14, 5.8], [15, 9], [16, 12], [17, 20.8]]
-                }
-			}
-		},
-        {
-			"id": "Routier souterrain - axe central - autoroute",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route_sou",
-			"minzoom": 13,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "AUTOROU_PEAGE_SOU",
-                                    "AUTOROU_LIBRE_SOU"
-            ],
-			"paint": {
-				"line-color": "#FFFFFF",
-		        "line-width": {
-					"stops": [[9, 0.6], [14, 0.7], [15, 1], [16, 1.2], [17, 2.1]]
-                }
-			}
-		},
-        {
-			"id": "Routier souterrain - filet interieur - autoroute en construction",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route_sou",
-			"minzoom": 10,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","AUTOROU_CONSTR_SOU"],
-			"paint": {
-				"line-color": {"stops": [[9, "#F2BA59"], [17, "#F2C261"]]},
-		        "line-width": {
-                    "stops": [[4, 0.7], [6, 2.5], [9, 3.5], [14, 7.5], [15, 11], [16, 15], [17, 26]]
-                },
-                "line-dasharray": [2,2]
-			}
-		},
-        {
-			"id": "Routier souterrain - axe central - autoroute en construction",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route_sou",
-			"minzoom": 13,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","AUTOROU_CONSTR_SOU"],
-			"paint": {
-				"line-color": "#808080",
-		        "line-width": {
-					"stops": [[9, 0.6], [14, 0.7], [15, 1], [16, 1.2], [17, 2.1]]
-                }
-			}
-		},
-        {
-			"id": "réseau hydro - cours d'eau temporaire",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "hydro_reseau",
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo","COURS_D_EAU_TEMP","COURS_D_EAU_TEMP_MOY"],
-			"paint": {
-				"line-color": "#AAD5E9",
-		        "line-width": {
-				"stops": [[12, 1.5], [17, 4]]
-                },
-                "line-dasharray": [6,2]
-			}
-		},
-        {
-			"id": "réseau hydro - cours d'eau",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "hydro_reseau",
-			"minzoom": 3,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","COURS_D_EAU"],
-			"paint": {
-				"line-color": "#AAD5E9",
-		        "line-width": {
-				"stops": [[4, 0.3], [7, 1.5], [12, 1.5], [17, 6.5]]
-                }
-			}
-		},
-		{
-        	"id": "réseau hydro - canal",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "hydro_reseau",
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","CANAL"],
-			"paint": {
-				"line-color": "#AAD5E9",
-		        "line-width": {
-				"stops": [[12, 1.4], [17, 5.9]]
-                }
-			}
-		},
-        {
-			"id": "réseau hydro - filet interieur - aqueduc",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "hydro_reseau",
-			"minzoom": 12,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","AQUEDUC_AU_SOL"],
-			"paint": {
-				"line-color": "#AAD5E9",
-		        "line-width": {
-				"stops": [[12, 1.4], [16, 3.5], [17, 5.9]]
-                }
-			}
-		},
-        {
-			"id": "réseau hydro - carre - aqueduc",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "hydro_reseau",
-			"minzoom": 12,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","AQUEDUC_AU_SOL"],
-			"paint": {
-				"line-color": "#AAD5E9",
-		        "line-width": {
-				"stops": [[12, 3.5], [16, 8.7], [17, 14.7]]
-                },
-			    "line-dasharray": [1,5]
-			}
-		},
-        {
-			"id": "réseau hydro - cours d'eau moyen ",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "hydro_reseau",
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-           "filter": ["==","symbo","COURS_D_EAU_MOY"],
-			"paint": {
-				"line-color": "#AAD5E9",
-		        "line-width": {
-				"stops": [[7, 2], [12, 2.5]]
-                }
-			}
-		},
-        {
-			"id": "réseau hydro - cours d'eau large ",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "hydro_reseau",
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","COURS_D_EAU_LAR"],
-			"paint": {
-				"line-color": "#AAD5E9",
-		        "line-width": {
-				"stops": [[7, 3], [11, 5]]
-                }
-			}
-		},
-		{
-			"id": "parcellaire - parcelle surface",
-			"type": "fill",
-			"source": "plan_ign",
-			"source-layer": "parcellaire_parcelle",
-			"layout": {
-				"visibility": "visible"
-			},
-            "filter": ["==","symbo","PARCELLE"],
-			"paint": {
-				"fill-color": "#FFFFD1",
-				"fill-opacity": 0.7
-			}
-		},
-		{
-			"id": "bati surfacique mairie - Zoom 14",
-			"type": "fill",
-			"source": "plan_ign",
-			"source-layer": "bati_surf",
-			"maxzoom": 14,
-			"layout": {
-				"visibility": "visible"
-			},
-			"filter": ["in","symbo",
-									"MAIRIE",
-									"MAIRIE_ANNEXE"
-			],
-			"paint": {
-				"fill-color": "#FFA6A6"
-			}
-		},
-		{
-			"id": "bati surfacique mairie - Zoom 15,16,17,18",
-			"type": "fill",
-			"source": "plan_ign",
-			"source-layer": "bati_surf",
-			"minzoom": 14,
-			"layout": {
-				"visibility": "visible"
-			},
-			"filter": ["in","symbo",
-									"MAIRIE",
-									"MAIRIE_ANNEXE"
-			],
-			"paint": {
-				"fill-color": {"stops": [[14, "#FFA6A6"], [15, "#FFAEAE"]]},
-				"fill-outline-color": "#FF7C7C"
-			}
-		},
-		{
-			"id": "bati surfacique fonctionnel industriel ou commercial - Zoom 14,15",
-			"type": "fill",
-			"source": "plan_ign",
-			"source-layer": "bati_surf",
-			"maxzoom": 15,
-			"layout": {
-				"visibility": "visible"
-			},
-            "filter": ["in","symbo",
-                                    "BATI_COMMERCIAL",
-                                    "BATI_INDUSTRIEL",
-                                    "HANGAR",
-                                    "HANGAR_COMMERCIAL",
-                                    "HANGAR_INDUSTRIEL"
-            ],
-			"paint": {
-				"fill-color": "#C8C8C8"
-			}
-		},
-		{
-			"id": "bati surfacique fonctionnel industriel ou commercial - Zoom 16,17,18",
-			"type": "fill",
-			"source": "plan_ign",
-			"source-layer": "bati_surf",
-			"minzoom": 15,
-			"layout": {
-				"visibility": "visible"
-			},
-            "filter": ["in","symbo",
-                                    "BATI_COMMERCIAL",
-                                    "BATI_INDUSTRIEL",
-                                    "HANGAR",
-                                    "HANGAR_COMMERCIAL",
-                                    "HANGAR_INDUSTRIEL"
-            ],
-			"paint": {
-				"fill-color": {
-                    "stops": [[15, "#D1D1D1"], [16, "#E6E6E6"]]
-                },
-				"fill-outline-color": "#B8B8B8"
-			}
-		},
-		{
-			"id": "bati surfacique fonctionnel public - Zoom 14,15",
-			"type": "fill",
-			"source": "plan_ign",
-			"source-layer": "bati_surf",
-			"maxzoom": 15,
-			"layout": {
-				"visibility": "visible"
-			},
-            "filter": ["in","symbo",
-                                   "BATI_PUBLIC",
-                                   "HANGAR_PUBLIC"
-            ],
-			"paint": {
-				"fill-color": "#B9B6D6"
-			}
-		},
-		{
-			"id": "bati surfacique fonctionnel public - Zoom 16,17,18",
-			"type": "fill",
-			"source": "plan_ign",
-			"source-layer": "bati_surf",
-			"minzoom": 15,
-			"layout": {
-				"visibility": "visible"
-			},
-            "filter": ["in","symbo",
-                                   "BATI_PUBLIC",
-                                   "HANGAR_PUBLIC"
-            ],
-			"paint": {
-				"fill-color": {
-                    "stops": [[15, "#CFC5DE"], [16, "#E4DAF3"]]
-                },
-				"fill-outline-color": "#A6A1D6"
-			}
-		},
-		{
-			"id": "bati surfacique fonctionnel sportif - bordure",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "bati_surf",
-			"minzoom": 15,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","BATI_SPORTIF"],
-			"paint": {
-				"line-color": "#BCD9AB",
-				"line-width": 4
-			}
-		},
-		{
-			"id": "bati surfacique fonctionnel sportif",
-			"type": "fill",
-			"source": "plan_ign",
-			"source-layer": "bati_surf",
-			"minzoom": 13,
-			"layout": {
-				"visibility": "visible"
-			},
-            "filter": ["==","symbo","BATI_SPORTIF"],
-			"paint": {
-				"fill-color": {
-                    "stops": [[14, "#C9E1DD"], [15, "#DCE6E4"]]
-                }
-			}
-		},
-		{
-			"id": "bati surfacique fonctionnel gare - Zoom 14,15",
-			"type": "fill",
-			"source": "plan_ign",
-			"source-layer": "bati_surf",
-			"maxzoom": 15,
-			"layout": {
-				"visibility": "visible"
-			},
-            "filter": ["==","symbo","BATI_GARE"],
-			"paint": {
-				"fill-color": "#B3B5F5"
-			}
-		},
-		{
-			"id": "bati surfacique fonctionnel gare - Zoom 16,17,18",
-			"type": "fill",
-			"source": "plan_ign",
-			"source-layer": "bati_surf",
-			"minzoom": 15,
-			"layout": {
-				"visibility": "visible"
-			},
-            "filter": ["==","symbo","BATI_GARE"],
-			"paint": {
-				"fill-color": {
-                    "stops": [[15, "#BFC1F5"], [16, "#CBCDF5"]]
-                },
-				"fill-outline-color": "#9B9EF6"
-			}
-		},
-		{
-			"id": "bati surfacique quelconque - Zoom 15",
-			"type": "fill",
-			"source": "plan_ign",
-			"source-layer": "bati_surf",
-			"minzoom": 14,
-			"maxzoom": 15,
-			"layout": {
-				"visibility": "visible"
-			},
-            "filter": ["==","symbo","BATI_QQUE"],
-			"paint": {
-				"fill-color": "#D6C6B8"
-			}
-		},
-		{
-			"id": "bati surfacique quelconque - Zoom 16,17,18",
-			"type": "fill",
-			"source": "plan_ign",
-			"source-layer": "bati_surf",
-			"minzoom": 15,
-			"layout": {
-				"visibility": "visible"
-			},
-            "filter": ["==","symbo","BATI_QQUE"],
-			"paint": {
-				"fill-color": {
-                    "stops": [[15, "#E6E0CF"], [16, "#F1EBD9"]]
-                },
-				"fill-outline-color": "#C3AA8E"
-			}
-		},
-		{
-			"id": "cimetiere surfacique 1",
-			"type": "fill",
-			"source": "plan_ign",
-			"source-layer": "bati_surf",
-			"layout": {
-				"visibility": "visible"
-			},
-            "filter": ["in","symbo",
-                                    "CIMETIERE_SURF",
-                                    "CIMETIERE_MILI_SURF",
-									"NECROPOLE_NATIONALE"
-            ],
-			"paint": {
-				"fill-color": "#F0F0F0",
-				"fill-opacity": 0.5,
-				"fill-outline-color": "#818181"
-			}
-		},
-		{
-			"id": "cimetiere surfacique 2",
-			"type": "fill",
-			"source": "plan_ign",
-			"source-layer": "bati_surf",
-			"layout": {
-				"visibility": "visible"
-			},
-            "filter": ["in","symbo",
-                                    "CIMETIERE_SURF",
-									"CIMETIERE_MILI_SURF",
-									"NECROPOLE_NATIONALE"
-            ],
-			"paint": {
-				"fill-pattern": "Cimetiere"
-			}
-		},
-		{
-			"id": "bati hydro surfacique - Autre",
-			"type": "fill",
-			"source": "plan_ign",
-			"source-layer": "bati_surf",
-			"layout": {
-				"visibility": "visible"
-			},
-            "filter": ["in","symbo",
-                                    "ECLUSE_SURF",
-                                    "RESERVOIR_EAU_SURF"
-            ],
-			"paint": {
-				"fill-color": "#ADCCD9",
-				"fill-outline-color": "#336699"
-			}
-		},
-		{
-			"id": "bati hydro surfacique - Pecherie",
-			"type": "fill",
-			"source": "plan_ign",
-			"source-layer": "bati_surf",
-			"layout": {
-				"visibility": "visible"
-			},
-            "filter": ["==","symbo","PECHERIE_SURF"],
-        	"paint": {
-				"fill-color": "#BFE2F0",
-				"fill-outline-color": "#509FEF"
-			}
-		},
-		{
-			"id": "bati hydro surfacique - Barrage",
-			"type": "fill",
-			"source": "plan_ign",
-			"source-layer": "bati_surf",
-			"layout": {
-				"visibility": "visible"
-			},
-            "filter": ["==","symbo","BARRAGE_SURF"],
-			"paint": {
-				"fill-color": "#FFFFFF",
-				"fill-outline-color": "#464646"
-			}
-		},
-		{
-			"id": "bati hydro surfacique - Chateau d'eau",
-			"type": "fill",
-			"source": "plan_ign",
-			"source-layer": "bati_surf",
-			"layout": {
-				"visibility": "visible"
-			},
-            "filter": ["==","symbo","CHATEAU_EAU_SURF"],
-			"paint": {
-				"fill-color": "#1466B2"
-			}
-		},
-        {
-			"id": "bati infra surfacique - Silo",
-			"type": "fill",
-			"source": "plan_ign",
-			"source-layer": "bati_surf",
-			"minzoom": 15,
-			"layout": {
-				"visibility": "visible"
-			},
-            "filter": ["==","symbo","SILO_SURF"],
-			"paint": {
-				"fill-color": "#C7A9AA",
-				"fill-outline-color": "#696969"
-			}
-		},
-		{
-			"id": "bati infra surfacique - Reservoir indus",
-			"type": "fill",
-			"source": "plan_ign",
-			"source-layer": "bati_surf",
-			"minzoom": 14,
-			"layout": {
-				"visibility": "visible"
-			},
-            "filter": ["==","symbo","RESERVOIR_INDUS_SURF"],
-			"paint": {
-				"fill-color": "#8D9DAA",
-				"fill-outline-color": "#464646"
-			}
-		},
-		{
-			"id": "bati infra surfacique - Serre",
-			"type": "fill",
-			"source": "plan_ign",
-			"source-layer": "bati_surf",
-			"minzoom": 13,
-			"layout": {
-				"visibility": "visible"
-			},
-            "filter": ["in","symbo","SERRE_SURF"],
-			"paint": {
-				"fill-color": "#CAD6D9",
-				"fill-outline-color": "#8C8C8C"
-			}
-		},
-		{
-			"id": "bati infra surfacique - poste electrique",
-			"type": "fill",
-			"source": "plan_ign",
-			"source-layer": "bati_surf",
-			"layout": {
-				"visibility": "visible"
-			},
-            "filter": ["in","symbo","POSTE_ELEC_SURF"],
-			"paint": {
-				"fill-color": "#7993B6",
-				"fill-opacity": 0.3
-			}
-		},
-		{
-			"id": "bati infra surfacique - poste electrique bord",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "bati_surf",
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","POSTE_ELEC_SURF"],
-			"paint": {
-				"line-color": "#000000",
-				"line-width": {"stops": [[12, 0.3], [17, 1.2]]}
-			}
-		},
-        {
-			"id": "bati religieux surfacique - Zoom 14",
-			"type": "fill",
-			"source": "plan_ign",
-			"source-layer": "bati_surf",
-			"maxzoom": 14,
-			"layout": {
-				"visibility": "visible"
-			},
-            "filter": ["in","symbo",
-									"CHAPELLE_SURF",
-									"EGLISE_SURF",
-									"CHRETIEN_SURF",
-                                    "SYNAGOGUE_SURF",
-                                    "MOSQUEE_SURF",
-                                    "AUTRE_CULTE_SURF"
-            ],
-			"paint": {
-				"fill-color": "#F7CBCB"
-			}
-		},
-		{
-			"id": "bati religieux surfacique - Zoom 15,16,17,18",
-			"type": "fill",
-			"source": "plan_ign",
-			"source-layer": "bati_surf",
-			"minzoom": 14,
-			"layout": {
-				"visibility": "visible"
-			},
-            "filter": ["in","symbo",
-									"CHAPELLE_SURF",
-									"EGLISE_SURF",
-									"CHRETIEN_SURF",
-                                    "SYNAGOGUE_SURF",
-                                    "MOSQUEE_SURF",
-                                    "AUTRE_CULTE_SURF"
-            ],
-			"paint": {
-				"fill-color": {"stops": [[14, "#F7CBCB"], [15, "#F7E1E1"]]},
-				"fill-outline-color": {"stops": [[14, "#F7A8A8"], [15, "#F7B7B7"]]}
-			}
-		},
-		{
-			"id": "bati remarquable surfacique",
-			"type": "fill",
-			"source": "plan_ign",
-			"source-layer": "bati_surf",
-			"minzoom": 13,
-			"layout": {
-				"visibility": "visible"
-			},
-            "filter": ["in","symbo",
-                                    "FORTIF_SURF",
-                                    "CHATEAU_SURF",
-                                    "TOUR_MOULIN_SURF",
-                                    "ARENE_THEATRE",
-                                    "ARC_TRIOMPHE_SURF",
-                                    "MONUMENT_SURF"
-            ],
-			"paint": {
-				"fill-color": "#9B9B9B",
-				"fill-outline-color": "#6E6E6E"
-			}
-		},
-		{
-			"id": "bati sportif surfacique fond",
-			"type": "fill",
-			"source": "plan_ign",
-			"source-layer": "bati_surf",
-			"layout": {
-				"visibility": "visible"
-			},
-            "filter": ["in","symbo",
-                                    "TENNIS_SURF",
-                                    "SPORT_INDIF_SURF",
-                                    "FOOT_SURF",
-									"MULTI_SPORT_SURF",
-                                    "PISTE_SPORT_SURF",
-                                    "NATATION_SURF"
-            ],
-			"paint": {
-				"fill-color": "#FFFFFF",
-				"fill-outline-color": "#FFFFFF"
-			}
-		},
-		{
-			"id": "bati sportif surfacique",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "bati_surf",
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "TENNIS_SURF",
-                                    "SPORT_INDIF_SURF",
-                                    "FOOT_SURF",
-									"MULTI_SPORT_SURF",
-                                    "PISTE_SPORT_SURF",
-                                    "NATATION_SURF"
-            ],
-			"paint": {
-				"line-color": "#BCD9AB",
-				"line-width": 2
-			}
-		},
-		{
-			"id": "bati transport surfacique - piste",
-			"type": "fill",
-			"source": "plan_ign",
-			"source-layer": "bati_surf",
-			"layout": {
-				"visibility": "visible"
-			},
-            "filter": ["in","symbo",
-                                    "PISTE_DUR",
-                                    "PISTE_HERBE"
-            ],
-			"paint": {
-                "fill-color": "#DBDBDB",
-                "fill-outline-color": "#808080"
-
-			}
-		},
-		{
-			"id": "bati ZAI - Autres",
-			"type": "fill",
-			"source": "plan_ign",
-			"source-layer": "bati_zai",
-            "minzoom":15,
-			"maxzoom": 18,   
-			"layout": {
-				"visibility": "visible"
-			},
-            "filter": ["in","nature",
-									"Lycée",
-									"Université",
-									"Capitainerie",
-									"Gendarmerie",
-									"Siège d'EPCI",
-									"Musée",
-									"Collège",
-									"Maison de retraite",
-									"Etablissement thermal",
-									"Autre service déconcentré de l'Etat",
-									"Etablissement pénitentiaire",
-									"Divers public ou administratif",
-									"Autre établissement d'enseignement",
-									"Maison du parc",
-									"Palais de justice",
-									"Enseignement primaire",
-									"Office de tourisme",
-									"Hôpital",
-									"Police",
-									"Piscine",
-									"Enseignement supérieur",
-									"Poste",
-									"Caserne",
-									"Etablissement hospitalier",
-									"Etablissement extraterritorial",
-									"Science",
-									"Structure d'accueil pour personnes handicapées",
-									"Administration centrale de l'Etat",
-									"Caserne de pompiers"
-            ],
-			"paint": {
-				"fill-color": "#E3BFE2",
-                "fill-opacity": 0.5,
-				"fill-outline-color": "#E39FE1"
-			}
-		},
-		{
-			"id": "bati ZAI - Commandement",
-			"type": "fill",
-			"source": "plan_ign",
-			"source-layer": "bati_zai",
-            "minzoom":15,
-			"layout": {
-				"visibility": "visible"
-			},
-            "filter": ["in","nature",
-                                    "Hôtel de département",
-									"Hôtel de région",
-									"Préfecture de région",
-									"Préfecture",
-									"Sous-préfecture"
-            ],
-			"paint": {
-				"fill-color": "#FF0000",
-                "fill-opacity": 0.3,
-				"fill-outline-color": "#B40000"
-			}
-		},
-        {
-			"id": "construction linéaire - mur",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "bati_lin",
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","MUR"],
-			"paint": {
-				"line-color": "#8C8C8C",
-		        "line-width": 0.3
-			}
-		},
-        {
-			"id": "construction linéaire - autre",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "bati_lin",
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "RUINE_LIN",
-                                    "MUR_SOUTENEMENT",
-                                    "FORTIF_LIN"
-            ],
-			"paint": {
-				"line-color": "#646464",
-		        "line-width": 0.5
-			}
-		},
-        {
-			"id": "construction hydrographique linéaire - Barrage",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "bati_lin",
-            "minzoom": 13,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","BARRAGE_LIN"],
-			"paint": {
-				"line-color": "#646464",
-		        "line-width": {"stops": [[13, 1.5], [17, 5]]}
-			}
-		},
-        {
-			"id": "construction hydrographique linéaire - Quai",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "bati_lin",
-            "minzoom": 12,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "QUAI",
-                                    "DIGUE"
-            ],
-			"paint": {
-				"line-color": "#828282",
-		        "line-width": {"stops": [[14, 1], [17, 2.5]]}
-			}
-		},
-      {
-			"id": "construction hydrographique linéaire - Pecherie",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "bati_lin",
-            "minzoom": 12,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","PECHERIE_LIN"],
-			"paint": {
-				"line-color": "#0066CC",
-		        "line-width": {"stops": [[14, 1], [17, 2.5]]}
-			}
-        },
-        {
-			"id": "Chemin a niveau - piste cyclable",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_chemin",
-			"minzoom": 13,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-			"filter": ["==","symbo","PISTE_CYCLABLE"],
-			"paint": {
-				"line-color": {"stops": [[17, "#9B5CCC"], [18, "#FFFFFF"]]},
-		        "line-width": {
-				"stops": [[14, 1.1], [15, 1.7], [16, 2], [17, 3.5], [18, 6]]
-                },
-				"line-dasharray": [6,2]
-			}
-		},
-        {
-        	"id": "Chemin a niveau - filet exterieur - escalier",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_chemin",
-			"minzoom": 14,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-			"filter": ["==","symbo","ESCALIER"],
-			"paint": {
-				"line-color": {"stops": [[17, "#8C7274"], [18, "#C8C8C8"]]},
-		        "line-width": {
-				"stops": [[14, 1.75], [15, 3], [16, 4.2], [17, 9.5]]
-                }
-			}
-		}, 		
-        {
-			"id": "Chemin a niveau - filet interieur - escalier",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_chemin",
-			"minzoom": 14,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-			"filter": ["==","symbo","ESCALIER"],
-			"paint": {
-				"line-color": "#FFFFFF",
-		        "line-width": {
-				"stops": [[14, 1], [15, 1.9], [16, 2.7], [17, 5.8]]
-                },
-				"line-dasharray": [1,0.2]
-			}
-		}, 		
-        {
-			"id": "Chemin a niveau - Rue pietonne",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_chemin",
-			"minzoom": 14,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-			"filter": ["==","symbo","RUE_PIETONNE"],
-			"paint": {
-				"line-color": {"stops": [[17, "#8C7274"], [18, "#F8E5D5"]]},
-		        "line-width": {
-				"stops": [[14, 1], [15, 1.2], [16, 1.4], [17, 2], [18, 5]]
-                },
-				"line-dasharray": [1,3]
-			}
-		},
-        {
-			"id": "Chemin a niveau - sentier",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_chemin",
-			"minzoom": 13,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-			"filter": ["==","symbo","SENTIER"],
-			"paint": {
-				"line-color": {"stops": [[17, "#8C7274"], [18, "#FFFFFF"]]},
-		        "line-width": {
-				"stops": [[14, 1], [15, 1.2], [16, 1.4], [17, 2], [18, 6]]
-                },
-				"line-dasharray": [4,3]
-			}
-		}, 		
-        {
-			"id": "Chemin a niveau - chemin",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_chemin",
-			"minzoom": 12,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-			"filter": ["==","symbo","CHEMIN"],
-			"paint": {
-				"line-color": {"stops": [[17, "#8C7274"], [18, "#FFFFFF"]]},
-		        "line-width": {
-				"stops": [[14, 1], [15, 1.2], [16, 1.4], [17, 2], [18, 7]]
-                }
-			}
-		},
-        {
-			"id": "Routier a niveau - filet extérieur - route non revetu carrosable",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route",
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-			"filter": ["==","symbo","NON_REVETUE_CARRO"],
-			"paint": {
-				"line-color": {"stops": [[12, "#646464"], [17, "#8C8C8C"]]},
-		        "line-width": {
-				"stops": [[14, 3.2], [15, 5.4], [16, 7.7], [17, 16.8]]
-                },
-				"line-dasharray": [2,2]
-			}
-		},
-        {
-			"id": "Routier a niveau - filet interieur - route non revetu carrosable",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route",
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-			"filter": ["==","symbo","NON_REVETUE_CARRO"],
-			"paint": {
-				"line-color": "#FFFFFF",
-		        "line-width": {
-				"stops": [[14, 2.3], [15, 4.1], [16, 6.3], [17, 13.5], [18, 16.8]]
-                }
-			}
-		},
-        {
-			"id": "Routier a niveau - filet extérieur - bretelle autoroute",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route",
-			"minzoom": 12,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "BRET_AUTO_PEAGE_3",
-                                    "BRET_AUTO_PEAGE_2",
-                                    "BRET_AUTO_PEAGE_1",
-                                    "BRET_AUTO_LIBRE_3",
-                                    "BRET_AUTO_LIBRE_2",
-                                    "BRET_AUTO_LIBRE_1"
-            ],
-			"paint": {
-				"line-color": {"stops": [[9, "#DE460E"], [17, "#F18800"], [18, "#FFFFFF"]]},
-				"line-width": {
-					"stops": [[12, 2.5], [14, 3.7], [15, 6.8], [16, 8.4], [17, 14]]
-                }
-			}
-		},
-        {
-			"id": "Routier a niveau - filet extérieur - route non classee restreint",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route",
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","NON_CLASSEE_RESTREINT"],
-			"paint": {
-				"line-color": {"stops": [[17, "#969696"], [18, "#FFFFFF"]]},
-		        "line-width": {
-				"stops": [[14, 3.2], [15, 5.4], [16, 7.7], [17, 16.8]]
-                }
-			}
-		},
-        {
-			"id": "Routier a niveau - filet extérieur - route non classee",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route",
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "NON_CLASSEE_4",
-                                    "NON_CLASSEE"
-            ],
-			"paint": {
-				"line-color": {"stops": [[17, "#969696"], [18, "#FFFFFF"]]},
-		        "line-width": {
-				"stops": [[14, 3.2], [15, 5.4], [16, 7.7], [17, 16.8]]
-                }
-			}
-		},
-        {
-			"id": "Routier a niveau - filet extérieur - route locale",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route",
-			"minzoom": 7,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "BRET_LOCALE",
-                                    "LOCALE_4",
-                                    "LOCALE_3",
-                                    "LOCALE_2",
-                                    "LOCALE_1"
-            ],
-			"paint": {
-				"line-color": {
-                    "stops": [[12, "#8C8C8C"], [13, "#B4B4B4"], [17, "#B4B4B4"], [18, "#FFFFFF"]]
-                },
-		        "line-width": {
-				"stops": [[9, 2], [14, 3.5], [15, 6], [16, 8.4], [17, 18.3]]
-                }
-			}
-		},
-        {
-			"id": "Routier a niveau - filet extérieur - route locale en construction",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route",
-			"minzoom": 11,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","LOCALE_CONSTR"],
-			"paint": {
-				"line-color": "#C8C8C8",
-		        "line-width": {
-				"stops": [[9, 2], [14, 3.5], [15, 6], [16, 8.4], [17, 18.3]]
-                }
-			}
-		},
-        {
-			"id": "Routier a niveau - filet extérieur - route regionale",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route",
-			"minzoom": 8,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "BRET_REGIONALE",
-                                    "REGIONALE_4",
-                                    "REGIONALE_3",
-                                    "REGIONALE_2",
-                                    "REGIONALE_1"
-            ],
-			"paint": {
-				"line-color": {
-                    "stops": [[9, "#828282"], [10, "#B4B4B4"], [17, "#B4B4B4"], [18, "#FFFFFF"]]
-                },
-		        "line-width": {
-					"stops": [[6, 1.5], [9, 2.3], [14, 5], [15, 8.1], [16, 11.2], [17, 22]]
-                }
-			}
-		},
-        {
-			"id": "Routier a niveau - filet extérieur - route regionale en construction",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route",
-			"minzoom": 10,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","REGIONALE_CONSTR"],
-			"paint": {
-				"line-color": "#C8C8C8",
-		        "line-width": {
-					"stops": [[6, 1.5], [9, 2.3], [14, 5], [15, 8.1], [16, 11.2], [17, 22]]
-                }
-			}
-		},
-        {
-			"id": "Routier a niveau - filet extérieur - route principale",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route",
-			"minzoom": 8,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "BRET_PRINCIPALE",
-                                    "PRINCIPALE_4",
-                                    "PRINCIPALE_3",
-                                    "PRINCIPALE_2",
-                                    "PRINCIPALE_1"
-            ],
-			"paint": {
-				"line-color": {"stops": [[17, "#E2A52A"], [18, "#FFFFFF"]]},
-		        "line-width": {
-					"stops": [[6, 1.8], [9, 2.7], [14, 5.9], [15, 9], [16, 12.2], [17, 22.5]]
-                }
-			}
-		},
-        {
-			"id": "Routier a niveau - filet extérieur - route principale en construction",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route",
-			"minzoom": 10,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","PRINCIPALE_CONSTR"],
-			"paint": {
-				"line-color": "#C8C8C8",
-		        "line-width": {
-					"stops": [[6, 1.8], [9, 2.7], [14, 5.9], [15, 9], [16, 12.2], [17, 22.5]]
-                }
-			}
-		},
-        {
-			"id": "Routier a niveau - filet extérieur - autoroute",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route",
-			"minzoom": 8,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "AUTOROU_PEAGE",
-                                    "AUTOROU_LIBRE"
-            ],
-			"paint": {
-				"line-color": {"stops": [[9, "#DE460E"], [17, "#F18800"], [18, "#FFFFFF"]]},
-		        "line-width": {
-					"stops": [[6, 2.5], [9, 3.5], [14, 7.5], [15, 11], [16, 15], [17, 26]]
-                }
-			}
-		},
-        {
-			"id": "Routier a niveau - filet extérieur - autoroute en construction",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route",
-			"minzoom": 8,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","AUTOROU_CONSTR"],
-			"paint": {
-				"line-color": "#C8C8C8",
-		        "line-width": {
-					"stops": [[6, 2.5], [9, 3.5], [14, 7.5], [15, 11], [16, 15], [17, 26]]
-                }
-			}
-		},
-        {
-			"id": "Routier a niveau - filet interieur - bretelle autoroute",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route",
-			"minzoom": 12,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "BRET_AUTO_PEAGE_3",
-                                    "BRET_AUTO_PEAGE_2",
-                                    "BRET_AUTO_PEAGE_1",
-                                    "BRET_AUTO_LIBRE_3",
-                                    "BRET_AUTO_LIBRE_2",
-                                    "BRET_AUTO_LIBRE_1"
-            ],
-			"paint": {
-				"line-color": {"stops": [[9, "#F18800"], [17, "#F2B230"]]},
-				"line-width": {
-					"stops": [[12, 1.5], [14, 2.6], [15, 5.2], [16, 6.7], [17, 10.8]]
-                }
-			}
-		},
-        {
-			"id": "Routier a niveau - filet interieur - route non classee restreint",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route",
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","NON_CLASSEE_RESTREINT"],
-			"paint": {
-				"line-color": "#EDF1FF",
-		        "line-width": {
-				"stops": [[14, 2.3], [15, 4.1], [16, 6.3], [17, 13.5]]
-                }
-			}
-		},
-        {
-			"id": "Routier a niveau - filet interieur - route non classee",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route",
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "NON_CLASSEE_4",
-                                    "NON_CLASSEE"
-            ],
-			"paint": {
-				"line-color": "#FFFFFF",
-		        "line-width": {
-				"stops": [[14, 2.3], [15, 4.1], [16, 6.3], [17, 13.5]]
-                }
-			}
-		},
-        {
-			"id": "Routier a niveau - filet interieur - route locale",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route",
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "BRET_LOCALE",
-                                    "LOCALE_4",
-                                    "LOCALE_3",
-                                    "LOCALE_2",
-                                    "LOCALE_1"
-            ],
-			"paint": {
-				"line-color": {
-                    "stops": [[6, "#F2B361"],[7, "#FFFFFF"], [12, "#FFFFFF"], [13, "#FCF4A8"], [17, "#FCF7C1"]]
-                },
-		        "line-width": {
-				"stops": [[9, 1.3], [14, 2.3], [15, 4.1], [16, 6.1], [17, 13.1]]
-                }
-			}
-		},
-        {
-			"id": "Routier a niveau - filet interieur - route locale en construction",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route",
-			"minzoom": 11,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","LOCALE_CONSTR"],
-			"paint": {
-				"line-color": {
-                    "stops": [[12, "#FFFFFF"], [13, "#FCF4A8"], [17, "#FCF7C1"], [18, "#EDEDED"]]
-                },
-		        "line-width": {
-				"stops": [[9, 2], [14, 3.5], [15, 6], [16, 8.4], [17, 18.3]]
-                },
-				"line-dasharray": [2, 2]
-			}
-		},
-        {
-			"id": "Routier a niveau - filet interieur - route regionale",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route",
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "BRET_REGIONALE",
-                                    "REGIONALE_4",
-                                    "REGIONALE_3",
-                                    "REGIONALE_2",
-                                    "REGIONALE_1"
-            ],
-			"paint": {
-				"line-color": {
-                    "stops": [[6, "#F2A949"], [7, "#FFFFFF"], [9, "#FFFFFF"], [10, "#FDF28B"], [17, "#FCF6BD"]]
-                },
-		        "line-width": {
-					"stops": [[4, 1.1], [6, 1.4], [9, 1.5], [14, 3.2], [15, 5.8], [16, 8.3], [17, 16.2]]
-                }
-			}
-		},
-        {
-			"id": "Routier a niveau - filet interieur - route regionale en construction",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route",
-			"minzoom": 10,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","REGIONALE_CONSTR"],
-			"paint": {
-				"line-color": {
-                    "stops": [[9, "#FFFFFF"], [10, "#FDF28B"], [17, "#FCF6BD"], [18, "#EDEDED"]]
-                },
-		        "line-width": {
-					"stops": [[4, 0.4], [6, 1.5], [9, 2.3], [14, 5], [15, 8.1], [16, 11.2], [17, 22]]
-                },
-				"line-dasharray": [2,2]
-			}
-		},
-        {
-			"id": "Routier a niveau - filet interieur - route principale",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route",
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "BRET_PRINCIPALE",
-                                    "PRINCIPALE_4",
-                                    "PRINCIPALE_3",
-                                    "PRINCIPALE_2",
-                                    "PRINCIPALE_1"
-            ],
-			"paint": {
-				"line-color": {"stops": [[6, "#F29924"], [7, "#F3C66D"], [9, "#F3C66D"], [17, "#F2DDB3"]]},
-		        "line-width": {
-					"stops": [[4, 0.6], [6, 1.8], [9, 2.1], [14, 4.4], [15, 7.3], [16, 10], [17, 18.5]]
-                }
-			}
-		},
-        {
-			"id": "Routier a niveau - filet interieur - route principale en construction",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route",
-			"minzoom": 10,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-			"filter": ["==","symbo","PRINCIPALE_CONSTR"],
-			"paint": {
-				"line-color": {"stops": [[9, "#F3C66D"], [17, "#F2DDB3"], [18, "#EDEDED"]]},
-		        "line-width": {
-					"stops": [[4, 0.5], [6, 1.8], [9, 2.7], [14, 5.9], [15, 9], [16, 12.2], [17, 22.5]]
-                },
-				"line-dasharray": [2,2]
-			}
-		},
-        {
-			"id": "Routier a niveau - filet interieur - autoroute",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route",
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "AUTOROU_PEAGE",
-                                    "AUTOROU_LIBRE"
-            ],
-			"paint": {
-				"line-color": {"stops": [[9, "#F18800"], [17, "#F2B230"]]},
-		        "line-width": {
-					"stops": [[4, 0.7], [6, 2.5], [9, 2.7], [14, 5.8], [15, 9], [16, 12], [17, 20.8]]
-                }
-			}
-		},
-        {
-			"id": "Routier a niveau - axe central - autoroute",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route",
-			"minzoom": 13,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "AUTOROU_PEAGE",
-                                    "AUTOROU_LIBRE"
-            ],
-			"paint": {
-				"line-color": "#FFFFFF",
-		        "line-width": {
-					"stops": [[9, 0.6], [14, 0.7], [15, 1], [16, 1.2], [17, 2.1]]
-                }
-			}
-		},
-        {
-			"id": "Routier a niveau - filet interieur - autoroute en construction",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route",
-			"minzoom": 8,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","AUTOROU_CONSTR"],
-			"paint": {
-				"line-color": {"stops": [[9, "#F18800"], [17, "#F2B230"], [18, "#EDEDED"]]},
-		        "line-width": {
-					"stops": [[4, 0.7], [6, 2.5], [9, 3.5], [14, 7.5], [15, 11], [16, 15], [17, 26]]
-                },
-                "line-dasharray": [2,2]
-			}
-		},
-        {
-			"id": "Routier a niveau - axe centrale - autoroute en construction",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route",
-			"minzoom": 13,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","AUTOROU_CONSTR"],
-			"paint": {
-				"line-color": "#808080",
-		        "line-width": {
-					"stops": [[9, 0.6], [14, 0.7], [15, 1], [16, 1.2], [17, 2.1]]
-                }
-			}
-		},
-        {
-			"id": "Ferre a niveau - voie normale",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "ferre",
-			"minzoom": 10,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "VF_1",
-                                    "VF_2",
-                                    "VF_3",
-                                    "VF_4",
-                                    "VF_ELEC_1",
-                                    "VF_ELEC_2",
-                                    "VF_ELEC_3",
-                                    "VF_ELEC_4"
-            ],
-			"paint": {
-				"line-color": "#787878",
-		        "line-width": {
-					"stops": [[10, 0.8], [17, 2.5]]
-				}
-			}
-		},
-        {
-			"id": "Ferre a niveau - voie normale trait perpendic",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "ferre",
-			"minzoom": 10,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "VF_1",
-                                    "VF_2",
-                                    "VF_3",
-                                    "VF_4",
-                                    "VF_ELEC_1",
-                                    "VF_ELEC_2",
-                                    "VF_ELEC_3",
-                                    "VF_ELEC_4"
-            ],
-			"paint": {
-				"line-color": "#787878",
-		        "line-width": {
-					"stops": [[10, 3.5], [17, 14.7]]
-				},
-				"line-dasharray": [0.1,10]
-			}
-		},
-        {
-			"id": "Ferre a niveau - voie etroite",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "ferre",
-			"minzoom": 10,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "VF_ETROITE_1",
-                                    "VF_ETROITE_2",
-									"VF_ETROITE"
-            ],
-			"paint": {
-				"line-color": "#787878",
-		        "line-width": {
-					"stops": [[10, 0.3], [17, 1.8]]
-				}
-			}
-		},
-        {
-			"id": "Ferre a niveau - voie etroite trait perpendic",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "ferre",
-			"minzoom": 10,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "VF_ETROITE_1",
-                                    "VF_ETROITE_2",
-									"VF_ETROITE"
-            ],
-			"paint": {
-				"line-color": "#787878",
-		        "line-width": {
-					"stops": [[10, 3.5], [17, 14.7]]
-				},
-				"line-dasharray": [0.1,10]
-			}
-		},
-        {
-			"id": "Ferre a niveau - voie service",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "ferre",
-			"minzoom": 14,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "VF_SERVICE",
-                                    "VF_NON_EXPLOITEE"
-            ],
-			"paint": {
-				"line-color": "#787878",
-		        "line-width": {
-					"stops": [[10, 0.3], [17, 1.8]]
-				},
-				"line-dasharray": [5,2,1,2]
-			}
-		},
-        {
-			"id": "Ferre a niveau - voie en construction",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "ferre",
-			"minzoom": 10,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","VF_EN_CONSTR"],
-			"paint": {
-				"line-color": "#787878",
-		        "line-width": {
-					"stops": [[10, 0.3], [17, 1.8]]
-				},
-                "line-dasharray": [2,2]
-			}
-		},
-       {
-			"id": "Ferre a niveau - voie en construction trait perpendic",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "ferre",
-			"minzoom": 10,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","VF_EN_CONSTR"],
-			"paint": {
-				"line-color": "#787878",
-		        "line-width": {
-					"stops": [[10, 3.5], [17, 14.7]]
-				},
-				"line-dasharray": [0.1,10]
-			}
-		},
-        {
-			"id": "Ferre a niveau - funic/urbain",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "ferre",
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "FUNI_CREMAILLERE",
-                                    "TRANSPORT_URBAIN"
-            ],
-			"paint": {
-				"line-color": "#787878",
-		        "line-width": {
-					"stops": [[10, 0.3], [17, 1.8]]
-				}
-			}
-		},
-         {
-			"id": "Ferre a niveau - 2 trait perpendic - funic/urbain",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "ferre",
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "FUNI_CREMAILLERE",
-                                    "TRANSPORT_URBAIN"
-            ],
-			"paint": {
-				"line-color": "#787878",
-		        "line-width": {
-					"stops": [[10, 3.5], [17, 17]]
-				},
-				"line-dasharray": [0.1,0.2,0.1,10]
-			}
-		},
-        {
-			"id": "liaison routiere - Bac Liaison Maritime",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_liaison",
-			"minzoom": 8,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-									"BAC_AUTO",
-									"LIAISON_MARITIME",
-									"BAC_LIAISON_MARITIME"
-			],
-			"paint": {
-				"line-color": "#5792C2",
-		        "line-width": {
-					"stops": [[8, 1], [13, 2.5]]
-                }					
-			}
-		},
-        {
-			"id": "liaison routiere - Gue route",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_liaison",
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","GUE_ROUTE"],
-			"paint": {
-				"line-color": {
-                    "stops": [[13, "#BEBEBE"], [17, "#646464"], [18, "#FFFFFF"]]
-                },
-		        "line-width": {
-				"stops": [[14, 2.3], [15, 4.1], [16, 6.3], [17, 13.5]]
-                }
-			}
-		},
-        {
-			"id": "liaison routiere - Gue chemin",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_liaison",
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","GUE_CHEMIN"],
-			"paint": {
-				"line-color": {
-                    "stops": [[13, "#BEBEBE"], [17, "#646464"]]
-                },
-		        "line-width": {
-				"stops": [[14, 1.6], [15, 2.9], [16, 4.4], [17, 6.5]]
-                }
-			}
-		},
-        {
-			"id": "liaison routiere - filet extérieur - Pont passerelle",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_liaison",
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "PONT_PASSERELLE",
-                                    "PONT_LIN",
-                                    "PONT_MOBILE_LIN"
-            ],
-			"paint": {
-				"line-color": {"stops": [[17, "#C8C8C8"], [18, "#FFFFFF"]]},
-		        "line-width": {
-				"stops": [[14, 2.2], [15, 3.8], [16, 5.4], [17, 11.8]]
-                }
-			}
-		},
-        {
-			"id": "liaison routiere - filet intérieur - Pont passerelle",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_liaison",
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "PONT_PASSERELLE",
-                                    "PONT_LIN",
-                                    "PONT_MOBILE_LIN"
-            ],
-			"paint": {
-				"line-color": "#FFFFFF",
-		        "line-width": {
-				"stops": [[14, 0.7], [15, 1.1], [16, 1.7], [17, 3.8]]
-                }
-			}
-		},
-        {
-			"id": "Routier surfacique",
-			"type": "fill",
-			"source": "plan_ign",
-			"source-layer": "routier_surf",
-			"layout": {
-				"visibility": "visible"
-			},
-            "filter": ["in","symbo",
-                                    "SURF_ROUT_PRINC",
-                                    "SURF_ROUT_REG",
-                                    "SURF_ROUT_LOC",
-                                    "SURF_ROUT_NON_CLA"],
-			"paint": {
-				"fill-color": "#FFFFFF",
-                "fill-outline-color": "#000000"
-			}
-		},
-        {
-			"id": "Routier surfacique - Dalle de protection",
-			"type": "fill",
-			"source": "plan_ign",
-			"source-layer": "routier_surf",
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible"
-			},
-            "filter": ["==","symbo","DALLE_DE_PROTECTION"],
-			"paint": {
-				"fill-opacity": 0.5,
-				"fill-color": "#FFFFFF",
-                "fill-outline-color": "#000000"
-			}
-		},
-        {
-			"id": "Routier surfacique - Escalier surfacique",
-			"type": "fill",
-			"source": "plan_ign",
-			"source-layer": "routier_surf",
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible"
-			},
-            "filter": ["==","symbo","ESCALIER_SURF"],
-			"paint": {
-				"fill-opacity": 0.8,
-				"fill-color": "#FFFFFF",
-                "fill-outline-color": "#918091"
-			}
-		},
-        {
-			"id": "Routier surfacique - Péage surfacique",
-			"type": "fill",
-			"source": "plan_ign",
-			"source-layer": "routier_surf",
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible"
-			},
-            "filter": ["==","symbo","SURF_PEAGE"],
-			"paint": {
-				"fill-color": "#F2DAAA",
-                "fill-outline-color": "#E2A52A"
-			}
-		},
-		{
-			"id": "bati transport surfacique - bati peage",
-			"type": "fill",
-			"source": "plan_ign",
-			"source-layer": "bati_surf",
-			"minzoom": 13,
-			"layout": {
-				"visibility": "visible"
-			},
-            "filter": ["==","symbo","BATI_PEAGE"],
-			"paint": {
-                "fill-color": "#DCDCDC",
-                "fill-outline-color": "#808080"
-
-			}
-		},
-		{
-			"id": "réseau hydro  - cours d'eau superieur",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "hydro_reseau_sup",
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-									"COURS_D_EAU_SUP",
-									"COURS_D_EAU_MOY_SUP"
-			],
-			"paint": {
-				"line-color": "#AAD5E9",
-		        "line-width": {
-					"stops": [[12, 1.5], [17, 6.5]]
-                }
-			}
-		},
-        {
-			"id": "réseau hydro - canal superieur",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "hydro_reseau_sup",
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","CANAL_SUP"],
-			"paint": {
-				"line-color": "#AAD5E9",
-		        "line-width": {
-				"stops": [[12, 1.4], [17, 5.9]]
-                }
-			}
-		},
-        {
-			"id": "réseau hydro - filet interieur - aqueduc superieur",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "hydro_reseau_sup",
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","AQUEDUC_SUP"],
-			"paint": {
-				"line-color": "#AAD5E9",
-		        "line-width": {
-				"stops": [[12, 1.4], [16, 3.5], [17, 5.9]]
-                }
-			}
-		},
-        {
-			"id": "réseau hydro - carre - aqueduc superieur",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "hydro_reseau_sup",
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","AQUEDUC_SUP"],
-			"paint": {
-				"line-color": "#AAD5E9",
-		        "line-width": {
-				"stops": [[12, 3.5], [16, 8.7], [17, 14.7]]
-                },
-			    "line-dasharray": [1,5]
-			}
-		},
-        {
-			"id": "Chemin superieur - piste cyclable",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_chemin_sup",
-			"minzoom": 13,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-			"filter": ["==","symbo","PISTE_CYCLABLE_SUP"],
-			"paint": {
-				"line-color": {"stops": [[17, "#9B5CCC"], [18, "#FFFFFF"]]},
-		        "line-width": {
-				"stops": [[14, 1.1], [15, 1.7], [16, 2], [17, 3.5], [18, 6]]
-                },
-				"line-dasharray": [6,2]
-			}
-		},
-        {
-			"id": "Chemin superieur - filet exterieur - escalier",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_chemin_sup",
-			"minzoom": 14,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-			"filter": ["==","symbo","ESCALIER_SUP"],
-			"paint": {
-				"line-color": {"stops": [[17, "#8C7274"], [18, "#C8C8C8"]]},
-		        "line-width": {
-				"stops": [[14, 1.75], [15, 3], [16, 4.2], [17, 9.5]]
-                }
-			}
-		},
-        {
-			"id": "Chemin superieur - filet interieur - escalier",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_chemin_sup",
-			"minzoom": 14,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-			"filter": ["==","symbo","ESCALIER_SUP"],
-			"paint": {
-				"line-color": "#FFFFFF",
-		        "line-width": {
-				"stops": [[14, 1], [15, 1.9], [16, 2.7], [17, 5.8]]
-                },
-				"line-dasharray": [1,0.2]
-			}
-		},
-        {
-			"id": "Chemin superieur - Rue pietonne",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_chemin_sup",
-			"minzoom": 14,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-			"filter": ["==","symbo","RUE_PIETONNE_SUP"],
-			"paint": {
-				"line-color": {"stops": [[17, "#8C7274"], [18, "#EBEBEB"]]},
-		        "line-width": {
-				"stops": [[14, 1], [15, 1.2], [16, 1.4], [17, 2], [18, 5]]
-                },
-				"line-dasharray": [1,3]
-			}
-		},
-        {
-			"id": "Chemin superieur - sentier",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_chemin_sup",
-			"minzoom": 13,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-			"filter": ["==","symbo","SENTIER_SUP"],
-			"paint": {
-				"line-color": {"stops": [[17, "#8C7274"], [18, "#FFFFFF"]]},
-		        "line-width": {
-				"stops": [[14, 1], [15, 1.2], [16, 1.4], [17, 2], [18, 6]]
-                },
-				"line-dasharray": [4,3]
-			}
-		},
-        {
-			"id": "Chemin superieur - chemin",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_chemin_sup",
-			"minzoom": 12,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-			"filter": ["==","symbo","CHEMIN_SUP"],
-			"paint": {
-				"line-color": {"stops": [[17, "#8C7274"], [18, "#FFFFFF"]]},
-		        "line-width": {
-				"stops": [[14, 1], [15, 1.2], [16, 1.4], [17, 2], [18, 7]]
-                }
-			}
-		},
-        {
-			"id": "Routier superieur - filet extérieur - route non revetu carrosable",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route_sup",
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-			"filter": ["==","symbo","NON_REVETUE_CARRO_SUP"],
-			"paint": {
-				"line-color": {"stops": [[12, "#646464"], [17, "#8C8C8C"]]},
-		        "line-width": {
-				"stops": [[14, 3.2], [15, 5.4], [16, 7.7], [17, 16.8]]
-                },
-				"line-dasharray": [2,2]
-			}
-		},
-        {
-			"id": "Routier superieur - filet extérieur - bretelle autoroute",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route_sup",
-			"minzoom": 12,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "BRET_AUTO_PEAGE_3_SUP",
-                                    "BRET_AUTO_PEAGE_2_SUP",
-                                    "BRET_AUTO_PEAGE_1_SUP",
-                                    "BRET_AUTO_LIBRE_3_SUP",
-                                    "BRET_AUTO_LIBRE_2_SUP",
-                                    "BRET_AUTO_LIBRE_1_SUP"
-            ],
-			"paint": {
-				"line-color": {"stops": [[9, "#DE460E"], [17, "#F18800"], [18, "#FFFFFF"]]},
-				"line-width": {
-					"stops": [[12, 2.5], [14, 3.7], [15, 6.8], [16, 8.4], [17, 14]]
-                }
-			}
-		},
-        {
-			"id": "Routier superieur - filet extérieur - route non classee restreint",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route_sup",
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","NON_CLASSEE_RESTREINT_SUP"],
-			"paint": {
-				"line-color": {"stops": [[17, "#969696"], [18, "#FFFFFF"]]},
-		        "line-width": {
-				"stops": [[14, 3.2], [15, 5.4], [16, 7.7], [17, 16.8]]
-                }
-			}
-		},
-        {
-			"id": "Routier superieur - filet extérieur - route non classee",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route_sup",
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "NON_CLASSEE_4_SUP",
-                                    "NON_CLASSEE_SUP"
-            ],
-			"paint": {
-				"line-color": {"stops": [[17, "#969696"], [18, "#FFFFFF"]]},
-		        "line-width": {
-				"stops": [[14, 3.2], [15, 5.4], [16, 7.7], [17, 16.8]]
-                }
-			}
-		},
-        {
-			"id": "Routier superieur - filet extérieur - route locale",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route_sup",
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "BRET_LOCALE_SUP",
-                                    "LOCALE_4_SUP",
-                                    "LOCALE_3_SUP",
-                                    "LOCALE_2_SUP",
-                                    "LOCALE_1_SUP"
-            ],
-			"paint": {
-				"line-color": {
-                    "stops": [[12, "#8C8C8C"], [13, "#B4B4B4"], [17, "#B4B4B4"], [18, "#FFFFFF"]]
-                },
-		        "line-width": {
-				"stops": [[9, 2], [14, 3.5], [15, 6], [16, 8.4], [17, 18.3]]
-                }
-			}
-		},
-        {
-			"id": "Routier superieur - filet extérieur - route locale en construction",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route_sup",
-			"minzoom": 11,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","LOCALE_CONSTR_SUP"],
-			"paint": {
-				"line-color": "#C8C8C8",
-		        "line-width": {
-				"stops": [[9, 2], [14, 3.5], [15, 6], [16, 8.4], [17, 18.3]]
-                }
-			}
-		},
-        {
-			"id": "Routier superieur - filet extérieur - route regionale",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route_sup",
-			"minzoom": 8,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "BRET_REGIONALE_SUP",
-                                    "REGIONALE_4_SUP",
-                                    "REGIONALE_3_SUP",
-                                    "REGIONALE_2_SUP",
-                                    "REGIONALE_1_SUP"
-            ],
-			"paint": {
-				"line-color": {
-                    "stops": [[9, "#828282"], [10, "#B4B4B4"], [17, "#B4B4B4"], [18, "#FFFFFF"]]
-                },
-		        "line-width": {
-					"stops": [[6, 1.5], [9, 2.3], [14, 5], [15, 8.1], [16, 11.2], [17, 22]]
-                }
-			}
-		},
-        {
-			"id": "Routier superieur - filet extérieur - route regionale en construction",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route_sup",
-			"minzoom": 10,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","REGIONALE_CONSTR_SUP"],
-			"paint": {
-				"line-color": "#C8C8C8",
-		        "line-width": {
-					"stops": [[6, 1.5], [9, 2.3], [14, 5], [15, 8.1], [16, 11.2], [17, 22]]
-                }					
-			}
-		},
-        {
-			"id": "Routier superieur - filet extérieur - route principale",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route_sup",
-			"minzoom": 8,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "BRET_PRINCIPALE_SUP",
-                                    "PRINCIPALE_4_SUP",
-                                    "PRINCIPALE_3_SUP",
-                                    "PRINCIPALE_2_SUP",
-                                    "PRINCIPALE_1_SUP"
-            ],
-			"paint": {
-				"line-color": {"stops": [[17, "#E2A52A"], [18, "#FFFFFF"]]},
-		        "line-width": {
-					"stops": [[6, 1.8], [9, 2.7], [14, 5.9], [15, 9], [16, 12.2], [17, 22.5]]
-                }
-			}
-		},
-        {
-			"id": "Routier superieur - filet extérieur - route principale en construction",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route_sup",
-			"minzoom": 10,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","PRINCIPALE_CONSTR_SUP"],
-			"paint": {
-				"line-color": "#C8C8C8",
-		        "line-width": {
-					"stops": [[6, 1.8], [9, 2.7], [14, 5.9], [15, 9], [16, 12.2], [17, 22.5]]
-                }
-			}
-		},
-        {
-			"id": "Routier superieur - filet extérieur - autoroute",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route_sup",
-			"minzoom": 8,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "AUTOROU_PEAGE_SUP",
-                                    "AUTOROU_LIBRE_SUP"
-            ],
-			"paint": {
-				"line-color": {"stops": [[9, "#DE460E"], [17, "#F18800"], [18, "#FFFFFF"]]},
-		        "line-width": {
-					"stops": [[6, 2.5], [9, 3.5], [14, 7.5], [15, 11], [16, 15], [17, 26]]
-                }
-			}
-		},
-        {
-			"id": "Routier superieur - filet extérieur - autoroute en construction",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route_sup",
-			"minzoom": 10,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-			"filter": ["==","symbo","AUTOROU_CONSTR_SUP"],
-			"paint": {
-				"line-color": "#C8C8C8",
-		        "line-width": {
-					"stops": [[6, 2.5], [9, 3.5], [14, 7.5], [15, 11], [16, 15], [17, 26]]
-                }
-			}
-		},
-        {
-			"id": "Routier superieur - filet interieur - route non revetu carrosable",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route_sup",
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-			"filter": ["==","symbo","NON_REVETUE_CARRO_SUP"],
-			"paint": {
-				"line-color": "#FFFFFF",
-		        "line-width": {
-				"stops": [[14, 2.3], [15, 4.1], [16, 6.3], [17, 13.5], [18, 16.8]]
-                }
-			}
-		},
-        {
-			"id": "Routier superieur - filet interieur - bretelle autoroute",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route_sup",
-			"minzoom": 12,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "BRET_AUTO_PEAGE_3_SUP",
-                                    "BRET_AUTO_PEAGE_2_SUP",
-                                    "BRET_AUTO_PEAGE_1_SUP",
-                                    "BRET_AUTO_LIBRE_3_SUP",
-                                    "BRET_AUTO_LIBRE_2_SUP",
-                                    "BRET_AUTO_LIBRE_1_SUP"
-            ],
-			"paint": {
-				"line-color": {"stops": [[9, "#F18800"], [17, "#F2B230"]]},
-				"line-width": {
-					"stops": [[12, 1.5], [14, 2.6], [15, 5.2], [16, 6.7], [17, 10.8]]
-                }
-			}
-		},
-        {
-			"id": "Routier superieur - filet interieur - route non classee restreint",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route_sup",
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","NON_CLASSEE_RESTREINT_SUP"],
-			"paint": {
-				"line-color": "#EDF1FF",
-		        "line-width": {
-				"stops": [[14, 2.3], [15, 4.1], [16, 6.3], [17, 13.5]]
-                }
-			}
-		},
-        {
-			"id": "Routier superieur - filet interieur - route non classee",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route_sup",
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "NON_CLASSEE_4_SUP",
-                                    "NON_CLASSEE_SUP"
-            ],
-			"paint": {
-				"line-color": "#FFFFFF",
-		        "line-width": {
-				"stops": [[14, 2.3], [15, 4.1], [16, 6.3], [17, 13.5]]
-                }
-			}
-		},
-        {
-			"id": "Routier superieur - filet interieur - route locale",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route_sup",
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "BRET_LOCALE_SUP",
-                                    "LOCALE_4_SUP",
-                                    "LOCALE_3_SUP",
-                                    "LOCALE_2_SUP",
-                                    "LOCALE_1_SUP"
-            ],
-			"paint": {
-				"line-color": {
-                    "stops": [[12, "#FFFFFF"], [13, "#FCF4A8"], [17, "#FCF7C1"]]
-                },
-		        "line-width": {
-				"stops": [[9, 1.3], [14, 2.3], [15, 4.1], [16, 6.1], [17, 13.1]]
-                }
-			}
-		},
-        {
-			"id": "Routier superieur - filet interieur - route locale en construction",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route_sup",
-			"minzoom": 11,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","LOCALE_CONSTR_SUP"],
-			"paint": {
-				"line-color": {
-                    "stops": [[12, "#FFFFFF"], [13, "#FCF4A8"], [17, "#FCF7C1"]]
-                },
-		        "line-width": {
-				"stops": [[9, 2], [14, 3.5], [15, 6], [16, 8.4], [17, 18.3]]
-                },
-				"line-dasharray": [2, 2]
-			}
-		},
-        {
-			"id": "Routier superieur - filet interieur - route regionale",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route_sup",
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "BRET_REGIONALE_SUP",
-                                    "REGIONALE_4_SUP",
-                                    "REGIONALE_3_SUP",
-                                    "REGIONALE_2_SUP",
-                                    "REGIONALE_1_SUP"
-            ],
-			"paint": {
-				"line-color": {
-                    "stops": [[9, "#FFFFFF"], [10, "#FDF28B"], [17, "#FCF6BD"]]
-                },
-		        "line-width": {
-					"stops": [[6, 1.4], [9, 1.5], [14, 3.2], [15, 5.8], [16, 8.3], [17, 16.2]]
-                }
-			}
-		},
-        {
-			"id": "Routier superieur - filet interieur - route regionale en construction",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route_sup",
-			"minzoom": 10,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","REGIONALE_CONSTR_SUP"],
-			"paint": {
-				"line-color": {
-                    "stops": [[9, "#FFFFFF"], [10, "#FDF28B"], [17, "#FCF6BD"]]
-                },
-		        "line-width": {
-					"stops": [[6, 1.5], [9, 2.3], [14, 5], [15, 8.1], [16, 11.2], [17, 22]]
-                },
-				"line-dasharray": [2,2]
-			}
-		},
-        {
-			"id": "Routier superieur - filet interieur - route principale",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route_sup",
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "BRET_PRINCIPALE_SUP",
-                                    "PRINCIPALE_4_SUP",
-                                    "PRINCIPALE_3_SUP",
-                                    "PRINCIPALE_2_SUP",
-                                    "PRINCIPALE_1_SUP"
-            ],
-			"paint": {
-				"line-color": {"stops": [[9, "#F3C66D"], [17, "#F2DDB3"]]},
-		        "line-width": {
-					"stops": [[4, 0.5], [6, 1.8], [9, 2.1], [14, 4.4], [15, 7.3], [16, 10], [17, 18.5]]
-                }
-			}
-		},
-        {
-			"id": "Routier superieur - filet interieur - route principale en construction",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route_sup",
-			"minzoom": 10,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-			"filter": ["==","symbo","PRINCIPALE_CONSTR_SUP"],
-			"paint": {
-				"line-color": {"stops": [[9, "#F3C66D"], [17, "#F2DDB3"]]},
-		        "line-width": {
-					"stops": [[6, 1.8], [9, 2.7], [14, 5.9], [15, 9], [16, 12.2], [17, 22.5]]
-                },
-				"line-dasharray": [2,2]
-			}
-		},
-        {
-			"id": "Routier superieur - filet interieur - autoroute",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route_sup",
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "AUTOROU_PEAGE_SUP",
-                                    "AUTOROU_LIBRE_SUP"
-            ],
-			"paint": {
-				"line-color": {"stops": [[9, "#F18800"], [17, "#F2B230"]]},
-		        "line-width": {
-					"stops": [[4, 0.7], [6, 2.5], [9, 2.7], [14, 5.8], [15, 9], [16, 12], [17, 20.8]]
-                }
-			}
-		},
-		{
-			"id": "Routier superieur - axe central - autoroute",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route_sup",
-			"minzoom": 13,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "AUTOROU_PEAGE_SUP",
-                                    "AUTOROU_LIBRE_SUP"
-            ],
-			"paint": {
-				"line-color": "#FFFFFF",
-		        "line-width": {
-					"stops": [[9, 0.6], [14, 0.7], [15, 1], [16, 1.2], [17, 2.1]]
-                }
-			}
-		},
-        {
-			"id": "Routier superieur - filet interieur - autoroute en construction",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route_sup",
-			"minzoom": 10,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","AUTOROU_CONSTR_SUP"],
-			"paint": {
-				"line-color": {"stops": [[9, "#F18800"], [17, "#F2B230"]]},
-		        "line-width": {
-					"stops": [[4, 0.7], [6, 2.5], [9, 3.5], [14, 7.5], [15, 11], [16, 15], [17, 26]]
-                },
-                "line-dasharray": [2,2]
-			}
-		},
-        {
-			"id": "Routier superieur - axe centrale - autoroute en construction",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "routier_route_sup",
-			"minzoom": 13,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","AUTOROU_CONSTR_SUP"],
-			"paint": {
-				"line-color": "#808080",
-		        "line-width": {
-					"stops": [[9, 0.6], [14, 0.7], [15, 1], [16, 1.2], [17, 2.1]]
-                }
-			}
-		},
-        {
-			"id": "Ferre superieur - voie normale",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "ferre_sup",
-			"minzoom": 10,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "VF_1_SUP",
-                                    "VF_2_SUP",
-                                    "VF_ELEC_1_SUP"
-            ],
-			"paint": {
-				"line-color": "#787878",
-		        "line-width": {
-					"stops": [[10, 0.8], [17, 2.5]]
-				}
-			}
-		},
-        {
-			"id": "Ferre superieur - voie normale trait perpendic",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "ferre_sup",
-			"minzoom": 10,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "VF_1_SUP",
-                                    "VF_2_SUP",
-                                    "VF_ELEC_1_SUP"
-            ],
-			"paint": {
-				"line-color": "#787878",
-		        "line-width": {
-					"stops": [[10, 3.5], [17, 14.7]]
-				},
-				"line-dasharray": [0.1,10]
-			}
-		},
-        {
-			"id": "Ferre superieur - voie etroite",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "ferre_sup",
-			"minzoom": 10,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "VF_ETROITE_1_SUP",
-									"VF_ETROITE_SUP"
-            ],
-			"paint": {
-				"line-color": "#787878",
-		        "line-width": {
-					"stops": [[10, 0.3], [17, 1.8]]
-				}
-			}
-		},
-        {
-			"id": "Ferre superieur - voie etroite trait perpendic",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "ferre_sup",
-			"minzoom": 10,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "VF_ETROITE_1_SUP",
-									"VF_ETROITE_SUP"
-            ],
-			"paint": {
-				"line-color": "#787878",
-		        "line-width": {
-					"stops": [[10, 3.5], [17, 14.7]]
-				},
-				"line-dasharray": [0.1,10]
-			}
-		},
-        {
-			"id": "Ferre superieur - voie service",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "ferre_sup",
-			"minzoom": 14,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "VF_SERVICE_SUP",
-                                    "VF_NON_EXPLOITEE_SUP"
-            ],
-			"paint": {
-				"line-color": "#787878",
-		        "line-width": {
-					"stops": [[10, 0.3], [17, 1.8]]
-				},
-				"line-dasharray": [5,2,1,2]
-			}
-		},
-        {
-			"id": "Ferre superieur - voie en construction",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "ferre_sup",
-			"minzoom": 10,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","VF_EN_CONSTR_SUP"],
-			"paint": {
-				"line-color": "#787878",
-		        "line-width": {
-					"stops": [[10, 0.3], [17, 1.8]]
-				},
-                "line-dasharray": [2,2]
-			}
-		},
-        {
-			"id": "Ferre superieur - voie en construction trait perpendic",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "ferre_sup",
-			"minzoom": 10,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","VF_EN_CONSTR_SUP"],
-			"paint": {
-				"line-color": "#787878",
-		        "line-width": {
-					"stops": [[10, 3.5], [17, 14.7]]
-				},
-				"line-dasharray": [0.1,10]
-			}
-		},
-        {
-			"id": "Ferre superieur - funic/urbain",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "ferre_sup",
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "FUNI_CREMAILLERE_SUP",
-                                    "TRANSPORT_URBAIN_SUP"
-            ],
-			"paint": {
-				"line-color": "#787878",
-		        "line-width": {
-					"stops": [[10, 0.3], [17, 1.8]]
-				}
-			}
-		},
-         {
-			"id": "Ferre superieur - 2 trait perpendic - funic/urbain",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "ferre_sup",
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "FUNI_CREMAILLERE_SUP",
-                                    "TRANSPORT_URBAIN_SUP"
-            ],
-			"paint": {
-				"line-color": "#787878",
-		        "line-width": {
-					"stops": [[10, 3.5], [17, 17]]
-				},
-				"line-dasharray": [0.1,0.2,0.1,10]
-			}
-		},
-		{
-			"id": "Limite - cloture",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "limite_lin",
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","CLOTURE"],
-			"paint": {
-				"line-color": "#000000",
-                "line-width": {
-					"stops": [[13, 0.6], [17, 1]]
-                },
-                "line-dasharray": [1.5, 4]
-			}
-		},
-        {
-			"id": "Limite - layon",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "limite_lin",
-			"minzoom": 14,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-			"filter": ["==","symbo","LAYON"],
-			"paint": {
-				"line-color": "#B3989A",
-		        "line-width": {
-				"stops": [[14, 1], [15, 1.2], [16, 1.4], [17, 2]]
-                },
-				"line-dasharray": [4,7]
-			}
-		},
-        {
-			"id": "Zone Règlementee - Enceinte militaire",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "limite_lin",
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "LIM_ZONE_REGLEMENTEE",
-                                    "LIM_ENCEINTE_MILITAIRE",
-                                    "LIM_ENCEINTE_MILI",
-                                    "LIM_CHAMP_TIR"
-            ],
-			"paint": {
-				"line-color": "rgba(226, 130, 92, 0.8)",
-                "line-width": {
-					"stops": [[13, 1.7], [17, 3.1]]
-                },
-                "line-dasharray": [4, 1, 2, 5]
-			}
-		},
-        {
-			"id": "limite zone naturelle",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "limite_lin",
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-            },
-            "filter": ["in","symbo",
-									"LIM_ZONE_NATURELLE",
-									"LIM_ZONE_NATURELLE_ILE",
-									"LIM_RESERVE_NATURELLE"
-			],
-			"paint": {
-				"line-color": "#FFC2CB",
-                "line-width": {
-					"stops": [[13, 2], [17, 4]]
-                },
-                "line-dasharray": [2, 1]
-			}
-		},
-        {
-			"id": "limite zone naturelle - Parc naturel 10",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "limite_lin",
-			"maxzoom": 10,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-            },
-            "filter": ["in","symbo",
-									"LIM_PARC_NATUREL",
-									"LIM_PARC_NATUREL_ILE"
-			],
-			"paint": {
-				"line-color": "#42A266",
-                "line-width": {
-					"stops": [[13, 2], [17, 4]]
-                },
-                "line-dasharray": [2, 1]
-			}
-		},
-        {
-			"id": "limite zone naturelle - Parc naturel 11",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "limite_lin",
-			"minzoom": 10,
-			"maxzoom": 11,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-            },
-            "filter": ["in","symbo",
-									"LIM_PARC_NATUREL",
-									"LIM_PARC_NATUREL_ILE"
-			],
-			"paint": {
-				"line-color": "#42A266",
-                "line-width": {
-					"stops": [[13, 2], [17, 4]]
-                },
-                "line-dasharray": [2, 2]
-			}
-		},
-        {
-			"id": "limite zone naturelle - Parc naturel 12",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "limite_lin",
-			"minzoom": 11,
-			"maxzoom": 12,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-            },
-            "filter": ["in","symbo",
-									"LIM_PARC_NATUREL",
-									"LIM_PARC_NATUREL_ILE"
-			],
-			"paint": {
-				"line-color": "#42A266",
-                "line-width": {
-					"stops": [[13, 2], [17, 4]]
-                },
-                "line-dasharray": [2, 3]
-			}
-		},
-        {
-			"id": "limite zone naturelle - Parc naturel 13",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "limite_lin",
-			"minzoom": 12,
-			"maxzoom": 13,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-            },
-            "filter": ["in","symbo",
-									"LIM_PARC_NATUREL",
-									"LIM_PARC_NATUREL_ILE"
-			],
-			"paint": {
-				"line-color": "#42A266",
-                "line-width": {
-					"stops": [[13, 2], [17, 4]]
-                },
-                "line-dasharray": [2, 4]
-			}
-		},
-        {
-			"id": "limite zone naturelle - Parc naturel 14",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "limite_lin",
-			"minzoom": 13,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-            },
-            "filter": ["in","symbo",
-									"LIM_PARC_NATUREL",
-									"LIM_PARC_NATUREL_ILE"
-			],
-			"paint": {
-				"line-color": "rgba(66, 162, 102, 0.7)",
-                "line-width": {
-					"stops": [[13, 2], [17, 4]]
-                },
-                "line-dasharray": [2, 5]
-			}
-		},
-        {
-			"id": "limite zone naturelle - Parc marin",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "limite_lin",
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","LIM_PARC_NATUREL_MARIN"],
-			"paint": {
-				"line-color": "#2A81A2",
-                "line-width": {
-					"stops": [[13, 2], [17, 4]]
-                },
-                "line-dasharray": [2, 1]
-			}
-		},
-		{
-			"id": "parcellaire - parcelle bordure",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "parcellaire_parcelle",
-			"layout": {
-				"visibility": "visible",
-				"line-cap": "round",
-				"line-join": "round"
-			},
-            "filter": ["==","symbo","PARCELLE"],
-			"paint": {
-				"line-color": "#9933FF",
-				"line-width": 1
-			}
-		},
-		{
-			"id": "parcellaire - section",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "parcellaire_section",
-			"layout": {
-				"visibility": "visible",
-				"line-cap": "butt",
-				"line-join": "round"
-			},
-            "filter": ["==","symbo","SECTION"],
-			"paint": {
-				"line-color": "#287B00",
-				"line-width": 1.9,
-				"line-dasharray": [2,4,2]
-			}
-		},
-		{
-            "id": "toponyme - parcellaire - section",
-            "type": "symbol",
-            "source": "plan_ign",
-            "source-layer": "toponyme_parcellaire_section",
-            "filter": ["==","txt_typo","SECTION"],
-            "layout": {
-                "symbol-placement": "line",
-				"text-offset": [0, 0],
-                "text-field": "{texte}",
-                "text-size": 15,
-                "text-anchor": "center",
-                "text-keep-upright": true,
-                "text-max-angle": 45,
-                "text-font": ["Source Sans Pro Regular"]
-            },
-            "paint": {
-                "text-color": "#287B00"
-            }
-        },
-		{
-            "id": "toponyme - parcellaire - parcelle",
-            "type": "symbol",
-            "source": "plan_ign",
-            "source-layer": "toponyme_parcellaire_parcelle",
-            "filter": ["==","txt_typo","PARCELLE"],
-            "layout": {
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-                "text-size": 11,
-                "text-anchor": "center",
-                "text-keep-upright": true,
-                "text-max-angle": 45,
-                "text-font": ["Source Sans Pro Bold"]
-            },
-            "paint": {
-                "text-color": "#9933FF",
-				"text-halo-width": 1,
-                "text-halo-color": "#FFFFFF"
-            }
-        },
-		{
-            "id": "toponyme - parcellaire - adresse",
-            "type": "symbol",
-            "source": "plan_ign",
-            "source-layer": "toponyme_parcellaire_adresse_ponc",
-            "filter": ["==","txt_typo","ADRESSE"],
-            "layout": {
-                "symbol-placement": "point",
-                "text-field": ["concat","{numero}","{indice_de_repetition}"],
-                "text-size": 11,
-                "text-anchor": "center",
-                "text-keep-upright": true,
-                "text-max-angle": 45,
-                "text-font": ["Source Sans Pro Bold"]
-            },
-            "paint": {
-                "text-color": "#695744",
-				"text-halo-width": 1,
-                "text-halo-color": "#FFFFFF"
-            }
-        },
-        {
-			"id": "limite admin - limite de commune",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "limite_lin",
-			"minzoom": 13,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "LIM_COMMUNE",
-                                    "LIM_CANTON",
-                                    "LIM_ARRONDISSEMENT"
-            ],
-			"paint": {
-				"line-color": "rgba(126, 119, 184, 0.5)",
-		        "line-width": {
-				"stops": [[13, 3], [17, 5.5]]
-                },
-                "line-dasharray": [4, 2, 1, 1, 1, 1, 1, 2]
-			}
-		},
-        {
-			"id": "limite admin - limite de département bandeau",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "limite_lin",
-			"minzoom": 8,
-			"maxzoom": 13,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-			"filter": ["==","symbo","LIM_DEPARTEMENT"],
-			"paint": {
-				"line-color": "rgba(178, 175, 219, 0.4)",
-		        "line-width": {
-				"stops": [[9, 4.1], [12, 6]]
-                }
-			}
-		},
-        {
-			"id": "limite admin - limite de département tiret",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "limite_lin",
-			"minzoom": 13,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-			"filter": ["==","symbo","LIM_DEPARTEMENT"],
-			"paint": {
-				"line-color": "rgba(126, 119, 184, 0.5)",
-		        "line-width": {
-				"stops": [[13, 3], [17, 5.5]]
-                },
-                "line-dasharray": [4, 2, 1, 1, 1, 2]
-			}
-		},
-        {
-			"id": "limite admin - limite de région bandeau",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "limite_lin",
-			"minzoom": 7,
-			"maxzoom": 13,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-			"filter": ["==","symbo","LIM_REGION"],
-			"paint": {
-				"line-color": "rgba(178, 175, 219, 0.5)",
-		        "line-width": {
-				"stops": [[9, 4.5], [12, 6.7]]
-                }
-			}
-		},
-        {
-			"id": "limite admin - limite de région tiret",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "limite_lin",
-			"minzoom": 13,
-			"maxzoom": 18,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-			"filter": ["==","symbo","LIM_REGION"],
-			"paint": {
-				"line-color": "rgba(126, 119, 184, 0.5)",
-		        "line-width": {
-				"stops": [[13, 3], [17, 5.5]]
-                },
-                "line-dasharray": [4, 2, 1, 2]
-			}
-		},
-        {
-			"id": "limite etat 1",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "limite_lin",
-			"minzoom": 2,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "LIM_ETAT",
-                                    "LIM_ETAT_ETRANGER"
-            ],
-			"paint": {
-				"line-color": "rgba(178, 175, 219, 0.6)",
-		        "line-width": {
-				"stops": [[2, 2], [3, 3.5], [9, 5], [14, 13], [15, 20], [16, 24], [17, 42]]
-                }
-			}
-		},
-        {
-			"id": "limite etat 2",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "limite_lin",
-			"minzoom": 7,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "LIM_ETAT",
-                                    "LIM_ETAT_ETRANGER"
-            ],
-			"paint": {
-				"line-color": "#9F9CB8",
-		        "line-width": {
-				"stops": [[9, 1.5], [14, 3.5], [15, 5.5], [16, 6.5], [17, 11]]
-                },
-                "line-dasharray": [4, 2]
-			}
-		},
-        {
-            "id": "limite cote",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "limite_lin",
-			"minzoom": 7,
-            "maxzoom":10,
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo","LIM_COTE"],
-			"paint": {
-				"line-color": "#82A3B2",
-                "line-width": 1
-			}
-        },
-        {
-			"id": "ligne electrique",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "bati_lin",
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-            },
-            "filter": ["==","symbo","LIGNE_ELECTRIQUE"],
-			"paint": {
-				"line-color": "#808080",
-		        "line-width": {
-					"stops": [[13, 1], [17, 2]]
-				}
-			}
-		},
-        {
-			"id": "autre construction linéaire",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "bati_lin",
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "round",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-									"CABLE",
-                                    "REMONTEE_MEC",
-                                    "HYDROCARBURES",
-                                    "CONDUITE_MATIERES_P",
-                                    "SPORT_MONTAGNE_LIN",
-									"PISTE_BOBSLEIGH",
-									"PISTE_LUGE",
-                                    "PISTE_AERO_LIN"
-            ],
-			"paint": {
-				"line-color": "#808080",
-		        "line-width": 1
-			}
-		},
-        {
-			"id": "autre construction linéaire - trait perpend cable",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "bati_lin",
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","CABLE"],
-			"paint": {
-				"line-color": "#808080",
-		        "line-width": 5,
-				"line-dasharray": [0.5,10]
-			}
-		},
-        {
-			"id": "autre construction linéaire - trait perpend 1 remont",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "bati_lin",
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","REMONTEE_MEC"],
-			"paint": {
-				"line-color": "#808080",
-		        "line-width": 6,
-				"line-dasharray": [1,10]
-			}
-		},
-        {
-			"id": "autre construction linéaire - trait perpend 2 remont",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "bati_lin",
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["==","symbo","REMONTEE_MEC"],
-			"paint": {
-				"line-color": "#BEBEBE",
-		        "line-width": 6,
-				"line-dasharray": [0.3,0.4,0.3,10]
-			}
-		},
-        {
-			"id": "autre construction linéaire - trait perpend carbur",
-			"type": "line",
-			"source": "plan_ign",
-			"source-layer": "bati_lin",
-			"layout": {
-				"visibility": "visible",
-                "line-cap": "butt",
-                "line-join": "round"
-			},
-            "filter": ["in","symbo",
-                                    "HYDROCARBURES",
-                                    "CONDUITE_MATIERES_P"
-            ],
-			"paint": {
-				"line-color": "#808080",
-		        "line-width": 5,
-				"line-dasharray": [1,10]
-			}
-		},
-		{
-			"id": "routier ponctuel - peage ponctuel",
-			"type": "circle",
-			"source": "plan_ign",
-			"source-layer": "routier_ponc",
-			"minzoom": 8,
-			"layout": {
-				"visibility": "visible"
-			},
-            "filter": ["==","symbo","PEAGE_PONC"],
-			"paint": {
-                "circle-radius": {
-				"stops": [[9, 3.5], [12, 6.5]]
-                },				
-                "circle-color": "#E2A52A",
-				"circle-stroke-width": 1,
-                "circle-stroke-color": "#808080"
-			}
-		},
-		{
-			"id": "routier ponctuel - barriere",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "routier_ponc",
-			"minzoom": 12,
-			"layout": {
-				"visibility": "visible",
-				"icon-image": "Barriere",
-				"icon-size": {
-				"stops": [[13, 0.25], [16, 0.45], [17, 0.7]]
-				},
-				"icon-allow-overlap": true,
-				"icon-rotate": ["get", "rotation"]
-			},
-            "filter": ["==","symbo","BARRIERE"],
-			"paint": {
-				"icon-color": "#969696"
-			}
-		},
-		{
-			"id": "hydro ponctuel",
-			"type": "circle",
-			"source": "plan_ign",
-			"source-layer": "hydro_ponc",
-			"minzoom": 13,
-			"layout": {
-				"visibility": "visible"
-			},
-            "filter": ["in","symbo",
-                                    "FONTAINE",
-                                    "POINT_D_EAU",
-                                    "SOURCE",
-                                    "SOURCE_CAPTEE",
-                                    "PERTE",
-                                    "RESURGENCE",
-                                    "CASCADE",
-									"AUTRE_HYDRO_PONC"
-            ],
-			"paint": {
-                "circle-radius": {
-				"stops": [[14, 3], [17, 7]]
-				},
-                "circle-color": "#FFFFFF",
-                "circle-opacity": 1,
-                "circle-stroke-width": {
-				"stops": [[14, 2], [17, 5]]
-				},
-                "circle-stroke-color": "#1466B2"
-			}
-		},
-		{
-			"id": "point coté",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "oro_ponc",
-			"minzoom": 11,
-			"maxzoom": 16,
-            "filter": ["in","symbo",
-                                    "POINT_COTE",
-                                    "POINT_COTE_TOPO",
-                                    "POINT_COTE_RESEAU",
-                                    "POINT_RBF"
-            ],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-				"icon-image": "Localite",
-				"icon-size": 0.1,
-                "text-field": "{texte}",
-                "text-size": 10,
-                "text-allow-overlap": false,
-				"text-anchor": "bottom-left",
-				"text-offset": [0.2, 0.4],
-                "text-padding": 2,
-                "text-font": ["Source Sans Pro Italic"]
-			},
-			"paint": {
-                "text-color": "#505050"
-			}
-		},
-		{
-			"id": "bati ponctuel : Hopital",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "bati_ponc",
-			"layout": {
-				"visibility": "visible",
-				"icon-image": "Hopital",
-				"icon-size": 0.33
-			},
-            "filter": ["==","symbo","HOPITAL_PONC"],
-			"paint": {
-				"icon-color": "#646464"
-			}
-		},
-		{
-			"id": "bati ponctuel hydrographique",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "bati_ponc",
-			"minzoom": 14,
-			"layout": {
-				"visibility": "visible",
-				"icon-image": "Pompage",
-				"icon-size": { "stops": [[13, 0.2], [17, 0.6]] },
-				"icon-allow-overlap": true
-			},
-            "filter": ["in","symbo",
-                                    "CITERNE",
-                                    "LAVOIR",
-                                    "STATION_EPURATION",
-                                    "STATION_DE_POMPAGE",
-									"USINE_PRODUCTION_EAU",
-									"USINE_ELEVATRICE"
-            ],
-			"paint": {
-				"icon-color": "#1C62A6"
-			}
-		},
-		{
-			"id": "bati ponctuel hydrographique - Puits-Abreuvoir",
-			"type": "circle",
-			"source": "plan_ign",
-			"source-layer": "bati_ponc",
-			"minzoom": 13,
-			"layout": {
-				"visibility": "visible"
-			},
-            "filter": ["in","symbo",
-                                    "PUITS",
-                                    "ABREUVOIR"
-            ],
-			"paint": {
-                "circle-radius": {
-				"stops": [[14, 3], [17, 7]]
-				},
-                "circle-color": "#FFFFFF",
-                "circle-opacity": 1,
-                "circle-stroke-width": {
-				"stops": [[14, 2], [17, 5]]
-				},
-                "circle-stroke-color": "#1466B2"
-			}
-		},
-		{
-			"id": "bati ponctuel hydrographique - Phare",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "bati_ponc",
-			"minzoom": 13,
-			"layout": {
-				"visibility": "visible",
-				"icon-image": "Phare",
-				"icon-size": { "stops": [[13, 0.7], [17, 1.3]] }
-			},
-            "filter": ["==","symbo","PHARE"],
-			"paint": {
-				"icon-color": "#646464"
-			}
-		},
-		{
-			"id": "bati ponctuel hydrographique - Amer-Feu",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "bati_ponc",
-			"minzoom": 13,
-			"layout": {
-				"visibility": "visible",
-				"icon-image": "Feu",
-				"icon-size": { "stops": [[13, 0.7], [17, 1.3]] }
-			},
-            "filter": ["in","symbo",
-                                    "AMER",
-                                    "FEU",
-                                    "FEU_PONC",
-									"TOURELLE_LUMINEUSE"
-            ],
-			"paint": {
-				"icon-color": "#646464"
-			}
-		},
-		{
-			"id": "bati ponctuel hydrographique - Balise",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "bati_ponc",
-			"minzoom": 13,
-			"layout": {
-				"visibility": "visible",
-				"icon-image": "Balise",
-				"icon-size": { "stops": [[13, 0.7], [17, 1.3]] }
-			},
-            "filter": ["in","symbo",
-									"BALISE",
-									"TOURELLE"
-			],
-			"paint": {
-				"icon-color": "#646464"
-			}
-		},
-		{
-			"id": "bati ponctuel hydrographique - Ecluse",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "bati_ponc",
-			"minzoom": 12,
-			"maxzoom": 15,
-			"layout": {
-				"visibility": "visible",
-				"icon-image": "Ecluse",
-				"icon-size": 0.2
-			},
-            "filter": ["==","symbo","ECLUSE_PONC"],
-			"paint": {
-				"icon-color": "#1C62A6"
-			}
-		},
-		{
-			"id": "bati ponctuel hydrographique - Barrage",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "bati_ponc",
-			"minzoom": 12,
-			"maxzoom": 14,
-			"layout": {
-				"visibility": "visible",
-				"icon-image": "Barrage",
-				"icon-size": 0.25
-			},
-            "filter": ["==","symbo","BARRAGE_PONC"],
-			"paint": {
-				"icon-color": "#1C62A6"
-			}
-		},
-		{
-			"id": "bati ponctuel hydrographique - Chateau d'eau",
-			"type": "circle",
-			"source": "plan_ign",
-			"source-layer": "bati_ponc",
-			"layout": {
-				"visibility": "visible"
-			},
-            "filter": ["==","symbo","CHATEAU_EAU_PONC"],
-			"paint": {
-                "circle-radius": {
-				"stops": [[14, 3], [17, 8]]
-				},
-                "circle-color": "#1466B2"
-			}			
-		},
-		{
-			"id": "bati ponctuel hydrographique - Réservoir d'eau",
-			"type": "circle",
-			"source": "plan_ign",
-			"source-layer": "bati_ponc",
-			"maxzoom": 15,
-			"layout": {
-				"visibility": "visible"
-			},
-            "filter": ["==","symbo","RESERVOIR_EAU_PONC"],
-			"paint": {
-                "circle-radius": {
-				"stops": [[14, 3], [17, 8]]
-				},
-                "circle-color": "#AAD5E9",
-                "circle-opacity": 1,
-                "circle-stroke-width": {
-				"stops": [[14, 1], [17, 2.5]]
-				},
-                "circle-stroke-color": "#1466B2"
-			}
-		},
-		{
-			"id": "bati ponctuel infrastructure - Constr spé",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "bati_ponc",
-			"layout": {
-				"visibility": "visible",
-				"icon-image": "ConstrSpeciale",
-				"icon-size": { "stops": [[13, 0.22], [17, 0.5]] }
-			},
-            "filter": ["in","symbo",
-                                    "ANTENNE",
-                                    "CONSTR_SPE_TECHNIQUE",
-                                    "CONSTR_INDIF_PONC",
-									"CHEMINEE",
-									"CHEVALEMENT",
-									"PUITS_GAZ",
-									"PUITS_PETROLE",
-									"PYLONE_METEO",
-									"TORCHERE",
-									"TOUR_GUET",
-									"TOUR_HERTZIENNE"
-            ],
-			"paint": {
-				"icon-color": "#646464"
-			}
-		},
-		{
-			"id": "bati ponctuel infrastructure - Silo",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "bati_ponc",
-			"maxzoom": 15,
-			"layout": {
-				"visibility": "visible",
-				"icon-image": "Silo",
-				"icon-size": { "stops": [[13, 0.22], [17, 0.5]] }
-			},
-            "filter": ["==","symbo","SILO_PONC"],
-			"paint": {
-				"icon-color": "#646464"
-			}
-		},
-		{
-			"id": "bati ponctuel infrastructure - Eolienne",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "bati_ponc",
-			"layout": {
-				"visibility": "visible",
-				"icon-image": "Eolienne",
-				"icon-size": { "stops": [[13, 0.4], [17, 1], [18, 0.8]] }
-			},
-            "filter": ["==","symbo","EOLIENNE"],
-			"paint": {
-				"icon-color": "#646464"
-			}
-		},
-		{
-			"id": "bati ponctuel infrastructure - Reservoir",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "bati_ponc",
-			"maxzoom": 15,
-			"layout": {
-				"visibility": "visible",
-				"icon-image": "Reservoir",
-				"icon-size": { "stops": [[13, 0.26], [17, 0.5]] }
-			},
-            "filter": ["==","symbo","RESERVOIR_PONC"],
-			"paint": {
-				"icon-color": "#646464"
-			}
-		},
-		{
-			"id": "bati ponctuel infrastructure - pylone électrique",
-			"type": "circle",
-			"source": "plan_ign",
-			"source-layer": "bati_ponc",
-			"layout": {
-				"visibility": "visible"
-			},
-            "filter": ["==","symbo","PYLONE_ELEC"],
-			"paint": {
-                "circle-radius" : {
-					"stops": [[13, 1], [17, 2]]
-				},
-                "circle-color" : "#000000"
-			}
-		},
-		{
-			"id": "bati ponctuel montagne - Abri",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "bati_ponc",
-			"layout": {
-				"visibility": "visible",
-				"icon-image": "Abri",
-				"icon-size": { "stops": [[13, 0.4], [15, 0.6], [17, 0.9]] }
-			},
-            "filter": ["==","symbo","ABRI"],
-			"paint": {
-				"icon-color": "#246138"
-			}
-		},
-		{
-			"id": "bati ponctuel montagne - Refuge Garde",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "bati_ponc",
-			"layout": {
-				"visibility": "visible",
-				"icon-image": "Refugegard",
-				"icon-size": { "stops": [[13, 0.4], [15, 0.6], [17, 0.9]] }
-			},
-            "filter": ["==","symbo","REFUGE_GARDE"],
-			"paint": {
-				"icon-color": "#246138"
-			}
-		},
-		{
-			"id": "bati ponctuel montagne - Refuge Non Garde",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "bati_ponc",
-			"layout": {
-				"visibility": "visible",
-				"icon-image": "Refugenongard",
-				"icon-size": { "stops": [[13, 0.4], [15, 0.6], [17, 0.9]] }
-			},
-            "filter": ["==","symbo","REFUGE"],
-			"paint": {
-				"icon-color": "#246138"
-			}
-		},
-		{
-			"id": "bati ponctuel transport aerien - Aeroport FXX",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "bati_ponc",
-			"layout": {
-				"visibility": "visible",
-                "icon-image": "Aeroport",
-				"icon-size": 0.5
-			},
-            "filter": ["all",
-                        ["==","symbo","AEROPORT_PONC"],
-                        ["==","territoire","FXX"]
-            ],
-			"paint": {
-                "icon-color": "#646464"
-            }
-		},
-		{
-			"id": "bati ponctuel transport aerien - Aerodrome FXX",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "bati_ponc",
-			"layout": {
-				"visibility": "visible",
-                "icon-image": "Aerodrome",
-				"icon-size": 0.4
-			},
-            "filter": ["all",
-                        ["==","symbo","AERODROME_PONC"],
-                        ["==","territoire","FXX"]
-            ],
-			"paint": {
-                "icon-color": "#646464"
-            }
-		},
-		{
-			"id": "bati ponctuel transport aerien - Aeroport DOM",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "bati_ponc",
-			"minzoom": 8,
-			"layout": {
-				"visibility": "visible",
-                "icon-image": "Aeroport",
-				"icon-size": 0.5
-			},
-            "filter": ["all",
-                        ["==","symbo","AEROPORT_PONC"],
-                        ["!=","territoire","FXX"]
-            ],
-			"paint": {
-                "icon-color": "#646464"
-            }
-		},
-		{
-			"id": "bati ponctuel transport aerien - Aerodrome DOM",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "bati_ponc",
-			"minzoom": 8,
-			"layout": {
-				"visibility": "visible",
-                "icon-image": "Aerodrome",
-				"icon-size": 0.4
-			},
-            "filter": ["all",
-                        ["==","symbo","AERODROME_PONC"],
-                        ["!=","territoire","FXX"]
-            ],
-			"paint": {
-                "icon-color": "#646464"
-            }
-		},
-		{
-			"id": "bati ponctuel transport ferroviaire",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "bati_ponc",
-			"layout": {
-				"visibility": "visible",
-                "icon-image": "Gare",
-				"icon-size" : 0.33
-			},
-            "filter": ["==","symbo","GARE_VOYAGEURS"],
-			"paint": {
-                "icon-color": "#787878"
-            }
-		},
-		{
-            "id": "toponyme - bornes postales haute - chemins",
-            "type": "symbol",
-            "source": "plan_ign",
-            "source-layer": "toponyme_routier_borne",
-			"minzoom": 17,
-			"maxzoom": 18,
-            "filter": ["in","symbo",
-                                        "CHEMIN",
-                                        "CHEMIN_SOU",
-                                        "CHEMIN_SUP",
-                                        "PISTE_CYCLABLE",
-                                        "PISTE_CYCLABLE_SOU",
-                                        "PISTE_CYCLABLE_SUP",
-                                        "RUE_PIETONNE",
-                                        "RUE_PIETONNE_SOU",
-                                        "RUE_PIETONNE_SUP",
-                                        "SENTIER",
-                                        "SENTIER_SOU",
-                                        "SENTIER_SUP",
-                                        "ESCALIER",
-                                        "ESCALIER_SUP"],
-            "layout": {
-                "symbol-placement": "line",
-                "text-field": "{borne_sur}",
-                "text-size": 11,
-                "text-anchor": "center",
-                "text-allow-overlap": true,
-                "text-offset": [
-                  0,
-                  -1
-                ],
-                "text-font": ["Source Sans Pro Regular"]
-            },
-            "paint": {
-                "text-color": "#79654F",
-                "text-halo-width": 1,
-                "text-halo-color": "#FFFFFF"
-            }
-        },
-		{
-            "id": "toponyme - bornes postales haute - non revetue, non classee",
-            "type": "symbol",
-            "source": "plan_ign",
-            "source-layer": "toponyme_routier_borne",
-			"minzoom": 17,
-			"maxzoom": 18,
-            "filter": ["in","symbo",
-                                        "NON_CLASSEE",
-                                        "NON_CLASSEE_4",
-                                        "NON_CLASSEE_4_SUP",
-                                        "NON_CLASSEE_RESTREINT",
-                                        "NON_CLASSEE_RESTREINT_SUP",
-                                        "NON_CLASSEE_SOU",
-                                        "NON_CLASSEE_SUP",
-                                        "NON_REVETUE_CARRO",
-                                        "NON_REVETUE_CARRO_SUP"],
-            "layout": {
-                "symbol-placement": "line",
-                "text-field": "{borne_sur}",
-                "text-size": 11,
-                "text-anchor": "center",
-                "text-allow-overlap": true,
-                "text-offset": [
-                  0,
-                  -1.3
-                ],
-                "text-font": ["Source Sans Pro Regular"]
-            },
-            "paint": {
-                "text-color": "#79654F",
-                "text-halo-width": 1,
-                "text-halo-color": "#FFFFFF"
-            }
-        },
-		{
-            "id": "toponyme - bornes postales haute - locales",
-            "type": "symbol",
-            "source": "plan_ign",
-            "source-layer": "toponyme_routier_borne",
-			"minzoom": 17,
-			"maxzoom": 18,
-            "filter": ["in","symbo",
-                                        "LOCALE_1",
-                                        "LOCALE_1_SOU",
-                                        "LOCALE_1_SUP",
-                                        "LOCALE_2",
-                                        "LOCALE_2_SOU",
-                                        "LOCALE_2_SUP",
-                                        "LOCALE_3",
-                                        "LOCALE_3_SOU",
-                                        "LOCALE_3_SUP",
-                                        "LOCALE_4",
-                                        "LOCALE_4_SOU",
-                                        "LOCALE_4_SUP",
-                                        "LOCALE_CONSTR",
-                                        "LOCALE_CONSTR_SUP"],
-            "layout": {
-                "symbol-placement": "line",
-                "text-field": "{borne_sur}",
-                "text-size": 11,
-                "text-anchor": "center",
-                "text-allow-overlap": true,
-                "text-offset": [
-                  0,
-                  -1.4
-                ],
-                "text-font": ["Source Sans Pro Regular"]
-            },
-            "paint": {
-                "text-color": "#79654F",
-                "text-halo-width": 1,
-                "text-halo-color": "#FFFFFF"
-            }
-        },
-		{
-            "id": "toponyme - bornes postales haute - regionales",
-            "type": "symbol",
-            "source": "plan_ign",
-            "source-layer": "toponyme_routier_borne",
-			"minzoom": 17,
-			"maxzoom": 18,
-            "filter": ["in","symbo",
-                                        "REGIONALE_1",
-                                        "REGIONALE_1_SOU",
-                                        "REGIONALE_1_SUP",
-                                        "REGIONALE_2",
-                                        "REGIONALE_2_SOU",
-                                        "REGIONALE_2_SUP",
-                                        "REGIONALE_3",
-                                        "REGIONALE_3_SOU",
-                                        "REGIONALE_3_SUP",
-                                        "REGIONALE_4",
-                                        "REGIONALE_4_SUP",
-                                        "REGIONALE_CONSTR"],
-            "layout": {
-                "symbol-placement": "line",
-                "text-field": "{borne_sur}",
-                "text-size": 11,
-                "text-anchor": "center",
-                "text-allow-overlap": true,
-                "text-offset": [
-                  0,
-                  -1.5
-                ],
-                "text-font": ["Source Sans Pro Regular"]
-            },
-            "paint": {
-                "text-color": "#79654F",
-                "text-halo-width": 1,
-                "text-halo-color": "#FFFFFF"
-            }
-        },
-		{
-            "id": "toponyme - bornes postales haute - principales",
-            "type": "symbol",
-            "source": "plan_ign",
-            "source-layer": "toponyme_routier_borne",
-			"minzoom": 17,
-			"maxzoom": 18,
-            "filter": ["in","symbo",
-                                        "PRINCIPALE_1",
-										"PRINCIPALE_1_SOU",
-                                        "PRINCIPALE_1_SUP",
-                                        "PRINCIPALE_2",
-                                        "PRINCIPALE_2_SOU",
-                                        "PRINCIPALE_2_SUP",
-                                        "PRINCIPALE_3",
-                                        "PRINCIPALE_3_SOU",
-                                        "PRINCIPALE_3_SUP",
-                                        "PRINCIPALE_4",
-										"PRINCIPALE_4_SOU",
-                                        "PRINCIPALE_4_SUP",
-                                        "PRINCIPALE_CONSTR"],
-            "layout": {
-                "symbol-placement": "line",
-                "text-field": "{borne_sur}",
-                "text-size": 11,
-                "text-anchor": "center",
-                "text-allow-overlap": true,
-                "text-offset": [
-                  0,
-                  -1.6
-                ],
-                "text-font": ["Source Sans Pro Regular"]
-            },
-            "paint": {
-                "text-color": "#79654F",
-                "text-halo-width": 1,
-                "text-halo-color": "#FFFFFF"
-            }
-        },
-		{
-            "id": "toponyme - bornes postales bas - chemins",
-            "type": "symbol",
-            "source": "plan_ign",
-            "source-layer": "toponyme_routier_borne",
-			"minzoom": 17,
-			"maxzoom": 18,
-            "filter": ["in","symbo",
-                                        "CHEMIN",
-                                        "CHEMIN_SOU",
-                                        "CHEMIN_SUP",
-                                        "PISTE_CYCLABLE",
-                                        "PISTE_CYCLABLE_SOU",
-                                        "PISTE_CYCLABLE_SUP",
-                                        "RUE_PIETONNE",
-                                        "RUE_PIETONNE_SOU",
-                                        "RUE_PIETONNE_SUP", 
-                                        "SENTIER",
-                                        "SENTIER_SOU",
-                                        "SENTIER_SUP",
-                                        "ESCALIER",
-                                        "ESCALIER_SUP"],
-            "layout": {
-                "symbol-placement": "line",
-                "text-field": "{borne_sous}",
-                "text-size": 11,
-                "text-anchor": "center",
-                "text-allow-overlap": true,
-                "text-offset": [
-                  0,
-                  1
-                ],
-                "text-font": ["Source Sans Pro Regular"]
-            },
-            "paint": {
-                "text-color": "#79654F",
-                "text-halo-width": 1,
-                "text-halo-color": "#FFFFFF"
-            }
-        },
-		{
-            "id": "toponyme - bornes postales bas - non revetue, non classee",
-            "type": "symbol",
-            "source": "plan_ign",
-            "source-layer": "toponyme_routier_borne",
-			"minzoom": 17,
-			"maxzoom": 18,
-            "filter": ["in","symbo",
-                                        "NON_CLASSEE",
-                                        "NON_CLASSEE_4",
-                                        "NON_CLASSEE_4_SUP",
-										"NON_CLASSEE_RESTREINT",
-                                        "NON_CLASSEE_RESTREINT_SUP",
-                                        "NON_CLASSEE_SOU",
-                                        "NON_CLASSEE_SUP",
-                                        "NON_REVETUE_CARRO",
-                                        "NON_REVETUE_CARRO_SUP"],
-            "layout": {
-                "symbol-placement": "line",
-                "text-field": "{borne_sous}",
-                "text-size": 11,
-                "text-anchor": "center",
-                "text-allow-overlap": true,
-                "text-offset": [
-                  0,
-                  1.3
-                ],
-                "text-font": ["Source Sans Pro Regular"]
-            },
-            "paint": {
-                "text-color": "#79654F",
-                "text-halo-width": 1,
-                "text-halo-color": "#FFFFFF"
-            }
-        },
-		{
-            "id": "toponyme - bornes postales bas - locales",
-            "type": "symbol",
-            "source": "plan_ign",
-            "source-layer": "toponyme_routier_borne",
-			"minzoom": 17,
-			"maxzoom": 18,
-            "filter": ["in","symbo",
-                                        "LOCALE_1",
-                                        "LOCALE_1_SOU",
-                                        "LOCALE_1_SUP",
-                                        "LOCALE_2",
-                                        "LOCALE_2_SOU",
-                                        "LOCALE_2_SUP",
-                                        "LOCALE_3",
-                                        "LOCALE_3_SOU",
-                                        "LOCALE_3_SUP",
-                                        "LOCALE_4",
-                                        "LOCALE_4_SOU",
-                                        "LOCALE_4_SUP",
-                                        "LOCALE_CONSTR",
-										"LOCALE_CONSTR_SUP"],
-            "layout": {
-                "symbol-placement": "line",
-                "text-field": "{borne_sous}",
-                "text-size": 11,
-                "text-anchor": "center",
-                "text-allow-overlap": true,
-                "text-offset": [
-                  0,
-                  1.4
-                ],
-                "text-font": ["Source Sans Pro Regular"]
-            },
-            "paint": {
-                "text-color": "#79654F",
-                "text-halo-width": 1,
-                "text-halo-color": "#FFFFFF"
-            }
-        },
-		{
-            "id": "toponyme - bornes postales bas - regionales",
-            "type": "symbol",
-            "source": "plan_ign",
-            "source-layer": "toponyme_routier_borne",
-			"minzoom": 17,
-			"maxzoom": 18,
-            "filter": ["in","symbo",
-                                        "REGIONALE_1",
-                                        "REGIONALE_1_SOU",
-                                        "REGIONALE_1_SUP",
-                                        "REGIONALE_2",
-                                        "REGIONALE_2_SOU",
-                                        "REGIONALE_2_SUP",
-                                        "REGIONALE_3",
-                                        "REGIONALE_3_SOU",
-                                        "REGIONALE_3_SUP",
-                                        "REGIONALE_4",
-                                        "REGIONALE_4_SUP",
-                                        "REGIONALE_CONSTR"],
-            "layout": {
-                "symbol-placement": "line",
-                "text-field": "{borne_sous}",
-                "text-size": 11,
-                "text-anchor": "center",
-                "text-allow-overlap": true,
-                "text-offset": [
-                  0,
-                  1.5
-                ],
-                "text-font": ["Source Sans Pro Regular"]
-            },
-            "paint": {
-                "text-color": "#79654F",
-                "text-halo-width": 1,
-                "text-halo-color": "#FFFFFF"
-            }
-        },
-		{
-            "id": "toponyme - bornes postales bas - principales",
-            "type": "symbol",
-            "source": "plan_ign",
-            "source-layer": "toponyme_routier_borne",
-			"minzoom": 17,
-			"maxzoom": 18,
-            "filter": ["in","symbo",
-                                        "PRINCIPALE_1",
-										"PRINCIPALE_1_SOU",
-                                        "PRINCIPALE_1_SUP",
-                                        "PRINCIPALE_2",
-                                        "PRINCIPALE_2_SOU",
-                                        "PRINCIPALE_2_SUP",
-                                        "PRINCIPALE_3",
-                                        "PRINCIPALE_3_SOU",
-                                        "PRINCIPALE_3_SUP",
-                                        "PRINCIPALE_4",
-										"PRINCIPALE_4_SOU",
-                                        "PRINCIPALE_4_SUP",
-                                        "PRINCIPALE_CONSTR"],
-            "layout": {
-                "symbol-placement": "line",
-                "text-field": "{borne_sous}",
-                "text-size": 11,
-                "text-anchor": "center",
-                "text-allow-overlap": true,
-                "text-offset": [
-                  0,
-                  1.6
-                ],
-                "text-font": ["Source Sans Pro Regular"]
-            },
-            "paint": {
-                "text-color": "#79654F",
-                "text-halo-width": 1,
-                "text-halo-color": "#FFFFFF"
-            }
-        },
-		{
-            "id": "toponyme - courbe rocher maitresse",
-            "type": "symbol",
-            "source": "plan_ign",
-            "source-layer": "toponyme_oro_ponc",
-            "filter": ["==","txt_typo","ORO_COURBE_ROCHER"],
-            "layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-                "text-size": 10,
-                "text-allow-overlap": false,
-                "text-padding": 30,
-                "text-rotate": { "type": "identity", "property": "rotation" },
-                "text-font": ["Source Sans Pro Italic"]
-			},
-			"paint": {
-                "text-color": "#333333",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 1
-			}
-        },
-		{
-            "id": "toponyme - courbe glacier maitresse",
-            "type": "symbol",
-            "source": "plan_ign",
-            "source-layer": "toponyme_oro_ponc",
-            "filter": ["==","txt_typo","ORO_COURBE_GLACIER"],
-            "layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-                "text-size": 10,
-                "text-allow-overlap": false,
-                "text-padding": 30,
-                "text-rotate": { "type": "identity", "property": "rotation" },
-                "text-font": ["Source Sans Pro Italic"]
-			},
-			"paint": {
-                "text-color": "#629FD9",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 1
-			}
-        },
-		{
-            "id": "toponyme - courbe maitresse",
-            "type": "symbol",
-            "source": "plan_ign",
-            "source-layer": "toponyme_oro_ponc",
-            "filter": ["==","txt_typo","ORO_COURBE"],
-            "layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-                "text-size": 10,
-                "text-allow-overlap": false,
-                "text-padding": 30,
-                "text-rotate": { "type": "identity", "property": "rotation" },
-                "text-font": ["Source Sans Pro Italic"]
-			},
-			"paint": {
-                "text-color": "#604A2F",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 1
-			}
-        },
-		{
-            "id": "toponyme - liaison maritime",
-            "type": "symbol",
-            "source": "plan_ign",
-            "source-layer": "toponyme_routier_liaison_lin",
-			"minzoom": 8,
-			"maxzoom": 18,
-            "filter": ["==","txt_typo","LIAISON_MARITIME"],
-            "layout": {
-                "symbol-placement": "line",
-                "text-field": "{texte}",
-                "text-size": 15,
-                "text-anchor": "center",
-                "text-keep-upright": true,
-                "text-max-angle": 45,
-                "text-padding": 10,
-                "text-font": ["Source Sans Pro Italic"]
-            },
-            "paint": {
-                "text-color": "#5792C2",
-                "text-halo-width": 5,
-                "text-halo-color": "#AAD5E9"
-            }
-        },
-		{
-			"id": "toponyme bati station de métro + bati ponctuel metro",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_bati_ponc",
-            "minzoom":14,
-            "filter": ["all",
-                        ["==","txt_typo","TYPO_E_1"],
-                        ["==","symbo","STATION_METRO"]
-                      ],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-                "text-size": 11,
-                "text-allow-overlap": false,
-				"text-offset": [0.30, -0.25],
-                "text-padding": 3,
-				"text-anchor": "bottom-left",
-                "text-font": ["Source Sans Pro"],
-				"icon-image": "Metro",
-				"icon-size": { "stops": [[15, 0.33], [17, 0.6]] }
-			},
-			"paint": {
-                "text-color": "#3C3C3C",
-				"icon-color": "#646464"
-			}
-		},
-		{
-            "id": "toponyme ferre lineaire",
-            "type": "symbol",
-            "source": "plan_ign",
-            "source-layer": "toponyme_ferre_lin",
-			"minzoom":12,
-			"filter": ["in","txt_typo",
-                                    "FER_NOM",
-                                    "FER_OUVRAGE"
-			],
-            "layout": {
-                "symbol-placement": "line",
-                "text-field": "{texte}",
-                "text-size": 10,
-                "text-anchor": "center",
-				"text-offset": [0,-1],
-                "text-font": ["Source Sans Pro Regular"]
-            },
-            "paint": {
-                "text-color": "#000000",
-                "text-halo-width": 1,
-                "text-halo-color": "rgba(255, 255, 255, 1)"
-            }
-        },
-		{
-			"id": "toponyme station epuration, de pompage, usine de production eau",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_bati_ponc",
-			"minzoom":14,
-            "filter": ["==","txt_typo","station"],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{designation}",
-				"text-anchor": "left",
-				"text-offset": [0.8, 0],
-                "text-size": 11,
-                "text-allow-overlap": false,
-                "text-padding": 1,
-                "text-font": ["Source Sans Pro Italic"]
-			},
-			"paint": {
-                "text-color": "#447FB3"
-			}
-		},
-		{
-			"id": "toponyme bati ponc gare",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_bati_ponc",
-            "minzoom":15,
-            "filter": ["==","txt_typo","gore"],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{designation}",
-                "text-size": 11,
-                "text-allow-overlap": false,
-                "text-padding": 1,
-                "text-font": ["Source Sans Pro Italic"]
-			},
-			"paint": {
-                "text-color": "#000000"
-			}
-		},
-		{
-			"id": "toponyme bati ponc barrage",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_bati_ponc",
-            "minzoom":12,
-            "filter": ["==","txt_typo","BARRAGE_PONC"],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-				"text-anchor": "left",
-				"text-offset": [0.8, 0],
-                "text-size": 11,
-                "text-allow-overlap": false,
-                "text-padding": 1,
-                "text-font": ["Source Sans Pro"]
-			},
-			"paint": {
-                "text-color": "#447FB3"
-			}
-		},
-		{
-			"id": "toponyme bati ponc phare - niveau 13",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_bati_ponc",
-            "maxzoom":13,
-            "filter": ["==","txt_typo","PHARE"],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-				"text-anchor": "right",
-                "text-size": 11,
-                "text-allow-overlap": false,
-                "text-padding": 1,
-                "text-font": ["Source Sans Pro"]
-			},
-			"paint": {
-                "text-color": "#532A2A"
-			}
-		},		
-		{
-			"id": "toponyme bati ponc phare - niveau 14à19",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_bati_ponc",
-            "minzoom":13,
-            "filter": ["all",
-						["==","symbo","PHARE"],
-						["in","txt_typo",
-										"TYPO_C_6",
-										"TYPO_C_7",
-										"TYPO_C_8",
-										"TYPO_E_GE"]
-			],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-				"text-anchor": "right",
-                "text-size": { "stops": [[13, 12], [18, 18]] },
-                "text-allow-overlap": false,
-				"text-offset": [-2.00, 0],
-                "text-padding": 3,
-				"text-anchor": "right",
-                "text-font": ["Source Sans Pro"]
-			},
-			"paint": {
-                "text-color": "#532A2A"
-			}
-		},			
-		{
-			"id": "toponyme bati ponc autre",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_bati_ponc",
-            "minzoom":12,
-            "filter": ["in","txt_typo",
-                                        "BAT_ACTIVITE",
-                                        "BAT_FORTIF",
-                                        "BAT_VILLAGE_DETRUIT"],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-				"text-anchor": "center",
-                "text-size": 11,
-                "text-allow-overlap": false,
-                "text-padding": 1,
-                "text-font": ["Source Sans Pro"]
-			},
-			"paint": {
-                "text-color": "#532A2A"
-			}
-		},
-		{
-			"id": "toponyme bati ponc aerogare",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_bati_ponc",
-            "minzoom":14,
-			"maxzoom":17,
-            "filter": ["all",
-                        ["==","txt_typo","TYPO_E_GE"],
-                        ["==","symbo","AEROGARE"]
-                      ],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-				"text-anchor": "center",
-                "text-size": {"stops": [[12, 9], [16, 11]]},
-                "text-allow-overlap": false,
-                "text-padding": 1,
-                "text-font": ["Source Sans Pro Italic"]
-			},
-			"paint": {
-                "text-color": "#120049",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 1
-			}
-		},
-		{
-			"id": "toponyme bati ponc aeroport 12",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_bati_ponc",
-            "minzoom":11,
-			"maxzoom":12,
-            "filter": ["==","txt_typo","AEROPORT_PONC"],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-				"text-anchor": "bottom",
-				"text-offset": [0, -1.3],
-                "text-size": 10.5,
-                "text-allow-overlap": false,
-                "text-padding": 1,
-                "text-font": ["Source Sans Pro"]
-			},
-			"paint": {
-                "text-color": "#120049",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 2
-			}
-		},
-		{
-			"id": "toponyme bati ponc aeroport 13",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_bati_ponc",
-            "minzoom":12,
-			"maxzoom":13,
-            "filter": ["==","txt_typo","AEROPORT_PONC"],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-				"text-anchor": "bottom",
-				"text-offset": [0, -2],
-                "text-size": 11,
-                "text-allow-overlap": false,
-                "text-padding": 1,
-                "text-font": ["Source Sans Pro"]
-			},
-			"paint": {
-                "text-color": "#120049",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 2
-			}
-		},
-		{
-			"id": "toponyme bati ponc aeroport",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_bati_ponc",
-            "minzoom":13,
-			"maxzoom":17,
-            "filter": ["all",
-                        ["==","txt_typo","TYPO_A_5"],
-                        ["==","symbo","AEROPORT"]
-                      ],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-				"text-anchor": "center",
-                "text-size": {"stops": [[12, 11], [16, 13]]},
-                "text-allow-overlap": false,
-                "text-padding": 1,
-                "text-font": ["Source Sans Pro"]
-			},
-			"paint": {
-                "text-color": "#120049",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 2
-			}
-		},
-		{
-			"id": "toponyme bati ponc aerodrome 12",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_bati_ponc",
-            "minzoom":11,
-			"maxzoom":12,
-            "filter": ["==","txt_typo","AERODROME_PONC"],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-				"text-anchor": "bottom",
-				"text-offset": [0, -1.3],
-                "text-size": 9.5,
-                "text-allow-overlap": false,
-                "text-padding": 1,
-                "text-font": ["Source Sans Pro"]
-			},
-			"paint": {
-                "text-color": "#120049",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 2
-			}
-		},
-		{
-			"id": "toponyme bati ponc aerodrome 13",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_bati_ponc",
-            "minzoom":12,
-			"maxzoom":13,
-            "filter": ["==","txt_typo","AERODROME_PONC"],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-				"text-anchor": "bottom",
-				"text-offset": [0, -2],
-                "text-size": 10,
-                "text-allow-overlap": false,
-                "text-padding": 1,
-                "text-font": ["Source Sans Pro"]
-			},
-			"paint": {
-                "text-color": "#120049",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 2
-			}
-		},
-		{
-			"id": "toponyme bati ponc aerodrome",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_bati_ponc",
-            "minzoom":13,
-			"maxzoom":17,
-            "filter": ["all",
-                        ["==","txt_typo","TYPO_A_7"],
-                        ["==","symbo","AERODROME"]
-                      ],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-				"text-anchor": "center",
-                "text-size": {"stops": [[12, 10], [16, 12]]},
-                "text-allow-overlap": false,
-                "text-padding": 1,
-                "text-font": ["Source Sans Pro"]
-			},
-			"paint": {
-                "text-color": "#120049",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 2
-			}
-		},
-		{
-			"id": "toponyme - hydro ponc 5",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_hydro_ponc",
-            "filter": ["in","txt_typo",
-                                    "TYPO_D_9",
-                                    "TYPO_D_10",
-                                    "TYPO_E_1_cyan"
-            ],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-                "text-size": {"stops": [[15, 11], [17, 14]]},
-                "text-allow-overlap": true,
-                "text-padding": 5,
-                "text-font": ["Source Sans Pro Regular"]
-			},
-			"paint": {
-                "text-color": "#447FB3",
-                "text-halo-color": "#FFFFFF",
-                "text-halo-width": 1
-			}
-		},
-		{
-            "id": "toponyme - hydro ponc glacier",
-            "type": "symbol",
-            "source": "plan_ign",
-            "source-layer": "toponyme_hydro_ponc",
-            "filter": ["==","txt_typo","ORO_GLACIER_2"],
-            "layout": {
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-                "text-size": 14,
-                "text-anchor": "center",
-                "text-allow-overlap": true,
-                "text-padding": 1,
-                "text-font": ["Source Sans Pro Italic"]
-            },
-            "paint": {
-                "text-color": "#447FB3",
-                "text-halo-width": 2,
-                "text-halo-color": "rgba(255, 255, 255, 0.5)"
-            }
-        },
-		{
-			"id": "toponyme - limite militaire ponc 3 et 4",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_limite_ponc",
-            "filter": ["in","txt_typo",
-                                    "LIM_MILI_3",
-                                    "LIM_MILI_4"
-            ],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-                "text-size": 12,
-                "text-allow-overlap": false,
-                "text-padding": 2,
-                "text-font": ["Source Sans Pro Regular"]
-			},
-			"paint": {
-                "text-color": "#0D2000",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 1
-			}
-		},
-		{
-			"id": "toponyme - limite parc ponc 3 et 4",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_limite_ponc",
-            "filter": ["in","txt_typo",
-                                    "LIM_PARC_3",
-                                    "LIM_PARC_4",
-									"RESERVE_NATURELLE_PONC"
-            ],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-                "text-size": 13,
-                "text-allow-overlap": false,
-                "text-padding": 2,
-                "text-font": ["Source Sans Pro Regular"]
-			},
-			"paint": {
-                "text-color": "#287B00",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 1
-			}
-		},
-        {
-            "id": "toponyme numéro de route - départementale",
-            "type": "symbol",
-            "source": "plan_ign",
-            "source-layer": "toponyme_routier_numero_lin",
-            "minzoom":11,
-            "maxzoom":16,
-            "filter": ["==","txt_typo","Départementale"],
-            "layout": {
-                "visibility": "visible",
-                "symbol-placement": "line",
-                "text-field": "{texte}",
-                "text-size": 10.5,
-                "text-allow-overlap": false,
-                "text-padding": 2,
-                "text-anchor": "center",
-                "text-font": ["Source Sans Pro Semibold"],
-                "text-rotation-alignment": "viewport"
-            },
-            "paint": {
-                "text-color": "#4D4D4D",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 4
-            }
-        },
-        {
-            "id": "toponyme numéro de route - nationale",
-            "type": "symbol",
-            "source": "plan_ign",
-            "source-layer": "toponyme_routier_numero_lin",
-            "minzoom":7,
-            "maxzoom":16,
-            "filter": ["==","txt_typo","Nationale"],
-            "layout": {
-                "visibility": "visible",
-                "symbol-placement": "line",
-                "text-field": "{texte}",
-                "text-size": 12,
-                "text-allow-overlap": false,
-                "text-padding": 0,
-                "text-anchor": "center",
-                "text-font": ["Source Sans Pro Regular"],
-                "icon-image": "Ecluse",
-                "icon-rotation-alignment": "viewport",
-                "text-rotation-alignment": "viewport",
-                "icon-text-fit": "both",
-                "icon-size": 0
-            },
-            "paint": {
-                "text-color": "#F0F0F0",
-                "icon-color": "#646464",
-                "text-halo-color": "rgba(80, 80, 80, 0.5)",
-                "text-halo-width": 4
-            }
-        },      
-        {
-            "id": "toponyme numéro de route - autoroute",
-            "type": "symbol",
-            "source": "plan_ign",
-            "source-layer": "toponyme_routier_numero_lin",
-            "minzoom":7,
-            "maxzoom":16,
-            "filter": ["==","txt_typo","Autoroute"],
-            "layout": {
-                "visibility": "visible",
-                "symbol-placement": "line",
-                "text-field": "{texte}",
-                "text-size": 15,
-                "text-allow-overlap": false,
-                "text-padding": 0,
-                "text-anchor": "center",
-                "text-font": ["Source Sans Pro Regular"],
-                "icon-image": "Ecluse",
-                "icon-rotation-alignment": "viewport",
-                "text-rotation-alignment": "viewport",
-                "icon-text-fit": "both",
-                "icon-size": 0
-            },
-            "paint": {
-                "text-color": "#F0F0F0",
-                "icon-color": "#646464",
-                "text-halo-color": "rgba(80, 80, 80, 0.5)",
-                "text-halo-width": 5
-            }
-        },
-		{
-            "id": "toponyme - odonyme abrégé",
-            "type": "symbol",
-            "source": "plan_ign",
-            "source-layer": "toponyme_routier_odonyme_lin",
-			"minzoom": 15,
-            "maxzoom":17,
-            "layout": {
-                "symbol-placement": "line",
-                "text-field": "{nom_gauche}",
-                "text-size": 10,
-                "text-anchor": "center",
-                "text-max-angle": 30,
-                "text-font": ["Source Sans Pro Regular"]
-            },
-            "paint": {
-                "text-color": "#000000",
-                "text-halo-width": 2,
-                "text-halo-color": "rgba(255, 255, 255, 1)"
-            }
-        },
-		{
-            "id": "toponyme - odonyme desabrégé",
-            "type": "symbol",
-            "source": "plan_ign",
-            "source-layer": "toponyme_routier_odonyme_lin",
-			"minzoom": 17,
-            "layout": {
-                "symbol-placement": "line",
-                "text-field": "{nom_desabrege}",
-                "text-size": 11,
-                "text-anchor": "center",
-                "text-max-angle": 30,
-                "text-font": ["Source Sans Pro Regular"]
-            },
-            "paint": {
-                "text-color": "#000000",
-                "text-halo-width": 2,
-                "text-halo-color": "rgba(255, 255, 255, 1)"
-            }
-        },
-		{
-			"id": "toponyme - lieu dit non habité 3",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_ocs_ponc",
-            "filter": ["all",
-                        ["==","symbo","LIEU-DIT_NON_HABITE"],
-                        ["in","txt_typo",
-                                    "TYPO_B_10",
-                                    "TYPO_B_11"
-                        ]
-            ],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-                "text-size": 11,
-                "text-allow-overlap": false,
-                "text-padding": 1,
-                "text-font": ["Source Sans Pro Italic"]
-			},
-			"paint": {
-                "text-color": "#000000",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 1
-			}
-		},
-		{
-			"id": "toponyme - bois",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_ocs_ponc",
-            "filter": ["all",
-                        ["==","symbo","BOIS"],
-                        ["in","txt_typo",
-                                    "TYPO_F_10",
-                                    "TYPO_F_11"
-                        ]
-            ],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-                "text-size": 13,
-                "text-allow-overlap": false,
-                "text-padding": 1,
-                "text-font": ["Source Sans Pro Italic"]
-			},
-			"paint": {
-                "text-color": "#287B00",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 1
-			}
-		},
-		{
-            "id": "toponyme - oro lineaire 4",
-            "type": "symbol",
-            "source": "plan_ign",
-            "source-layer": "toponyme_oro_lin",
-            "filter": ["in","txt_typo",
-                                    "ORO_SOMMET_3",
-                                    "ORO_GORGE_2"
-            ],
-            "layout": {
-                "symbol-placement": "line",
-                "text-field": "{texte}",
-                "text-size": 11,
-                "text-anchor": "center",
-                "text-keep-upright": true,
-                "text-max-angle": 45,
-                "text-padding": 1,
-                "text-font": ["Source Sans Pro Italic"]
-            },
-            "paint": {
-                "text-color": "#863831",
-                "text-halo-width": 1.5,
-                "text-halo-color": "rgba(255, 255, 255, 0.5)"
-            }
-        },
-		{
-			"id": "toponyme - oro ponc 4",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_oro_ponc",
-            "filter": ["in","txt_typo",
-                                    "ORO_SOMMET_3",
-                                    "ORO_GORGE_2",
-                                    "GROTTE",
-                                    "GORGE",
-                                    "TYPO_G_9",
-                                    "TYPO_G_10"
-            ],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-                "text-size": {"stops": [[13, 11], [16, 16]]},
-                "text-allow-overlap": true,
-                "text-padding": 1,
-                "text-font": ["Source Sans Pro Italic"]
-			},
-			"paint": {
-                "text-color": "#863831",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 1.5
-			}
-		},
-		{
-			"id": "toponyme - hydro ponc 4",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_hydro_ponc",
-            "filter": ["in","txt_typo",
-                                    "lac - étang - bassin",
-                                    "HYD_SURF_4",
-                                    "HYD_SURF_4_T",
-                                    "HYD_SURF_5",
-                                    "HYD_SURF_5_T",
-                                    "TYPO_D_8",
-                                    "SOURCE"
-            ],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-                "text-size": {"stops": [[14, 13], [17, 16]]},
-                "text-allow-overlap": true,
-                "text-padding": 5,
-                "text-font": ["Source Sans Pro Regular"]
-			},
-			"paint": {
-                "text-color": "#447FB3",
-                "text-halo-color": "#FFFFFF",
-                "text-halo-width": 1
-			}
-		},
-		{
-			"id": "toponyme quartier ",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_localite_ponc",
-            "filter": ["in","txt_typo",
-                                    "BAT_QUARTIER",
-                                    "BAT_QUARTIER_T"
-            ],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-                "text-size": 11,
-                "text-allow-overlap": false,
-                "text-padding": 1,
-                "text-font": ["Source Sans Pro Italic"]
-			},
-			"paint": {
-                "text-color": "#000000",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 2
-			}
-		},
-		{
-			"id": "toponyme localite n0 typoA10",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_localite_ponc",
-            "maxzoom": 18,
-            "filter": ["==","txt_typo","TYPO_A_10"],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-                "text-size": {"stops": [[15, 11], [17, 13.5]]},
-                "text-allow-overlap": true,
-				"text-anchor": "center",
-                "text-padding": 1,
-                "text-font": ["Source Sans Pro Regular"]
-			},
-			"paint": {
-                "text-color": "#000000",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 2
-			}
-		},
-		{
-			"id": "toponyme - lieu dit non habité",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_ocs_ponc",
-            "filter": ["all",
-                        ["==","symbo","LIEU-DIT_NON_HABITE"],
-                        ["in","txt_typo",
-                                    "TYPO_B_7",
-                                    "TYPO_B_8",
-                                    "TYPO_B_9"
-                        ]
-            ],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-                "text-size": 12,
-                "text-allow-overlap": false,
-                "text-padding": 1,
-                "text-font": ["Source Sans Pro Italic"]
-			},
-			"paint": {
-                "text-color": "#000000",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 1
-			}
-		},
-		{
-			"id": "toponyme - bois 2",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_ocs_ponc",
-            "filter": ["all",
-                        ["==","symbo","BOIS"],
-                        ["in","txt_typo",
-                                    "TYPO_F_7",
-                                    "TYPO_F_8",
-                                    "TYPO_F_9"
-                        ]
-            ],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-                "text-size": 16,
-                "text-allow-overlap": false,
-                "text-padding": 1,
-                "text-font": ["Source Sans Pro Italic"]
-			},
-			"paint": {
-                "text-color": "#287B00",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 2
-			}
-		},
-		{
-			"id": "toponyme localite hameau ",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_localite_ponc",
-			"minzoom": 11,
-			"maxzoom": 13,
-            "filter": ["in","txt_typo",
-                                    "BAT_HAMEAU",
-                                    "BAT_HAMEAU_T"
-            ],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-				"icon-image": "Localite",
-				"icon-size": 0.17,
-                "text-field": "{texte}",
-                "text-size": 11,
-                "text-allow-overlap": false,
-				"text-anchor": "bottom-left",
-				"text-offset": [0.30, 0.10],
-                "text-padding": 1,
-                "text-font": ["Source Sans Pro Regular"]
-			},
-			"paint": {
-                "text-color": "#000000",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 2
-			}
-		},
-		{
-			"id": "toponyme localite importance 5",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_localite_ponc",
-			"minzoom": 9,
-            "filter": ["in","txt_typo",
-                                    "commune 5",
-                                    "BAT_COMMUNE_5",
-                                    "BAT_COMMUNE_5_T",
-                                    "BAT_CHEF_LIEU_COM",
-                                    "BAT_CHEF_LIEU_COM_T",
-									"BAT_CHEF_LIEU_COM-T",
-									"BAT_ANCIENNE_COM",
-									"BAT_ANCIENNE_COM_T",
-									"BAT_COMMUNE_ASSOCIEE",
-									"BAT_COMMUNE_ASSOCIEE_T",
-                                    "Commune très petite"
-            ],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-				"icon-image": "Localite",
-				"icon-size": 0.21,
-                "text-field": "{texte}",
-                "text-size": 11.5,
-                "text-allow-overlap": false,
-				"text-anchor": "bottom-left",
-				"text-offset": [0.30, 0.10],
-                "text-padding": 1,
-                "text-font": ["Source Sans Pro Regular"]
-			},
-			"paint": {
-                "text-color": "#000000",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 2
-			}
-		},
-		{
-            "id": "toponyme - ocs lineaire 3",
-            "type": "symbol",
-            "source": "plan_ign",
-            "source-layer": "toponyme_ocs_lin",
-            "filter": ["==","txt_typo","OCS_FORET_3"],
-            "layout": {
-                "symbol-placement": "line",
-                "text-field": "{texte}",
-                "text-size": {"stops": [[10, 12], [12, 15]]},
-                "text-anchor": "center",
-                "text-keep-upright": true,
-                "text-max-angle": 45,
-                "text-padding": 1,
-                "text-font": ["Source Sans Pro Italic"]
-            },
-            "paint": {
-                "text-color": "#287B00",
-                "text-halo-width": 1,
-                "text-halo-color": "rgba(255, 255, 255, 0.5)"
-            }
-        },
-		{
-			"id": "toponyme - lieu dit non habité 1",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_ocs_ponc",
-            "filter": ["all",
-                        ["==","symbo","LIEU-DIT_NON_HABITE"],
-                        ["in","txt_typo",
-                            "TYPO_B_5",
-                            "TYPO_B_4"
-                            
-                        ]
-            ],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-                "text-size": 15,
-                "text-allow-overlap": false,
-                "text-padding": 1,
-                "text-font": ["Source Sans Pro Italic"]
-			},
-			"paint": {
-                "text-color": "#000000",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 1
-			}
-		},
-		{
-			"id": "toponyme - bois 1",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_ocs_ponc",
-            "filter": ["all",
-                        ["==","symbo","BOIS"],
-                        ["in","txt_typo",
-                            "TYPO_F_5",
-                            "TYPO_F_4"                            
-                        ]
-            ],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-                "text-size": 19,
-                "text-allow-overlap": false,
-                "text-padding": 1,
-                "text-font": ["Source Sans Pro Italic"]
-			},
-			"paint": {
-                "text-color": "#287B00",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 2
-			}
-		},
-		{
-			"id": "toponyme - bois 0",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_ocs_ponc",
-            "filter": ["all",
-                        ["==","symbo","BOIS"],
-                        ["in","txt_typo",
-                            "TYPO_F_3",
-                            "TYPO_F_2"
-                        ]
-            ],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-                "text-size": 22,
-                "text-allow-overlap": false,
-                "text-padding": 1,
-                "text-font": ["Source Sans Pro Italic"]
-			},
-			"paint": {
-                "text-color": "#287B00",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 2
-			}
-		},
-		{
-			"id": "toponyme - ocs ponc 3",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_ocs_ponc",
-            "filter": ["==","txt_typo","OCS_FORET_3"],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-                "text-size": {"stops": [[10, 12], [12, 15]]},
-                "text-allow-overlap": false,
-                "text-padding": 1,
-				"text-anchor": "center",
-                "text-font": ["Source Sans Pro Italic"]
-			},
-			"paint": {
-                "text-color": "#287B00",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 1
-			}
-		},
-		{
-            "id": "toponyme - oro lineaire 3",
-            "type": "symbol",
-            "source": "plan_ign",
-            "source-layer": "toponyme_oro_lin",
-            "filter": ["in","txt_typo",
-                                    "ORO_ILE_3",
-                                    "ORO_RELIEF_3",
-                                    "ORO_RELIEF_3_T",
-                                    "ORO_RELIEF_4",
-                                    "ORO_RELIEF_4_T",
-                                    "ORO_CAP_2",
-                                    "ORO_CAP_3",
-                                    "ORO_SOMMET_2",
-                                    "ORO_COL_2",
-                                    "ORO_GORGE_1",
-									"ORO_GORGE-1"
-            ],
-            "layout": {
-                "symbol-placement": "line",
-                "text-field": "{texte}",
-                "text-size": 12,
-                "text-anchor": "center",
-                "text-keep-upright": true,
-                "text-max-angle": 45,
-                "text-padding": 10,
-                "text-font": ["Source Sans Pro Italic"]
-            },
-            "paint": {
-                "text-color": "#863831",
-                "text-halo-width": 1.5,
-                "text-halo-color": "rgba(255, 255, 255, 0.5)"
-            }
-        },
-		{
-			"id": "toponyme - oro ponc 3",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_oro_ponc",
-            "filter": ["in","txt_typo",
-                                    "ORO_ILE_3",
-                                    "ORO_RELIEF_3",
-                                    "ORO_RELIEF_3_T",
-                                    "ORO_RELIEF_4",
-                                    "ORO_RELIEF_4_T",
-                                    "ORO_CAP_2",
-                                    "ORO_CAP_3",
-                                    "ORO_SOMMET_2",
-                                    "ORO_COL_2",
-                                    "ORO_GORGE_1",
-									"ORO_GORGE-1",
-                                    "TYPO_G_7",
-                                    "TYPO_G_8"
-            ],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-                "text-size": {"stops": [[13, 12], [16, 17]]},
-                "text-allow-overlap": true,
-                "text-padding": 1,
-                "text-font": ["Source Sans Pro Italic"]
-			},
-			"paint": {
-                "text-color": "#863831",
-                "text-halo-color": "#FFFFFF",
-                "text-halo-width": 1.5
-			}
-		},
-		{
-            "id": "toponyme - hydro lineaire 3",
-            "type": "symbol",
-            "source": "plan_ign",
-            "source-layer": "toponyme_hydro_lin",
-            "filter": ["in","txt_typo",
-                                    "HYD_LIN_3",
-                                    "HYD_LIN_4",
-                                    "HYD_LIN_5",
-                                    "petite rivière",
-                                    "canal",
-                                    "HYD_SURF_3",
-                                    "HYD_SURF_3_T",
-                                    "HYD_SURF_4",
-                                    "HYD_SURF_4_T",
-                                    "HYD_SURF_5",
-                                    "HYD_SURF_5_T",
-                                    "TYPO_D_5"
-            ],
-            "layout": {
-                "symbol-placement": "line",
-                "text-field": "{texte}",
-                "text-size": {"stops": [[14, 12], [18, 19]]},
-                "text-anchor": "center",
-                "text-keep-upright": true,
-                "text-max-angle": 45,
-                "text-padding": 10,
-                "text-font": ["Source Sans Pro Regular"]
-            },
-            "paint": {
-                "text-color": "#447FB3",
-                "text-halo-width": 1.5,
-                "text-halo-color": "rgba(255, 255, 255, 0.7)"
-            }
-        },
-		{
-            "id": "toponyme - hydro lineaire 4",
-            "type": "symbol",
-            "source": "plan_ign",
-            "source-layer": "toponyme_hydro_lin",
-			"minzoom":14,
-            "filter": ["in","txt_typo",
-                                    "TYPO_D_6",
-                                    "TYPO_D_8",
-                                    "TYPO_D_9",
-                                    "TYPO_D_10"
-            ],
-            "layout": {
-                "symbol-placement": "line",
-                "text-field": "{texte}",
-                "text-size": {"stops": [[14, 10], [18, 16]]},
-                "text-anchor": "center",
-                "text-keep-upright": true,
-                "text-max-angle": 45,
-                "text-padding": 10,
-                "text-font": ["Source Sans Pro Regular"]
-            },
-            "paint": {
-                "text-color": "#447FB3",
-                "text-halo-width": 1.5,
-                "text-halo-color": "rgba(255, 255, 255, 0.7)"
-            }
-        },
-		{
-			"id": "toponyme - hydro ponc 3",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_hydro_ponc",
-            "filter": ["in","txt_typo",
-                                    "petit golfe",
-                                    "grande baie",
-                                    "baie",
-                                    "HYD_SURF_3",
-                                    "TYPO_D_5",
-                                    "TYPO_D_6",
-                                    "TYPO_D_7"
-            ],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-                "text-size": {"stops": [[15, 15], [17, 18]]},
-                "text-allow-overlap": true,
-                "text-padding": 10,
-                "text-font": ["Source Sans Pro Regular"]
-			},
-			"paint": {
-                "text-color": "#447FB3",
-                "text-halo-color": "#FFFFFF",
-                "text-halo-width": 2
-			}
-		},
-		{
-			"id": "toponyme bati ponc zai zoom 16",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_bati_ponc",
-            "minzoom":15,
-            "maxzoom":16,
-            "filter": ["==","txt_typo","zai"],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{designation}",
-                "text-size": 11,
-                "text-allow-overlap": false,
-                "text-padding": 1,
-                "text-font": ["Source Sans Pro Italic"]
-			},
-			"paint": {
-                "text-color": "#000000"
-			}
-		},
-		{
-			"id": "toponyme bati ponc zai zoom 17 et 18",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_bati_ponc",
-            "minzoom":16,
-            "filter": ["==","txt_typo","zai"],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-                "text-size": 11,
-                "text-allow-overlap": false,
-                "text-padding": 1,
-                "text-font": ["Source Sans Pro Italic"]
-			},
-			"paint": {
-                "text-color": "#000000"
-			}
-		},
-		{
-			"id": "toponyme localite importance 4",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_localite_ponc",
-			"minzoom": 7,
-            "filter": ["in","txt_typo",
-                                    "commune 4",
-                                    "BAT_COMMUNE_4",
-                                    "BAT_COMMUNE_4_T"
-             ],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-				"icon-image": "Localite",
-				"icon-size": 0.21,
-                "text-field": "{texte}",
-                "text-size": 13,
-                "text-allow-overlap": false,
-				"text-anchor": "bottom-left",
-				"text-offset": [0.30, 0.10],
-                "text-padding": 1,
-                "text-font": ["Source Sans Pro Regular"]
-			},
-			"paint": {
-                "text-color": "#000000",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 2
-			}
-		},
-		{
-			"id": "toponyme localite n0 typoA9",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_localite_ponc",
-            "maxzoom": 18,
-            "filter": ["==","txt_typo","TYPO_A_9"],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-                "text-size": {"stops": [[15, 11.5], [17, 14]]},
-                "text-allow-overlap": true,
-				"text-anchor": "center",
-                "text-padding": 1,
-                "text-font": ["Source Sans Pro Regular"]
-			},
-			"paint": {
-                "text-color": "#000000",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 2
-			}
-		},
-		{
-			"id": "toponyme localite n0 typoA8",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_localite_ponc",
-            "maxzoom": 18,
-            "filter": ["==","txt_typo","TYPO_A_8"],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-                "text-size": {"stops": [[15, 12], [17, 15]]},
-                "text-allow-overlap": true,
-				"text-anchor": "center",
-                "text-padding": 1,
-                "text-font": ["Source Sans Pro Regular"]
-			},
-			"paint": {
-                "text-color": "#000000",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 2
-			}
-		},
-		{
-			"id": "toponyme - limite militaire ponc 1 et 2",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_limite_ponc",
-            "filter": ["in","txt_typo",
-                                    "LIM_MILI_1",
-                                    "LIM_MILI_2"
-            ],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-                "text-size": 15,
-                "text-allow-overlap": false,
-                "text-padding": 5,
-                "text-font": ["Source Sans Pro Regular"]
-			},
-			"paint": {
-                "text-color": "#0D2000",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 2
-			}
-		},
-		{
-			"id": "toponyme - limite parc marin",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_limite_ponc",
-			"minzoom": 8,
-            "filter": ["==","txt_typo","LIM_PARC_NATUREL_MARIN"],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-                "text-size": 15,
-                "text-allow-overlap": false,
-                "text-padding": 10,
-                "text-transform": "uppercase",
-                "text-font": ["Source Sans Pro Regular"]
-			},
-			"paint": {
-                "text-color": "#2A81A2",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 2
-			}
-		},
-		{
-			"id": "toponyme - limite parc ponc 1 et 2",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_limite_ponc",
-			"minzoom":8,
-            "filter": ["in","txt_typo",
-                                    "LIM_PARC_1",
-                                    "LIM_PARC_2",
-                                    "LIM_PARC_NATUREL"
-            ],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-                "text-size": 15,
-                "text-allow-overlap": false,
-                "text-padding": 10,
-                "text-transform": "uppercase",
-                "text-font": ["Source Sans Pro Regular"]
-			},
-			"paint": {
-                "text-color": "#287B00",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 2
-			}
-		},
-		{
-            "id": "toponyme - ocs lineaire 2",
-            "type": "symbol",
-            "source": "plan_ign",
-            "source-layer": "toponyme_ocs_lin",
-            "filter": ["==","txt_typo","OCS_FORET_2"],
-            "layout": {
-                "symbol-placement": "line",
-                "text-field": "{texte}",
-                "text-size": {"stops": [[10, 15], [12, 18]]},
-                "text-anchor": "center",
-                "text-keep-upright": true,
-                "text-max-angle": 45,
-                "text-padding": 1,
-                "text-font": ["Source Sans Pro Regular"]
-            },
-            "paint": {
-                "text-color": "#287B00",
-                "text-halo-width": 2,
-                "text-halo-color": "rgba(255, 255, 255, 0.5)"
-            }
-        },
-		{
-			"id": "toponyme - ocs ponc 2",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_ocs_ponc",
-            "filter": ["==","txt_typo","OCS_FORET_2"],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-                "text-size": {"stops": [[10, 15], [12, 18]]},
-                "text-allow-overlap": false,
-                "text-padding": 1,
-				"text-anchor": "center",
-                "text-font": ["Source Sans Pro Regular"]
-			},
-			"paint": {
-                "text-color": "#287B00",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 2
-			}
-		},
-		{
-            "id": "toponyme - oro lineaire 2",
-            "type": "symbol",
-            "source": "plan_ign",
-            "source-layer": "toponyme_oro_lin",
-            "filter": ["in","txt_typo",
-                                    "ORO_ILE_2",
-                                    "ORO_RELIEF_2",
-                                    "ORO_RELIEF_2_T",
-                                    "ORO_CAP_1",
-                                    "ORO_SOMMET_1"
-            ],
-            "layout": {
-                "symbol-placement": "line",
-                "text-field": "{texte}",
-                "text-size": 15,
-                "text-anchor": "center",
-                "text-keep-upright": true,
-				"text-padding": 10,
-                "text-max-angle": 45,
-                "text-font": ["Source Sans Pro Regular"]
-            },
-            "paint": {
-                "text-color": "#863831",
-                "text-halo-width": 2,
-                "text-halo-color": "rgba(255, 255, 255, 0.5)"
-            }
-        },
-		{
-			"id": "toponyme - oro ponc 2",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_oro_ponc",
-			"minzoom":9,
-            "filter": ["in","txt_typo",
-                                    "ORO_ILE_2",
-                                    "ORO_RELIEF_2",
-                                    "ORO_RELIEF_2_T",
-                                    "ORO_CAP_1",
-                                    "ORO_COL_1",
-                                    "sommet ou col",
-                                    "ORO_SOMMET_1",
-                                    "TYPO_G_4",
-                                    "TYPO_G_6"
-            ],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-                "text-size": {"stops": [[9, 13], [10, 15], [13, 15], [16, 19]]},
-                "text-allow-overlap": false,
-                "text-padding": 1,
-                "text-font": ["Source Sans Pro Regular"]
-			},
-			"paint": {
-                "text-color": "#863831",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 2
-			}
-		},
-		{
-			"id": "toponyme - oro ponc 2B",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_oro_ponc",
-			"minzoom":8,
-            "filter": ["in","txt_typo",
-                                    "île",
-                                    "cap ou pointe"
-            ],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-                "text-size": 15,
-                "text-allow-overlap": false,
-                "text-padding": 1,
-                "text-font": ["Source Sans Pro Regular"]
-			},
-			"paint": {
-                "text-color": "#863831",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 2
-			}
-		},
-		{
-            "id": "toponyme - hydro lineaire 2",
-            "type": "symbol",
-            "source": "plan_ign",
-            "source-layer": "toponyme_hydro_lin",
-            "filter": ["in","txt_typo",
-                                    "HYD_LIN_2",
-                                    "rivière moyenne",
-                                    "HYD_SURF_2",
-                                    "HYD_SURF_2_T",
-                                    "TYPO_D_3"
-            ],
-            "layout": {
-                "symbol-placement": "line",
-                "text-field": "{texte}",
-                "text-size": {"stops": [[14, 15], [18, 21]]},
-                "text-anchor": "center",
-                "text-keep-upright": true,
-                "text-max-angle": 45,
-                "text-padding": 10,
-                "text-font": ["Source Sans Pro Regular"]
-            },
-            "paint": {
-                "text-color": "#447FB3",
-                "text-halo-width": 2,
-                "text-halo-color": "rgba(255, 255, 255, 0.5)"
-            }
-        },
-		{
-			"id": "toponyme - hydro ponc 2",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_hydro_ponc",
-			"minzoom": 5,
-            "filter": ["in","txt_typo",
-                                    "moyen",
-                                    "golfe moyen",
-                                    "HYD_SURF_2",
-                                    "TYPO_D_2",
-                                    "TYPO_D_3",
-                                    "TYPO_D_4"
-            ],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-                "text-size": {"stops": [[5, 12], [6, 18], [10, 17], [18, 21]]},
-                "text-allow-overlap": false,
-                "text-padding": 10,
-                "text-font": ["Source Sans Pro Regular"]
-			},
-			"paint": {
-                "text-color": "#447FB3",
-                "text-halo-color": "#FFFFFF",
-                "text-halo-width": 2
-			}
-		},
-		{
-			"id": "toponyme localite importance 3",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_localite_ponc",
-			"minzoom": 5,
-            "filter": ["in","txt_typo",
-                                    "commune 3",
-                                    "BAT_COMMUNE_3",
-                                    "BAT_COMMUNE_3_T"
-            ],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-				"icon-image": "Localite",
-				"icon-size": 0.21,
-                "text-field": "{texte}",
-                "text-size": {"stops": [[5, 10], [6, 15]]},
-                "text-allow-overlap": false,
-				"text-anchor": "bottom-left",
-				"text-offset": [0.30, 0.10],
-                "text-padding": 1,
-                "text-font": ["Source Sans Pro Regular"]
-			},
-			"paint": {
-                "text-color": "#000000",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 2
-			}
-		},
-		{
-			"id": "toponyme localite n0 typoA7 non commune",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_localite_ponc",
-            "maxzoom": 18,
-            "filter": ["all",
-						["!=","symbo","COMMUNE_FUSIONNEE"],
-						["!=","symbo","COMMUNE_CHEF_LIEU"],
-						["==","txt_typo","TYPO_A_7"]
-            ],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-                "text-size": {"stops": [[15, 13], [17, 16]]},
-                "text-allow-overlap": true,
-				"text-anchor": "center",
-                "text-padding": 1,
-                "text-font": ["Source Sans Pro Regular"]
-			},
-			"paint": {
-                "text-color": "#000000",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 2
-			}
-		},
-		{
-			"id": "toponyme localite n0 typoA6 non commune",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_localite_ponc",
-            "maxzoom": 18,
-            "filter": ["all",
-						["!=","symbo","COMMUNE_FUSIONNEE"],
-						["!=","symbo","COMMUNE_CHEF_LIEU"],
-						["==","txt_typo","TYPO_A_6"]
-            ],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-                "text-size": {"stops": [[15, 15], [17, 18]]},
-                "text-allow-overlap": true,
-				"text-anchor": "center",
-                "text-padding": 1,
-                "text-font": ["Source Sans Pro Regular"]
-			},
-			"paint": {
-                "text-color": "#000000",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 2
-			}
-		},
-		{
-            "id": "toponyme - oro lineaire 1",
-            "type": "symbol",
-            "source": "plan_ign",
-            "source-layer": "toponyme_oro_lin",
-            "filter": ["in","txt_typo",
-                                    "ORO_ILE_1",
-                                    "ORO_RELIEF_1",
-                                    "ORO_RELIEF_1_T"
-            ],
-            "layout": {
-                "symbol-placement": "line",
-                "text-field": "{texte}",
-                "text-size": 20,
-                "text-anchor": "center",
-                "text-keep-upright": true,
-                "text-padding": 5,
-                "text-max-angle": 45,
-                "text-font": ["Source Sans Pro Regular"]
-            },
-            "paint": {
-                "text-color": "#863831",
-                "text-halo-width": 2,
-                "text-halo-color": "rgba(255, 255, 255, 0.5)"
-            }
-        },
-		{
-			"id": "toponyme - oro ponc monde",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_oro_ponc",
-            "minzoom": 5,
-            "filter": ["in","txt_typo",
-                                    "Basin",
-                                    "Depression",
-                                    "Desert",
-                                    "Geoarea",
-                                    "Gorge",
-                                    "Isthmus",
-                                    "Lake",
-                                    "Lowland",
-                                    "Pen/cape",
-                                    "Plain",
-                                    "Plateau",
-                                    "Range/mtn",
-                                    "Tundra",
-                                    "Valley",
-                                    "Island",
-                                    "Island group"
-            ],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-                "text-size": 11,
-                "text-allow-overlap": false,
-                "text-padding": 1,
-                "text-font": ["Source Sans Pro Italic"]
-			},
-			"paint": {
-                "text-color": "#863831",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 2
-			}
-		},
-		{
-			"id": "toponyme localite n0 typoA4 non commune",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_localite_ponc",
-            "maxzoom": 16,
-            "filter": ["all",
-						["!=","symbo","COMMUNE_FUSIONNEE"],
-						["!=","symbo","COMMUNE_CHEF_LIEU"],
-						["==","txt_typo","TYPO_A_4"]
-            ],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-                "text-size": 17,
-                "text-allow-overlap": true,
-				"text-anchor": "center",
-                "text-padding": 1,
-                "text-font": ["Source Sans Pro Regular"]
-			},
-			"paint": {
-                "text-color": "#000000",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 3
-			}
-		},
-		{
-            "id": "toponyme - ocs lineaire 1",
-            "type": "symbol",
-            "source": "plan_ign",
-            "source-layer": "toponyme_ocs_lin",
-            "filter": ["==","txt_typo","OCS_FORET_1"],
-            "layout": {
-                "symbol-placement": "line",
-                "text-field": "{texte}",
-                "text-size": {"stops": [[10, 18], [12, 22]]},
-                "text-anchor": "center",
-                "text-keep-upright": true,
-                "text-padding": 1,
-                "text-max-angle": 45,
-                "text-font": ["Source Sans Pro Regular"]
-            },
-            "paint": {
-                "text-color": "#287B00",
-                "text-halo-width": 2,
-                "text-halo-color": "rgba(255, 255, 255, 0.5)"
-            }
-        },
-		{
-			"id": "toponyme - ocs ponc 1",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_ocs_ponc",
-            "filter": ["==","txt_typo","OCS_FORET_1"],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-                "text-size": {"stops": [[10, 18], [12, 22]]},
-                "text-allow-overlap": true,
-                "text-padding": 1,
-                "text-font": ["Source Sans Pro Regular"]
-			},
-			"paint": {
-                "text-color": "#287B00",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 2
-			}
-		},
-		{
-			"id": "toponyme - oro ponc 1",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_oro_ponc",
-			"minzoom":8,
-            "filter": ["in","txt_typo",
-                                    "grande île",
-                                    "ORO_ILE_1",
-                                    "ORO_RELIEF_1",
-                                    "ORO_RELIEF_1_T",
-                                    "TYPO_G_3",
-                                    "TYPO_G_2",
-                                    "TYPO_G_1"
-            ],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-                "text-size": 21,
-                "text-allow-overlap": true,
-                "text-padding": 1,
-                "text-font": ["Source Sans Pro Regular"]
-			},
-			"paint": {
-                "text-color": "#863831",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 2
-			}
-		},
-		{
-            "id": "toponyme - hydro lineaire glacier",
-            "type": "symbol",
-            "source": "plan_ign",
-            "source-layer": "toponyme_hydro_lin",
-            "filter": ["in","txt_typo",
-                                    "ORO_GLACIER_1",
-                                    "ORO_GLACIER_2"
-            ],
-            "layout": {
-                "symbol-placement": "line",
-                "text-field": "{texte}",
-                "text-size": 15,
-                "text-anchor": "center",
-                "text-keep-upright": true,
-                "text-max-angle": 45,
-                "text-font": ["Source Sans Pro Italic"]
-            },
-            "paint": {
-                "text-color": "#447FB3",
-                "text-halo-width": 2,
-                "text-halo-color": "rgba(255, 255, 255, 0.5)"
-            }
-        },
-		{
-            "id": "toponyme - hydro lineaire 1",
-            "type": "symbol",
-            "source": "plan_ign",
-            "source-layer": "toponyme_hydro_lin",
-            "filter": ["in","txt_typo",
-                                    "HYD_LIN_1",
-									"HYD-LIN-1",
-                                    "grande rivière",
-                                    "HYD_SURF_1",
-                                    "HYD_SURF_1_T",
-                                    "TYPO_D_1",
-                                    "TYPO_D_2"
-            ],
-            "layout": {
-                "symbol-placement": "line",
-                "text-field": "{texte}",
-                "text-size": 18,
-                "text-anchor": "center",
-                "text-keep-upright": true,
-                "text-max-angle": 45,
-                "text-padding": 10,
-                "text-font": ["Source Sans Pro Regular"]
-            },
-            "paint": {
-                "text-color": "#447FB3",
-                "text-halo-width": 2,
-                "text-halo-color": "rgba(255, 255, 255, 0.5)"
-            }
-        },
-		{
-            "id": "toponyme - hydro lineaire ocean",
-            "type": "symbol",
-            "source": "plan_ign",
-            "source-layer": "toponyme_hydro_lin",
-            "filter": ["==","txt_typo","mer et océan"],
-            "layout": {
-                "symbol-placement": "line",
-                "text-field": "{texte}",
-                "text-size": 30,
-                "text-anchor": "center",
-                "text-keep-upright": true,
-                "text-max-angle": 45,
-                "text-padding": 10,
-                "text-font": ["Source Sans Pro Regular"]
-            },
-            "paint": {
-                "text-color": "#447FB3",
-                "text-halo-width": 4,
-                "text-halo-color": "rgba(255, 255, 255, 0.5)"
-            }
-        },
-		{
-			"id": "toponyme - hydro ponc 1",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_hydro_ponc",
-			"minzoom": 4,
-            "filter": ["in","txt_typo",
-                                    "mer",
-                                    "grand",
-                                    "grand golfe",
-                                    "HYD_SURF_1",
-                                    "TYPO_D_1"
-            ],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-                "text-size": {"stops": [[4, 16], [6, 30], [10, 25]]},
-                "text-allow-overlap": true,
-                "text-padding": 10,
-                "text-font": ["Source Sans Pro Regular"]
-			},
-			"paint": {
-                "text-color": "#447FB3",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 4
-			}
-		},
-		{
-			"id": "toponyme localite importance 2",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_localite_ponc",
-			"minzoom": 4,
-            "filter": ["in","txt_typo",
-                                    "commune 2",
-                                    "BAT_COMMUNE_2",
-									"BAT_COMMUNE-2",
-                                    "BAT_COMMUNE_2_T"
-            ],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-				"icon-image": "Localite",
-				"icon-size": 0.25,
-                "text-field": "{texte}",
-                "text-size": {"stops": [[4, 10], [6, 17]]},
-                "text-allow-overlap": true,
-				"text-anchor": "bottom-left",
-				"text-offset": [0.30, 0.2],
-                "text-padding": 1,
-                "text-transform": "uppercase",
-                "text-font": {"stops": [[1, ["Source Sans Pro Regular"]], [7, ["Source Sans Pro Bold"]], [10, ["Source Sans Pro Regular"]]]}
-			},
-			"paint": {
-                "text-color": "#000000",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 3
-			}
-		},
-		{
-			"id": "toponyme localite n0 typoA3 non commune",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_localite_ponc",
-            "maxzoom": 16,
-            "filter": ["all",
-						["!=","symbo","COMMUNE_FUSIONNEE"],
-						["!=","symbo","COMMUNE_CHEF_LIEU"],
-						["==","txt_typo","TYPO_A_3"]
-            ],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-                "text-size": 19,
-                "text-allow-overlap": true,
-				"text-anchor": "center",
-                "text-padding": 1,
-                "text-font": ["Source Sans Pro Regular"]
-			},
-			"paint": {
-                "text-color": "#000000",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 3
-			}
-		},
-		{
-			"id": "toponyme localite n0 typoA2 non commune",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_localite_ponc",
-            "maxzoom": 16,
-            "filter": ["all",
-						["!=","symbo","COMMUNE_FUSIONNEE"],
-						["!=","symbo","COMMUNE_CHEF_LIEU"],
-						["==","txt_typo","TYPO_A_2"]
-            ],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-                "text-size": 21,
-                "text-allow-overlap": true,
-				"text-anchor": "center",
-                "text-padding": 1,
-                "text-font": ["Source Sans Pro Regular"]
-			},
-			"paint": {
-                "text-color": "#000000",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 4
-			}
-		},
-		{
-			"id": "toponyme localite n0 typoA7 commune",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_localite_ponc",
-            "maxzoom": 18,
-            "filter": ["all",
-						["in","symbo","COMMUNE_FUSIONNEE","COMMUNE_CHEF_LIEU"],
-						["==","txt_typo","TYPO_A_7"]
-            ],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-                "text-size": {"stops": [[15, 13], [17, 16]]},
-                "text-allow-overlap": true,
-				"text-anchor": "center",
-                "text-padding": 1,
-				"text-transform": "uppercase",
-                "text-font": ["Source Sans Pro Regular"]
-			},
-			"paint": {
-                "text-color": "#000000",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 2
-			}
-		},
-		{
-			"id": "toponyme localite n0 typoA6 commune",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_localite_ponc",
-            "maxzoom": 18,
-            "filter": ["all",
-						["in","symbo","COMMUNE_FUSIONNEE","COMMUNE_CHEF_LIEU"],
-						["==","txt_typo","TYPO_A_6"]
-            ],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-                "text-size": {"stops": [[15, 15], [17, 18]]},
-                "text-allow-overlap": true,
-				"text-anchor": "center",
-                "text-padding": 1,
-				"text-transform": "uppercase",
-                "text-font": ["Source Sans Pro Regular"]
-			},
-			"paint": {
-                "text-color": "#000000",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 2
-			}
-		},
-		{
-			"id": "toponyme localite n0 typoA1 non commune",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_localite_ponc",
-            "maxzoom": 16,
-            "filter": ["all",
-						["!=","symbo","COMMUNE_FUSIONNEE"],
-						["!=","symbo","COMMUNE_CHEF_LIEU"],
-						["==","txt_typo","TYPO_A_1"]
-            ],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-                "text-size": 23,
-                "text-allow-overlap": true,
-				"text-anchor": "center",
-                "text-padding": 1,
-                "text-font": ["Source Sans Pro Regular"]
-			},
-			"paint": {
-                "text-color": "#000000",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 4
-			}
-		},
-		{
-			"id": "toponyme localite n0 typoA4 commune",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_localite_ponc",
-            "maxzoom": 16,
-            "filter": ["all",
-						["in","symbo","COMMUNE_FUSIONNEE","COMMUNE_CHEF_LIEU"],
-						["==","txt_typo","TYPO_A_4"]
-            ],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-                "text-size": 17,
-                "text-allow-overlap": true,
-				"text-anchor": "center",
-                "text-padding": 1,
-                "text-transform": "uppercase",
-                "text-font": ["Source Sans Pro Regular"]
-			},
-			"paint": {
-                "text-color": "#000000",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 3
-			}
-		},
-		{
-			"id": "toponyme localite n0 typoA3 commune",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_localite_ponc",
-            "maxzoom": 16,
-            "filter": ["all",
-						["in","symbo","COMMUNE_FUSIONNEE","COMMUNE_CHEF_LIEU"],
-						["==","txt_typo","TYPO_A_3"]
-            ],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-                "text-size": 19,
-                "text-allow-overlap": true,
-				"text-anchor": "center",
-                "text-padding": 1,
-                "text-transform": "uppercase",
-                "text-font": ["Source Sans Pro Regular"]
-			},
-			"paint": {
-                "text-color": "#000000",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 3
-			}
-		},
-		{
-			"id": "toponyme localite n0 typoA2 commune",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_localite_ponc",
-            "maxzoom": 16,
-            "filter": ["all",
-						["in","symbo","COMMUNE_FUSIONNEE","COMMUNE_CHEF_LIEU"],
-						["==","txt_typo","TYPO_A_2"]
-            ],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-                "text-size": 21,
-                "text-allow-overlap": true,
-				"text-anchor": "center",
-                "text-padding": 1,
-                "text-transform": "uppercase",
-                "text-font": ["Source Sans Pro Regular"]
-			},
-			"paint": {
-                "text-color": "#000000",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 4
-			}
-		},
-		{
-			"id": "toponyme localite importance 1",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_localite_ponc",
-			"minzoom": 3,
-            "filter": ["in","txt_typo",
-                                    "commune 1",
-                                    "BAT_COMMUNE_1",
-                                    "BAT_COMMUNE_1_T"
-            ],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-				"icon-image": "Localite",
-				"icon-size": 0.3,
-                "text-field": "{texte}",
-                "text-size": {"stops": [[3, 10], [6, 20]]},
-                "text-allow-overlap": false,
-				"text-anchor": "bottom-left",
-				"text-offset": [0.25, -0.10],
-                "text-padding": 1,
-                "text-transform": "uppercase",
-                "text-font": {"stops": [[1, ["Source Sans Pro Regular"]], [7, ["Source Sans Pro Bold"]], [10, ["Source Sans Pro Regular"]]]}
-			},
-			"paint": {
-                "text-color": "#000000",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 4
-			}
-		},
-		{
-			"id": "toponyme localite n0 typoA1 commune",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_localite_ponc",
-            "maxzoom": 16,
-            "filter": ["all",
-						["in","symbo","COMMUNE_FUSIONNEE","COMMUNE_CHEF_LIEU"],
-						["==","txt_typo","TYPO_A_1"]
-            ],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-                "text-size": 23,
-                "text-allow-overlap": true,
-				"text-anchor": "center",
-                "text-padding": 1,
-                "text-transform": "uppercase",
-                "text-font": ["Source Sans Pro Regular"]
-			},
-			"paint": {
-                "text-color": "#000000",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 4
-			}
-		},
-		{
-			"id": "toponyme - hydro ponc ocean",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_hydro_ponc",
-			"minzoom": 1,
-            "filter": ["==","txt_typo","ocean"],
-			"layout": {
-				"visibility": "visible",
-                "symbol-placement": "point",
-                "text-field": "{texte}",
-                "text-size": {"stops": [[1, 16], [6, 30]]},
-                "text-allow-overlap": true,
-				"text-anchor": "center",
-                "text-padding": 10,
-                "text-font": ["Source Sans Pro Regular"]
-			},
-			"paint": {
-                "text-color": "#447FB3",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 4
-			}
-		},
-    	{
-			"id": "toponyme pays 3",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_localite_ponc",
-			"minzoom": 4,
-			"maxzoom": 5,
-            "filter": ["==","txt_typo","pays 3"],
-			"layout": {
-				"visibility": "visible",
-                "text-field": "{texte}",
-                "text-size": 9,
-                "text-allow-overlap": true,
-				"text-anchor": "center",
-                "text-padding": 1,
-                "text-transform": "uppercase",
-                "text-font": ["Source Sans Pro Regular"]
-			},
-			"paint": {
-                "text-color": "#787878",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 4
-			}
-		},
-    	{
-			"id": "toponyme pays 2",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_localite_ponc",
-			"minzoom": 2,
-			"maxzoom": 5,
-            "filter": ["==","txt_typo","pays 2"],
-			"layout": {
-				"visibility": "visible",
-                "text-field": "{texte}",
-                "text-size": 13,
-                "text-allow-overlap": true,
-				"text-anchor": "center",
-                "text-padding": 2,
-                "text-transform": "uppercase",
-                "text-font": ["Source Sans Pro Regular"]
-			},
-			"paint": {
-                "text-color": "#787878",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 4
-			}
-		},
-        {
-			"id": "toponyme pays 1",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_localite_ponc",
-			"minzoom": 2,
-			"maxzoom": 5,
-            "filter": ["==","txt_typo","pays 1"],    
-			"layout": {
-				"visibility": "visible",
-                "text-field": "{texte}",
-                "text-size": 13,
-                "text-allow-overlap": true,
-				"text-anchor": "center",
-                "text-padding": 2,
-                "text-transform": "uppercase",
-                "text-font": ["Source Sans Pro Regular"]
-			},
-			"paint": {
-                "text-color": "#787878",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 4
-			}
-		},
-        {
-			"id": "toponyme continent",
-			"type": "symbol",
-			"source": "plan_ign",
-			"source-layer": "toponyme_localite_ponc",
-			"maxzoom": 3,
-            "filter": ["==","txt_typo","continent"],
-			"layout": {
-				"visibility": "visible",
-                "text-field": "{texte}",
-                "text-size": 15,
-                "text-allow-overlap": true,
-				"text-anchor": "center",
-                "text-padding": 1,
-                "text-transform": "uppercase",
-                "text-font": ["Source Sans Pro Bold"]
-			},
-			"paint": {
-                "text-color": "#787878",
-                "text-halo-color": "rgba(255, 255, 255, 0.5)",
-                "text-halo-width": 4
-			}
-		}
+	 {
+	  "id": "bckgrd",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "fond_opaque",
+	  "minzoom": 0,
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "paint": {
+	   "fill-color": "#FFFFFF",
+	   "fill-opacity": 1
+	  }
+	 },
+	 {
+	  "id": "orographie : relief - 0m",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "oro_relief",
+	  "minzoom": 0,
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "HYPSO_0"
+	  ],
+	  "paint": {
+	   "fill-color": "#D6E5BA",
+	   "fill-opacity": 1
+	  }
+	 },
+	 {
+	  "id": "orographie : relief - 100m",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "oro_relief",
+	  "minzoom": 0,
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "HYPSO_100"
+	  ],
+	  "paint": {
+	   "fill-color": "#F7F2DA",
+	   "fill-opacity": 1
+	  }
+	 },
+	 {
+	  "id": "orographie : relief - 200m",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "oro_relief",
+	  "minzoom": 0,
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "HYPSO_200"
+	  ],
+	  "paint": {
+	   "fill-color": "#EBDEBF",
+	   "fill-opacity": 1
+	  }
+	 },
+	 {
+	  "id": "orographie : relief - 1000m",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "oro_relief",
+	  "minzoom": 0,
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "HYPSO_1000"
+	  ],
+	  "paint": {
+	   "fill-color": "#DABE97",
+	   "fill-opacity": 1
+	  }
+	 },
+	 {
+	  "id": "orographie : relief - 3000m",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "oro_relief",
+	  "minzoom": 0,
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "HYPSO_3000"
+	  ],
+	  "paint": {
+	   "fill-color": "#B28773",
+	   "fill-opacity": 1
+	  }
+	 },
+	 {
+	  "id": "orographie : relief - 4000m",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "oro_relief",
+	  "minzoom": 0,
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "HYPSO_4000"
+	  ],
+	  "paint": {
+	   "fill-color": "#9E6A54",
+	   "fill-opacity": 1
+	  }
+	 },
+	 {
+	  "id": "orographie : relief - 5000m",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "oro_relief",
+	  "minzoom": 0,
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "HYPSO_5000"
+	  ],
+	  "paint": {
+	   "fill-color": "#773A2B",
+	   "fill-opacity": 1
+	  }
+	 },
+	 {
+	  "id": "orographie : relief - glacier",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "oro_relief",
+	  "minzoom": 0,
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "GLACIER"
+	  ],
+	  "paint": {
+	   "fill-color": "#FFFFFF",
+	   "fill-opacity": 0.7
+	  }
+	 },
+	 {
+	  "id": "ocs - vegetation - zone boiséee, foret fermee, peupleraie",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "ocs_vegetation_surf",
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "ZONE_BOISEE",
+	   "ZONE_FORET_FERMEE_FEUIL",
+	   "ZONE_FORET_FERMEE_CONI",
+	   "ZONE_FORET_FERMEE_MIXTE",
+	   "ZONE_PEUPLERAIE"
+	  ],
+	  "paint": {
+	   "fill-color": "#DFE8D5",
+	   "fill-outline-color": "#DFE8D5"
+	  }
+	 },
+	 {
+	  "id": "ocs - vegetation - forêt ouverte",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "ocs_vegetation_surf",
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "ZONE_FORET_OUVERTE"
+	  ],
+	  "paint": {
+	   "fill-color": "#EDF2D9",
+	   "fill-outline-color": "#EDF2D9"
+	  }
+	 },
+	 {
+	  "id": "ocs - vegetation - lande ligneuse",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "ocs_vegetation_surf",
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "ZONE_LANDE_LIGNEUSE"
+	  ],
+	  "paint": {
+	   "fill-color": "#F2EECD"
+	  }
+	 },
+	 {
+	  "id": "ocs - vegetation - vigne",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "ocs_vegetation_surf",
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "ZONE_VIGNE"
+	  ],
+	  "paint": {
+	   "fill-color": "#FFEDD9"
+	  }
+	 },
+	 {
+	  "id": "ocs - vegetation - verger",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "ocs_vegetation_surf",
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "ZONE_VERGER"
+	  ],
+	  "paint": {
+	   "fill-color": "#FAE2C5"
+	  }
+	 },
+	 {
+	  "id": "ocs - vegetation - canne à sucre, bananeraie",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "ocs_vegetation_surf",
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "ZONE_CANNE_BANANE"
+	  ],
+	  "paint": {
+	   "fill-color": "#FAEDFA"
+	  }
+	 },
+	 {
+	  "id": "hydro surfacique - Estran",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "hydro_surf",
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "ZONE_D_ESTRAN"
+	  ],
+	  "paint": {
+	   "fill-color": "#C3DDE9",
+	   "fill-outline-color": "#C3DDE9"
+	  }
+	 },
+	 {
+	  "id": "ocs - vegetation - mangrovre",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "ocs_vegetation_surf",
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "ZONE_MANGROVE"
+	  ],
+	  "paint": {
+	   "fill-color": {
+		"stops": [
+		 [
+		  9,
+		  "#85CCCB"
+		 ],
+		 [
+		  10,
+		  "#90CCCB"
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "ocs - vegetation - marais",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "ocs_vegetation_surf",
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "ZONE_MARAIS"
+	  ],
+	  "paint": {
+	   "fill-pattern": "Marais"
+	  }
+	 },
+	 {
+	  "id": "ocs - vegetation - marais salant",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "ocs_vegetation_surf",
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "ZONE_MARAIS_SALANT"
+	  ],
+	  "paint": {
+	   "fill-pattern": "MaraisSalant"
+	  }
+	 },
+	 {
+	  "id": "ocs - Zone",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "ocs_nature_sol_surf",
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "ZONE_ROCHEUSE"
+	  ],
+	  "paint": {
+	   "fill-color": "#D0D0D0",
+	   "fill-opacity": 0.3
+	  }
+	 },
+	 {
+	  "id": "ocs - Zone sable sec",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "ocs_nature_sol_surf",
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "ZONE_SABLE_SEC"
+	  ],
+	  "paint": {
+	   "fill-pattern": "Sable"
+	  }
+	 },
+	 {
+	  "id": "ocs - Zone sable humide",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "ocs_nature_sol_surf",
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "ZONE_SABLE_HUMIDE",
+	   "FOND_CUVETTE_HUMIDE"
+	  ],
+	  "paint": {
+	   "fill-pattern": "SableHumide"
+	  }
+	 },
+	 {
+	  "id": "ocs - Zone graviers galets secs",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "ocs_nature_sol_surf",
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "GRAVIERS_GALETS_SEC"
+	  ],
+	  "paint": {
+	   "fill-pattern": "GravierSec"
+	  }
+	 },
+	 {
+	  "id": "ocs - Zone graviers galets humides",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "ocs_nature_sol_surf",
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "GRAVIERS_GALETS_HUM"
+	  ],
+	  "paint": {
+	   "fill-pattern": "Gravier"
+	  }
+	 },
+	 {
+	  "id": "ocs - Zone rocher hydro",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "ocs_nature_sol_surf",
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "ZONE_ROCHER_HYDRO"
+	  ],
+	  "paint": {
+	   "fill-pattern": "RocherHydro"
+	  }
+	 },
+	 {
+	  "id": "ocs - Zone glacier",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "ocs_nature_sol_surf",
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "ZONE_GLACIER"
+	  ],
+	  "paint": {
+	   "fill-pattern": "Glacier",
+	   "fill-opacity": {
+		"stops": [
+		 [
+		  10,
+		  0.5
+		 ],
+		 [
+		  12,
+		  0.3
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "zone batie",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "bati_zone_surf",
+	  "minzoom": 7,
+	  "maxzoom": 15,
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "ZONE_BATI"
+	  ],
+	  "paint": {
+	   "fill-color": "#E8E2D1",
+	   "fill-opacity": {
+		"stops": [
+		 [
+		  12,
+		  1
+		 ],
+		 [
+		  13,
+		  0.9
+		 ],
+		 [
+		  14,
+		  0.5
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "zone d'activité",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "bati_zone_surf",
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "ZONE_INDUS_ACTI"
+	  ],
+	  "paint": {
+	   "fill-color": "#D9D9D9"
+	  }
+	 },
+	 {
+	  "id": "oro - courbe et cuvette maitresse",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "oro_courbe",
+	  "maxzoom": 16,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "CNV_MAITRESSE",
+	   "CUVETTE_MAITRESSE"
+	  ],
+	  "paint": {
+	   "line-color": "#D9C8A9",
+	   "line-width": {
+		"stops": [
+		 [
+		  13,
+		  1.7
+		 ],
+		 [
+		  15,
+		  2
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "oro - courbe et cuvette normale",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "oro_courbe",
+	  "maxzoom": 16,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "CNV_NORMALE",
+	   "CUVETTE_NORMALE"
+	  ],
+	  "paint": {
+	   "line-color": "#D9C8A9",
+	   "line-width": {
+		"stops": [
+		 [
+		  13,
+		  1
+		 ],
+		 [
+		  15,
+		  1.2
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "oro - courbe et cuvette intercalaire",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "oro_courbe",
+	  "maxzoom": 16,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "CNV_INTERCALAIRE",
+	   "CUVETTE_INTERCAL",
+	   "CNV_SS_INTERCALAIRE"
+	  ],
+	  "paint": {
+	   "line-color": "#D9C8A9",
+	   "line-width": 0.7,
+	   "line-dasharray": [
+		20,
+		7
+	   ]
+	  }
+	 },
+	 {
+	  "id": "oro - courbe et cuvette glacier maitresse",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "oro_courbe",
+	  "maxzoom": 16,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "CNV_GLACIER_MAITRESSE",
+	   "CUV_GLACIER_MAITRESSE"
+	  ],
+	  "paint": {
+	   "line-color": "#A4BFD9",
+	   "line-width": {
+		"stops": [
+		 [
+		  13,
+		  1.7
+		 ],
+		 [
+		  15,
+		  2
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "oro - courbe et cuvette glacier normale",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "oro_courbe",
+	  "maxzoom": 16,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "CNV_GLACIER_NORMALE",
+	   "CUV_GLACIER_NORMALE"
+	  ],
+	  "paint": {
+	   "line-color": "#A4BFD9",
+	   "line-width": {
+		"stops": [
+		 [
+		  13,
+		  1
+		 ],
+		 [
+		  15,
+		  1.2
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "oro - courbe et cuvette glacier intercalaire",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "oro_courbe",
+	  "maxzoom": 16,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "CNV_GLACIER_INTERCAL",
+	   "CUV_GLACIER_INTERCAL"
+	  ],
+	  "paint": {
+	   "line-color": "#A4BFD9",
+	   "line-width": {
+		"stops": [
+		 [
+		  13,
+		  0.7
+		 ],
+		 [
+		  15,
+		  0.9
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		20,
+		7
+	   ]
+	  }
+	 },
+	 {
+	  "id": "oro - courbe et cuvette rocher maitresse",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "oro_courbe",
+	  "maxzoom": 16,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "CNV_ROCHER_MAITRESSE",
+	   "CUV_ROCHER_MAITRESSE"
+	  ],
+	  "paint": {
+	   "line-color": "#AAAAAA",
+	   "line-width": 1.7
+	  }
+	 },
+	 {
+	  "id": "oro - courbe et cuvette rocher normale",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "oro_courbe",
+	  "maxzoom": 16,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "CNV_ROCHER_NORMALE",
+	   "CUV_ROCHER_NORMALE"
+	  ],
+	  "paint": {
+	   "line-color": "#AAAAAA",
+	   "line-width": 1
+	  }
+	 },
+	 {
+	  "id": "oro - courbe et cuvette rocher intercalaire",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "oro_courbe",
+	  "maxzoom": 16,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "CNV_ROCHER_INTERCAL",
+	   "CUV_ROCHER_INTERCAL"
+	  ],
+	  "paint": {
+	   "line-color": "#AAAAAA",
+	   "line-width": {
+		"stops": [
+		 [
+		  13,
+		  0.7
+		 ],
+		 [
+		  15,
+		  0.9
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		20,
+		7
+	   ]
+	  }
+	 },
+	 {
+	  "id": "oro - courbe et cuvette bathymetrique",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "oro_courbe",
+	  "maxzoom": 16,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "CNV_BATHYMETRIQUE",
+	   "CUV_BATHYMETRIQUE"
+	  ],
+	  "paint": {
+	   "line-color": "#0000FF",
+	   "line-width": 1
+	  }
+	 },
+	 {
+	  "id": "oro lin - talus",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "oro_lin",
+	  "minzoom": 14,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "TALUS"
+	  ],
+	  "paint": {
+	   "line-color": "#D9C8A9",
+	   "line-width": 1
+	  }
+	 },
+	 {
+	  "id": "oro lin - talus - trait perpendiculaire",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "oro_lin",
+	  "minzoom": 14,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "TALUS"
+	  ],
+	  "paint": {
+	   "line-color": "#D9C8A9",
+	   "line-width": {
+		"stops": [
+		 [
+		  14,
+		  7
+		 ],
+		 [
+		  16,
+		  9
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		0.1,
+		1
+	   ],
+	   "line-translate": [
+		0,
+		4
+	   ]
+	  }
+	 },
+	 {
+	  "id": "toponyme - cote de courbe normale",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "oro_courbe",
+	  "minzoom": 13,
+	  "maxzoom": 16,
+	  "layout": {
+	   "symbol-placement": "line",
+	   "text-field": "{texte}",
+	   "text-size": {
+		"stops": [
+		 [
+		  13,
+		  10
+		 ],
+		 [
+		  15,
+		  13
+		 ]
+		]
+	   },
+	   "text-anchor": "center",
+	   "text-rotation-alignment": "map",
+	   "text-pitch-alignment": "viewport",
+	   "text-keep-upright": false,
+	   "text-max-angle": 20,
+	   "text-max-width": 100,
+	   "text-font": [
+		"Source Sans Pro Italic"
+	   ],
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "all",
+	   [
+		"!=",
+		"texte",
+		"0"
+	   ],
+	   [
+		"==",
+		"hors_zone",
+		"true"
+	   ],
+	   [
+		"in",
+		"symbo",
+		"CNV_MAITRESSE",
+		"CUVETTE_MAITRESSE"
+	   ]
+	  ],
+	  "paint": {
+	   "text-color": "#604A2F",
+	   "text-halo-width": 0.5,
+	   "text-halo-color": "#FFFFFF"
+	  }
+	 },
+	 {
+	  "id": "toponyme - cote de courbe rocher",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "oro_courbe",
+	  "minzoom": 13,
+	  "maxzoom": 16,
+	  "layout": {
+	   "symbol-placement": "line",
+	   "text-field": "{texte}",
+	   "text-size": {
+		"stops": [
+		 [
+		  13,
+		  10
+		 ],
+		 [
+		  15,
+		  13
+		 ]
+		]
+	   },
+	   "text-anchor": "center",
+	   "text-rotation-alignment": "map",
+	   "text-pitch-alignment": "viewport",
+	   "text-keep-upright": false,
+	   "text-max-angle": 20,
+	   "text-max-width": 100,
+	   "text-font": [
+		"Source Sans Pro Italic"
+	   ],
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "all",
+	   [
+		"!=",
+		"texte",
+		"0"
+	   ],
+	   [
+		"==",
+		"hors_zone",
+		"true"
+	   ],
+	   [
+		"in",
+		"symbo",
+		"CNV_ROCHER_MAITRESSE",
+		"CUV_ROCHER_MAITRESSE"
+	   ]
+	  ],
+	  "paint": {
+	   "text-color": "#333333",
+	   "text-halo-width": 0.5,
+	   "text-halo-color": "#FFFFFF"
+	  }
+	 },
+	 {
+	  "id": "toponyme - cote de courbe glacier",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "oro_courbe",
+	  "minzoom": 13,
+	  "maxzoom": 16,
+	  "layout": {
+	   "symbol-placement": "line",
+	   "text-field": "{texte}",
+	   "text-size": {
+		"stops": [
+		 [
+		  13,
+		  10
+		 ],
+		 [
+		  15,
+		  13
+		 ]
+		]
+	   },
+	   "text-anchor": "center",
+	   "text-rotation-alignment": "map",
+	   "text-pitch-alignment": "viewport",
+	   "text-keep-upright": false,
+	   "text-max-angle": 20,
+	   "text-max-width": 100,
+	   "text-font": [
+		"Source Sans Pro Italic"
+	   ],
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "all",
+	   [
+		"!=",
+		"texte",
+		"0"
+	   ],
+	   [
+		"==",
+		"hors_zone",
+		"true"
+	   ],
+	   [
+		"in",
+		"symbo",
+		"CNV_GLACIER_MAITRESSE",
+		"CUV_GLACIER_MAITRESSE"
+	   ]
+	  ],
+	  "paint": {
+	   "text-color": "#629FD9",
+	   "text-halo-width": 0.5,
+	   "text-halo-color": "#FFFFFF"
+	  }
+	 },
+	 {
+	  "id": "hydro surfacique",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "hydro_surf",
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "SURFACE_D_EAU",
+	   "BASSIN",
+	   "ZONE_MARINE"
+	  ],
+	  "paint": {
+	   "fill-color": "#AAD5E9",
+	   "fill-outline-color": "#AAD5E9"
+	  }
+	 },
+	 {
+	  "id": "hydro surfacique temporaire",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "hydro_surf",
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "SURFACE_D_EAU_TEMP"
+	  ],
+	  "paint": {
+	   "fill-color": "rgba(168, 203, 220, 0.5)"
+	  }
+	 },
+	 {
+	  "id": "réseau hydro  - cours d'eau souterrain",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "hydro_reseau_sou",
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "COURS_D_EAU_SOU",
+	   "COURS_D_EAU_MOY_SOU"
+	  ],
+	  "paint": {
+	   "line-color": "#AAD5E9",
+	   "line-width": {
+		"stops": [
+		 [
+		  12,
+		  1.5
+		 ],
+		 [
+		  17,
+		  6.5
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		2,
+		2
+	   ]
+	  }
+	 },
+	 {
+	  "id": "réseau hydro - filet interieur - aqueduc souterrain",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "hydro_reseau_sou",
+	  "minzoom": 12,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "AQUEDUC_SOU"
+	  ],
+	  "paint": {
+	   "line-color": "#AAD5E9",
+	   "line-width": {
+		"stops": [
+		 [
+		  12,
+		  1.4
+		 ],
+		 [
+		  16,
+		  3.5
+		 ],
+		 [
+		  17,
+		  5.9
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		2,
+		2
+	   ]
+	  }
+	 },
+	 {
+	  "id": "réseau hydro - carre - aqueduc souterrain",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "hydro_reseau_sou",
+	  "minzoom": 12,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "AQUEDUC_SOU"
+	  ],
+	  "paint": {
+	   "line-color": "#AAD5E9",
+	   "line-width": {
+		"stops": [
+		 [
+		  12,
+		  3.5
+		 ],
+		 [
+		  16,
+		  8.7
+		 ],
+		 [
+		  17,
+		  14.7
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		1,
+		5
+	   ]
+	  }
+	 },
+	 {
+	  "id": "Ferre souterrain - voie normale",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "ferre_sou",
+	  "minzoom": 10,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "VF_1_SOU",
+	   "VF_2_SOU",
+	   "VF_ELEC_1_SOU",
+	   "VF_FERRO_ROUTIER_SOU"
+	  ],
+	  "paint": {
+	   "line-color": "#B4B4B4",
+	   "line-width": {
+		"stops": [
+		 [
+		  10,
+		  0.8
+		 ],
+		 [
+		  17,
+		  2.5
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Ferre souterrain - trait perpendic épais",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "ferre_sou",
+	  "minzoom": 10,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "VF_1_SOU",
+	   "VF_2_SOU",
+	   "VF_ELEC_1_SOU",
+	   "VF_FERRO_ROUTIER_SOU"
+	  ],
+	  "paint": {
+	   "line-color": "#B4B4B4",
+	   "line-width": {
+		"stops": [
+		 [
+		  10,
+		  3.5
+		 ],
+		 [
+		  17,
+		  14.7
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		0.1,
+		10
+	   ]
+	  }
+	 },
+	 {
+	  "id": "Ferre souterrain - voie etroite",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "ferre_sou",
+	  "minzoom": 10,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "VF_ETROITE_1_SOU",
+	   "VF_ETROITE_SOU"
+	  ],
+	  "paint": {
+	   "line-color": "#B4B4B4",
+	   "line-width": {
+		"stops": [
+		 [
+		  10,
+		  0.3
+		 ],
+		 [
+		  17,
+		  1.8
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Ferre souterrain - trait perpendic fin",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "ferre_sou",
+	  "minzoom": 10,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "VF_ETROITE_1_SOU",
+	   "VF_ETROITE_SOU"
+	  ],
+	  "paint": {
+	   "line-color": "#B4B4B4",
+	   "line-width": {
+		"stops": [
+		 [
+		  10,
+		  3.5
+		 ],
+		 [
+		  17,
+		  14.7
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		0.1,
+		10
+	   ]
+	  }
+	 },
+	 {
+	  "id": "Ferre souterrain - voie service",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "ferre_sou",
+	  "minzoom": 14,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "VF_SERVICE_SOU",
+	   "VF_NON_EXPLOITEE_SOU"
+	  ],
+	  "paint": {
+	   "line-color": "#B4B4B4",
+	   "line-width": {
+		"stops": [
+		 [
+		  10,
+		  0.3
+		 ],
+		 [
+		  17,
+		  1.8
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		5,
+		2,
+		1,
+		2
+	   ]
+	  }
+	 },
+	 {
+	  "id": "Ferre souterrain - funic/urbain",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "ferre_sou",
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "FUNI_CREMAILLERE_SOU",
+	   "TRANSPORT_URBAIN_SOU"
+	  ],
+	  "paint": {
+	   "line-color": "#B4B4B4",
+	   "line-width": {
+		"stops": [
+		 [
+		  10,
+		  0.3
+		 ],
+		 [
+		  17,
+		  1.8
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Ferre souterrain - 2 trait perpendic - funic/urbain",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "ferre_sou",
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "FUNI_CREMAILLERE_SOU",
+	   "TRANSPORT_URBAIN_SOU"
+	  ],
+	  "paint": {
+	   "line-color": "#B4B4B4",
+	   "line-width": {
+		"stops": [
+		 [
+		  10,
+		  3.5
+		 ],
+		 [
+		  17,
+		  17
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		0.1,
+		0.2,
+		0.1,
+		10
+	   ]
+	  }
+	 },
+	 {
+	  "id": "Chemin souterrain - piste cyclable",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_chemin_sou",
+	  "minzoom": 13,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "PISTE_CYCLABLE_SOU"
+	  ],
+	  "paint": {
+	   "line-color": "#AB81CC",
+	   "line-width": {
+		"stops": [
+		 [
+		  14,
+		  1.1
+		 ],
+		 [
+		  15,
+		  1.7
+		 ],
+		 [
+		  16,
+		  2
+		 ],
+		 [
+		  17,
+		  3.5
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		6,
+		2
+	   ]
+	  }
+	 },
+	 {
+	  "id": "Chemin souterrain - filet exterieur - escalier",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_chemin_sou",
+	  "minzoom": 14,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "ESCALIER_SOU"
+	  ],
+	  "paint": {
+	   "line-color": "#B3989A",
+	   "line-width": {
+		"stops": [
+		 [
+		  14,
+		  1.75
+		 ],
+		 [
+		  15,
+		  3
+		 ],
+		 [
+		  16,
+		  4.2
+		 ],
+		 [
+		  17,
+		  9.5
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Chemin souterrain - filet interieur - escalier",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_chemin_sou",
+	  "minzoom": 14,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "ESCALIER_SOU"
+	  ],
+	  "paint": {
+	   "line-color": "#FFFFFF",
+	   "line-width": {
+		"stops": [
+		 [
+		  14,
+		  1
+		 ],
+		 [
+		  15,
+		  1.9
+		 ],
+		 [
+		  16,
+		  2.7
+		 ],
+		 [
+		  17,
+		  5.8
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		1,
+		0.2
+	   ]
+	  }
+	 },
+	 {
+	  "id": "Chemin souterrain - Rue pietonne",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_chemin_sou",
+	  "minzoom": 14,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "RUE_PIETONNE_SOU"
+	  ],
+	  "paint": {
+	   "line-color": "#B3989A",
+	   "line-width": {
+		"stops": [
+		 [
+		  14,
+		  1
+		 ],
+		 [
+		  15,
+		  1.2
+		 ],
+		 [
+		  16,
+		  1.4
+		 ],
+		 [
+		  17,
+		  2
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		1,
+		3
+	   ]
+	  }
+	 },
+	 {
+	  "id": "Chemin souterrain - sentier",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_chemin_sou",
+	  "minzoom": 13,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "SENTIER_SOU"
+	  ],
+	  "paint": {
+	   "line-color": "#B3989A",
+	   "line-width": {
+		"stops": [
+		 [
+		  14,
+		  1
+		 ],
+		 [
+		  15,
+		  1.2
+		 ],
+		 [
+		  16,
+		  1.4
+		 ],
+		 [
+		  17,
+		  2
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		4,
+		3
+	   ]
+	  }
+	 },
+	 {
+	  "id": "Chemin souterrain - chemin",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_chemin_sou",
+	  "minzoom": 12,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "CHEMIN_SOU"
+	  ],
+	  "paint": {
+	   "line-color": "#B3989A",
+	   "line-width": {
+		"stops": [
+		 [
+		  14,
+		  1
+		 ],
+		 [
+		  15,
+		  1.2
+		 ],
+		 [
+		  16,
+		  1.4
+		 ],
+		 [
+		  17,
+		  2
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier souterrain - filet extérieur - route non revetu carrosable",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route_sou",
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "NON_REVETUE_CARRO_SOU"
+	  ],
+	  "paint": {
+	   "line-color": "#AFAFAF",
+	   "line-width": {
+		"stops": [
+		 [
+		  14,
+		  3.2
+		 ],
+		 [
+		  15,
+		  5.4
+		 ],
+		 [
+		  16,
+		  7.7
+		 ],
+		 [
+		  17,
+		  16.8
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		2,
+		2
+	   ]
+	  }
+	 },
+	 {
+	  "id": "Routier souterrain - filet extérieur - bretelle autoroute",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route_sou",
+	  "minzoom": 12,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "BRET_AUTO_PEAGE_3_SOU",
+	   "BRET_AUTO_PEAGE_2_SOU",
+	   "BRET_AUTO_PEAGE_1_SOU",
+	   "BRET_AUTO_LIBRE_3_SOU",
+	   "BRET_AUTO_LIBRE_2_SOU",
+	   "BRET_AUTO_LIBRE_1_SOU"
+	  ],
+	  "paint": {
+	   "line-color": "rgba(222, 70, 14, 0.5)",
+	   "line-width": {
+		"stops": [
+		 [
+		  12,
+		  2.5
+		 ],
+		 [
+		  14,
+		  3.7
+		 ],
+		 [
+		  15,
+		  6.8
+		 ],
+		 [
+		  16,
+		  8.4
+		 ],
+		 [
+		  17,
+		  14
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier souterrain - filet extérieur - route non classee restreint",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route_sou",
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "NON_CLASSEE_RESTREINT_SOU"
+	  ],
+	  "paint": {
+	   "line-color": "#AFAFAF",
+	   "line-width": {
+		"stops": [
+		 [
+		  14,
+		  3.2
+		 ],
+		 [
+		  15,
+		  5.4
+		 ],
+		 [
+		  16,
+		  7.7
+		 ],
+		 [
+		  17,
+		  16.8
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier souterrain - filet extérieur - route non classee",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route_sou",
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "NON_CLASSEE_4_SOU",
+	   "NON_CLASSEE_SOU"
+	  ],
+	  "paint": {
+	   "line-color": "#AFAFAF",
+	   "line-width": {
+		"stops": [
+		 [
+		  14,
+		  3.2
+		 ],
+		 [
+		  15,
+		  5.4
+		 ],
+		 [
+		  16,
+		  7.7
+		 ],
+		 [
+		  17,
+		  16.8
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier souterrain - filet extérieur - route locale",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route_sou",
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "BRET_LOCALE_SOU",
+	   "LOCALE_4_SOU",
+	   "LOCALE_3_SOU",
+	   "LOCALE_2_SOU",
+	   "LOCALE_1_SOU"
+	  ],
+	  "paint": {
+	   "line-color": "rgba(130, 130, 130, 0.5)",
+	   "line-width": {
+		"stops": [
+		 [
+		  9,
+		  2
+		 ],
+		 [
+		  14,
+		  3.5
+		 ],
+		 [
+		  15,
+		  6
+		 ],
+		 [
+		  16,
+		  8.4
+		 ],
+		 [
+		  17,
+		  18.3
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier souterrain - filet extérieur - route locale en construction",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route_sou",
+	  "minzoom": 11,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "LOCALE_CONSTR_SOU"
+	  ],
+	  "paint": {
+	   "line-color": "#C8C8C8",
+	   "line-width": {
+		"stops": [
+		 [
+		  9,
+		  2
+		 ],
+		 [
+		  14,
+		  3.5
+		 ],
+		 [
+		  15,
+		  6
+		 ],
+		 [
+		  16,
+		  8.4
+		 ],
+		 [
+		  17,
+		  18.3
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier souterrain - filet extérieur - route regionale",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route_sou",
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "BRET_REGIONALE_SOU",
+	   "REGIONALE_4_SOU",
+	   "REGIONALE_3_SOU",
+	   "REGIONALE_2_SOU",
+	   "REGIONALE_1_SOU"
+	  ],
+	  "paint": {
+	   "line-color": "rgba(130, 130, 130, 0.5)",
+	   "line-width": {
+		"stops": [
+		 [
+		  6,
+		  1.5
+		 ],
+		 [
+		  9,
+		  2.3
+		 ],
+		 [
+		  14,
+		  5
+		 ],
+		 [
+		  15,
+		  8.1
+		 ],
+		 [
+		  16,
+		  11.2
+		 ],
+		 [
+		  17,
+		  22
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier souterrain - filet extérieur - route regionale en construction",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route_sou",
+	  "minzoom": 10,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "REGIONALE_CONSTR_SOU"
+	  ],
+	  "paint": {
+	   "line-color": "#C8C8C8",
+	   "line-width": {
+		"stops": [
+		 [
+		  6,
+		  1.5
+		 ],
+		 [
+		  9,
+		  2.3
+		 ],
+		 [
+		  14,
+		  5
+		 ],
+		 [
+		  15,
+		  8.1
+		 ],
+		 [
+		  16,
+		  11.2
+		 ],
+		 [
+		  17,
+		  22
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier souterrain - filet extérieur - route principale",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route_sou",
+	  "minzoom": 7,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "BRET_PRINCIPALE_SOU",
+	   "PRINCIPALE_4_SOU",
+	   "PRINCIPALE_3_SOU",
+	   "PRINCIPALE_2_SOU",
+	   "PRINCIPALE_1_SOU"
+	  ],
+	  "paint": {
+	   "line-color": "rgba(222, 70, 14, 0.5)",
+	   "line-width": {
+		"stops": [
+		 [
+		  6,
+		  1.8
+		 ],
+		 [
+		  9,
+		  2.7
+		 ],
+		 [
+		  14,
+		  5.9
+		 ],
+		 [
+		  15,
+		  9
+		 ],
+		 [
+		  16,
+		  12.2
+		 ],
+		 [
+		  17,
+		  22.5
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier souterrain - filet extérieur - route principale en construction",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route_sou",
+	  "minzoom": 10,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "PRINCIPALE_CONSTR_SOU"
+	  ],
+	  "paint": {
+	   "line-color": "#C8C8C8",
+	   "line-width": {
+		"stops": [
+		 [
+		  6,
+		  1.8
+		 ],
+		 [
+		  9,
+		  2.7
+		 ],
+		 [
+		  14,
+		  5.9
+		 ],
+		 [
+		  15,
+		  9
+		 ],
+		 [
+		  16,
+		  12.2
+		 ],
+		 [
+		  17,
+		  22.5
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier souterrain - filet extérieur - autoroute",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route_sou",
+	  "minzoom": 7,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "AUTOROU_PEAGE_SOU",
+	   "AUTOROU_LIBRE_SOU"
+	  ],
+	  "paint": {
+	   "line-color": "rgba(222, 70, 14, 0.5)",
+	   "line-width": {
+		"stops": [
+		 [
+		  6,
+		  2.5
+		 ],
+		 [
+		  9,
+		  3.5
+		 ],
+		 [
+		  14,
+		  7.5
+		 ],
+		 [
+		  15,
+		  11
+		 ],
+		 [
+		  16,
+		  15
+		 ],
+		 [
+		  17,
+		  26
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier souterrain - filet extérieur - autoroute en construction",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route_sou",
+	  "minzoom": 10,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "AUTOROU_CONSTR_SOU"
+	  ],
+	  "paint": {
+	   "line-color": "#C8C8C8",
+	   "line-width": {
+		"stops": [
+		 [
+		  6,
+		  2.5
+		 ],
+		 [
+		  9,
+		  3.5
+		 ],
+		 [
+		  14,
+		  7.5
+		 ],
+		 [
+		  15,
+		  11
+		 ],
+		 [
+		  16,
+		  15
+		 ],
+		 [
+		  17,
+		  26
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier souterrain - filet interieur - route non revetu carrosable",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route_sou",
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "NON_REVETUE_CARRO_SOU"
+	  ],
+	  "paint": {
+	   "line-color": "#DCDCDC",
+	   "line-width": {
+		"stops": [
+		 [
+		  14,
+		  2.3
+		 ],
+		 [
+		  15,
+		  4.1
+		 ],
+		 [
+		  16,
+		  6.3
+		 ],
+		 [
+		  17,
+		  13.5
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier souterrain - filet interieur - bretelle autoroute",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route_sou",
+	  "minzoom": 12,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "BRET_AUTO_PEAGE_3_SOU",
+	   "BRET_AUTO_PEAGE_2_SOU",
+	   "BRET_AUTO_PEAGE_1_SOU",
+	   "BRET_AUTO_LIBRE_3_SOU",
+	   "BRET_AUTO_LIBRE_2_SOU",
+	   "BRET_AUTO_LIBRE_1_SOU"
+	  ],
+	  "paint": {
+	   "line-color": "rgba(255, 255, 255, 0.5)",
+	   "line-width": {
+		"stops": [
+		 [
+		  12,
+		  1.5
+		 ],
+		 [
+		  14,
+		  2.6
+		 ],
+		 [
+		  15,
+		  5.2
+		 ],
+		 [
+		  16,
+		  6.7
+		 ],
+		 [
+		  17,
+		  10.8
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier souterrain - filet interieur - route non classee restreint",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route_sou",
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "NON_CLASSEE_RESTREINT_SOU"
+	  ],
+	  "paint": {
+	   "line-color": "#F2F5FF",
+	   "line-width": {
+		"stops": [
+		 [
+		  14,
+		  2.3
+		 ],
+		 [
+		  15,
+		  4.1
+		 ],
+		 [
+		  16,
+		  6.3
+		 ],
+		 [
+		  17,
+		  13.5
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier souterrain - filet interieur - route non classee",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route_sou",
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "NON_CLASSEE_4_SOU",
+	   "NON_CLASSEE_SOU"
+	  ],
+	  "paint": {
+	   "line-color": "#DCDCDC",
+	   "line-width": {
+		"stops": [
+		 [
+		  14,
+		  2.3
+		 ],
+		 [
+		  15,
+		  4.1
+		 ],
+		 [
+		  16,
+		  6.3
+		 ],
+		 [
+		  17,
+		  13.5
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier souterrain - filet interieur - route locale",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route_sou",
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "BRET_LOCALE_SOU",
+	   "LOCALE_4_SOU",
+	   "LOCALE_3_SOU",
+	   "LOCALE_2_SOU",
+	   "LOCALE_1_SOU"
+	  ],
+	  "paint": {
+	   "line-color": "rgba(255, 255, 255, 0.5)",
+	   "line-width": {
+		"stops": [
+		 [
+		  9,
+		  1.3
+		 ],
+		 [
+		  14,
+		  2.3
+		 ],
+		 [
+		  15,
+		  4.1
+		 ],
+		 [
+		  16,
+		  6.1
+		 ],
+		 [
+		  17,
+		  13.1
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier souterrain - filet interieur - route locale en construction",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route_sou",
+	  "minzoom": 11,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "LOCALE_CONSTR_SOU"
+	  ],
+	  "paint": {
+	   "line-color": {
+		"stops": [
+		 [
+		  12,
+		  "#FFFFFF"
+		 ],
+		 [
+		  13,
+		  "#FCF4A8"
+		 ],
+		 [
+		  17,
+		  "#FCF7C1"
+		 ]
+		]
+	   },
+	   "line-width": {
+		"stops": [
+		 [
+		  9,
+		  2
+		 ],
+		 [
+		  14,
+		  3.5
+		 ],
+		 [
+		  15,
+		  6
+		 ],
+		 [
+		  16,
+		  8.4
+		 ],
+		 [
+		  17,
+		  18.3
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		2,
+		2
+	   ]
+	  }
+	 },
+	 {
+	  "id": "Routier souterrain - filet interieur - route regionale",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route_sou",
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "BRET_REGIONALE_SOU",
+	   "REGIONALE_4_SOU",
+	   "REGIONALE_3_SOU",
+	   "REGIONALE_2_SOU",
+	   "REGIONALE_1_SOU"
+	  ],
+	  "paint": {
+	   "line-color": "rgba(255, 255, 255, 0.5)",
+	   "line-width": {
+		"stops": [
+		 [
+		  6,
+		  1.4
+		 ],
+		 [
+		  9,
+		  1.5
+		 ],
+		 [
+		  14,
+		  3.2
+		 ],
+		 [
+		  15,
+		  5.8
+		 ],
+		 [
+		  16,
+		  8.3
+		 ],
+		 [
+		  17,
+		  16.2
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier souterrain - filet interieur - route regionale en construction",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route_sou",
+	  "minzoom": 10,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "REGIONALE_CONSTR_SOU"
+	  ],
+	  "paint": {
+	   "line-color": {
+		"stops": [
+		 [
+		  9,
+		  "#FFFFFF"
+		 ],
+		 [
+		  10,
+		  "#FDF28B"
+		 ],
+		 [
+		  17,
+		  "#FCF6BD"
+		 ]
+		]
+	   },
+	   "line-width": {
+		"stops": [
+		 [
+		  4,
+		  0.4
+		 ],
+		 [
+		  6,
+		  1.5
+		 ],
+		 [
+		  9,
+		  2.3
+		 ],
+		 [
+		  14,
+		  5
+		 ],
+		 [
+		  15,
+		  8.1
+		 ],
+		 [
+		  16,
+		  11.2
+		 ],
+		 [
+		  17,
+		  22
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		2,
+		2
+	   ]
+	  }
+	 },
+	 {
+	  "id": "Routier souterrain - filet interieur - route principale",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route_sou",
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "BRET_PRINCIPALE_SOU",
+	   "PRINCIPALE_4_SOU",
+	   "PRINCIPALE_3_SOU",
+	   "PRINCIPALE_2_SOU",
+	   "PRINCIPALE_1_SOU"
+	  ],
+	  "paint": {
+	   "line-color": "rgba(255, 255, 255, 0.5)",
+	   "line-width": {
+		"stops": [
+		 [
+		  4,
+		  0.5
+		 ],
+		 [
+		  6,
+		  1.8
+		 ],
+		 [
+		  9,
+		  2.1
+		 ],
+		 [
+		  14,
+		  4.4
+		 ],
+		 [
+		  15,
+		  7.3
+		 ],
+		 [
+		  16,
+		  10
+		 ],
+		 [
+		  17,
+		  18.5
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier souterrain - filet interieur - route principale en construction",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route_sou",
+	  "minzoom": 10,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "PRINCIPALE_CONSTR_SOU"
+	  ],
+	  "paint": {
+	   "line-color": {
+		"stops": [
+		 [
+		  9,
+		  "#F3C66D"
+		 ],
+		 [
+		  17,
+		  "#F2DDB3"
+		 ]
+		]
+	   },
+	   "line-width": {
+		"stops": [
+		 [
+		  4,
+		  0.5
+		 ],
+		 [
+		  6,
+		  1.8
+		 ],
+		 [
+		  9,
+		  2.7
+		 ],
+		 [
+		  14,
+		  5.9
+		 ],
+		 [
+		  15,
+		  9
+		 ],
+		 [
+		  16,
+		  12.2
+		 ],
+		 [
+		  17,
+		  22.5
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		2,
+		2
+	   ]
+	  }
+	 },
+	 {
+	  "id": "Routier souterrain - filet interieur - autoroute",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route_sou",
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "AUTOROU_PEAGE_SOU",
+	   "AUTOROU_LIBRE_SOU"
+	  ],
+	  "paint": {
+	   "line-color": "rgba(255, 255, 255, 0.5)",
+	   "line-width": {
+		"stops": [
+		 [
+		  4,
+		  0.7
+		 ],
+		 [
+		  6,
+		  2.5
+		 ],
+		 [
+		  9,
+		  2.7
+		 ],
+		 [
+		  14,
+		  5.8
+		 ],
+		 [
+		  15,
+		  9
+		 ],
+		 [
+		  16,
+		  12
+		 ],
+		 [
+		  17,
+		  20.8
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier souterrain - axe central - autoroute",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route_sou",
+	  "minzoom": 13,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "AUTOROU_PEAGE_SOU",
+	   "AUTOROU_LIBRE_SOU"
+	  ],
+	  "paint": {
+	   "line-color": "#FFFFFF",
+	   "line-width": {
+		"stops": [
+		 [
+		  9,
+		  0.6
+		 ],
+		 [
+		  14,
+		  0.7
+		 ],
+		 [
+		  15,
+		  1
+		 ],
+		 [
+		  16,
+		  1.2
+		 ],
+		 [
+		  17,
+		  2.1
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier souterrain - filet interieur - autoroute en construction",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route_sou",
+	  "minzoom": 10,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "AUTOROU_CONSTR_SOU"
+	  ],
+	  "paint": {
+	   "line-color": {
+		"stops": [
+		 [
+		  9,
+		  "#F2BA59"
+		 ],
+		 [
+		  17,
+		  "#F2C261"
+		 ]
+		]
+	   },
+	   "line-width": {
+		"stops": [
+		 [
+		  4,
+		  0.7
+		 ],
+		 [
+		  6,
+		  2.5
+		 ],
+		 [
+		  9,
+		  3.5
+		 ],
+		 [
+		  14,
+		  7.5
+		 ],
+		 [
+		  15,
+		  11
+		 ],
+		 [
+		  16,
+		  15
+		 ],
+		 [
+		  17,
+		  26
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		2,
+		2
+	   ]
+	  }
+	 },
+	 {
+	  "id": "Routier souterrain - axe central - autoroute en construction",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route_sou",
+	  "minzoom": 13,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "AUTOROU_CONSTR_SOU"
+	  ],
+	  "paint": {
+	   "line-color": "#808080",
+	   "line-width": {
+		"stops": [
+		 [
+		  9,
+		  0.6
+		 ],
+		 [
+		  14,
+		  0.7
+		 ],
+		 [
+		  15,
+		  1
+		 ],
+		 [
+		  16,
+		  1.2
+		 ],
+		 [
+		  17,
+		  2.1
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "réseau hydro - cours d'eau temporaire",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "hydro_reseau",
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "COURS_D_EAU_TEMP",
+	   "COURS_D_EAU_TEMP_MOY"
+	  ],
+	  "paint": {
+	   "line-color": "#AAD5E9",
+	   "line-width": {
+		"stops": [
+		 [
+		  12,
+		  1.5
+		 ],
+		 [
+		  17,
+		  4
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		6,
+		2
+	   ]
+	  }
+	 },
+	 {
+	  "id": "réseau hydro - cours d'eau",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "hydro_reseau",
+	  "minzoom": 3,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "COURS_D_EAU"
+	  ],
+	  "paint": {
+	   "line-color": "#AAD5E9",
+	   "line-width": {
+		"stops": [
+		 [
+		  4,
+		  0.3
+		 ],
+		 [
+		  7,
+		  1.5
+		 ],
+		 [
+		  12,
+		  1.5
+		 ],
+		 [
+		  17,
+		  6.5
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "réseau hydro - canal",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "hydro_reseau",
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "CANAL"
+	  ],
+	  "paint": {
+	   "line-color": "#AAD5E9",
+	   "line-width": {
+		"stops": [
+		 [
+		  12,
+		  1.4
+		 ],
+		 [
+		  17,
+		  5.9
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "réseau hydro - filet interieur - aqueduc",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "hydro_reseau",
+	  "minzoom": 12,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "AQUEDUC_AU_SOL"
+	  ],
+	  "paint": {
+	   "line-color": "#AAD5E9",
+	   "line-width": {
+		"stops": [
+		 [
+		  12,
+		  1.4
+		 ],
+		 [
+		  16,
+		  3.5
+		 ],
+		 [
+		  17,
+		  5.9
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "réseau hydro - carre - aqueduc",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "hydro_reseau",
+	  "minzoom": 12,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "AQUEDUC_AU_SOL"
+	  ],
+	  "paint": {
+	   "line-color": "#AAD5E9",
+	   "line-width": {
+		"stops": [
+		 [
+		  12,
+		  3.5
+		 ],
+		 [
+		  16,
+		  8.7
+		 ],
+		 [
+		  17,
+		  14.7
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		1,
+		5
+	   ]
+	  }
+	 },
+	 {
+	  "id": "réseau hydro - cours d'eau moyen ",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "hydro_reseau",
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "COURS_D_EAU_MOY"
+	  ],
+	  "paint": {
+	   "line-color": "#AAD5E9",
+	   "line-width": {
+		"stops": [
+		 [
+		  7,
+		  2
+		 ],
+		 [
+		  12,
+		  2.5
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "réseau hydro - cours d'eau large ",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "hydro_reseau",
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "COURS_D_EAU_LAR"
+	  ],
+	  "paint": {
+	   "line-color": "#AAD5E9",
+	   "line-width": {
+		"stops": [
+		 [
+		  7,
+		  3
+		 ],
+		 [
+		  11,
+		  5
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "parcellaire - parcelle surface",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "parcellaire_parcelle",
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "PARCELLE"
+	  ],
+	  "paint": {
+	   "fill-color": "#FFFFD1",
+	   "fill-opacity": 0.7
+	  }
+	 },
+	 {
+	  "id": "bati surfacique mairie - Zoom 14",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "bati_surf",
+	  "maxzoom": 14,
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "MAIRIE",
+	   "MAIRIE_ANNEXE"
+	  ],
+	  "paint": {
+	   "fill-color": "#FFA6A6"
+	  }
+	 },
+	 {
+	  "id": "bati surfacique mairie - Zoom 15,16,17,18",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "bati_surf",
+	  "minzoom": 14,
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "MAIRIE",
+	   "MAIRIE_ANNEXE"
+	  ],
+	  "paint": {
+	   "fill-color": {
+		"stops": [
+		 [
+		  14,
+		  "#FFA6A6"
+		 ],
+		 [
+		  15,
+		  "#FFAEAE"
+		 ]
+		]
+	   },
+	   "fill-outline-color": "#FF7C7C"
+	  }
+	 },
+	 {
+	  "id": "bati surfacique fonctionnel industriel ou commercial - Zoom 14,15",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "bati_surf",
+	  "maxzoom": 15,
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "BATI_COMMERCIAL",
+	   "BATI_INDUSTRIEL",
+	   "HANGAR",
+	   "HANGAR_COMMERCIAL",
+	   "HANGAR_INDUSTRIEL"
+	  ],
+	  "paint": {
+	   "fill-color": "#C8C8C8"
+	  }
+	 },
+	 {
+	  "id": "bati surfacique fonctionnel industriel ou commercial - Zoom 16,17,18",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "bati_surf",
+	  "minzoom": 15,
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "BATI_COMMERCIAL",
+	   "BATI_INDUSTRIEL",
+	   "HANGAR",
+	   "HANGAR_COMMERCIAL",
+	   "HANGAR_INDUSTRIEL"
+	  ],
+	  "paint": {
+	   "fill-color": {
+		"stops": [
+		 [
+		  15,
+		  "#D1D1D1"
+		 ],
+		 [
+		  16,
+		  "#E6E6E6"
+		 ]
+		]
+	   },
+	   "fill-outline-color": "#B8B8B8"
+	  }
+	 },
+	 {
+	  "id": "bati surfacique fonctionnel public - Zoom 14,15",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "bati_surf",
+	  "maxzoom": 15,
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "BATI_PUBLIC",
+	   "HANGAR_PUBLIC"
+	  ],
+	  "paint": {
+	   "fill-color": "#B9B6D6"
+	  }
+	 },
+	 {
+	  "id": "bati surfacique fonctionnel public - Zoom 16,17,18",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "bati_surf",
+	  "minzoom": 15,
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "BATI_PUBLIC",
+	   "HANGAR_PUBLIC"
+	  ],
+	  "paint": {
+	   "fill-color": {
+		"stops": [
+		 [
+		  15,
+		  "#CFC5DE"
+		 ],
+		 [
+		  16,
+		  "#E4DAF3"
+		 ]
+		]
+	   },
+	   "fill-outline-color": "#A6A1D6"
+	  }
+	 },
+	 {
+	  "id": "bati surfacique fonctionnel sportif - bordure",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "bati_surf",
+	  "minzoom": 15,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "BATI_SPORTIF"
+	  ],
+	  "paint": {
+	   "line-color": "#BCD9AB",
+	   "line-width": 4
+	  }
+	 },
+	 {
+	  "id": "bati surfacique fonctionnel sportif",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "bati_surf",
+	  "minzoom": 13,
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "BATI_SPORTIF"
+	  ],
+	  "paint": {
+	   "fill-color": {
+		"stops": [
+		 [
+		  14,
+		  "#C9E1DD"
+		 ],
+		 [
+		  15,
+		  "#DCE6E4"
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "bati surfacique fonctionnel gare - Zoom 14,15",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "bati_surf",
+	  "maxzoom": 15,
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "BATI_GARE"
+	  ],
+	  "paint": {
+	   "fill-color": "#B3B5F5"
+	  }
+	 },
+	 {
+	  "id": "bati surfacique fonctionnel gare - Zoom 16,17,18",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "bati_surf",
+	  "minzoom": 15,
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "BATI_GARE"
+	  ],
+	  "paint": {
+	   "fill-color": {
+		"stops": [
+		 [
+		  15,
+		  "#BFC1F5"
+		 ],
+		 [
+		  16,
+		  "#CBCDF5"
+		 ]
+		]
+	   },
+	   "fill-outline-color": "#9B9EF6"
+	  }
+	 },
+	 {
+	  "id": "bati surfacique quelconque - Zoom 15",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "bati_surf",
+	  "minzoom": 14,
+	  "maxzoom": 15,
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "BATI_QQUE"
+	  ],
+	  "paint": {
+	   "fill-color": "#D6C6B8"
+	  }
+	 },
+	 {
+	  "id": "bati surfacique quelconque - Zoom 16,17,18",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "bati_surf",
+	  "minzoom": 15,
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "BATI_QQUE"
+	  ],
+	  "paint": {
+	   "fill-color": {
+		"stops": [
+		 [
+		  15,
+		  "#E6E0CF"
+		 ],
+		 [
+		  16,
+		  "#F1EBD9"
+		 ]
+		]
+	   },
+	   "fill-outline-color": "#C3AA8E"
+	  }
+	 },
+	 {
+	  "id": "cimetiere surfacique 1",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "bati_surf",
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "CIMETIERE_SURF",
+	   "CIMETIERE_MILI_SURF",
+	   "NECROPOLE_NATIONALE"
+	  ],
+	  "paint": {
+	   "fill-color": "#F0F0F0",
+	   "fill-opacity": 0.5,
+	   "fill-outline-color": "#818181"
+	  }
+	 },
+	 {
+	  "id": "cimetiere surfacique 2",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "bati_surf",
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "CIMETIERE_SURF",
+	   "CIMETIERE_MILI_SURF",
+	   "NECROPOLE_NATIONALE"
+	  ],
+	  "paint": {
+	   "fill-pattern": "Cimetiere"
+	  }
+	 },
+	 {
+	  "id": "bati hydro surfacique - Autre",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "bati_surf",
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "ECLUSE_SURF",
+	   "RESERVOIR_EAU_SURF"
+	  ],
+	  "paint": {
+	   "fill-color": "#ADCCD9",
+	   "fill-outline-color": "#336699"
+	  }
+	 },
+	 {
+	  "id": "bati hydro surfacique - Pecherie",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "bati_surf",
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "PECHERIE_SURF"
+	  ],
+	  "paint": {
+	   "fill-color": "#BFE2F0",
+	   "fill-outline-color": "#509FEF"
+	  }
+	 },
+	 {
+	  "id": "bati hydro surfacique - Barrage",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "bati_surf",
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "BARRAGE_SURF"
+	  ],
+	  "paint": {
+	   "fill-color": "#FFFFFF",
+	   "fill-outline-color": "#464646"
+	  }
+	 },
+	 {
+	  "id": "bati hydro surfacique - Chateau d'eau",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "bati_surf",
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "CHATEAU_EAU_SURF"
+	  ],
+	  "paint": {
+	   "fill-color": "#1466B2"
+	  }
+	 },
+	 {
+	  "id": "bati infra surfacique - Silo",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "bati_surf",
+	  "minzoom": 15,
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "SILO_SURF"
+	  ],
+	  "paint": {
+	   "fill-color": "#C7A9AA",
+	   "fill-outline-color": "#696969"
+	  }
+	 },
+	 {
+	  "id": "bati infra surfacique - Reservoir indus",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "bati_surf",
+	  "minzoom": 14,
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "RESERVOIR_INDUS_SURF"
+	  ],
+	  "paint": {
+	   "fill-color": "#8D9DAA",
+	   "fill-outline-color": "#464646"
+	  }
+	 },
+	 {
+	  "id": "bati infra surfacique - Serre",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "bati_surf",
+	  "minzoom": 13,
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "SERRE_SURF"
+	  ],
+	  "paint": {
+	   "fill-color": "#CAD6D9",
+	   "fill-outline-color": "#8C8C8C"
+	  }
+	 },
+	 {
+	  "id": "bati infra surfacique - poste electrique",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "bati_surf",
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "POSTE_ELEC_SURF"
+	  ],
+	  "paint": {
+	   "fill-color": "#7993B6",
+	   "fill-opacity": 0.3
+	  }
+	 },
+	 {
+	  "id": "bati infra surfacique - poste electrique bord",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "bati_surf",
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "POSTE_ELEC_SURF"
+	  ],
+	  "paint": {
+	   "line-color": "#000000",
+	   "line-width": {
+		"stops": [
+		 [
+		  12,
+		  0.3
+		 ],
+		 [
+		  17,
+		  1.2
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "bati religieux surfacique - Zoom 14",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "bati_surf",
+	  "maxzoom": 14,
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "CHAPELLE_SURF",
+	   "EGLISE_SURF",
+	   "CHRETIEN_SURF",
+	   "SYNAGOGUE_SURF",
+	   "MOSQUEE_SURF",
+	   "AUTRE_CULTE_SURF"
+	  ],
+	  "paint": {
+	   "fill-color": "#F7CBCB"
+	  }
+	 },
+	 {
+	  "id": "bati religieux surfacique - Zoom 15,16,17,18",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "bati_surf",
+	  "minzoom": 14,
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "CHAPELLE_SURF",
+	   "EGLISE_SURF",
+	   "CHRETIEN_SURF",
+	   "SYNAGOGUE_SURF",
+	   "MOSQUEE_SURF",
+	   "AUTRE_CULTE_SURF"
+	  ],
+	  "paint": {
+	   "fill-color": {
+		"stops": [
+		 [
+		  14,
+		  "#F7CBCB"
+		 ],
+		 [
+		  15,
+		  "#F7E1E1"
+		 ]
+		]
+	   },
+	   "fill-outline-color": {
+		"stops": [
+		 [
+		  14,
+		  "#F7A8A8"
+		 ],
+		 [
+		  15,
+		  "#F7B7B7"
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "bati remarquable surfacique",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "bati_surf",
+	  "minzoom": 13,
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "FORTIF_SURF",
+	   "CHATEAU_SURF",
+	   "TOUR_MOULIN_SURF",
+	   "ARENE_THEATRE",
+	   "ARC_TRIOMPHE_SURF",
+	   "MONUMENT_SURF"
+	  ],
+	  "paint": {
+	   "fill-color": "#9B9B9B",
+	   "fill-outline-color": "#6E6E6E"
+	  }
+	 },
+	 {
+	  "id": "bati sportif surfacique fond",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "bati_surf",
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "TENNIS_SURF",
+	   "SPORT_INDIF_SURF",
+	   "FOOT_SURF",
+	   "MULTI_SPORT_SURF",
+	   "PISTE_SPORT_SURF",
+	   "NATATION_SURF"
+	  ],
+	  "paint": {
+	   "fill-color": "#FFFFFF",
+	   "fill-outline-color": "#FFFFFF"
+	  }
+	 },
+	 {
+	  "id": "bati sportif surfacique",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "bati_surf",
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "TENNIS_SURF",
+	   "SPORT_INDIF_SURF",
+	   "FOOT_SURF",
+	   "MULTI_SPORT_SURF",
+	   "PISTE_SPORT_SURF",
+	   "NATATION_SURF"
+	  ],
+	  "paint": {
+	   "line-color": "#BCD9AB",
+	   "line-width": 2
+	  }
+	 },
+	 {
+	  "id": "bati transport surfacique - piste",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "bati_surf",
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "PISTE_DUR",
+	   "PISTE_HERBE"
+	  ],
+	  "paint": {
+	   "fill-color": "#DBDBDB",
+	   "fill-outline-color": "#808080"
+	  }
+	 },
+	 {
+	  "id": "bati ZAI - Autres",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "bati_zai",
+	  "minzoom": 15,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "in",
+	   "nature",
+	   "Lycée",
+	   "Université",
+	   "Capitainerie",
+	   "Gendarmerie",
+	   "Siège d'EPCI",
+	   "Musée",
+	   "Collège",
+	   "Maison de retraite",
+	   "Etablissement thermal",
+	   "Autre service déconcentré de l'Etat",
+	   "Etablissement pénitentiaire",
+	   "Divers public ou administratif",
+	   "Autre établissement d'enseignement",
+	   "Maison du parc",
+	   "Palais de justice",
+	   "Enseignement primaire",
+	   "Office de tourisme",
+	   "Hôpital",
+	   "Police",
+	   "Piscine",
+	   "Enseignement supérieur",
+	   "Poste",
+	   "Caserne",
+	   "Etablissement hospitalier",
+	   "Etablissement extraterritorial",
+	   "Science",
+	   "Structure d'accueil pour personnes handicapées",
+	   "Administration centrale de l'Etat",
+	   "Caserne de pompiers"
+	  ],
+	  "paint": {
+	   "fill-color": "#E3BFE2",
+	   "fill-opacity": 0.5,
+	   "fill-outline-color": "#E39FE1"
+	  }
+	 },
+	 {
+	  "id": "bati ZAI - Commandement",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "bati_zai",
+	  "minzoom": 15,
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "in",
+	   "nature",
+	   "Hôtel de département",
+	   "Hôtel de région",
+	   "Préfecture de région",
+	   "Préfecture",
+	   "Sous-préfecture"
+	  ],
+	  "paint": {
+	   "fill-color": "#FF0000",
+	   "fill-opacity": 0.3,
+	   "fill-outline-color": "#B40000"
+	  }
+	 },
+	 {
+	  "id": "construction linéaire - mur",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "bati_lin",
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "MUR"
+	  ],
+	  "paint": {
+	   "line-color": "#8C8C8C",
+	   "line-width": 0.3
+	  }
+	 },
+	 {
+	  "id": "construction linéaire - autre",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "bati_lin",
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "RUINE_LIN",
+	   "MUR_SOUTENEMENT",
+	   "FORTIF_LIN"
+	  ],
+	  "paint": {
+	   "line-color": "#646464",
+	   "line-width": 0.5
+	  }
+	 },
+	 {
+	  "id": "construction hydrographique linéaire - Barrage",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "bati_lin",
+	  "minzoom": 13,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "BARRAGE_LIN"
+	  ],
+	  "paint": {
+	   "line-color": "#646464",
+	   "line-width": {
+		"stops": [
+		 [
+		  13,
+		  1.5
+		 ],
+		 [
+		  17,
+		  5
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "construction hydrographique linéaire - Quai",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "bati_lin",
+	  "minzoom": 12,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "QUAI",
+	   "DIGUE"
+	  ],
+	  "paint": {
+	   "line-color": "#828282",
+	   "line-width": {
+		"stops": [
+		 [
+		  14,
+		  1
+		 ],
+		 [
+		  17,
+		  2.5
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "construction hydrographique linéaire - Pecherie",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "bati_lin",
+	  "minzoom": 12,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "PECHERIE_LIN"
+	  ],
+	  "paint": {
+	   "line-color": "#0066CC",
+	   "line-width": {
+		"stops": [
+		 [
+		  14,
+		  1
+		 ],
+		 [
+		  17,
+		  2.5
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Chemin a niveau - piste cyclable",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_chemin",
+	  "minzoom": 13,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "PISTE_CYCLABLE"
+	  ],
+	  "paint": {
+	   "line-color": {
+		"stops": [
+		 [
+		  17,
+		  "#9B5CCC"
+		 ],
+		 [
+		  18,
+		  "#FFFFFF"
+		 ]
+		]
+	   },
+	   "line-width": {
+		"stops": [
+		 [
+		  14,
+		  1.1
+		 ],
+		 [
+		  15,
+		  1.7
+		 ],
+		 [
+		  16,
+		  2
+		 ],
+		 [
+		  17,
+		  3.5
+		 ],
+		 [
+		  18,
+		  6
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		6,
+		2
+	   ]
+	  }
+	 },
+	 {
+	  "id": "Chemin a niveau - filet exterieur - escalier",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_chemin",
+	  "minzoom": 14,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "ESCALIER"
+	  ],
+	  "paint": {
+	   "line-color": {
+		"stops": [
+		 [
+		  17,
+		  "#8C7274"
+		 ],
+		 [
+		  18,
+		  "#C8C8C8"
+		 ]
+		]
+	   },
+	   "line-width": {
+		"stops": [
+		 [
+		  14,
+		  1.75
+		 ],
+		 [
+		  15,
+		  3
+		 ],
+		 [
+		  16,
+		  4.2
+		 ],
+		 [
+		  17,
+		  9.5
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Chemin a niveau - filet interieur - escalier",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_chemin",
+	  "minzoom": 14,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "ESCALIER"
+	  ],
+	  "paint": {
+	   "line-color": "#FFFFFF",
+	   "line-width": {
+		"stops": [
+		 [
+		  14,
+		  1
+		 ],
+		 [
+		  15,
+		  1.9
+		 ],
+		 [
+		  16,
+		  2.7
+		 ],
+		 [
+		  17,
+		  5.8
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		1,
+		0.2
+	   ]
+	  }
+	 },
+	 {
+	  "id": "Chemin a niveau - Rue pietonne",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_chemin",
+	  "minzoom": 14,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "RUE_PIETONNE"
+	  ],
+	  "paint": {
+	   "line-color": {
+		"stops": [
+		 [
+		  17,
+		  "#8C7274"
+		 ],
+		 [
+		  18,
+		  "#F8E5D5"
+		 ]
+		]
+	   },
+	   "line-width": {
+		"stops": [
+		 [
+		  14,
+		  1
+		 ],
+		 [
+		  15,
+		  1.2
+		 ],
+		 [
+		  16,
+		  1.4
+		 ],
+		 [
+		  17,
+		  2
+		 ],
+		 [
+		  18,
+		  5
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		1,
+		3
+	   ]
+	  }
+	 },
+	 {
+	  "id": "Chemin a niveau - sentier",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_chemin",
+	  "minzoom": 13,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "SENTIER"
+	  ],
+	  "paint": {
+	   "line-color": {
+		"stops": [
+		 [
+		  17,
+		  "#8C7274"
+		 ],
+		 [
+		  18,
+		  "#FFFFFF"
+		 ]
+		]
+	   },
+	   "line-width": {
+		"stops": [
+		 [
+		  14,
+		  1
+		 ],
+		 [
+		  15,
+		  1.2
+		 ],
+		 [
+		  16,
+		  1.4
+		 ],
+		 [
+		  17,
+		  2
+		 ],
+		 [
+		  18,
+		  6
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		4,
+		3
+	   ]
+	  }
+	 },
+	 {
+	  "id": "Chemin a niveau - chemin",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_chemin",
+	  "minzoom": 12,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "CHEMIN"
+	  ],
+	  "paint": {
+	   "line-color": {
+		"stops": [
+		 [
+		  17,
+		  "#8C7274"
+		 ],
+		 [
+		  18,
+		  "#FFFFFF"
+		 ]
+		]
+	   },
+	   "line-width": {
+		"stops": [
+		 [
+		  14,
+		  1
+		 ],
+		 [
+		  15,
+		  1.2
+		 ],
+		 [
+		  16,
+		  1.4
+		 ],
+		 [
+		  17,
+		  2
+		 ],
+		 [
+		  18,
+		  7
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier a niveau - filet extérieur - route non revetu carrosable",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route",
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "NON_REVETUE_CARRO"
+	  ],
+	  "paint": {
+	   "line-color": {
+		"stops": [
+		 [
+		  12,
+		  "#646464"
+		 ],
+		 [
+		  17,
+		  "#8C8C8C"
+		 ]
+		]
+	   },
+	   "line-width": {
+		"stops": [
+		 [
+		  14,
+		  3.2
+		 ],
+		 [
+		  15,
+		  5.4
+		 ],
+		 [
+		  16,
+		  7.7
+		 ],
+		 [
+		  17,
+		  16.8
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		2,
+		2
+	   ]
+	  }
+	 },
+	 {
+	  "id": "Routier a niveau - filet interieur - route non revetu carrosable",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route",
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "NON_REVETUE_CARRO"
+	  ],
+	  "paint": {
+	   "line-color": "#FFFFFF",
+	   "line-width": {
+		"stops": [
+		 [
+		  14,
+		  2.3
+		 ],
+		 [
+		  15,
+		  4.1
+		 ],
+		 [
+		  16,
+		  6.3
+		 ],
+		 [
+		  17,
+		  13.5
+		 ],
+		 [
+		  18,
+		  16.8
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier a niveau - filet extérieur - bretelle autoroute",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route",
+	  "minzoom": 12,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "BRET_AUTO_PEAGE_3",
+	   "BRET_AUTO_PEAGE_2",
+	   "BRET_AUTO_PEAGE_1",
+	   "BRET_AUTO_LIBRE_3",
+	   "BRET_AUTO_LIBRE_2",
+	   "BRET_AUTO_LIBRE_1"
+	  ],
+	  "paint": {
+	   "line-color": {
+		"stops": [
+		 [
+		  9,
+		  "#DE460E"
+		 ],
+		 [
+		  17,
+		  "#F18800"
+		 ],
+		 [
+		  18,
+		  "#FFFFFF"
+		 ]
+		]
+	   },
+	   "line-width": {
+		"stops": [
+		 [
+		  12,
+		  2.5
+		 ],
+		 [
+		  14,
+		  3.7
+		 ],
+		 [
+		  15,
+		  6.8
+		 ],
+		 [
+		  16,
+		  8.4
+		 ],
+		 [
+		  17,
+		  14
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier a niveau - filet extérieur - route non classee restreint",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route",
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "NON_CLASSEE_RESTREINT"
+	  ],
+	  "paint": {
+	   "line-color": {
+		"stops": [
+		 [
+		  17,
+		  "#969696"
+		 ],
+		 [
+		  18,
+		  "#FFFFFF"
+		 ]
+		]
+	   },
+	   "line-width": {
+		"stops": [
+		 [
+		  14,
+		  3.2
+		 ],
+		 [
+		  15,
+		  5.4
+		 ],
+		 [
+		  16,
+		  7.7
+		 ],
+		 [
+		  17,
+		  16.8
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier a niveau - filet extérieur - route non classee",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route",
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "NON_CLASSEE_4",
+	   "NON_CLASSEE"
+	  ],
+	  "paint": {
+	   "line-color": {
+		"stops": [
+		 [
+		  17,
+		  "#969696"
+		 ],
+		 [
+		  18,
+		  "#FFFFFF"
+		 ]
+		]
+	   },
+	   "line-width": {
+		"stops": [
+		 [
+		  14,
+		  3.2
+		 ],
+		 [
+		  15,
+		  5.4
+		 ],
+		 [
+		  16,
+		  7.7
+		 ],
+		 [
+		  17,
+		  16.8
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier a niveau - filet extérieur - route locale",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route",
+	  "minzoom": 7,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "BRET_LOCALE",
+	   "LOCALE_4",
+	   "LOCALE_3",
+	   "LOCALE_2",
+	   "LOCALE_1"
+	  ],
+	  "paint": {
+	   "line-color": {
+		"stops": [
+		 [
+		  12,
+		  "#8C8C8C"
+		 ],
+		 [
+		  13,
+		  "#B4B4B4"
+		 ],
+		 [
+		  17,
+		  "#B4B4B4"
+		 ],
+		 [
+		  18,
+		  "#FFFFFF"
+		 ]
+		]
+	   },
+	   "line-width": {
+		"stops": [
+		 [
+		  9,
+		  2
+		 ],
+		 [
+		  14,
+		  3.5
+		 ],
+		 [
+		  15,
+		  6
+		 ],
+		 [
+		  16,
+		  8.4
+		 ],
+		 [
+		  17,
+		  18.3
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier a niveau - filet extérieur - route locale en construction",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route",
+	  "minzoom": 11,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "LOCALE_CONSTR"
+	  ],
+	  "paint": {
+	   "line-color": "#C8C8C8",
+	   "line-width": {
+		"stops": [
+		 [
+		  9,
+		  2
+		 ],
+		 [
+		  14,
+		  3.5
+		 ],
+		 [
+		  15,
+		  6
+		 ],
+		 [
+		  16,
+		  8.4
+		 ],
+		 [
+		  17,
+		  18.3
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier a niveau - filet extérieur - route regionale",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route",
+	  "minzoom": 8,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "BRET_REGIONALE",
+	   "REGIONALE_4",
+	   "REGIONALE_3",
+	   "REGIONALE_2",
+	   "REGIONALE_1"
+	  ],
+	  "paint": {
+	   "line-color": {
+		"stops": [
+		 [
+		  9,
+		  "#828282"
+		 ],
+		 [
+		  10,
+		  "#B4B4B4"
+		 ],
+		 [
+		  17,
+		  "#B4B4B4"
+		 ],
+		 [
+		  18,
+		  "#FFFFFF"
+		 ]
+		]
+	   },
+	   "line-width": {
+		"stops": [
+		 [
+		  6,
+		  1.5
+		 ],
+		 [
+		  9,
+		  2.3
+		 ],
+		 [
+		  14,
+		  5
+		 ],
+		 [
+		  15,
+		  8.1
+		 ],
+		 [
+		  16,
+		  11.2
+		 ],
+		 [
+		  17,
+		  22
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier a niveau - filet extérieur - route regionale en construction",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route",
+	  "minzoom": 10,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "REGIONALE_CONSTR"
+	  ],
+	  "paint": {
+	   "line-color": "#C8C8C8",
+	   "line-width": {
+		"stops": [
+		 [
+		  6,
+		  1.5
+		 ],
+		 [
+		  9,
+		  2.3
+		 ],
+		 [
+		  14,
+		  5
+		 ],
+		 [
+		  15,
+		  8.1
+		 ],
+		 [
+		  16,
+		  11.2
+		 ],
+		 [
+		  17,
+		  22
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier a niveau - filet extérieur - route principale",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route",
+	  "minzoom": 8,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "BRET_PRINCIPALE",
+	   "PRINCIPALE_4",
+	   "PRINCIPALE_3",
+	   "PRINCIPALE_2",
+	   "PRINCIPALE_1"
+	  ],
+	  "paint": {
+	   "line-color": {
+		"stops": [
+		 [
+		  17,
+		  "#E2A52A"
+		 ],
+		 [
+		  18,
+		  "#FFFFFF"
+		 ]
+		]
+	   },
+	   "line-width": {
+		"stops": [
+		 [
+		  6,
+		  1.8
+		 ],
+		 [
+		  9,
+		  2.7
+		 ],
+		 [
+		  14,
+		  5.9
+		 ],
+		 [
+		  15,
+		  9
+		 ],
+		 [
+		  16,
+		  12.2
+		 ],
+		 [
+		  17,
+		  22.5
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier a niveau - filet extérieur - route principale en construction",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route",
+	  "minzoom": 10,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "PRINCIPALE_CONSTR"
+	  ],
+	  "paint": {
+	   "line-color": "#C8C8C8",
+	   "line-width": {
+		"stops": [
+		 [
+		  6,
+		  1.8
+		 ],
+		 [
+		  9,
+		  2.7
+		 ],
+		 [
+		  14,
+		  5.9
+		 ],
+		 [
+		  15,
+		  9
+		 ],
+		 [
+		  16,
+		  12.2
+		 ],
+		 [
+		  17,
+		  22.5
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier a niveau - filet extérieur - autoroute",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route",
+	  "minzoom": 8,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "AUTOROU_PEAGE",
+	   "AUTOROU_LIBRE"
+	  ],
+	  "paint": {
+	   "line-color": {
+		"stops": [
+		 [
+		  9,
+		  "#DE460E"
+		 ],
+		 [
+		  17,
+		  "#F18800"
+		 ],
+		 [
+		  18,
+		  "#FFFFFF"
+		 ]
+		]
+	   },
+	   "line-width": {
+		"stops": [
+		 [
+		  6,
+		  2.5
+		 ],
+		 [
+		  9,
+		  3.5
+		 ],
+		 [
+		  14,
+		  7.5
+		 ],
+		 [
+		  15,
+		  11
+		 ],
+		 [
+		  16,
+		  15
+		 ],
+		 [
+		  17,
+		  26
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier a niveau - filet extérieur - autoroute en construction",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route",
+	  "minzoom": 8,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "AUTOROU_CONSTR"
+	  ],
+	  "paint": {
+	   "line-color": "#C8C8C8",
+	   "line-width": {
+		"stops": [
+		 [
+		  6,
+		  2.5
+		 ],
+		 [
+		  9,
+		  3.5
+		 ],
+		 [
+		  14,
+		  7.5
+		 ],
+		 [
+		  15,
+		  11
+		 ],
+		 [
+		  16,
+		  15
+		 ],
+		 [
+		  17,
+		  26
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier a niveau - filet interieur - bretelle autoroute",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route",
+	  "minzoom": 12,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "BRET_AUTO_PEAGE_3",
+	   "BRET_AUTO_PEAGE_2",
+	   "BRET_AUTO_PEAGE_1",
+	   "BRET_AUTO_LIBRE_3",
+	   "BRET_AUTO_LIBRE_2",
+	   "BRET_AUTO_LIBRE_1"
+	  ],
+	  "paint": {
+	   "line-color": {
+		"stops": [
+		 [
+		  9,
+		  "#F18800"
+		 ],
+		 [
+		  17,
+		  "#F2B230"
+		 ]
+		]
+	   },
+	   "line-width": {
+		"stops": [
+		 [
+		  12,
+		  1.5
+		 ],
+		 [
+		  14,
+		  2.6
+		 ],
+		 [
+		  15,
+		  5.2
+		 ],
+		 [
+		  16,
+		  6.7
+		 ],
+		 [
+		  17,
+		  10.8
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier a niveau - filet interieur - route non classee restreint",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route",
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "NON_CLASSEE_RESTREINT"
+	  ],
+	  "paint": {
+	   "line-color": "#EDF1FF",
+	   "line-width": {
+		"stops": [
+		 [
+		  14,
+		  2.3
+		 ],
+		 [
+		  15,
+		  4.1
+		 ],
+		 [
+		  16,
+		  6.3
+		 ],
+		 [
+		  17,
+		  13.5
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier a niveau - filet interieur - route non classee",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route",
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "NON_CLASSEE_4",
+	   "NON_CLASSEE"
+	  ],
+	  "paint": {
+	   "line-color": "#FFFFFF",
+	   "line-width": {
+		"stops": [
+		 [
+		  14,
+		  2.3
+		 ],
+		 [
+		  15,
+		  4.1
+		 ],
+		 [
+		  16,
+		  6.3
+		 ],
+		 [
+		  17,
+		  13.5
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier a niveau - filet interieur - route locale",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route",
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "BRET_LOCALE",
+	   "LOCALE_4",
+	   "LOCALE_3",
+	   "LOCALE_2",
+	   "LOCALE_1"
+	  ],
+	  "paint": {
+	   "line-color": {
+		"stops": [
+		 [
+		  6,
+		  "#F2B361"
+		 ],
+		 [
+		  7,
+		  "#FFFFFF"
+		 ],
+		 [
+		  12,
+		  "#FFFFFF"
+		 ],
+		 [
+		  13,
+		  "#FCF4A8"
+		 ],
+		 [
+		  17,
+		  "#FCF7C1"
+		 ]
+		]
+	   },
+	   "line-width": {
+		"stops": [
+		 [
+		  9,
+		  1.3
+		 ],
+		 [
+		  14,
+		  2.3
+		 ],
+		 [
+		  15,
+		  4.1
+		 ],
+		 [
+		  16,
+		  6.1
+		 ],
+		 [
+		  17,
+		  13.1
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier a niveau - filet interieur - route locale en construction",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route",
+	  "minzoom": 11,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "LOCALE_CONSTR"
+	  ],
+	  "paint": {
+	   "line-color": {
+		"stops": [
+		 [
+		  12,
+		  "#FFFFFF"
+		 ],
+		 [
+		  13,
+		  "#FCF4A8"
+		 ],
+		 [
+		  17,
+		  "#FCF7C1"
+		 ],
+		 [
+		  18,
+		  "#EDEDED"
+		 ]
+		]
+	   },
+	   "line-width": {
+		"stops": [
+		 [
+		  9,
+		  2
+		 ],
+		 [
+		  14,
+		  3.5
+		 ],
+		 [
+		  15,
+		  6
+		 ],
+		 [
+		  16,
+		  8.4
+		 ],
+		 [
+		  17,
+		  18.3
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		2,
+		2
+	   ]
+	  }
+	 },
+	 {
+	  "id": "Routier a niveau - filet interieur - route regionale",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route",
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "BRET_REGIONALE",
+	   "REGIONALE_4",
+	   "REGIONALE_3",
+	   "REGIONALE_2",
+	   "REGIONALE_1"
+	  ],
+	  "paint": {
+	   "line-color": {
+		"stops": [
+		 [
+		  6,
+		  "#F2A949"
+		 ],
+		 [
+		  7,
+		  "#FFFFFF"
+		 ],
+		 [
+		  9,
+		  "#FFFFFF"
+		 ],
+		 [
+		  10,
+		  "#FDF28B"
+		 ],
+		 [
+		  17,
+		  "#FCF6BD"
+		 ]
+		]
+	   },
+	   "line-width": {
+		"stops": [
+		 [
+		  4,
+		  1.1
+		 ],
+		 [
+		  6,
+		  1.4
+		 ],
+		 [
+		  9,
+		  1.5
+		 ],
+		 [
+		  14,
+		  3.2
+		 ],
+		 [
+		  15,
+		  5.8
+		 ],
+		 [
+		  16,
+		  8.3
+		 ],
+		 [
+		  17,
+		  16.2
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier a niveau - filet interieur - route regionale en construction",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route",
+	  "minzoom": 10,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "REGIONALE_CONSTR"
+	  ],
+	  "paint": {
+	   "line-color": {
+		"stops": [
+		 [
+		  9,
+		  "#FFFFFF"
+		 ],
+		 [
+		  10,
+		  "#FDF28B"
+		 ],
+		 [
+		  17,
+		  "#FCF6BD"
+		 ],
+		 [
+		  18,
+		  "#EDEDED"
+		 ]
+		]
+	   },
+	   "line-width": {
+		"stops": [
+		 [
+		  4,
+		  0.4
+		 ],
+		 [
+		  6,
+		  1.5
+		 ],
+		 [
+		  9,
+		  2.3
+		 ],
+		 [
+		  14,
+		  5
+		 ],
+		 [
+		  15,
+		  8.1
+		 ],
+		 [
+		  16,
+		  11.2
+		 ],
+		 [
+		  17,
+		  22
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		2,
+		2
+	   ]
+	  }
+	 },
+	 {
+	  "id": "Routier a niveau - filet interieur - route principale",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route",
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "BRET_PRINCIPALE",
+	   "PRINCIPALE_4",
+	   "PRINCIPALE_3",
+	   "PRINCIPALE_2",
+	   "PRINCIPALE_1"
+	  ],
+	  "paint": {
+	   "line-color": {
+		"stops": [
+		 [
+		  6,
+		  "#F29924"
+		 ],
+		 [
+		  7,
+		  "#F3C66D"
+		 ],
+		 [
+		  9,
+		  "#F3C66D"
+		 ],
+		 [
+		  17,
+		  "#F2DDB3"
+		 ]
+		]
+	   },
+	   "line-width": {
+		"stops": [
+		 [
+		  4,
+		  0.6
+		 ],
+		 [
+		  6,
+		  1.8
+		 ],
+		 [
+		  9,
+		  2.1
+		 ],
+		 [
+		  14,
+		  4.4
+		 ],
+		 [
+		  15,
+		  7.3
+		 ],
+		 [
+		  16,
+		  10
+		 ],
+		 [
+		  17,
+		  18.5
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier a niveau - filet interieur - route principale en construction",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route",
+	  "minzoom": 10,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "PRINCIPALE_CONSTR"
+	  ],
+	  "paint": {
+	   "line-color": {
+		"stops": [
+		 [
+		  9,
+		  "#F3C66D"
+		 ],
+		 [
+		  17,
+		  "#F2DDB3"
+		 ],
+		 [
+		  18,
+		  "#EDEDED"
+		 ]
+		]
+	   },
+	   "line-width": {
+		"stops": [
+		 [
+		  4,
+		  0.5
+		 ],
+		 [
+		  6,
+		  1.8
+		 ],
+		 [
+		  9,
+		  2.7
+		 ],
+		 [
+		  14,
+		  5.9
+		 ],
+		 [
+		  15,
+		  9
+		 ],
+		 [
+		  16,
+		  12.2
+		 ],
+		 [
+		  17,
+		  22.5
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		2,
+		2
+	   ]
+	  }
+	 },
+	 {
+	  "id": "Routier a niveau - filet interieur - autoroute",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route",
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "AUTOROU_PEAGE",
+	   "AUTOROU_LIBRE"
+	  ],
+	  "paint": {
+	   "line-color": {
+		"stops": [
+		 [
+		  9,
+		  "#F18800"
+		 ],
+		 [
+		  17,
+		  "#F2B230"
+		 ]
+		]
+	   },
+	   "line-width": {
+		"stops": [
+		 [
+		  4,
+		  0.7
+		 ],
+		 [
+		  6,
+		  2.5
+		 ],
+		 [
+		  9,
+		  2.7
+		 ],
+		 [
+		  14,
+		  5.8
+		 ],
+		 [
+		  15,
+		  9
+		 ],
+		 [
+		  16,
+		  12
+		 ],
+		 [
+		  17,
+		  20.8
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier a niveau - axe central - autoroute",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route",
+	  "minzoom": 13,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "AUTOROU_PEAGE",
+	   "AUTOROU_LIBRE"
+	  ],
+	  "paint": {
+	   "line-color": "#FFFFFF",
+	   "line-width": {
+		"stops": [
+		 [
+		  9,
+		  0.6
+		 ],
+		 [
+		  14,
+		  0.7
+		 ],
+		 [
+		  15,
+		  1
+		 ],
+		 [
+		  16,
+		  1.2
+		 ],
+		 [
+		  17,
+		  2.1
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier a niveau - filet interieur - autoroute en construction",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route",
+	  "minzoom": 8,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "AUTOROU_CONSTR"
+	  ],
+	  "paint": {
+	   "line-color": {
+		"stops": [
+		 [
+		  9,
+		  "#F18800"
+		 ],
+		 [
+		  17,
+		  "#F2B230"
+		 ],
+		 [
+		  18,
+		  "#EDEDED"
+		 ]
+		]
+	   },
+	   "line-width": {
+		"stops": [
+		 [
+		  4,
+		  0.7
+		 ],
+		 [
+		  6,
+		  2.5
+		 ],
+		 [
+		  9,
+		  3.5
+		 ],
+		 [
+		  14,
+		  7.5
+		 ],
+		 [
+		  15,
+		  11
+		 ],
+		 [
+		  16,
+		  15
+		 ],
+		 [
+		  17,
+		  26
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		2,
+		2
+	   ]
+	  }
+	 },
+	 {
+	  "id": "Routier a niveau - axe centrale - autoroute en construction",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route",
+	  "minzoom": 13,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "AUTOROU_CONSTR"
+	  ],
+	  "paint": {
+	   "line-color": "#808080",
+	   "line-width": {
+		"stops": [
+		 [
+		  9,
+		  0.6
+		 ],
+		 [
+		  14,
+		  0.7
+		 ],
+		 [
+		  15,
+		  1
+		 ],
+		 [
+		  16,
+		  1.2
+		 ],
+		 [
+		  17,
+		  2.1
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Ferre a niveau - voie normale",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "ferre",
+	  "minzoom": 10,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "VF_1",
+	   "VF_2",
+	   "VF_3",
+	   "VF_4",
+	   "VF_ELEC_1",
+	   "VF_ELEC_2",
+	   "VF_ELEC_3",
+	   "VF_ELEC_4"
+	  ],
+	  "paint": {
+	   "line-color": "#787878",
+	   "line-width": {
+		"stops": [
+		 [
+		  10,
+		  0.8
+		 ],
+		 [
+		  17,
+		  2.5
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Ferre a niveau - voie normale trait perpendic",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "ferre",
+	  "minzoom": 10,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "VF_1",
+	   "VF_2",
+	   "VF_3",
+	   "VF_4",
+	   "VF_ELEC_1",
+	   "VF_ELEC_2",
+	   "VF_ELEC_3",
+	   "VF_ELEC_4"
+	  ],
+	  "paint": {
+	   "line-color": "#787878",
+	   "line-width": {
+		"stops": [
+		 [
+		  10,
+		  3.5
+		 ],
+		 [
+		  17,
+		  14.7
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		0.1,
+		10
+	   ]
+	  }
+	 },
+	 {
+	  "id": "Ferre a niveau - voie etroite",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "ferre",
+	  "minzoom": 10,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "VF_ETROITE_1",
+	   "VF_ETROITE_2",
+	   "VF_ETROITE"
+	  ],
+	  "paint": {
+	   "line-color": "#787878",
+	   "line-width": {
+		"stops": [
+		 [
+		  10,
+		  0.3
+		 ],
+		 [
+		  17,
+		  1.8
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Ferre a niveau - voie etroite trait perpendic",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "ferre",
+	  "minzoom": 10,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "VF_ETROITE_1",
+	   "VF_ETROITE_2",
+	   "VF_ETROITE"
+	  ],
+	  "paint": {
+	   "line-color": "#787878",
+	   "line-width": {
+		"stops": [
+		 [
+		  10,
+		  3.5
+		 ],
+		 [
+		  17,
+		  14.7
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		0.1,
+		10
+	   ]
+	  }
+	 },
+	 {
+	  "id": "Ferre a niveau - voie service",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "ferre",
+	  "minzoom": 14,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "VF_SERVICE",
+	   "VF_NON_EXPLOITEE"
+	  ],
+	  "paint": {
+	   "line-color": "#787878",
+	   "line-width": {
+		"stops": [
+		 [
+		  10,
+		  0.3
+		 ],
+		 [
+		  17,
+		  1.8
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		5,
+		2,
+		1,
+		2
+	   ]
+	  }
+	 },
+	 {
+	  "id": "Ferre a niveau - voie en construction",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "ferre",
+	  "minzoom": 10,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "VF_EN_CONSTR"
+	  ],
+	  "paint": {
+	   "line-color": "#787878",
+	   "line-width": {
+		"stops": [
+		 [
+		  10,
+		  0.3
+		 ],
+		 [
+		  17,
+		  1.8
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		2,
+		2
+	   ]
+	  }
+	 },
+	 {
+	  "id": "Ferre a niveau - voie en construction trait perpendic",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "ferre",
+	  "minzoom": 10,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "VF_EN_CONSTR"
+	  ],
+	  "paint": {
+	   "line-color": "#787878",
+	   "line-width": {
+		"stops": [
+		 [
+		  10,
+		  3.5
+		 ],
+		 [
+		  17,
+		  14.7
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		0.1,
+		10
+	   ]
+	  }
+	 },
+	 {
+	  "id": "Ferre a niveau - funic/urbain",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "ferre",
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "FUNI_CREMAILLERE",
+	   "TRANSPORT_URBAIN"
+	  ],
+	  "paint": {
+	   "line-color": "#787878",
+	   "line-width": {
+		"stops": [
+		 [
+		  10,
+		  0.3
+		 ],
+		 [
+		  17,
+		  1.8
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Ferre a niveau - 2 trait perpendic - funic/urbain",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "ferre",
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "FUNI_CREMAILLERE",
+	   "TRANSPORT_URBAIN"
+	  ],
+	  "paint": {
+	   "line-color": "#787878",
+	   "line-width": {
+		"stops": [
+		 [
+		  10,
+		  3.5
+		 ],
+		 [
+		  17,
+		  17
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		0.1,
+		0.2,
+		0.1,
+		10
+	   ]
+	  }
+	 },
+	 {
+	  "id": "liaison routiere - Bac Liaison Maritime",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_liaison",
+	  "minzoom": 8,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "BAC_AUTO",
+	   "LIAISON_MARITIME",
+	   "BAC_LIAISON_MARITIME"
+	  ],
+	  "paint": {
+	   "line-color": "#5792C2",
+	   "line-width": {
+		"stops": [
+		 [
+		  8,
+		  1
+		 ],
+		 [
+		  13,
+		  2.5
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "liaison routiere - Gue route",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_liaison",
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "GUE_ROUTE"
+	  ],
+	  "paint": {
+	   "line-color": {
+		"stops": [
+		 [
+		  13,
+		  "#BEBEBE"
+		 ],
+		 [
+		  17,
+		  "#646464"
+		 ],
+		 [
+		  18,
+		  "#FFFFFF"
+		 ]
+		]
+	   },
+	   "line-width": {
+		"stops": [
+		 [
+		  14,
+		  2.3
+		 ],
+		 [
+		  15,
+		  4.1
+		 ],
+		 [
+		  16,
+		  6.3
+		 ],
+		 [
+		  17,
+		  13.5
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "liaison routiere - Gue chemin",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_liaison",
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "GUE_CHEMIN"
+	  ],
+	  "paint": {
+	   "line-color": {
+		"stops": [
+		 [
+		  13,
+		  "#BEBEBE"
+		 ],
+		 [
+		  17,
+		  "#646464"
+		 ]
+		]
+	   },
+	   "line-width": {
+		"stops": [
+		 [
+		  14,
+		  1.6
+		 ],
+		 [
+		  15,
+		  2.9
+		 ],
+		 [
+		  16,
+		  4.4
+		 ],
+		 [
+		  17,
+		  6.5
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "liaison routiere - filet extérieur - Pont passerelle",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_liaison",
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "PONT_PASSERELLE",
+	   "PONT_LIN",
+	   "PONT_MOBILE_LIN"
+	  ],
+	  "paint": {
+	   "line-color": {
+		"stops": [
+		 [
+		  17,
+		  "#C8C8C8"
+		 ],
+		 [
+		  18,
+		  "#FFFFFF"
+		 ]
+		]
+	   },
+	   "line-width": {
+		"stops": [
+		 [
+		  14,
+		  2.2
+		 ],
+		 [
+		  15,
+		  3.8
+		 ],
+		 [
+		  16,
+		  5.4
+		 ],
+		 [
+		  17,
+		  11.8
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "liaison routiere - filet intérieur - Pont passerelle",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_liaison",
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "PONT_PASSERELLE",
+	   "PONT_LIN",
+	   "PONT_MOBILE_LIN"
+	  ],
+	  "paint": {
+	   "line-color": "#FFFFFF",
+	   "line-width": {
+		"stops": [
+		 [
+		  14,
+		  0.7
+		 ],
+		 [
+		  15,
+		  1.1
+		 ],
+		 [
+		  16,
+		  1.7
+		 ],
+		 [
+		  17,
+		  3.8
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier surfacique",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "routier_surf",
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "SURF_ROUT_PRINC",
+	   "SURF_ROUT_REG",
+	   "SURF_ROUT_LOC",
+	   "SURF_ROUT_NON_CLA"
+	  ],
+	  "paint": {
+	   "fill-color": "#FFFFFF",
+	   "fill-outline-color": "#000000"
+	  }
+	 },
+	 {
+	  "id": "Routier surfacique - Dalle de protection",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "routier_surf",
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "DALLE_DE_PROTECTION"
+	  ],
+	  "paint": {
+	   "fill-opacity": 0.5,
+	   "fill-color": "#FFFFFF",
+	   "fill-outline-color": "#000000"
+	  }
+	 },
+	 {
+	  "id": "Routier surfacique - Escalier surfacique",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "routier_surf",
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "ESCALIER_SURF"
+	  ],
+	  "paint": {
+	   "fill-opacity": 0.8,
+	   "fill-color": "#FFFFFF",
+	   "fill-outline-color": "#918091"
+	  }
+	 },
+	 {
+	  "id": "Routier surfacique - Péage surfacique",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "routier_surf",
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "SURF_PEAGE"
+	  ],
+	  "paint": {
+	   "fill-color": "#F2DAAA",
+	   "fill-outline-color": "#E2A52A"
+	  }
+	 },
+	 {
+	  "id": "bati transport surfacique - bati peage",
+	  "type": "fill",
+	  "source": "plan_ign",
+	  "source-layer": "bati_surf",
+	  "minzoom": 13,
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "BATI_PEAGE"
+	  ],
+	  "paint": {
+	   "fill-color": "#DCDCDC",
+	   "fill-outline-color": "#808080"
+	  }
+	 },
+	 {
+	  "id": "réseau hydro  - cours d'eau superieur",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "hydro_reseau_sup",
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "COURS_D_EAU_SUP",
+	   "COURS_D_EAU_MOY_SUP"
+	  ],
+	  "paint": {
+	   "line-color": "#AAD5E9",
+	   "line-width": {
+		"stops": [
+		 [
+		  12,
+		  1.5
+		 ],
+		 [
+		  17,
+		  6.5
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "réseau hydro - canal superieur",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "hydro_reseau_sup",
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "CANAL_SUP"
+	  ],
+	  "paint": {
+	   "line-color": "#AAD5E9",
+	   "line-width": {
+		"stops": [
+		 [
+		  12,
+		  1.4
+		 ],
+		 [
+		  17,
+		  5.9
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "réseau hydro - filet interieur - aqueduc superieur",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "hydro_reseau_sup",
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "AQUEDUC_SUP"
+	  ],
+	  "paint": {
+	   "line-color": "#AAD5E9",
+	   "line-width": {
+		"stops": [
+		 [
+		  12,
+		  1.4
+		 ],
+		 [
+		  16,
+		  3.5
+		 ],
+		 [
+		  17,
+		  5.9
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "réseau hydro - carre - aqueduc superieur",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "hydro_reseau_sup",
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "AQUEDUC_SUP"
+	  ],
+	  "paint": {
+	   "line-color": "#AAD5E9",
+	   "line-width": {
+		"stops": [
+		 [
+		  12,
+		  3.5
+		 ],
+		 [
+		  16,
+		  8.7
+		 ],
+		 [
+		  17,
+		  14.7
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		1,
+		5
+	   ]
+	  }
+	 },
+	 {
+	  "id": "Chemin superieur - piste cyclable",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_chemin_sup",
+	  "minzoom": 13,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "PISTE_CYCLABLE_SUP"
+	  ],
+	  "paint": {
+	   "line-color": {
+		"stops": [
+		 [
+		  17,
+		  "#9B5CCC"
+		 ],
+		 [
+		  18,
+		  "#FFFFFF"
+		 ]
+		]
+	   },
+	   "line-width": {
+		"stops": [
+		 [
+		  14,
+		  1.1
+		 ],
+		 [
+		  15,
+		  1.7
+		 ],
+		 [
+		  16,
+		  2
+		 ],
+		 [
+		  17,
+		  3.5
+		 ],
+		 [
+		  18,
+		  6
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		6,
+		2
+	   ]
+	  }
+	 },
+	 {
+	  "id": "Chemin superieur - filet exterieur - escalier",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_chemin_sup",
+	  "minzoom": 14,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "ESCALIER_SUP"
+	  ],
+	  "paint": {
+	   "line-color": {
+		"stops": [
+		 [
+		  17,
+		  "#8C7274"
+		 ],
+		 [
+		  18,
+		  "#C8C8C8"
+		 ]
+		]
+	   },
+	   "line-width": {
+		"stops": [
+		 [
+		  14,
+		  1.75
+		 ],
+		 [
+		  15,
+		  3
+		 ],
+		 [
+		  16,
+		  4.2
+		 ],
+		 [
+		  17,
+		  9.5
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Chemin superieur - filet interieur - escalier",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_chemin_sup",
+	  "minzoom": 14,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "ESCALIER_SUP"
+	  ],
+	  "paint": {
+	   "line-color": "#FFFFFF",
+	   "line-width": {
+		"stops": [
+		 [
+		  14,
+		  1
+		 ],
+		 [
+		  15,
+		  1.9
+		 ],
+		 [
+		  16,
+		  2.7
+		 ],
+		 [
+		  17,
+		  5.8
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		1,
+		0.2
+	   ]
+	  }
+	 },
+	 {
+	  "id": "Chemin superieur - Rue pietonne",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_chemin_sup",
+	  "minzoom": 14,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "RUE_PIETONNE_SUP"
+	  ],
+	  "paint": {
+	   "line-color": {
+		"stops": [
+		 [
+		  17,
+		  "#8C7274"
+		 ],
+		 [
+		  18,
+		  "#EBEBEB"
+		 ]
+		]
+	   },
+	   "line-width": {
+		"stops": [
+		 [
+		  14,
+		  1
+		 ],
+		 [
+		  15,
+		  1.2
+		 ],
+		 [
+		  16,
+		  1.4
+		 ],
+		 [
+		  17,
+		  2
+		 ],
+		 [
+		  18,
+		  5
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		1,
+		3
+	   ]
+	  }
+	 },
+	 {
+	  "id": "Chemin superieur - sentier",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_chemin_sup",
+	  "minzoom": 13,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "SENTIER_SUP"
+	  ],
+	  "paint": {
+	   "line-color": {
+		"stops": [
+		 [
+		  17,
+		  "#8C7274"
+		 ],
+		 [
+		  18,
+		  "#FFFFFF"
+		 ]
+		]
+	   },
+	   "line-width": {
+		"stops": [
+		 [
+		  14,
+		  1
+		 ],
+		 [
+		  15,
+		  1.2
+		 ],
+		 [
+		  16,
+		  1.4
+		 ],
+		 [
+		  17,
+		  2
+		 ],
+		 [
+		  18,
+		  6
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		4,
+		3
+	   ]
+	  }
+	 },
+	 {
+	  "id": "Chemin superieur - chemin",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_chemin_sup",
+	  "minzoom": 12,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "CHEMIN_SUP"
+	  ],
+	  "paint": {
+	   "line-color": {
+		"stops": [
+		 [
+		  17,
+		  "#8C7274"
+		 ],
+		 [
+		  18,
+		  "#FFFFFF"
+		 ]
+		]
+	   },
+	   "line-width": {
+		"stops": [
+		 [
+		  14,
+		  1
+		 ],
+		 [
+		  15,
+		  1.2
+		 ],
+		 [
+		  16,
+		  1.4
+		 ],
+		 [
+		  17,
+		  2
+		 ],
+		 [
+		  18,
+		  7
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier superieur - filet extérieur - route non revetu carrosable",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route_sup",
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "NON_REVETUE_CARRO_SUP"
+	  ],
+	  "paint": {
+	   "line-color": {
+		"stops": [
+		 [
+		  12,
+		  "#646464"
+		 ],
+		 [
+		  17,
+		  "#8C8C8C"
+		 ]
+		]
+	   },
+	   "line-width": {
+		"stops": [
+		 [
+		  14,
+		  3.2
+		 ],
+		 [
+		  15,
+		  5.4
+		 ],
+		 [
+		  16,
+		  7.7
+		 ],
+		 [
+		  17,
+		  16.8
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		2,
+		2
+	   ]
+	  }
+	 },
+	 {
+	  "id": "Routier superieur - filet extérieur - bretelle autoroute",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route_sup",
+	  "minzoom": 12,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "BRET_AUTO_PEAGE_3_SUP",
+	   "BRET_AUTO_PEAGE_2_SUP",
+	   "BRET_AUTO_PEAGE_1_SUP",
+	   "BRET_AUTO_LIBRE_3_SUP",
+	   "BRET_AUTO_LIBRE_2_SUP",
+	   "BRET_AUTO_LIBRE_1_SUP"
+	  ],
+	  "paint": {
+	   "line-color": {
+		"stops": [
+		 [
+		  9,
+		  "#DE460E"
+		 ],
+		 [
+		  17,
+		  "#F18800"
+		 ],
+		 [
+		  18,
+		  "#FFFFFF"
+		 ]
+		]
+	   },
+	   "line-width": {
+		"stops": [
+		 [
+		  12,
+		  2.5
+		 ],
+		 [
+		  14,
+		  3.7
+		 ],
+		 [
+		  15,
+		  6.8
+		 ],
+		 [
+		  16,
+		  8.4
+		 ],
+		 [
+		  17,
+		  14
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier superieur - filet extérieur - route non classee restreint",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route_sup",
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "NON_CLASSEE_RESTREINT_SUP"
+	  ],
+	  "paint": {
+	   "line-color": {
+		"stops": [
+		 [
+		  17,
+		  "#969696"
+		 ],
+		 [
+		  18,
+		  "#FFFFFF"
+		 ]
+		]
+	   },
+	   "line-width": {
+		"stops": [
+		 [
+		  14,
+		  3.2
+		 ],
+		 [
+		  15,
+		  5.4
+		 ],
+		 [
+		  16,
+		  7.7
+		 ],
+		 [
+		  17,
+		  16.8
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier superieur - filet extérieur - route non classee",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route_sup",
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "NON_CLASSEE_4_SUP",
+	   "NON_CLASSEE_SUP"
+	  ],
+	  "paint": {
+	   "line-color": {
+		"stops": [
+		 [
+		  17,
+		  "#969696"
+		 ],
+		 [
+		  18,
+		  "#FFFFFF"
+		 ]
+		]
+	   },
+	   "line-width": {
+		"stops": [
+		 [
+		  14,
+		  3.2
+		 ],
+		 [
+		  15,
+		  5.4
+		 ],
+		 [
+		  16,
+		  7.7
+		 ],
+		 [
+		  17,
+		  16.8
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier superieur - filet extérieur - route locale",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route_sup",
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "BRET_LOCALE_SUP",
+	   "LOCALE_4_SUP",
+	   "LOCALE_3_SUP",
+	   "LOCALE_2_SUP",
+	   "LOCALE_1_SUP"
+	  ],
+	  "paint": {
+	   "line-color": {
+		"stops": [
+		 [
+		  12,
+		  "#8C8C8C"
+		 ],
+		 [
+		  13,
+		  "#B4B4B4"
+		 ],
+		 [
+		  17,
+		  "#B4B4B4"
+		 ],
+		 [
+		  18,
+		  "#FFFFFF"
+		 ]
+		]
+	   },
+	   "line-width": {
+		"stops": [
+		 [
+		  9,
+		  2
+		 ],
+		 [
+		  14,
+		  3.5
+		 ],
+		 [
+		  15,
+		  6
+		 ],
+		 [
+		  16,
+		  8.4
+		 ],
+		 [
+		  17,
+		  18.3
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier superieur - filet extérieur - route locale en construction",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route_sup",
+	  "minzoom": 11,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "LOCALE_CONSTR_SUP"
+	  ],
+	  "paint": {
+	   "line-color": "#C8C8C8",
+	   "line-width": {
+		"stops": [
+		 [
+		  9,
+		  2
+		 ],
+		 [
+		  14,
+		  3.5
+		 ],
+		 [
+		  15,
+		  6
+		 ],
+		 [
+		  16,
+		  8.4
+		 ],
+		 [
+		  17,
+		  18.3
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier superieur - filet extérieur - route regionale",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route_sup",
+	  "minzoom": 8,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "BRET_REGIONALE_SUP",
+	   "REGIONALE_4_SUP",
+	   "REGIONALE_3_SUP",
+	   "REGIONALE_2_SUP",
+	   "REGIONALE_1_SUP"
+	  ],
+	  "paint": {
+	   "line-color": {
+		"stops": [
+		 [
+		  9,
+		  "#828282"
+		 ],
+		 [
+		  10,
+		  "#B4B4B4"
+		 ],
+		 [
+		  17,
+		  "#B4B4B4"
+		 ],
+		 [
+		  18,
+		  "#FFFFFF"
+		 ]
+		]
+	   },
+	   "line-width": {
+		"stops": [
+		 [
+		  6,
+		  1.5
+		 ],
+		 [
+		  9,
+		  2.3
+		 ],
+		 [
+		  14,
+		  5
+		 ],
+		 [
+		  15,
+		  8.1
+		 ],
+		 [
+		  16,
+		  11.2
+		 ],
+		 [
+		  17,
+		  22
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier superieur - filet extérieur - route regionale en construction",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route_sup",
+	  "minzoom": 10,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "REGIONALE_CONSTR_SUP"
+	  ],
+	  "paint": {
+	   "line-color": "#C8C8C8",
+	   "line-width": {
+		"stops": [
+		 [
+		  6,
+		  1.5
+		 ],
+		 [
+		  9,
+		  2.3
+		 ],
+		 [
+		  14,
+		  5
+		 ],
+		 [
+		  15,
+		  8.1
+		 ],
+		 [
+		  16,
+		  11.2
+		 ],
+		 [
+		  17,
+		  22
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier superieur - filet extérieur - route principale",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route_sup",
+	  "minzoom": 8,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "BRET_PRINCIPALE_SUP",
+	   "PRINCIPALE_4_SUP",
+	   "PRINCIPALE_3_SUP",
+	   "PRINCIPALE_2_SUP",
+	   "PRINCIPALE_1_SUP"
+	  ],
+	  "paint": {
+	   "line-color": {
+		"stops": [
+		 [
+		  17,
+		  "#E2A52A"
+		 ],
+		 [
+		  18,
+		  "#FFFFFF"
+		 ]
+		]
+	   },
+	   "line-width": {
+		"stops": [
+		 [
+		  6,
+		  1.8
+		 ],
+		 [
+		  9,
+		  2.7
+		 ],
+		 [
+		  14,
+		  5.9
+		 ],
+		 [
+		  15,
+		  9
+		 ],
+		 [
+		  16,
+		  12.2
+		 ],
+		 [
+		  17,
+		  22.5
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier superieur - filet extérieur - route principale en construction",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route_sup",
+	  "minzoom": 10,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "PRINCIPALE_CONSTR_SUP"
+	  ],
+	  "paint": {
+	   "line-color": "#C8C8C8",
+	   "line-width": {
+		"stops": [
+		 [
+		  6,
+		  1.8
+		 ],
+		 [
+		  9,
+		  2.7
+		 ],
+		 [
+		  14,
+		  5.9
+		 ],
+		 [
+		  15,
+		  9
+		 ],
+		 [
+		  16,
+		  12.2
+		 ],
+		 [
+		  17,
+		  22.5
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier superieur - filet extérieur - autoroute",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route_sup",
+	  "minzoom": 8,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "AUTOROU_PEAGE_SUP",
+	   "AUTOROU_LIBRE_SUP"
+	  ],
+	  "paint": {
+	   "line-color": {
+		"stops": [
+		 [
+		  9,
+		  "#DE460E"
+		 ],
+		 [
+		  17,
+		  "#F18800"
+		 ],
+		 [
+		  18,
+		  "#FFFFFF"
+		 ]
+		]
+	   },
+	   "line-width": {
+		"stops": [
+		 [
+		  6,
+		  2.5
+		 ],
+		 [
+		  9,
+		  3.5
+		 ],
+		 [
+		  14,
+		  7.5
+		 ],
+		 [
+		  15,
+		  11
+		 ],
+		 [
+		  16,
+		  15
+		 ],
+		 [
+		  17,
+		  26
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier superieur - filet extérieur - autoroute en construction",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route_sup",
+	  "minzoom": 10,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "AUTOROU_CONSTR_SUP"
+	  ],
+	  "paint": {
+	   "line-color": "#C8C8C8",
+	   "line-width": {
+		"stops": [
+		 [
+		  6,
+		  2.5
+		 ],
+		 [
+		  9,
+		  3.5
+		 ],
+		 [
+		  14,
+		  7.5
+		 ],
+		 [
+		  15,
+		  11
+		 ],
+		 [
+		  16,
+		  15
+		 ],
+		 [
+		  17,
+		  26
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier superieur - filet interieur - route non revetu carrosable",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route_sup",
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "NON_REVETUE_CARRO_SUP"
+	  ],
+	  "paint": {
+	   "line-color": "#FFFFFF",
+	   "line-width": {
+		"stops": [
+		 [
+		  14,
+		  2.3
+		 ],
+		 [
+		  15,
+		  4.1
+		 ],
+		 [
+		  16,
+		  6.3
+		 ],
+		 [
+		  17,
+		  13.5
+		 ],
+		 [
+		  18,
+		  16.8
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier superieur - filet interieur - bretelle autoroute",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route_sup",
+	  "minzoom": 12,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "BRET_AUTO_PEAGE_3_SUP",
+	   "BRET_AUTO_PEAGE_2_SUP",
+	   "BRET_AUTO_PEAGE_1_SUP",
+	   "BRET_AUTO_LIBRE_3_SUP",
+	   "BRET_AUTO_LIBRE_2_SUP",
+	   "BRET_AUTO_LIBRE_1_SUP"
+	  ],
+	  "paint": {
+	   "line-color": {
+		"stops": [
+		 [
+		  9,
+		  "#F18800"
+		 ],
+		 [
+		  17,
+		  "#F2B230"
+		 ]
+		]
+	   },
+	   "line-width": {
+		"stops": [
+		 [
+		  12,
+		  1.5
+		 ],
+		 [
+		  14,
+		  2.6
+		 ],
+		 [
+		  15,
+		  5.2
+		 ],
+		 [
+		  16,
+		  6.7
+		 ],
+		 [
+		  17,
+		  10.8
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier superieur - filet interieur - route non classee restreint",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route_sup",
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "NON_CLASSEE_RESTREINT_SUP"
+	  ],
+	  "paint": {
+	   "line-color": "#EDF1FF",
+	   "line-width": {
+		"stops": [
+		 [
+		  14,
+		  2.3
+		 ],
+		 [
+		  15,
+		  4.1
+		 ],
+		 [
+		  16,
+		  6.3
+		 ],
+		 [
+		  17,
+		  13.5
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier superieur - filet interieur - route non classee",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route_sup",
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "NON_CLASSEE_4_SUP",
+	   "NON_CLASSEE_SUP"
+	  ],
+	  "paint": {
+	   "line-color": "#FFFFFF",
+	   "line-width": {
+		"stops": [
+		 [
+		  14,
+		  2.3
+		 ],
+		 [
+		  15,
+		  4.1
+		 ],
+		 [
+		  16,
+		  6.3
+		 ],
+		 [
+		  17,
+		  13.5
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier superieur - filet interieur - route locale",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route_sup",
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "BRET_LOCALE_SUP",
+	   "LOCALE_4_SUP",
+	   "LOCALE_3_SUP",
+	   "LOCALE_2_SUP",
+	   "LOCALE_1_SUP"
+	  ],
+	  "paint": {
+	   "line-color": {
+		"stops": [
+		 [
+		  12,
+		  "#FFFFFF"
+		 ],
+		 [
+		  13,
+		  "#FCF4A8"
+		 ],
+		 [
+		  17,
+		  "#FCF7C1"
+		 ]
+		]
+	   },
+	   "line-width": {
+		"stops": [
+		 [
+		  9,
+		  1.3
+		 ],
+		 [
+		  14,
+		  2.3
+		 ],
+		 [
+		  15,
+		  4.1
+		 ],
+		 [
+		  16,
+		  6.1
+		 ],
+		 [
+		  17,
+		  13.1
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier superieur - filet interieur - route locale en construction",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route_sup",
+	  "minzoom": 11,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "LOCALE_CONSTR_SUP"
+	  ],
+	  "paint": {
+	   "line-color": {
+		"stops": [
+		 [
+		  12,
+		  "#FFFFFF"
+		 ],
+		 [
+		  13,
+		  "#FCF4A8"
+		 ],
+		 [
+		  17,
+		  "#FCF7C1"
+		 ]
+		]
+	   },
+	   "line-width": {
+		"stops": [
+		 [
+		  9,
+		  2
+		 ],
+		 [
+		  14,
+		  3.5
+		 ],
+		 [
+		  15,
+		  6
+		 ],
+		 [
+		  16,
+		  8.4
+		 ],
+		 [
+		  17,
+		  18.3
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		2,
+		2
+	   ]
+	  }
+	 },
+	 {
+	  "id": "Routier superieur - filet interieur - route regionale",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route_sup",
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "BRET_REGIONALE_SUP",
+	   "REGIONALE_4_SUP",
+	   "REGIONALE_3_SUP",
+	   "REGIONALE_2_SUP",
+	   "REGIONALE_1_SUP"
+	  ],
+	  "paint": {
+	   "line-color": {
+		"stops": [
+		 [
+		  9,
+		  "#FFFFFF"
+		 ],
+		 [
+		  10,
+		  "#FDF28B"
+		 ],
+		 [
+		  17,
+		  "#FCF6BD"
+		 ]
+		]
+	   },
+	   "line-width": {
+		"stops": [
+		 [
+		  6,
+		  1.4
+		 ],
+		 [
+		  9,
+		  1.5
+		 ],
+		 [
+		  14,
+		  3.2
+		 ],
+		 [
+		  15,
+		  5.8
+		 ],
+		 [
+		  16,
+		  8.3
+		 ],
+		 [
+		  17,
+		  16.2
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier superieur - filet interieur - route regionale en construction",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route_sup",
+	  "minzoom": 10,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "REGIONALE_CONSTR_SUP"
+	  ],
+	  "paint": {
+	   "line-color": {
+		"stops": [
+		 [
+		  9,
+		  "#FFFFFF"
+		 ],
+		 [
+		  10,
+		  "#FDF28B"
+		 ],
+		 [
+		  17,
+		  "#FCF6BD"
+		 ]
+		]
+	   },
+	   "line-width": {
+		"stops": [
+		 [
+		  6,
+		  1.5
+		 ],
+		 [
+		  9,
+		  2.3
+		 ],
+		 [
+		  14,
+		  5
+		 ],
+		 [
+		  15,
+		  8.1
+		 ],
+		 [
+		  16,
+		  11.2
+		 ],
+		 [
+		  17,
+		  22
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		2,
+		2
+	   ]
+	  }
+	 },
+	 {
+	  "id": "Routier superieur - filet interieur - route principale",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route_sup",
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "BRET_PRINCIPALE_SUP",
+	   "PRINCIPALE_4_SUP",
+	   "PRINCIPALE_3_SUP",
+	   "PRINCIPALE_2_SUP",
+	   "PRINCIPALE_1_SUP"
+	  ],
+	  "paint": {
+	   "line-color": {
+		"stops": [
+		 [
+		  9,
+		  "#F3C66D"
+		 ],
+		 [
+		  17,
+		  "#F2DDB3"
+		 ]
+		]
+	   },
+	   "line-width": {
+		"stops": [
+		 [
+		  4,
+		  0.5
+		 ],
+		 [
+		  6,
+		  1.8
+		 ],
+		 [
+		  9,
+		  2.1
+		 ],
+		 [
+		  14,
+		  4.4
+		 ],
+		 [
+		  15,
+		  7.3
+		 ],
+		 [
+		  16,
+		  10
+		 ],
+		 [
+		  17,
+		  18.5
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier superieur - filet interieur - route principale en construction",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route_sup",
+	  "minzoom": 10,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "PRINCIPALE_CONSTR_SUP"
+	  ],
+	  "paint": {
+	   "line-color": {
+		"stops": [
+		 [
+		  9,
+		  "#F3C66D"
+		 ],
+		 [
+		  17,
+		  "#F2DDB3"
+		 ]
+		]
+	   },
+	   "line-width": {
+		"stops": [
+		 [
+		  6,
+		  1.8
+		 ],
+		 [
+		  9,
+		  2.7
+		 ],
+		 [
+		  14,
+		  5.9
+		 ],
+		 [
+		  15,
+		  9
+		 ],
+		 [
+		  16,
+		  12.2
+		 ],
+		 [
+		  17,
+		  22.5
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		2,
+		2
+	   ]
+	  }
+	 },
+	 {
+	  "id": "Routier superieur - filet interieur - autoroute",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route_sup",
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "AUTOROU_PEAGE_SUP",
+	   "AUTOROU_LIBRE_SUP"
+	  ],
+	  "paint": {
+	   "line-color": {
+		"stops": [
+		 [
+		  9,
+		  "#F18800"
+		 ],
+		 [
+		  17,
+		  "#F2B230"
+		 ]
+		]
+	   },
+	   "line-width": {
+		"stops": [
+		 [
+		  4,
+		  0.7
+		 ],
+		 [
+		  6,
+		  2.5
+		 ],
+		 [
+		  9,
+		  2.7
+		 ],
+		 [
+		  14,
+		  5.8
+		 ],
+		 [
+		  15,
+		  9
+		 ],
+		 [
+		  16,
+		  12
+		 ],
+		 [
+		  17,
+		  20.8
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier superieur - axe central - autoroute",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route_sup",
+	  "minzoom": 13,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "AUTOROU_PEAGE_SUP",
+	   "AUTOROU_LIBRE_SUP"
+	  ],
+	  "paint": {
+	   "line-color": "#FFFFFF",
+	   "line-width": {
+		"stops": [
+		 [
+		  9,
+		  0.6
+		 ],
+		 [
+		  14,
+		  0.7
+		 ],
+		 [
+		  15,
+		  1
+		 ],
+		 [
+		  16,
+		  1.2
+		 ],
+		 [
+		  17,
+		  2.1
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Routier superieur - filet interieur - autoroute en construction",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route_sup",
+	  "minzoom": 10,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "AUTOROU_CONSTR_SUP"
+	  ],
+	  "paint": {
+	   "line-color": {
+		"stops": [
+		 [
+		  9,
+		  "#F18800"
+		 ],
+		 [
+		  17,
+		  "#F2B230"
+		 ]
+		]
+	   },
+	   "line-width": {
+		"stops": [
+		 [
+		  4,
+		  0.7
+		 ],
+		 [
+		  6,
+		  2.5
+		 ],
+		 [
+		  9,
+		  3.5
+		 ],
+		 [
+		  14,
+		  7.5
+		 ],
+		 [
+		  15,
+		  11
+		 ],
+		 [
+		  16,
+		  15
+		 ],
+		 [
+		  17,
+		  26
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		2,
+		2
+	   ]
+	  }
+	 },
+	 {
+	  "id": "Routier superieur - axe centrale - autoroute en construction",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "routier_route_sup",
+	  "minzoom": 13,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "AUTOROU_CONSTR_SUP"
+	  ],
+	  "paint": {
+	   "line-color": "#808080",
+	   "line-width": {
+		"stops": [
+		 [
+		  9,
+		  0.6
+		 ],
+		 [
+		  14,
+		  0.7
+		 ],
+		 [
+		  15,
+		  1
+		 ],
+		 [
+		  16,
+		  1.2
+		 ],
+		 [
+		  17,
+		  2.1
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Ferre superieur - voie normale",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "ferre_sup",
+	  "minzoom": 10,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "VF_1_SUP",
+	   "VF_2_SUP",
+	   "VF_ELEC_1_SUP"
+	  ],
+	  "paint": {
+	   "line-color": "#787878",
+	   "line-width": {
+		"stops": [
+		 [
+		  10,
+		  0.8
+		 ],
+		 [
+		  17,
+		  2.5
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Ferre superieur - voie normale trait perpendic",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "ferre_sup",
+	  "minzoom": 10,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "VF_1_SUP",
+	   "VF_2_SUP",
+	   "VF_ELEC_1_SUP"
+	  ],
+	  "paint": {
+	   "line-color": "#787878",
+	   "line-width": {
+		"stops": [
+		 [
+		  10,
+		  3.5
+		 ],
+		 [
+		  17,
+		  14.7
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		0.1,
+		10
+	   ]
+	  }
+	 },
+	 {
+	  "id": "Ferre superieur - voie etroite",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "ferre_sup",
+	  "minzoom": 10,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "VF_ETROITE_1_SUP",
+	   "VF_ETROITE_SUP"
+	  ],
+	  "paint": {
+	   "line-color": "#787878",
+	   "line-width": {
+		"stops": [
+		 [
+		  10,
+		  0.3
+		 ],
+		 [
+		  17,
+		  1.8
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Ferre superieur - voie etroite trait perpendic",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "ferre_sup",
+	  "minzoom": 10,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "VF_ETROITE_1_SUP",
+	   "VF_ETROITE_SUP"
+	  ],
+	  "paint": {
+	   "line-color": "#787878",
+	   "line-width": {
+		"stops": [
+		 [
+		  10,
+		  3.5
+		 ],
+		 [
+		  17,
+		  14.7
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		0.1,
+		10
+	   ]
+	  }
+	 },
+	 {
+	  "id": "Ferre superieur - voie service",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "ferre_sup",
+	  "minzoom": 14,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "VF_SERVICE_SUP",
+	   "VF_NON_EXPLOITEE_SUP"
+	  ],
+	  "paint": {
+	   "line-color": "#787878",
+	   "line-width": {
+		"stops": [
+		 [
+		  10,
+		  0.3
+		 ],
+		 [
+		  17,
+		  1.8
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		5,
+		2,
+		1,
+		2
+	   ]
+	  }
+	 },
+	 {
+	  "id": "Ferre superieur - voie en construction",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "ferre_sup",
+	  "minzoom": 10,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "VF_EN_CONSTR_SUP"
+	  ],
+	  "paint": {
+	   "line-color": "#787878",
+	   "line-width": {
+		"stops": [
+		 [
+		  10,
+		  0.3
+		 ],
+		 [
+		  17,
+		  1.8
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		2,
+		2
+	   ]
+	  }
+	 },
+	 {
+	  "id": "Ferre superieur - voie en construction trait perpendic",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "ferre_sup",
+	  "minzoom": 10,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "VF_EN_CONSTR_SUP"
+	  ],
+	  "paint": {
+	   "line-color": "#787878",
+	   "line-width": {
+		"stops": [
+		 [
+		  10,
+		  3.5
+		 ],
+		 [
+		  17,
+		  14.7
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		0.1,
+		10
+	   ]
+	  }
+	 },
+	 {
+	  "id": "Ferre superieur - funic/urbain",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "ferre_sup",
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "FUNI_CREMAILLERE_SUP",
+	   "TRANSPORT_URBAIN_SUP"
+	  ],
+	  "paint": {
+	   "line-color": "#787878",
+	   "line-width": {
+		"stops": [
+		 [
+		  10,
+		  0.3
+		 ],
+		 [
+		  17,
+		  1.8
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "Ferre superieur - 2 trait perpendic - funic/urbain",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "ferre_sup",
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "FUNI_CREMAILLERE_SUP",
+	   "TRANSPORT_URBAIN_SUP"
+	  ],
+	  "paint": {
+	   "line-color": "#787878",
+	   "line-width": {
+		"stops": [
+		 [
+		  10,
+		  3.5
+		 ],
+		 [
+		  17,
+		  17
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		0.1,
+		0.2,
+		0.1,
+		10
+	   ]
+	  }
+	 },
+	 {
+	  "id": "Limite - cloture",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "limite_lin",
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "CLOTURE"
+	  ],
+	  "paint": {
+	   "line-color": "#000000",
+	   "line-width": {
+		"stops": [
+		 [
+		  13,
+		  0.6
+		 ],
+		 [
+		  17,
+		  1
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		1.5,
+		4
+	   ]
+	  }
+	 },
+	 {
+	  "id": "Limite - layon",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "limite_lin",
+	  "minzoom": 14,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "LAYON"
+	  ],
+	  "paint": {
+	   "line-color": "#B3989A",
+	   "line-width": {
+		"stops": [
+		 [
+		  14,
+		  1
+		 ],
+		 [
+		  15,
+		  1.2
+		 ],
+		 [
+		  16,
+		  1.4
+		 ],
+		 [
+		  17,
+		  2
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		4,
+		7
+	   ]
+	  }
+	 },
+	 {
+	  "id": "Zone Règlementee - Enceinte militaire",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "limite_lin",
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "LIM_ZONE_REGLEMENTEE",
+	   "LIM_ENCEINTE_MILITAIRE",
+	   "LIM_ENCEINTE_MILI",
+	   "LIM_CHAMP_TIR"
+	  ],
+	  "paint": {
+	   "line-color": "rgba(226, 130, 92, 0.8)",
+	   "line-width": {
+		"stops": [
+		 [
+		  13,
+		  1.7
+		 ],
+		 [
+		  17,
+		  3.1
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		4,
+		1,
+		2,
+		5
+	   ]
+	  }
+	 },
+	 {
+	  "id": "limite zone naturelle",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "limite_lin",
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "LIM_ZONE_NATURELLE",
+	   "LIM_ZONE_NATURELLE_ILE",
+	   "LIM_RESERVE_NATURELLE"
+	  ],
+	  "paint": {
+	   "line-color": "#FFC2CB",
+	   "line-width": {
+		"stops": [
+		 [
+		  13,
+		  2
+		 ],
+		 [
+		  17,
+		  4
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		2,
+		1
+	   ]
+	  }
+	 },
+	 {
+	  "id": "limite zone naturelle - Parc naturel 10",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "limite_lin",
+	  "maxzoom": 10,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "LIM_PARC_NATUREL",
+	   "LIM_PARC_NATUREL_ILE"
+	  ],
+	  "paint": {
+	   "line-color": "#42A266",
+	   "line-width": {
+		"stops": [
+		 [
+		  13,
+		  2
+		 ],
+		 [
+		  17,
+		  4
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		2,
+		1
+	   ]
+	  }
+	 },
+	 {
+	  "id": "limite zone naturelle - Parc naturel 11",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "limite_lin",
+	  "minzoom": 10,
+	  "maxzoom": 11,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "LIM_PARC_NATUREL",
+	   "LIM_PARC_NATUREL_ILE"
+	  ],
+	  "paint": {
+	   "line-color": "#42A266",
+	   "line-width": {
+		"stops": [
+		 [
+		  13,
+		  2
+		 ],
+		 [
+		  17,
+		  4
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		2,
+		2
+	   ]
+	  }
+	 },
+	 {
+	  "id": "limite zone naturelle - Parc naturel 12",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "limite_lin",
+	  "minzoom": 11,
+	  "maxzoom": 12,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "LIM_PARC_NATUREL",
+	   "LIM_PARC_NATUREL_ILE"
+	  ],
+	  "paint": {
+	   "line-color": "#42A266",
+	   "line-width": {
+		"stops": [
+		 [
+		  13,
+		  2
+		 ],
+		 [
+		  17,
+		  4
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		2,
+		3
+	   ]
+	  }
+	 },
+	 {
+	  "id": "limite zone naturelle - Parc naturel 13",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "limite_lin",
+	  "minzoom": 12,
+	  "maxzoom": 13,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "LIM_PARC_NATUREL",
+	   "LIM_PARC_NATUREL_ILE"
+	  ],
+	  "paint": {
+	   "line-color": "#42A266",
+	   "line-width": {
+		"stops": [
+		 [
+		  13,
+		  2
+		 ],
+		 [
+		  17,
+		  4
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		2,
+		4
+	   ]
+	  }
+	 },
+	 {
+	  "id": "limite zone naturelle - Parc naturel 14",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "limite_lin",
+	  "minzoom": 13,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "LIM_PARC_NATUREL",
+	   "LIM_PARC_NATUREL_ILE"
+	  ],
+	  "paint": {
+	   "line-color": "rgba(66, 162, 102, 0.7)",
+	   "line-width": {
+		"stops": [
+		 [
+		  13,
+		  2
+		 ],
+		 [
+		  17,
+		  4
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		2,
+		5
+	   ]
+	  }
+	 },
+	 {
+	  "id": "limite zone naturelle - Parc marin",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "limite_lin",
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "LIM_PARC_NATUREL_MARIN"
+	  ],
+	  "paint": {
+	   "line-color": "#2A81A2",
+	   "line-width": {
+		"stops": [
+		 [
+		  13,
+		  2
+		 ],
+		 [
+		  17,
+		  4
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		2,
+		1
+	   ]
+	  }
+	 },
+	 {
+	  "id": "parcellaire - parcelle bordure",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "parcellaire_parcelle",
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "PARCELLE"
+	  ],
+	  "paint": {
+	   "line-color": "#9933FF",
+	   "line-width": 1
+	  }
+	 },
+	 {
+	  "id": "parcellaire - section",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "parcellaire_section",
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "SECTION"
+	  ],
+	  "paint": {
+	   "line-color": "#287B00",
+	   "line-width": 1.9,
+	   "line-dasharray": [
+		2,
+		4,
+		2
+	   ]
+	  }
+	 },
+	 {
+	  "id": "toponyme - parcellaire - section",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_parcellaire_section",
+	  "filter": [
+	   "==",
+	   "txt_typo",
+	   "SECTION"
+	  ],
+	  "layout": {
+	   "symbol-placement": "line",
+	   "text-offset": [
+		0,
+		0
+	   ],
+	   "text-field": "{texte}",
+	   "text-size": 15,
+	   "text-anchor": "center",
+	   "text-keep-upright": true,
+	   "text-max-angle": 45,
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ],
+	   "visibility": "visible"
+	  },
+	  "paint": {
+	   "text-color": "#287B00"
+	  }
+	 },
+	 {
+	  "id": "toponyme - parcellaire - parcelle",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_parcellaire_parcelle",
+	  "filter": [
+	   "==",
+	   "txt_typo",
+	   "PARCELLE"
+	  ],
+	  "layout": {
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-size": 11,
+	   "text-anchor": "center",
+	   "text-keep-upright": true,
+	   "text-max-angle": 45,
+	   "text-font": [
+		"Source Sans Pro Bold"
+	   ],
+	   "visibility": "visible"
+	  },
+	  "paint": {
+	   "text-color": "#9933FF",
+	   "text-halo-width": 1,
+	   "text-halo-color": "#FFFFFF"
+	  }
+	 },
+	 {
+	  "id": "toponyme - parcellaire - adresse",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_parcellaire_adresse_ponc",
+	  "filter": [
+	   "==",
+	   "txt_typo",
+	   "ADRESSE"
+	  ],
+	  "layout": {
+	   "symbol-placement": "point",
+	   "text-field": [
+		"concat",
+		"{numero}",
+		"{indice_de_repetition}"
+	   ],
+	   "text-size": 11,
+	   "text-anchor": "center",
+	   "text-keep-upright": true,
+	   "text-max-angle": 45,
+	   "text-font": [
+		"Source Sans Pro Bold"
+	   ],
+	   "visibility": "visible"
+	  },
+	  "paint": {
+	   "text-color": "#695744",
+	   "text-halo-width": 1,
+	   "text-halo-color": "#FFFFFF"
+	  }
+	 },
+	 {
+	  "id": "limite admin - limite de commune",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "limite_lin",
+	  "minzoom": 13,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "LIM_COMMUNE",
+	   "LIM_CANTON",
+	   "LIM_ARRONDISSEMENT"
+	  ],
+	  "paint": {
+	   "line-color": "rgba(126, 119, 184, 0.5)",
+	   "line-width": {
+		"stops": [
+		 [
+		  13,
+		  3
+		 ],
+		 [
+		  17,
+		  5.5
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		4,
+		2,
+		1,
+		1,
+		1,
+		1,
+		1,
+		2
+	   ]
+	  }
+	 },
+	 {
+	  "id": "limite admin - limite de département bandeau",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "limite_lin",
+	  "minzoom": 8,
+	  "maxzoom": 13,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "LIM_DEPARTEMENT"
+	  ],
+	  "paint": {
+	   "line-color": "rgba(178, 175, 219, 0.4)",
+	   "line-width": {
+		"stops": [
+		 [
+		  9,
+		  4.1
+		 ],
+		 [
+		  12,
+		  6
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "limite admin - limite de département tiret",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "limite_lin",
+	  "minzoom": 13,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "LIM_DEPARTEMENT"
+	  ],
+	  "paint": {
+	   "line-color": "rgba(126, 119, 184, 0.5)",
+	   "line-width": {
+		"stops": [
+		 [
+		  13,
+		  3
+		 ],
+		 [
+		  17,
+		  5.5
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		4,
+		2,
+		1,
+		1,
+		1,
+		2
+	   ]
+	  }
+	 },
+	 {
+	  "id": "limite admin - limite de région bandeau",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "limite_lin",
+	  "minzoom": 7,
+	  "maxzoom": 13,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "LIM_REGION"
+	  ],
+	  "paint": {
+	   "line-color": "rgba(178, 175, 219, 0.5)",
+	   "line-width": {
+		"stops": [
+		 [
+		  9,
+		  4.5
+		 ],
+		 [
+		  12,
+		  6.7
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "limite admin - limite de région tiret",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "limite_lin",
+	  "minzoom": 13,
+	  "maxzoom": 18,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "LIM_REGION"
+	  ],
+	  "paint": {
+	   "line-color": "rgba(126, 119, 184, 0.5)",
+	   "line-width": {
+		"stops": [
+		 [
+		  13,
+		  3
+		 ],
+		 [
+		  17,
+		  5.5
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		4,
+		2,
+		1,
+		2
+	   ]
+	  }
+	 },
+	 {
+	  "id": "limite etat 1",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "limite_lin",
+	  "minzoom": 2,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "LIM_ETAT",
+	   "LIM_ETAT_ETRANGER"
+	  ],
+	  "paint": {
+	   "line-color": "rgba(178, 175, 219, 0.6)",
+	   "line-width": {
+		"stops": [
+		 [
+		  2,
+		  2
+		 ],
+		 [
+		  3,
+		  3.5
+		 ],
+		 [
+		  9,
+		  5
+		 ],
+		 [
+		  14,
+		  13
+		 ],
+		 [
+		  15,
+		  20
+		 ],
+		 [
+		  16,
+		  24
+		 ],
+		 [
+		  17,
+		  42
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "limite etat 2",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "limite_lin",
+	  "minzoom": 7,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "LIM_ETAT",
+	   "LIM_ETAT_ETRANGER"
+	  ],
+	  "paint": {
+	   "line-color": "#9F9CB8",
+	   "line-width": {
+		"stops": [
+		 [
+		  9,
+		  1.5
+		 ],
+		 [
+		  14,
+		  3.5
+		 ],
+		 [
+		  15,
+		  5.5
+		 ],
+		 [
+		  16,
+		  6.5
+		 ],
+		 [
+		  17,
+		  11
+		 ]
+		]
+	   },
+	   "line-dasharray": [
+		4,
+		2
+	   ]
+	  }
+	 },
+	 {
+	  "id": "limite cote",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "limite_lin",
+	  "minzoom": 7,
+	  "maxzoom": 10,
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "LIM_COTE"
+	  ],
+	  "paint": {
+	   "line-color": "#82A3B2",
+	   "line-width": 1
+	  }
+	 },
+	 {
+	  "id": "ligne electrique",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "bati_lin",
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "LIGNE_ELECTRIQUE"
+	  ],
+	  "paint": {
+	   "line-color": "#808080",
+	   "line-width": {
+		"stops": [
+		 [
+		  13,
+		  1
+		 ],
+		 [
+		  17,
+		  2
+		 ]
+		]
+	   }
+	  }
+	 },
+	 {
+	  "id": "autre construction linéaire",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "bati_lin",
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "round",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "CABLE",
+	   "REMONTEE_MEC",
+	   "HYDROCARBURES",
+	   "CONDUITE_MATIERES_P",
+	   "SPORT_MONTAGNE_LIN",
+	   "PISTE_BOBSLEIGH",
+	   "PISTE_LUGE",
+	   "PISTE_AERO_LIN"
+	  ],
+	  "paint": {
+	   "line-color": "#808080",
+	   "line-width": 1
+	  }
+	 },
+	 {
+	  "id": "autre construction linéaire - trait perpend cable",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "bati_lin",
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "CABLE"
+	  ],
+	  "paint": {
+	   "line-color": "#808080",
+	   "line-width": 5,
+	   "line-dasharray": [
+		0.5,
+		10
+	   ]
+	  }
+	 },
+	 {
+	  "id": "autre construction linéaire - trait perpend 1 remont",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "bati_lin",
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "REMONTEE_MEC"
+	  ],
+	  "paint": {
+	   "line-color": "#808080",
+	   "line-width": 6,
+	   "line-dasharray": [
+		1,
+		10
+	   ]
+	  }
+	 },
+	 {
+	  "id": "autre construction linéaire - trait perpend 2 remont",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "bati_lin",
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "REMONTEE_MEC"
+	  ],
+	  "paint": {
+	   "line-color": "#BEBEBE",
+	   "line-width": 6,
+	   "line-dasharray": [
+		0.3,
+		0.4,
+		0.3,
+		10
+	   ]
+	  }
+	 },
+	 {
+	  "id": "autre construction linéaire - trait perpend carbur",
+	  "type": "line",
+	  "source": "plan_ign",
+	  "source-layer": "bati_lin",
+	  "layout": {
+	   "visibility": "visible",
+	   "line-cap": "butt",
+	   "line-join": "round"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "HYDROCARBURES",
+	   "CONDUITE_MATIERES_P"
+	  ],
+	  "paint": {
+	   "line-color": "#808080",
+	   "line-width": 5,
+	   "line-dasharray": [
+		1,
+		10
+	   ]
+	  }
+	 },
+	 {
+	  "id": "routier ponctuel - peage ponctuel",
+	  "type": "circle",
+	  "source": "plan_ign",
+	  "source-layer": "routier_ponc",
+	  "minzoom": 8,
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "PEAGE_PONC"
+	  ],
+	  "paint": {
+	   "circle-radius": {
+		"stops": [
+		 [
+		  9,
+		  3.5
+		 ],
+		 [
+		  12,
+		  6.5
+		 ]
+		]
+	   },
+	   "circle-color": "#E2A52A",
+	   "circle-stroke-width": 1,
+	   "circle-stroke-color": "#808080"
+	  }
+	 },
+	 {
+	  "id": "routier ponctuel - barriere",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "routier_ponc",
+	  "minzoom": 12,
+	  "layout": {
+	   "visibility": "visible",
+	   "icon-image": "Barriere",
+	   "icon-size": {
+		"stops": [
+		 [
+		  13,
+		  0.25
+		 ],
+		 [
+		  16,
+		  0.45
+		 ],
+		 [
+		  17,
+		  0.7
+		 ]
+		]
+	   },
+	   "icon-allow-overlap": true,
+	   "icon-rotate": [
+		"get",
+		"rotation"
+	   ]
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "BARRIERE"
+	  ],
+	  "paint": {
+	   "icon-color": "#969696"
+	  }
+	 },
+	 {
+	  "id": "hydro ponctuel",
+	  "type": "circle",
+	  "source": "plan_ign",
+	  "source-layer": "hydro_ponc",
+	  "minzoom": 13,
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "FONTAINE",
+	   "POINT_D_EAU",
+	   "SOURCE",
+	   "SOURCE_CAPTEE",
+	   "PERTE",
+	   "RESURGENCE",
+	   "CASCADE",
+	   "AUTRE_HYDRO_PONC"
+	  ],
+	  "paint": {
+	   "circle-radius": {
+		"stops": [
+		 [
+		  14,
+		  3
+		 ],
+		 [
+		  17,
+		  7
+		 ]
+		]
+	   },
+	   "circle-color": "#FFFFFF",
+	   "circle-opacity": 1,
+	   "circle-stroke-width": {
+		"stops": [
+		 [
+		  14,
+		  2
+		 ],
+		 [
+		  17,
+		  5
+		 ]
+		]
+	   },
+	   "circle-stroke-color": "#1466B2"
+	  }
+	 },
+	 {
+	  "id": "point coté",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "oro_ponc",
+	  "minzoom": 11,
+	  "maxzoom": 16,
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "POINT_COTE",
+	   "POINT_COTE_TOPO",
+	   "POINT_COTE_RESEAU",
+	   "POINT_RBF"
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "icon-image": "Localite",
+	   "icon-size": 0.1,
+	   "text-field": "{texte}",
+	   "text-size": 10,
+	   "text-allow-overlap": false,
+	   "text-anchor": "bottom-left",
+	   "text-offset": [
+		0.2,
+		0.4
+	   ],
+	   "text-padding": 2,
+	   "text-font": [
+		"Source Sans Pro Italic"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#505050"
+	  }
+	 },
+	 {
+	  "id": "bati ponctuel : Hopital",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "bati_ponc",
+	  "layout": {
+	   "visibility": "visible",
+	   "icon-image": "Hopital",
+	   "icon-size": 0.33
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "HOPITAL_PONC"
+	  ],
+	  "paint": {
+	   "icon-color": "#646464"
+	  }
+	 },
+	 {
+	  "id": "bati ponctuel hydrographique",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "bati_ponc",
+	  "minzoom": 14,
+	  "layout": {
+	   "visibility": "visible",
+	   "icon-image": "Pompage",
+	   "icon-size": {
+		"stops": [
+		 [
+		  13,
+		  0.2
+		 ],
+		 [
+		  17,
+		  0.6
+		 ]
+		]
+	   },
+	   "icon-allow-overlap": true
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "CITERNE",
+	   "LAVOIR",
+	   "STATION_EPURATION",
+	   "STATION_DE_POMPAGE",
+	   "USINE_PRODUCTION_EAU",
+	   "USINE_ELEVATRICE"
+	  ],
+	  "paint": {
+	   "icon-color": "#1C62A6"
+	  }
+	 },
+	 {
+	  "id": "bati ponctuel hydrographique - Puits-Abreuvoir",
+	  "type": "circle",
+	  "source": "plan_ign",
+	  "source-layer": "bati_ponc",
+	  "minzoom": 13,
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "PUITS",
+	   "ABREUVOIR"
+	  ],
+	  "paint": {
+	   "circle-radius": {
+		"stops": [
+		 [
+		  14,
+		  3
+		 ],
+		 [
+		  17,
+		  7
+		 ]
+		]
+	   },
+	   "circle-color": "#FFFFFF",
+	   "circle-opacity": 1,
+	   "circle-stroke-width": {
+		"stops": [
+		 [
+		  14,
+		  2
+		 ],
+		 [
+		  17,
+		  5
+		 ]
+		]
+	   },
+	   "circle-stroke-color": "#1466B2"
+	  }
+	 },
+	 {
+	  "id": "bati ponctuel hydrographique - Phare",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "bati_ponc",
+	  "minzoom": 13,
+	  "layout": {
+	   "visibility": "visible",
+	   "icon-image": "Phare",
+	   "icon-size": {
+		"stops": [
+		 [
+		  13,
+		  0.7
+		 ],
+		 [
+		  17,
+		  1.3
+		 ]
+		]
+	   }
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "PHARE"
+	  ],
+	  "paint": {
+	   "icon-color": "#646464"
+	  }
+	 },
+	 {
+	  "id": "bati ponctuel hydrographique - Amer-Feu",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "bati_ponc",
+	  "minzoom": 13,
+	  "layout": {
+	   "visibility": "visible",
+	   "icon-image": "Feu",
+	   "icon-size": {
+		"stops": [
+		 [
+		  13,
+		  0.7
+		 ],
+		 [
+		  17,
+		  1.3
+		 ]
+		]
+	   }
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "AMER",
+	   "FEU",
+	   "FEU_PONC",
+	   "TOURELLE_LUMINEUSE"
+	  ],
+	  "paint": {
+	   "icon-color": "#646464"
+	  }
+	 },
+	 {
+	  "id": "bati ponctuel hydrographique - Balise",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "bati_ponc",
+	  "minzoom": 13,
+	  "layout": {
+	   "visibility": "visible",
+	   "icon-image": "Balise",
+	   "icon-size": {
+		"stops": [
+		 [
+		  13,
+		  0.7
+		 ],
+		 [
+		  17,
+		  1.3
+		 ]
+		]
+	   }
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "BALISE",
+	   "TOURELLE"
+	  ],
+	  "paint": {
+	   "icon-color": "#646464"
+	  }
+	 },
+	 {
+	  "id": "bati ponctuel hydrographique - Ecluse",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "bati_ponc",
+	  "minzoom": 12,
+	  "maxzoom": 15,
+	  "layout": {
+	   "visibility": "visible",
+	   "icon-image": "Ecluse",
+	   "icon-size": 0.2
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "ECLUSE_PONC"
+	  ],
+	  "paint": {
+	   "icon-color": "#1C62A6"
+	  }
+	 },
+	 {
+	  "id": "bati ponctuel hydrographique - Barrage",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "bati_ponc",
+	  "minzoom": 12,
+	  "maxzoom": 14,
+	  "layout": {
+	   "visibility": "visible",
+	   "icon-image": "Barrage",
+	   "icon-size": 0.25
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "BARRAGE_PONC"
+	  ],
+	  "paint": {
+	   "icon-color": "#1C62A6"
+	  }
+	 },
+	 {
+	  "id": "bati ponctuel hydrographique - Chateau d'eau",
+	  "type": "circle",
+	  "source": "plan_ign",
+	  "source-layer": "bati_ponc",
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "CHATEAU_EAU_PONC"
+	  ],
+	  "paint": {
+	   "circle-radius": {
+		"stops": [
+		 [
+		  14,
+		  3
+		 ],
+		 [
+		  17,
+		  8
+		 ]
+		]
+	   },
+	   "circle-color": "#1466B2"
+	  }
+	 },
+	 {
+	  "id": "bati ponctuel hydrographique - Réservoir d'eau",
+	  "type": "circle",
+	  "source": "plan_ign",
+	  "source-layer": "bati_ponc",
+	  "maxzoom": 15,
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "RESERVOIR_EAU_PONC"
+	  ],
+	  "paint": {
+	   "circle-radius": {
+		"stops": [
+		 [
+		  14,
+		  3
+		 ],
+		 [
+		  17,
+		  8
+		 ]
+		]
+	   },
+	   "circle-color": "#AAD5E9",
+	   "circle-opacity": 1,
+	   "circle-stroke-width": {
+		"stops": [
+		 [
+		  14,
+		  1
+		 ],
+		 [
+		  17,
+		  2.5
+		 ]
+		]
+	   },
+	   "circle-stroke-color": "#1466B2"
+	  }
+	 },
+	 {
+	  "id": "bati ponctuel infrastructure - Constr spé",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "bati_ponc",
+	  "layout": {
+	   "visibility": "visible",
+	   "icon-image": "ConstrSpeciale",
+	   "icon-size": {
+		"stops": [
+		 [
+		  13,
+		  0.22
+		 ],
+		 [
+		  17,
+		  0.5
+		 ]
+		]
+	   }
+	  },
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "ANTENNE",
+	   "CONSTR_SPE_TECHNIQUE",
+	   "CONSTR_INDIF_PONC",
+	   "CHEMINEE",
+	   "CHEVALEMENT",
+	   "PUITS_GAZ",
+	   "PUITS_PETROLE",
+	   "PYLONE_METEO",
+	   "TORCHERE",
+	   "TOUR_GUET",
+	   "TOUR_HERTZIENNE"
+	  ],
+	  "paint": {
+	   "icon-color": "#646464"
+	  }
+	 },
+	 {
+	  "id": "bati ponctuel infrastructure - Silo",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "bati_ponc",
+	  "maxzoom": 15,
+	  "layout": {
+	   "visibility": "visible",
+	   "icon-image": "Silo",
+	   "icon-size": {
+		"stops": [
+		 [
+		  13,
+		  0.22
+		 ],
+		 [
+		  17,
+		  0.5
+		 ]
+		]
+	   }
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "SILO_PONC"
+	  ],
+	  "paint": {
+	   "icon-color": "#646464"
+	  }
+	 },
+	 {
+	  "id": "bati ponctuel infrastructure - Eolienne",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "bati_ponc",
+	  "layout": {
+	   "visibility": "visible",
+	   "icon-image": "Eolienne",
+	   "icon-size": {
+		"stops": [
+		 [
+		  13,
+		  0.4
+		 ],
+		 [
+		  17,
+		  1
+		 ],
+		 [
+		  18,
+		  0.8
+		 ]
+		]
+	   }
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "EOLIENNE"
+	  ],
+	  "paint": {
+	   "icon-color": "#646464"
+	  }
+	 },
+	 {
+	  "id": "bati ponctuel infrastructure - Reservoir",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "bati_ponc",
+	  "maxzoom": 15,
+	  "layout": {
+	   "visibility": "visible",
+	   "icon-image": "Reservoir",
+	   "icon-size": {
+		"stops": [
+		 [
+		  13,
+		  0.26
+		 ],
+		 [
+		  17,
+		  0.5
+		 ]
+		]
+	   }
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "RESERVOIR_PONC"
+	  ],
+	  "paint": {
+	   "icon-color": "#646464"
+	  }
+	 },
+	 {
+	  "id": "bati ponctuel infrastructure - pylone électrique",
+	  "type": "circle",
+	  "source": "plan_ign",
+	  "source-layer": "bati_ponc",
+	  "layout": {
+	   "visibility": "visible"
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "PYLONE_ELEC"
+	  ],
+	  "paint": {
+	   "circle-radius": {
+		"stops": [
+		 [
+		  13,
+		  1
+		 ],
+		 [
+		  17,
+		  2
+		 ]
+		]
+	   },
+	   "circle-color": "#000000"
+	  }
+	 },
+	 {
+	  "id": "bati ponctuel montagne - Abri",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "bati_ponc",
+	  "layout": {
+	   "visibility": "visible",
+	   "icon-image": "Abri",
+	   "icon-size": {
+		"stops": [
+		 [
+		  13,
+		  0.4
+		 ],
+		 [
+		  15,
+		  0.6
+		 ],
+		 [
+		  17,
+		  0.9
+		 ]
+		]
+	   }
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "ABRI"
+	  ],
+	  "paint": {
+	   "icon-color": "#246138"
+	  }
+	 },
+	 {
+	  "id": "bati ponctuel montagne - Refuge Garde",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "bati_ponc",
+	  "layout": {
+	   "visibility": "visible",
+	   "icon-image": "Refugegard",
+	   "icon-size": {
+		"stops": [
+		 [
+		  13,
+		  0.4
+		 ],
+		 [
+		  15,
+		  0.6
+		 ],
+		 [
+		  17,
+		  0.9
+		 ]
+		]
+	   }
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "REFUGE_GARDE"
+	  ],
+	  "paint": {
+	   "icon-color": "#246138"
+	  }
+	 },
+	 {
+	  "id": "bati ponctuel montagne - Refuge Non Garde",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "bati_ponc",
+	  "layout": {
+	   "visibility": "visible",
+	   "icon-image": "Refugenongard",
+	   "icon-size": {
+		"stops": [
+		 [
+		  13,
+		  0.4
+		 ],
+		 [
+		  15,
+		  0.6
+		 ],
+		 [
+		  17,
+		  0.9
+		 ]
+		]
+	   }
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "REFUGE"
+	  ],
+	  "paint": {
+	   "icon-color": "#246138"
+	  }
+	 },
+	 {
+	  "id": "bati ponctuel transport aerien - Aeroport FXX",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "bati_ponc",
+	  "layout": {
+	   "visibility": "visible",
+	   "icon-image": "Aeroport",
+	   "icon-size": 0.5
+	  },
+	  "filter": [
+	   "all",
+	   [
+		"==",
+		"symbo",
+		"AEROPORT_PONC"
+	   ],
+	   [
+		"==",
+		"territoire",
+		"FXX"
+	   ]
+	  ],
+	  "paint": {
+	   "icon-color": "#646464"
+	  }
+	 },
+	 {
+	  "id": "bati ponctuel transport aerien - Aerodrome FXX",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "bati_ponc",
+	  "layout": {
+	   "visibility": "visible",
+	   "icon-image": "Aerodrome",
+	   "icon-size": 0.4
+	  },
+	  "filter": [
+	   "all",
+	   [
+		"==",
+		"symbo",
+		"AERODROME_PONC"
+	   ],
+	   [
+		"==",
+		"territoire",
+		"FXX"
+	   ]
+	  ],
+	  "paint": {
+	   "icon-color": "#646464"
+	  }
+	 },
+	 {
+	  "id": "bati ponctuel transport aerien - Aeroport DOM",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "bati_ponc",
+	  "minzoom": 8,
+	  "layout": {
+	   "visibility": "visible",
+	   "icon-image": "Aeroport",
+	   "icon-size": 0.5
+	  },
+	  "filter": [
+	   "all",
+	   [
+		"==",
+		"symbo",
+		"AEROPORT_PONC"
+	   ],
+	   [
+		"!=",
+		"territoire",
+		"FXX"
+	   ]
+	  ],
+	  "paint": {
+	   "icon-color": "#646464"
+	  }
+	 },
+	 {
+	  "id": "bati ponctuel transport aerien - Aerodrome DOM",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "bati_ponc",
+	  "minzoom": 8,
+	  "layout": {
+	   "visibility": "visible",
+	   "icon-image": "Aerodrome",
+	   "icon-size": 0.4
+	  },
+	  "filter": [
+	   "all",
+	   [
+		"==",
+		"symbo",
+		"AERODROME_PONC"
+	   ],
+	   [
+		"!=",
+		"territoire",
+		"FXX"
+	   ]
+	  ],
+	  "paint": {
+	   "icon-color": "#646464"
+	  }
+	 },
+	 {
+	  "id": "bati ponctuel transport ferroviaire",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "bati_ponc",
+	  "layout": {
+	   "visibility": "visible",
+	   "icon-image": "Gare",
+	   "icon-size": 0.33
+	  },
+	  "filter": [
+	   "==",
+	   "symbo",
+	   "GARE_VOYAGEURS"
+	  ],
+	  "paint": {
+	   "icon-color": "#787878"
+	  }
+	 },
+	 {
+	  "id": "toponyme - bornes postales haute - chemins",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_routier_borne",
+	  "minzoom": 17,
+	  "maxzoom": 18,
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "CHEMIN",
+	   "CHEMIN_SOU",
+	   "CHEMIN_SUP",
+	   "PISTE_CYCLABLE",
+	   "PISTE_CYCLABLE_SOU",
+	   "PISTE_CYCLABLE_SUP",
+	   "RUE_PIETONNE",
+	   "RUE_PIETONNE_SOU",
+	   "RUE_PIETONNE_SUP",
+	   "SENTIER",
+	   "SENTIER_SOU",
+	   "SENTIER_SUP",
+	   "ESCALIER",
+	   "ESCALIER_SUP"
+	  ],
+	  "layout": {
+	   "symbol-placement": "line",
+	   "text-field": "{borne_sur}",
+	   "text-size": 11,
+	   "text-anchor": "center",
+	   "text-allow-overlap": true,
+	   "text-offset": [
+		0,
+		-1
+	   ],
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ],
+	   "visibility": "none"
+	  },
+	  "paint": {
+	   "text-color": "#79654F",
+	   "text-halo-width": 1,
+	   "text-halo-color": "#FFFFFF"
+	  }
+	 },
+	 {
+	  "id": "toponyme - bornes postales haute - non revetue, non classee",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_routier_borne",
+	  "minzoom": 17,
+	  "maxzoom": 18,
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "NON_CLASSEE",
+	   "NON_CLASSEE_4",
+	   "NON_CLASSEE_4_SUP",
+	   "NON_CLASSEE_RESTREINT",
+	   "NON_CLASSEE_RESTREINT_SUP",
+	   "NON_CLASSEE_SOU",
+	   "NON_CLASSEE_SUP",
+	   "NON_REVETUE_CARRO",
+	   "NON_REVETUE_CARRO_SUP"
+	  ],
+	  "layout": {
+	   "symbol-placement": "line",
+	   "text-field": "{borne_sur}",
+	   "text-size": 11,
+	   "text-anchor": "center",
+	   "text-allow-overlap": true,
+	   "text-offset": [
+		0,
+		-1.3
+	   ],
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ],
+	   "visibility": "none"
+	  },
+	  "paint": {
+	   "text-color": "#79654F",
+	   "text-halo-width": 1,
+	   "text-halo-color": "#FFFFFF"
+	  }
+	 },
+	 {
+	  "id": "toponyme - bornes postales haute - locales",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_routier_borne",
+	  "minzoom": 17,
+	  "maxzoom": 18,
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "LOCALE_1",
+	   "LOCALE_1_SOU",
+	   "LOCALE_1_SUP",
+	   "LOCALE_2",
+	   "LOCALE_2_SOU",
+	   "LOCALE_2_SUP",
+	   "LOCALE_3",
+	   "LOCALE_3_SOU",
+	   "LOCALE_3_SUP",
+	   "LOCALE_4",
+	   "LOCALE_4_SOU",
+	   "LOCALE_4_SUP",
+	   "LOCALE_CONSTR",
+	   "LOCALE_CONSTR_SUP"
+	  ],
+	  "layout": {
+	   "symbol-placement": "line",
+	   "text-field": "{borne_sur}",
+	   "text-size": 11,
+	   "text-anchor": "center",
+	   "text-allow-overlap": true,
+	   "text-offset": [
+		0,
+		-1.4
+	   ],
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ],
+	   "visibility": "none"
+	  },
+	  "paint": {
+	   "text-color": "#79654F",
+	   "text-halo-width": 1,
+	   "text-halo-color": "#FFFFFF"
+	  }
+	 },
+	 {
+	  "id": "toponyme - bornes postales haute - regionales",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_routier_borne",
+	  "minzoom": 17,
+	  "maxzoom": 18,
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "REGIONALE_1",
+	   "REGIONALE_1_SOU",
+	   "REGIONALE_1_SUP",
+	   "REGIONALE_2",
+	   "REGIONALE_2_SOU",
+	   "REGIONALE_2_SUP",
+	   "REGIONALE_3",
+	   "REGIONALE_3_SOU",
+	   "REGIONALE_3_SUP",
+	   "REGIONALE_4",
+	   "REGIONALE_4_SUP",
+	   "REGIONALE_CONSTR"
+	  ],
+	  "layout": {
+	   "symbol-placement": "line",
+	   "text-field": "{borne_sur}",
+	   "text-size": 11,
+	   "text-anchor": "center",
+	   "text-allow-overlap": true,
+	   "text-offset": [
+		0,
+		-1.5
+	   ],
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ],
+	   "visibility": "none"
+	  },
+	  "paint": {
+	   "text-color": "#79654F",
+	   "text-halo-width": 1,
+	   "text-halo-color": "#FFFFFF"
+	  }
+	 },
+	 {
+	  "id": "toponyme - bornes postales haute - principales",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_routier_borne",
+	  "minzoom": 17,
+	  "maxzoom": 18,
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "PRINCIPALE_1",
+	   "PRINCIPALE_1_SOU",
+	   "PRINCIPALE_1_SUP",
+	   "PRINCIPALE_2",
+	   "PRINCIPALE_2_SOU",
+	   "PRINCIPALE_2_SUP",
+	   "PRINCIPALE_3",
+	   "PRINCIPALE_3_SOU",
+	   "PRINCIPALE_3_SUP",
+	   "PRINCIPALE_4",
+	   "PRINCIPALE_4_SOU",
+	   "PRINCIPALE_4_SUP",
+	   "PRINCIPALE_CONSTR"
+	  ],
+	  "layout": {
+	   "symbol-placement": "line",
+	   "text-field": "{borne_sur}",
+	   "text-size": 11,
+	   "text-anchor": "center",
+	   "text-allow-overlap": true,
+	   "text-offset": [
+		0,
+		-1.6
+	   ],
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ],
+	   "visibility": "none"
+	  },
+	  "paint": {
+	   "text-color": "#79654F",
+	   "text-halo-width": 1,
+	   "text-halo-color": "#FFFFFF"
+	  }
+	 },
+	 {
+	  "id": "toponyme - bornes postales bas - chemins",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_routier_borne",
+	  "minzoom": 17,
+	  "maxzoom": 18,
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "CHEMIN",
+	   "CHEMIN_SOU",
+	   "CHEMIN_SUP",
+	   "PISTE_CYCLABLE",
+	   "PISTE_CYCLABLE_SOU",
+	   "PISTE_CYCLABLE_SUP",
+	   "RUE_PIETONNE",
+	   "RUE_PIETONNE_SOU",
+	   "RUE_PIETONNE_SUP",
+	   "SENTIER",
+	   "SENTIER_SOU",
+	   "SENTIER_SUP",
+	   "ESCALIER",
+	   "ESCALIER_SUP"
+	  ],
+	  "layout": {
+	   "symbol-placement": "line",
+	   "text-field": "{borne_sous}",
+	   "text-size": 11,
+	   "text-anchor": "center",
+	   "text-allow-overlap": true,
+	   "text-offset": [
+		0,
+		1
+	   ],
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ],
+	   "visibility": "none"
+	  },
+	  "paint": {
+	   "text-color": "#79654F",
+	   "text-halo-width": 1,
+	   "text-halo-color": "#FFFFFF"
+	  }
+	 },
+	 {
+	  "id": "toponyme - bornes postales bas - non revetue, non classee",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_routier_borne",
+	  "minzoom": 17,
+	  "maxzoom": 18,
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "NON_CLASSEE",
+	   "NON_CLASSEE_4",
+	   "NON_CLASSEE_4_SUP",
+	   "NON_CLASSEE_RESTREINT",
+	   "NON_CLASSEE_RESTREINT_SUP",
+	   "NON_CLASSEE_SOU",
+	   "NON_CLASSEE_SUP",
+	   "NON_REVETUE_CARRO",
+	   "NON_REVETUE_CARRO_SUP"
+	  ],
+	  "layout": {
+	   "symbol-placement": "line",
+	   "text-field": "{borne_sous}",
+	   "text-size": 11,
+	   "text-anchor": "center",
+	   "text-allow-overlap": true,
+	   "text-offset": [
+		0,
+		1.3
+	   ],
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ],
+	   "visibility": "none"
+	  },
+	  "paint": {
+	   "text-color": "#79654F",
+	   "text-halo-width": 1,
+	   "text-halo-color": "#FFFFFF"
+	  }
+	 },
+	 {
+	  "id": "toponyme - bornes postales bas - locales",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_routier_borne",
+	  "minzoom": 17,
+	  "maxzoom": 18,
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "LOCALE_1",
+	   "LOCALE_1_SOU",
+	   "LOCALE_1_SUP",
+	   "LOCALE_2",
+	   "LOCALE_2_SOU",
+	   "LOCALE_2_SUP",
+	   "LOCALE_3",
+	   "LOCALE_3_SOU",
+	   "LOCALE_3_SUP",
+	   "LOCALE_4",
+	   "LOCALE_4_SOU",
+	   "LOCALE_4_SUP",
+	   "LOCALE_CONSTR",
+	   "LOCALE_CONSTR_SUP"
+	  ],
+	  "layout": {
+	   "symbol-placement": "line",
+	   "text-field": "{borne_sous}",
+	   "text-size": 11,
+	   "text-anchor": "center",
+	   "text-allow-overlap": true,
+	   "text-offset": [
+		0,
+		1.4
+	   ],
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ],
+	   "visibility": "none"
+	  },
+	  "paint": {
+	   "text-color": "#79654F",
+	   "text-halo-width": 1,
+	   "text-halo-color": "#FFFFFF"
+	  }
+	 },
+	 {
+	  "id": "toponyme - bornes postales bas - regionales",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_routier_borne",
+	  "minzoom": 17,
+	  "maxzoom": 18,
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "REGIONALE_1",
+	   "REGIONALE_1_SOU",
+	   "REGIONALE_1_SUP",
+	   "REGIONALE_2",
+	   "REGIONALE_2_SOU",
+	   "REGIONALE_2_SUP",
+	   "REGIONALE_3",
+	   "REGIONALE_3_SOU",
+	   "REGIONALE_3_SUP",
+	   "REGIONALE_4",
+	   "REGIONALE_4_SUP",
+	   "REGIONALE_CONSTR"
+	  ],
+	  "layout": {
+	   "symbol-placement": "line",
+	   "text-field": "{borne_sous}",
+	   "text-size": 11,
+	   "text-anchor": "center",
+	   "text-allow-overlap": true,
+	   "text-offset": [
+		0,
+		1.5
+	   ],
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ],
+	   "visibility": "none"
+	  },
+	  "paint": {
+	   "text-color": "#79654F",
+	   "text-halo-width": 1,
+	   "text-halo-color": "#FFFFFF"
+	  }
+	 },
+	 {
+	  "id": "toponyme - bornes postales bas - principales",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_routier_borne",
+	  "minzoom": 17,
+	  "maxzoom": 18,
+	  "filter": [
+	   "in",
+	   "symbo",
+	   "PRINCIPALE_1",
+	   "PRINCIPALE_1_SOU",
+	   "PRINCIPALE_1_SUP",
+	   "PRINCIPALE_2",
+	   "PRINCIPALE_2_SOU",
+	   "PRINCIPALE_2_SUP",
+	   "PRINCIPALE_3",
+	   "PRINCIPALE_3_SOU",
+	   "PRINCIPALE_3_SUP",
+	   "PRINCIPALE_4",
+	   "PRINCIPALE_4_SOU",
+	   "PRINCIPALE_4_SUP",
+	   "PRINCIPALE_CONSTR"
+	  ],
+	  "layout": {
+	   "symbol-placement": "line",
+	   "text-field": "{borne_sous}",
+	   "text-size": 11,
+	   "text-anchor": "center",
+	   "text-allow-overlap": true,
+	   "text-offset": [
+		0,
+		1.6
+	   ],
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ],
+	   "visibility": "none"
+	  },
+	  "paint": {
+	   "text-color": "#79654F",
+	   "text-halo-width": 1,
+	   "text-halo-color": "#FFFFFF"
+	  }
+	 },
+	 {
+	  "id": "toponyme - courbe rocher maitresse",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_oro_ponc",
+	  "filter": [
+	   "==",
+	   "txt_typo",
+	   "ORO_COURBE_ROCHER"
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-size": 10,
+	   "text-allow-overlap": false,
+	   "text-padding": 30,
+	   "text-rotate": {
+		"type": "identity",
+		"property": "rotation"
+	   },
+	   "text-font": [
+		"Source Sans Pro Italic"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#333333",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 1
+	  }
+	 },
+	 {
+	  "id": "toponyme - courbe glacier maitresse",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_oro_ponc",
+	  "filter": [
+	   "==",
+	   "txt_typo",
+	   "ORO_COURBE_GLACIER"
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-size": 10,
+	   "text-allow-overlap": false,
+	   "text-padding": 30,
+	   "text-rotate": {
+		"type": "identity",
+		"property": "rotation"
+	   },
+	   "text-font": [
+		"Source Sans Pro Italic"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#629FD9",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 1
+	  }
+	 },
+	 {
+	  "id": "toponyme - courbe maitresse",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_oro_ponc",
+	  "filter": [
+	   "==",
+	   "txt_typo",
+	   "ORO_COURBE"
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-size": 10,
+	   "text-allow-overlap": false,
+	   "text-padding": 30,
+	   "text-rotate": {
+		"type": "identity",
+		"property": "rotation"
+	   },
+	   "text-font": [
+		"Source Sans Pro Italic"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#604A2F",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 1
+	  }
+	 },
+	 {
+	  "id": "toponyme - liaison maritime",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_routier_liaison_lin",
+	  "minzoom": 8,
+	  "maxzoom": 18,
+	  "filter": [
+	   "==",
+	   "txt_typo",
+	   "LIAISON_MARITIME"
+	  ],
+	  "layout": {
+	   "symbol-placement": "line",
+	   "text-field": "{texte}",
+	   "text-size": 15,
+	   "text-anchor": "center",
+	   "text-keep-upright": true,
+	   "text-max-angle": 45,
+	   "text-padding": 10,
+	   "text-font": [
+		"Source Sans Pro Italic"
+	   ],
+	   "visibility": "visible"
+	  },
+	  "paint": {
+	   "text-color": "#5792C2",
+	   "text-halo-width": 5,
+	   "text-halo-color": "#AAD5E9"
+	  }
+	 },
+	 {
+	  "id": "toponyme bati station de métro + bati ponctuel metro",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_bati_ponc",
+	  "minzoom": 14,
+	  "filter": [
+	   "all",
+	   [
+		"==",
+		"txt_typo",
+		"TYPO_E_1"
+	   ],
+	   [
+		"==",
+		"symbo",
+		"STATION_METRO"
+	   ]
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-size": 11,
+	   "text-allow-overlap": false,
+	   "text-offset": [
+		0.3,
+		-0.25
+	   ],
+	   "text-padding": 3,
+	   "text-anchor": "bottom-left",
+	   "text-font": [
+		"Source Sans Pro"
+	   ],
+	   "icon-image": "Metro",
+	   "icon-size": {
+		"stops": [
+		 [
+		  15,
+		  0.33
+		 ],
+		 [
+		  17,
+		  0.6
+		 ]
+		]
+	   }
+	  },
+	  "paint": {
+	   "text-color": "#3C3C3C",
+	   "icon-color": "#646464"
+	  }
+	 },
+	 {
+	  "id": "toponyme ferre lineaire",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_ferre_lin",
+	  "minzoom": 12,
+	  "filter": [
+	   "in",
+	   "txt_typo",
+	   "FER_NOM",
+	   "FER_OUVRAGE"
+	  ],
+	  "layout": {
+	   "symbol-placement": "line",
+	   "text-field": "{texte}",
+	   "text-size": 10,
+	   "text-anchor": "center",
+	   "text-offset": [
+		0,
+		-1
+	   ],
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ],
+	   "visibility": "visible"
+	  },
+	  "paint": {
+	   "text-color": "#000000",
+	   "text-halo-width": 1,
+	   "text-halo-color": "rgba(255, 255, 255, 1)"
+	  }
+	 },
+	 {
+	  "id": "toponyme station epuration, de pompage, usine de production eau",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_bati_ponc",
+	  "minzoom": 14,
+	  "filter": [
+	   "==",
+	   "txt_typo",
+	   "station"
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{designation}",
+	   "text-anchor": "left",
+	   "text-offset": [
+		0.8,
+		0
+	   ],
+	   "text-size": 11,
+	   "text-allow-overlap": false,
+	   "text-padding": 1,
+	   "text-font": [
+		"Source Sans Pro Italic"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#447FB3"
+	  }
+	 },
+	 {
+	  "id": "toponyme bati ponc gare",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_bati_ponc",
+	  "minzoom": 15,
+	  "filter": [
+	   "==",
+	   "txt_typo",
+	   "gore"
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{designation}",
+	   "text-size": 11,
+	   "text-allow-overlap": false,
+	   "text-padding": 1,
+	   "text-font": [
+		"Source Sans Pro Italic"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#000000"
+	  }
+	 },
+	 {
+	  "id": "toponyme bati ponc barrage",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_bati_ponc",
+	  "minzoom": 12,
+	  "filter": [
+	   "==",
+	   "txt_typo",
+	   "BARRAGE_PONC"
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-anchor": "left",
+	   "text-offset": [
+		0.8,
+		0
+	   ],
+	   "text-size": 11,
+	   "text-allow-overlap": false,
+	   "text-padding": 1,
+	   "text-font": [
+		"Source Sans Pro"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#447FB3"
+	  }
+	 },
+	 {
+	  "id": "toponyme bati ponc phare - niveau 13",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_bati_ponc",
+	  "maxzoom": 13,
+	  "filter": [
+	   "==",
+	   "txt_typo",
+	   "PHARE"
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-anchor": "right",
+	   "text-size": 11,
+	   "text-allow-overlap": false,
+	   "text-padding": 1,
+	   "text-font": [
+		"Source Sans Pro"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#532A2A"
+	  }
+	 },
+	 {
+	  "id": "toponyme bati ponc phare - niveau 14à19",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_bati_ponc",
+	  "minzoom": 13,
+	  "filter": [
+	   "all",
+	   [
+		"==",
+		"symbo",
+		"PHARE"
+	   ],
+	   [
+		"in",
+		"txt_typo",
+		"TYPO_C_6",
+		"TYPO_C_7",
+		"TYPO_C_8",
+		"TYPO_E_GE"
+	   ]
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-anchor": "right",
+	   "text-size": {
+		"stops": [
+		 [
+		  13,
+		  12
+		 ],
+		 [
+		  18,
+		  18
+		 ]
+		]
+	   },
+	   "text-allow-overlap": false,
+	   "text-offset": [
+		-2,
+		0
+	   ],
+	   "text-padding": 3,
+	   "text-font": [
+		"Source Sans Pro"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#532A2A"
+	  }
+	 },
+	 {
+	  "id": "toponyme bati ponc autre",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_bati_ponc",
+	  "minzoom": 12,
+	  "filter": [
+	   "in",
+	   "txt_typo",
+	   "BAT_ACTIVITE",
+	   "BAT_FORTIF",
+	   "BAT_VILLAGE_DETRUIT"
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-anchor": "center",
+	   "text-size": 11,
+	   "text-allow-overlap": false,
+	   "text-padding": 1,
+	   "text-font": [
+		"Source Sans Pro"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#532A2A"
+	  }
+	 },
+	 {
+	  "id": "toponyme bati ponc aerogare",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_bati_ponc",
+	  "minzoom": 14,
+	  "maxzoom": 17,
+	  "filter": [
+	   "all",
+	   [
+		"==",
+		"txt_typo",
+		"TYPO_E_GE"
+	   ],
+	   [
+		"==",
+		"symbo",
+		"AEROGARE"
+	   ]
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-anchor": "center",
+	   "text-size": {
+		"stops": [
+		 [
+		  12,
+		  9
+		 ],
+		 [
+		  16,
+		  11
+		 ]
+		]
+	   },
+	   "text-allow-overlap": false,
+	   "text-padding": 1,
+	   "text-font": [
+		"Source Sans Pro Italic"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#120049",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 1
+	  }
+	 },
+	 {
+	  "id": "toponyme bati ponc aeroport 12",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_bati_ponc",
+	  "minzoom": 11,
+	  "maxzoom": 12,
+	  "filter": [
+	   "==",
+	   "txt_typo",
+	   "AEROPORT_PONC"
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-anchor": "bottom",
+	   "text-offset": [
+		0,
+		-1.3
+	   ],
+	   "text-size": 10.5,
+	   "text-allow-overlap": false,
+	   "text-padding": 1,
+	   "text-font": [
+		"Source Sans Pro"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#120049",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 2
+	  }
+	 },
+	 {
+	  "id": "toponyme bati ponc aeroport 13",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_bati_ponc",
+	  "minzoom": 12,
+	  "maxzoom": 13,
+	  "filter": [
+	   "==",
+	   "txt_typo",
+	   "AEROPORT_PONC"
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-anchor": "bottom",
+	   "text-offset": [
+		0,
+		-2
+	   ],
+	   "text-size": 11,
+	   "text-allow-overlap": false,
+	   "text-padding": 1,
+	   "text-font": [
+		"Source Sans Pro"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#120049",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 2
+	  }
+	 },
+	 {
+	  "id": "toponyme bati ponc aeroport",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_bati_ponc",
+	  "minzoom": 13,
+	  "maxzoom": 17,
+	  "filter": [
+	   "all",
+	   [
+		"==",
+		"txt_typo",
+		"TYPO_A_5"
+	   ],
+	   [
+		"==",
+		"symbo",
+		"AEROPORT"
+	   ]
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-anchor": "center",
+	   "text-size": {
+		"stops": [
+		 [
+		  12,
+		  11
+		 ],
+		 [
+		  16,
+		  13
+		 ]
+		]
+	   },
+	   "text-allow-overlap": false,
+	   "text-padding": 1,
+	   "text-font": [
+		"Source Sans Pro"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#120049",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 2
+	  }
+	 },
+	 {
+	  "id": "toponyme bati ponc aerodrome 12",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_bati_ponc",
+	  "minzoom": 11,
+	  "maxzoom": 12,
+	  "filter": [
+	   "==",
+	   "txt_typo",
+	   "AERODROME_PONC"
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-anchor": "bottom",
+	   "text-offset": [
+		0,
+		-1.3
+	   ],
+	   "text-size": 9.5,
+	   "text-allow-overlap": false,
+	   "text-padding": 1,
+	   "text-font": [
+		"Source Sans Pro"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#120049",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 2
+	  }
+	 },
+	 {
+	  "id": "toponyme bati ponc aerodrome 13",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_bati_ponc",
+	  "minzoom": 12,
+	  "maxzoom": 13,
+	  "filter": [
+	   "==",
+	   "txt_typo",
+	   "AERODROME_PONC"
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-anchor": "bottom",
+	   "text-offset": [
+		0,
+		-2
+	   ],
+	   "text-size": 10,
+	   "text-allow-overlap": false,
+	   "text-padding": 1,
+	   "text-font": [
+		"Source Sans Pro"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#120049",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 2
+	  }
+	 },
+	 {
+	  "id": "toponyme bati ponc aerodrome",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_bati_ponc",
+	  "minzoom": 13,
+	  "maxzoom": 17,
+	  "filter": [
+	   "all",
+	   [
+		"==",
+		"txt_typo",
+		"TYPO_A_7"
+	   ],
+	   [
+		"==",
+		"symbo",
+		"AERODROME"
+	   ]
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-anchor": "center",
+	   "text-size": {
+		"stops": [
+		 [
+		  12,
+		  10
+		 ],
+		 [
+		  16,
+		  12
+		 ]
+		]
+	   },
+	   "text-allow-overlap": false,
+	   "text-padding": 1,
+	   "text-font": [
+		"Source Sans Pro"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#120049",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 2
+	  }
+	 },
+	 {
+	  "id": "toponyme - hydro ponc 5",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_hydro_ponc",
+	  "filter": [
+	   "in",
+	   "txt_typo",
+	   "TYPO_D_9",
+	   "TYPO_D_10",
+	   "TYPO_E_1_cyan"
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-size": {
+		"stops": [
+		 [
+		  15,
+		  11
+		 ],
+		 [
+		  17,
+		  14
+		 ]
+		]
+	   },
+	   "text-allow-overlap": true,
+	   "text-padding": 5,
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#447FB3",
+	   "text-halo-color": "#FFFFFF",
+	   "text-halo-width": 1
+	  }
+	 },
+	 {
+	  "id": "toponyme - hydro ponc glacier",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_hydro_ponc",
+	  "filter": [
+	   "==",
+	   "txt_typo",
+	   "ORO_GLACIER_2"
+	  ],
+	  "layout": {
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-size": 14,
+	   "text-anchor": "center",
+	   "text-allow-overlap": true,
+	   "text-padding": 1,
+	   "text-font": [
+		"Source Sans Pro Italic"
+	   ],
+	   "visibility": "visible"
+	  },
+	  "paint": {
+	   "text-color": "#447FB3",
+	   "text-halo-width": 2,
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)"
+	  }
+	 },
+	 {
+	  "id": "toponyme - limite militaire ponc 3 et 4",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_limite_ponc",
+	  "filter": [
+	   "in",
+	   "txt_typo",
+	   "LIM_MILI_3",
+	   "LIM_MILI_4"
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-size": 12,
+	   "text-allow-overlap": false,
+	   "text-padding": 2,
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#0D2000",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 1
+	  }
+	 },
+	 {
+	  "id": "toponyme - limite parc ponc 3 et 4",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_limite_ponc",
+	  "filter": [
+	   "in",
+	   "txt_typo",
+	   "LIM_PARC_3",
+	   "LIM_PARC_4",
+	   "RESERVE_NATURELLE_PONC"
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-size": 13,
+	   "text-allow-overlap": false,
+	   "text-padding": 2,
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#287B00",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 1
+	  }
+	 },
+	 {
+	  "id": "toponyme numéro de route - départementale",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_routier_numero_lin",
+	  "minzoom": 11,
+	  "maxzoom": 16,
+	  "filter": [
+	   "==",
+	   "txt_typo",
+	   "Départementale"
+	  ],
+	  "layout": {
+	   "visibility": "none",
+	   "symbol-placement": "line",
+	   "text-field": "{texte}",
+	   "text-size": 10.5,
+	   "text-allow-overlap": false,
+	   "text-padding": 2,
+	   "text-anchor": "center",
+	   "text-font": [
+		"Source Sans Pro Semibold"
+	   ],
+	   "text-rotation-alignment": "viewport"
+	  },
+	  "paint": {
+	   "text-color": "#4D4D4D",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 4
+	  }
+	 },
+	 {
+	  "id": "toponyme numéro de route - nationale",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_routier_numero_lin",
+	  "minzoom": 7,
+	  "maxzoom": 16,
+	  "filter": [
+	   "==",
+	   "txt_typo",
+	   "Nationale"
+	  ],
+	  "layout": {
+	   "visibility": "none",
+	   "symbol-placement": "line",
+	   "text-field": "{texte}",
+	   "text-size": 12,
+	   "text-allow-overlap": false,
+	   "text-padding": 0,
+	   "text-anchor": "center",
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ],
+	   "icon-image": "Ecluse",
+	   "icon-rotation-alignment": "viewport",
+	   "text-rotation-alignment": "viewport",
+	   "icon-text-fit": "both",
+	   "icon-size": 0
+	  },
+	  "paint": {
+	   "text-color": "#F0F0F0",
+	   "icon-color": "#646464",
+	   "text-halo-color": "rgba(80, 80, 80, 0.5)",
+	   "text-halo-width": 4
+	  }
+	 },
+	 {
+	  "id": "toponyme numéro de route - autoroute",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_routier_numero_lin",
+	  "minzoom": 7,
+	  "maxzoom": 16,
+	  "filter": [
+	   "==",
+	   "txt_typo",
+	   "Autoroute"
+	  ],
+	  "layout": {
+	   "visibility": "none",
+	   "symbol-placement": "line",
+	   "text-field": "{texte}",
+	   "text-size": 15,
+	   "text-allow-overlap": false,
+	   "text-padding": 0,
+	   "text-anchor": "center",
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ],
+	   "icon-image": "Ecluse",
+	   "icon-rotation-alignment": "viewport",
+	   "text-rotation-alignment": "viewport",
+	   "icon-text-fit": "both",
+	   "icon-size": 0
+	  },
+	  "paint": {
+	   "text-color": "#F0F0F0",
+	   "icon-color": "#646464",
+	   "text-halo-color": "rgba(80, 80, 80, 0.5)",
+	   "text-halo-width": 5
+	  }
+	 },
+	 {
+	  "id": "toponyme - odonyme abrégé",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_routier_odonyme_lin",
+	  "minzoom": 15,
+	  "maxzoom": 17,
+	  "layout": {
+	   "symbol-placement": "line",
+	   "text-field": "{nom_gauche}",
+	   "text-size": 10,
+	   "text-anchor": "center",
+	   "text-max-angle": 30,
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ],
+	   "visibility": "none"
+	  },
+	  "paint": {
+	   "text-color": "#000000",
+	   "text-halo-width": 2,
+	   "text-halo-color": "rgba(255, 255, 255, 1)"
+	  }
+	 },
+	 {
+	  "id": "toponyme - odonyme desabrégé",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_routier_odonyme_lin",
+	  "minzoom": 17,
+	  "layout": {
+	   "symbol-placement": "line",
+	   "text-field": "{nom_desabrege}",
+	   "text-size": 11,
+	   "text-anchor": "center",
+	   "text-max-angle": 30,
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ],
+	   "visibility": "none"
+	  },
+	  "paint": {
+	   "text-color": "#000000",
+	   "text-halo-width": 2,
+	   "text-halo-color": "rgba(255, 255, 255, 1)"
+	  }
+	 },
+	 {
+	  "id": "toponyme - lieu dit non habité 3",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_ocs_ponc",
+	  "filter": [
+	   "all",
+	   [
+		"==",
+		"symbo",
+		"LIEU-DIT_NON_HABITE"
+	   ],
+	   [
+		"in",
+		"txt_typo",
+		"TYPO_B_10",
+		"TYPO_B_11"
+	   ]
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-size": 11,
+	   "text-allow-overlap": false,
+	   "text-padding": 1,
+	   "text-font": [
+		"Source Sans Pro Italic"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#000000",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 1
+	  }
+	 },
+	 {
+	  "id": "toponyme - bois",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_ocs_ponc",
+	  "filter": [
+	   "all",
+	   [
+		"==",
+		"symbo",
+		"BOIS"
+	   ],
+	   [
+		"in",
+		"txt_typo",
+		"TYPO_F_10",
+		"TYPO_F_11"
+	   ]
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-size": 13,
+	   "text-allow-overlap": false,
+	   "text-padding": 1,
+	   "text-font": [
+		"Source Sans Pro Italic"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#287B00",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 1
+	  }
+	 },
+	 {
+	  "id": "toponyme - oro lineaire 4",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_oro_lin",
+	  "filter": [
+	   "in",
+	   "txt_typo",
+	   "ORO_SOMMET_3",
+	   "ORO_GORGE_2"
+	  ],
+	  "layout": {
+	   "symbol-placement": "line",
+	   "text-field": "{texte}",
+	   "text-size": 11,
+	   "text-anchor": "center",
+	   "text-keep-upright": true,
+	   "text-max-angle": 45,
+	   "text-padding": 1,
+	   "text-font": [
+		"Source Sans Pro Italic"
+	   ],
+	   "visibility": "visible"
+	  },
+	  "paint": {
+	   "text-color": "#863831",
+	   "text-halo-width": 1.5,
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)"
+	  }
+	 },
+	 {
+	  "id": "toponyme - oro ponc 4",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_oro_ponc",
+	  "filter": [
+	   "in",
+	   "txt_typo",
+	   "ORO_SOMMET_3",
+	   "ORO_GORGE_2",
+	   "GROTTE",
+	   "GORGE",
+	   "TYPO_G_9",
+	   "TYPO_G_10"
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-size": {
+		"stops": [
+		 [
+		  13,
+		  11
+		 ],
+		 [
+		  16,
+		  16
+		 ]
+		]
+	   },
+	   "text-allow-overlap": true,
+	   "text-padding": 1,
+	   "text-font": [
+		"Source Sans Pro Italic"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#863831",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 1.5
+	  }
+	 },
+	 {
+	  "id": "toponyme - hydro ponc 4",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_hydro_ponc",
+	  "filter": [
+	   "in",
+	   "txt_typo",
+	   "lac - étang - bassin",
+	   "HYD_SURF_4",
+	   "HYD_SURF_4_T",
+	   "HYD_SURF_5",
+	   "HYD_SURF_5_T",
+	   "TYPO_D_8",
+	   "SOURCE"
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-size": {
+		"stops": [
+		 [
+		  14,
+		  13
+		 ],
+		 [
+		  17,
+		  16
+		 ]
+		]
+	   },
+	   "text-allow-overlap": true,
+	   "text-padding": 5,
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#447FB3",
+	   "text-halo-color": "#FFFFFF",
+	   "text-halo-width": 1
+	  }
+	 },
+	 {
+	  "id": "toponyme quartier ",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_localite_ponc",
+	  "filter": [
+	   "in",
+	   "txt_typo",
+	   "BAT_QUARTIER",
+	   "BAT_QUARTIER_T"
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-size": 11,
+	   "text-allow-overlap": false,
+	   "text-padding": 1,
+	   "text-font": [
+		"Source Sans Pro Italic"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#000000",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 2
+	  }
+	 },
+	 {
+	  "id": "toponyme localite n0 typoA10",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_localite_ponc",
+	  "maxzoom": 18,
+	  "filter": [
+	   "==",
+	   "txt_typo",
+	   "TYPO_A_10"
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-size": {
+		"stops": [
+		 [
+		  15,
+		  11
+		 ],
+		 [
+		  17,
+		  13.5
+		 ]
+		]
+	   },
+	   "text-allow-overlap": true,
+	   "text-anchor": "center",
+	   "text-padding": 1,
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#000000",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 2
+	  }
+	 },
+	 {
+	  "id": "toponyme - lieu dit non habité",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_ocs_ponc",
+	  "filter": [
+	   "all",
+	   [
+		"==",
+		"symbo",
+		"LIEU-DIT_NON_HABITE"
+	   ],
+	   [
+		"in",
+		"txt_typo",
+		"TYPO_B_7",
+		"TYPO_B_8",
+		"TYPO_B_9"
+	   ]
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-size": 12,
+	   "text-allow-overlap": false,
+	   "text-padding": 1,
+	   "text-font": [
+		"Source Sans Pro Italic"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#000000",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 1
+	  }
+	 },
+	 {
+	  "id": "toponyme - bois 2",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_ocs_ponc",
+	  "filter": [
+	   "all",
+	   [
+		"==",
+		"symbo",
+		"BOIS"
+	   ],
+	   [
+		"in",
+		"txt_typo",
+		"TYPO_F_7",
+		"TYPO_F_8",
+		"TYPO_F_9"
+	   ]
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-size": 16,
+	   "text-allow-overlap": false,
+	   "text-padding": 1,
+	   "text-font": [
+		"Source Sans Pro Italic"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#287B00",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 2
+	  }
+	 },
+	 {
+	  "id": "toponyme localite hameau ",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_localite_ponc",
+	  "minzoom": 11,
+	  "maxzoom": 13,
+	  "filter": [
+	   "in",
+	   "txt_typo",
+	   "BAT_HAMEAU",
+	   "BAT_HAMEAU_T"
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "icon-image": "Localite",
+	   "icon-size": 0.17,
+	   "text-field": "{texte}",
+	   "text-size": 11,
+	   "text-allow-overlap": false,
+	   "text-anchor": "bottom-left",
+	   "text-offset": [
+		0.3,
+		0.1
+	   ],
+	   "text-padding": 1,
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#000000",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 2
+	  }
+	 },
+	 {
+	  "id": "toponyme localite importance 5",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_localite_ponc",
+	  "minzoom": 9,
+	  "filter": [
+	   "in",
+	   "txt_typo",
+	   "commune 5",
+	   "BAT_COMMUNE_5",
+	   "BAT_COMMUNE_5_T",
+	   "BAT_CHEF_LIEU_COM",
+	   "BAT_CHEF_LIEU_COM_T",
+	   "BAT_CHEF_LIEU_COM-T",
+	   "BAT_ANCIENNE_COM",
+	   "BAT_ANCIENNE_COM_T",
+	   "BAT_COMMUNE_ASSOCIEE",
+	   "BAT_COMMUNE_ASSOCIEE_T",
+	   "Commune très petite"
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "icon-image": "Localite",
+	   "icon-size": 0.21,
+	   "text-field": "{texte}",
+	   "text-size": 11.5,
+	   "text-allow-overlap": false,
+	   "text-anchor": "bottom-left",
+	   "text-offset": [
+		0.3,
+		0.1
+	   ],
+	   "text-padding": 1,
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#000000",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 2
+	  }
+	 },
+	 {
+	  "id": "toponyme - ocs lineaire 3",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_ocs_lin",
+	  "filter": [
+	   "==",
+	   "txt_typo",
+	   "OCS_FORET_3"
+	  ],
+	  "layout": {
+	   "symbol-placement": "line",
+	   "text-field": "{texte}",
+	   "text-size": {
+		"stops": [
+		 [
+		  10,
+		  12
+		 ],
+		 [
+		  12,
+		  15
+		 ]
+		]
+	   },
+	   "text-anchor": "center",
+	   "text-keep-upright": true,
+	   "text-max-angle": 45,
+	   "text-padding": 1,
+	   "text-font": [
+		"Source Sans Pro Italic"
+	   ],
+	   "visibility": "visible"
+	  },
+	  "paint": {
+	   "text-color": "#287B00",
+	   "text-halo-width": 1,
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)"
+	  }
+	 },
+	 {
+	  "id": "toponyme - lieu dit non habité 1",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_ocs_ponc",
+	  "filter": [
+	   "all",
+	   [
+		"==",
+		"symbo",
+		"LIEU-DIT_NON_HABITE"
+	   ],
+	   [
+		"in",
+		"txt_typo",
+		"TYPO_B_5",
+		"TYPO_B_4"
+	   ]
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-size": 15,
+	   "text-allow-overlap": false,
+	   "text-padding": 1,
+	   "text-font": [
+		"Source Sans Pro Italic"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#000000",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 1
+	  }
+	 },
+	 {
+	  "id": "toponyme - bois 1",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_ocs_ponc",
+	  "filter": [
+	   "all",
+	   [
+		"==",
+		"symbo",
+		"BOIS"
+	   ],
+	   [
+		"in",
+		"txt_typo",
+		"TYPO_F_5",
+		"TYPO_F_4"
+	   ]
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-size": 19,
+	   "text-allow-overlap": false,
+	   "text-padding": 1,
+	   "text-font": [
+		"Source Sans Pro Italic"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#287B00",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 2
+	  }
+	 },
+	 {
+	  "id": "toponyme - bois 0",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_ocs_ponc",
+	  "filter": [
+	   "all",
+	   [
+		"==",
+		"symbo",
+		"BOIS"
+	   ],
+	   [
+		"in",
+		"txt_typo",
+		"TYPO_F_3",
+		"TYPO_F_2"
+	   ]
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-size": 22,
+	   "text-allow-overlap": false,
+	   "text-padding": 1,
+	   "text-font": [
+		"Source Sans Pro Italic"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#287B00",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 2
+	  }
+	 },
+	 {
+	  "id": "toponyme - ocs ponc 3",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_ocs_ponc",
+	  "filter": [
+	   "==",
+	   "txt_typo",
+	   "OCS_FORET_3"
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-size": {
+		"stops": [
+		 [
+		  10,
+		  12
+		 ],
+		 [
+		  12,
+		  15
+		 ]
+		]
+	   },
+	   "text-allow-overlap": false,
+	   "text-padding": 1,
+	   "text-anchor": "center",
+	   "text-font": [
+		"Source Sans Pro Italic"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#287B00",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 1
+	  }
+	 },
+	 {
+	  "id": "toponyme - oro lineaire 3",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_oro_lin",
+	  "filter": [
+	   "in",
+	   "txt_typo",
+	   "ORO_ILE_3",
+	   "ORO_RELIEF_3",
+	   "ORO_RELIEF_3_T",
+	   "ORO_RELIEF_4",
+	   "ORO_RELIEF_4_T",
+	   "ORO_CAP_2",
+	   "ORO_CAP_3",
+	   "ORO_SOMMET_2",
+	   "ORO_COL_2",
+	   "ORO_GORGE_1",
+	   "ORO_GORGE-1"
+	  ],
+	  "layout": {
+	   "symbol-placement": "line",
+	   "text-field": "{texte}",
+	   "text-size": 12,
+	   "text-anchor": "center",
+	   "text-keep-upright": true,
+	   "text-max-angle": 45,
+	   "text-padding": 10,
+	   "text-font": [
+		"Source Sans Pro Italic"
+	   ],
+	   "visibility": "visible"
+	  },
+	  "paint": {
+	   "text-color": "#863831",
+	   "text-halo-width": 1.5,
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)"
+	  }
+	 },
+	 {
+	  "id": "toponyme - oro ponc 3",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_oro_ponc",
+	  "filter": [
+	   "in",
+	   "txt_typo",
+	   "ORO_ILE_3",
+	   "ORO_RELIEF_3",
+	   "ORO_RELIEF_3_T",
+	   "ORO_RELIEF_4",
+	   "ORO_RELIEF_4_T",
+	   "ORO_CAP_2",
+	   "ORO_CAP_3",
+	   "ORO_SOMMET_2",
+	   "ORO_COL_2",
+	   "ORO_GORGE_1",
+	   "ORO_GORGE-1",
+	   "TYPO_G_7",
+	   "TYPO_G_8"
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-size": {
+		"stops": [
+		 [
+		  13,
+		  12
+		 ],
+		 [
+		  16,
+		  17
+		 ]
+		]
+	   },
+	   "text-allow-overlap": true,
+	   "text-padding": 1,
+	   "text-font": [
+		"Source Sans Pro Italic"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#863831",
+	   "text-halo-color": "#FFFFFF",
+	   "text-halo-width": 1.5
+	  }
+	 },
+	 {
+	  "id": "toponyme - hydro lineaire 3",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_hydro_lin",
+	  "filter": [
+	   "in",
+	   "txt_typo",
+	   "HYD_LIN_3",
+	   "HYD_LIN_4",
+	   "HYD_LIN_5",
+	   "petite rivière",
+	   "canal",
+	   "HYD_SURF_3",
+	   "HYD_SURF_3_T",
+	   "HYD_SURF_4",
+	   "HYD_SURF_4_T",
+	   "HYD_SURF_5",
+	   "HYD_SURF_5_T",
+	   "TYPO_D_5"
+	  ],
+	  "layout": {
+	   "symbol-placement": "line",
+	   "text-field": "{texte}",
+	   "text-size": {
+		"stops": [
+		 [
+		  14,
+		  12
+		 ],
+		 [
+		  18,
+		  19
+		 ]
+		]
+	   },
+	   "text-anchor": "center",
+	   "text-keep-upright": true,
+	   "text-max-angle": 45,
+	   "text-padding": 10,
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ],
+	   "visibility": "visible"
+	  },
+	  "paint": {
+	   "text-color": "#447FB3",
+	   "text-halo-width": 1.5,
+	   "text-halo-color": "rgba(255, 255, 255, 0.7)"
+	  }
+	 },
+	 {
+	  "id": "toponyme - hydro lineaire 4",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_hydro_lin",
+	  "minzoom": 14,
+	  "filter": [
+	   "in",
+	   "txt_typo",
+	   "TYPO_D_6",
+	   "TYPO_D_8",
+	   "TYPO_D_9",
+	   "TYPO_D_10"
+	  ],
+	  "layout": {
+	   "symbol-placement": "line",
+	   "text-field": "{texte}",
+	   "text-size": {
+		"stops": [
+		 [
+		  14,
+		  10
+		 ],
+		 [
+		  18,
+		  16
+		 ]
+		]
+	   },
+	   "text-anchor": "center",
+	   "text-keep-upright": true,
+	   "text-max-angle": 45,
+	   "text-padding": 10,
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ],
+	   "visibility": "visible"
+	  },
+	  "paint": {
+	   "text-color": "#447FB3",
+	   "text-halo-width": 1.5,
+	   "text-halo-color": "rgba(255, 255, 255, 0.7)"
+	  }
+	 },
+	 {
+	  "id": "toponyme - hydro ponc 3",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_hydro_ponc",
+	  "filter": [
+	   "in",
+	   "txt_typo",
+	   "petit golfe",
+	   "grande baie",
+	   "baie",
+	   "HYD_SURF_3",
+	   "TYPO_D_5",
+	   "TYPO_D_6",
+	   "TYPO_D_7"
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-size": {
+		"stops": [
+		 [
+		  15,
+		  15
+		 ],
+		 [
+		  17,
+		  18
+		 ]
+		]
+	   },
+	   "text-allow-overlap": true,
+	   "text-padding": 10,
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#447FB3",
+	   "text-halo-color": "#FFFFFF",
+	   "text-halo-width": 2
+	  }
+	 },
+	 {
+	  "id": "toponyme bati ponc zai zoom 16",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_bati_ponc",
+	  "minzoom": 15,
+	  "maxzoom": 16,
+	  "filter": [
+	   "==",
+	   "txt_typo",
+	   "zai"
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{designation}",
+	   "text-size": 11,
+	   "text-allow-overlap": false,
+	   "text-padding": 1,
+	   "text-font": [
+		"Source Sans Pro Italic"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#000000"
+	  }
+	 },
+	 {
+	  "id": "toponyme bati ponc zai zoom 17 et 18",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_bati_ponc",
+	  "minzoom": 16,
+	  "filter": [
+	   "==",
+	   "txt_typo",
+	   "zai"
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-size": 11,
+	   "text-allow-overlap": false,
+	   "text-padding": 1,
+	   "text-font": [
+		"Source Sans Pro Italic"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#000000"
+	  }
+	 },
+	 {
+	  "id": "toponyme localite importance 4",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_localite_ponc",
+	  "minzoom": 7,
+	  "filter": [
+	   "in",
+	   "txt_typo",
+	   "commune 4",
+	   "BAT_COMMUNE_4",
+	   "BAT_COMMUNE_4_T"
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "icon-image": "Localite",
+	   "icon-size": 0.21,
+	   "text-field": "{texte}",
+	   "text-size": 13,
+	   "text-allow-overlap": false,
+	   "text-anchor": "bottom-left",
+	   "text-offset": [
+		0.3,
+		0.1
+	   ],
+	   "text-padding": 1,
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#000000",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 2
+	  }
+	 },
+	 {
+	  "id": "toponyme localite n0 typoA9",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_localite_ponc",
+	  "maxzoom": 18,
+	  "filter": [
+	   "==",
+	   "txt_typo",
+	   "TYPO_A_9"
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-size": {
+		"stops": [
+		 [
+		  15,
+		  11.5
+		 ],
+		 [
+		  17,
+		  14
+		 ]
+		]
+	   },
+	   "text-allow-overlap": true,
+	   "text-anchor": "center",
+	   "text-padding": 1,
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#000000",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 2
+	  }
+	 },
+	 {
+	  "id": "toponyme localite n0 typoA8",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_localite_ponc",
+	  "maxzoom": 18,
+	  "filter": [
+	   "==",
+	   "txt_typo",
+	   "TYPO_A_8"
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-size": {
+		"stops": [
+		 [
+		  15,
+		  12
+		 ],
+		 [
+		  17,
+		  15
+		 ]
+		]
+	   },
+	   "text-allow-overlap": true,
+	   "text-anchor": "center",
+	   "text-padding": 1,
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#000000",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 2
+	  }
+	 },
+	 {
+	  "id": "toponyme - limite militaire ponc 1 et 2",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_limite_ponc",
+	  "filter": [
+	   "in",
+	   "txt_typo",
+	   "LIM_MILI_1",
+	   "LIM_MILI_2"
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-size": 15,
+	   "text-allow-overlap": false,
+	   "text-padding": 5,
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#0D2000",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 2
+	  }
+	 },
+	 {
+	  "id": "toponyme - limite parc marin",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_limite_ponc",
+	  "minzoom": 8,
+	  "filter": [
+	   "==",
+	   "txt_typo",
+	   "LIM_PARC_NATUREL_MARIN"
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-size": 15,
+	   "text-allow-overlap": false,
+	   "text-padding": 10,
+	   "text-transform": "uppercase",
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#2A81A2",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 2
+	  }
+	 },
+	 {
+	  "id": "toponyme - limite parc ponc 1 et 2",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_limite_ponc",
+	  "minzoom": 8,
+	  "filter": [
+	   "in",
+	   "txt_typo",
+	   "LIM_PARC_1",
+	   "LIM_PARC_2",
+	   "LIM_PARC_NATUREL"
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-size": 15,
+	   "text-allow-overlap": false,
+	   "text-padding": 10,
+	   "text-transform": "uppercase",
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#287B00",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 2
+	  }
+	 },
+	 {
+	  "id": "toponyme - ocs lineaire 2",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_ocs_lin",
+	  "filter": [
+	   "==",
+	   "txt_typo",
+	   "OCS_FORET_2"
+	  ],
+	  "layout": {
+	   "symbol-placement": "line",
+	   "text-field": "{texte}",
+	   "text-size": {
+		"stops": [
+		 [
+		  10,
+		  15
+		 ],
+		 [
+		  12,
+		  18
+		 ]
+		]
+	   },
+	   "text-anchor": "center",
+	   "text-keep-upright": true,
+	   "text-max-angle": 45,
+	   "text-padding": 1,
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ],
+	   "visibility": "visible"
+	  },
+	  "paint": {
+	   "text-color": "#287B00",
+	   "text-halo-width": 2,
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)"
+	  }
+	 },
+	 {
+	  "id": "toponyme - ocs ponc 2",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_ocs_ponc",
+	  "filter": [
+	   "==",
+	   "txt_typo",
+	   "OCS_FORET_2"
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-size": {
+		"stops": [
+		 [
+		  10,
+		  15
+		 ],
+		 [
+		  12,
+		  18
+		 ]
+		]
+	   },
+	   "text-allow-overlap": false,
+	   "text-padding": 1,
+	   "text-anchor": "center",
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#287B00",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 2
+	  }
+	 },
+	 {
+	  "id": "toponyme - oro lineaire 2",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_oro_lin",
+	  "filter": [
+	   "in",
+	   "txt_typo",
+	   "ORO_ILE_2",
+	   "ORO_RELIEF_2",
+	   "ORO_RELIEF_2_T",
+	   "ORO_CAP_1",
+	   "ORO_SOMMET_1"
+	  ],
+	  "layout": {
+	   "symbol-placement": "line",
+	   "text-field": "{texte}",
+	   "text-size": 15,
+	   "text-anchor": "center",
+	   "text-keep-upright": true,
+	   "text-padding": 10,
+	   "text-max-angle": 45,
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ],
+	   "visibility": "visible"
+	  },
+	  "paint": {
+	   "text-color": "#863831",
+	   "text-halo-width": 2,
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)"
+	  }
+	 },
+	 {
+	  "id": "toponyme - oro ponc 2",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_oro_ponc",
+	  "minzoom": 9,
+	  "filter": [
+	   "in",
+	   "txt_typo",
+	   "ORO_ILE_2",
+	   "ORO_RELIEF_2",
+	   "ORO_RELIEF_2_T",
+	   "ORO_CAP_1",
+	   "ORO_COL_1",
+	   "sommet ou col",
+	   "ORO_SOMMET_1",
+	   "TYPO_G_4",
+	   "TYPO_G_6"
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-size": {
+		"stops": [
+		 [
+		  9,
+		  13
+		 ],
+		 [
+		  10,
+		  15
+		 ],
+		 [
+		  13,
+		  15
+		 ],
+		 [
+		  16,
+		  19
+		 ]
+		]
+	   },
+	   "text-allow-overlap": false,
+	   "text-padding": 1,
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#863831",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 2
+	  }
+	 },
+	 {
+	  "id": "toponyme - oro ponc 2B",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_oro_ponc",
+	  "minzoom": 8,
+	  "filter": [
+	   "in",
+	   "txt_typo",
+	   "île",
+	   "cap ou pointe"
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-size": 15,
+	   "text-allow-overlap": false,
+	   "text-padding": 1,
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#863831",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 2
+	  }
+	 },
+	 {
+	  "id": "toponyme - hydro lineaire 2",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_hydro_lin",
+	  "filter": [
+	   "in",
+	   "txt_typo",
+	   "HYD_LIN_2",
+	   "rivière moyenne",
+	   "HYD_SURF_2",
+	   "HYD_SURF_2_T",
+	   "TYPO_D_3"
+	  ],
+	  "layout": {
+	   "symbol-placement": "line",
+	   "text-field": "{texte}",
+	   "text-size": {
+		"stops": [
+		 [
+		  14,
+		  15
+		 ],
+		 [
+		  18,
+		  21
+		 ]
+		]
+	   },
+	   "text-anchor": "center",
+	   "text-keep-upright": true,
+	   "text-max-angle": 45,
+	   "text-padding": 10,
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ],
+	   "visibility": "visible"
+	  },
+	  "paint": {
+	   "text-color": "#447FB3",
+	   "text-halo-width": 2,
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)"
+	  }
+	 },
+	 {
+	  "id": "toponyme - hydro ponc 2",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_hydro_ponc",
+	  "minzoom": 5,
+	  "filter": [
+	   "in",
+	   "txt_typo",
+	   "moyen",
+	   "golfe moyen",
+	   "HYD_SURF_2",
+	   "TYPO_D_2",
+	   "TYPO_D_3",
+	   "TYPO_D_4"
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-size": {
+		"stops": [
+		 [
+		  5,
+		  12
+		 ],
+		 [
+		  6,
+		  18
+		 ],
+		 [
+		  10,
+		  17
+		 ],
+		 [
+		  18,
+		  21
+		 ]
+		]
+	   },
+	   "text-allow-overlap": false,
+	   "text-padding": 10,
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#447FB3",
+	   "text-halo-color": "#FFFFFF",
+	   "text-halo-width": 2
+	  }
+	 },
+	 {
+	  "id": "toponyme localite importance 3",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_localite_ponc",
+	  "minzoom": 5,
+	  "filter": [
+	   "in",
+	   "txt_typo",
+	   "commune 3",
+	   "BAT_COMMUNE_3",
+	   "BAT_COMMUNE_3_T"
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "icon-image": "Localite",
+	   "icon-size": 0.21,
+	   "text-field": "{texte}",
+	   "text-size": {
+		"stops": [
+		 [
+		  5,
+		  10
+		 ],
+		 [
+		  6,
+		  15
+		 ]
+		]
+	   },
+	   "text-allow-overlap": false,
+	   "text-anchor": "bottom-left",
+	   "text-offset": [
+		0.3,
+		0.1
+	   ],
+	   "text-padding": 1,
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#000000",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 2
+	  }
+	 },
+	 {
+	  "id": "toponyme localite n0 typoA7 non commune",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_localite_ponc",
+	  "maxzoom": 18,
+	  "filter": [
+	   "all",
+	   [
+		"!=",
+		"symbo",
+		"COMMUNE_FUSIONNEE"
+	   ],
+	   [
+		"!=",
+		"symbo",
+		"COMMUNE_CHEF_LIEU"
+	   ],
+	   [
+		"==",
+		"txt_typo",
+		"TYPO_A_7"
+	   ]
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-size": {
+		"stops": [
+		 [
+		  15,
+		  13
+		 ],
+		 [
+		  17,
+		  16
+		 ]
+		]
+	   },
+	   "text-allow-overlap": true,
+	   "text-anchor": "center",
+	   "text-padding": 1,
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#000000",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 2
+	  }
+	 },
+	 {
+	  "id": "toponyme localite n0 typoA6 non commune",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_localite_ponc",
+	  "maxzoom": 18,
+	  "filter": [
+	   "all",
+	   [
+		"!=",
+		"symbo",
+		"COMMUNE_FUSIONNEE"
+	   ],
+	   [
+		"!=",
+		"symbo",
+		"COMMUNE_CHEF_LIEU"
+	   ],
+	   [
+		"==",
+		"txt_typo",
+		"TYPO_A_6"
+	   ]
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-size": {
+		"stops": [
+		 [
+		  15,
+		  15
+		 ],
+		 [
+		  17,
+		  18
+		 ]
+		]
+	   },
+	   "text-allow-overlap": true,
+	   "text-anchor": "center",
+	   "text-padding": 1,
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#000000",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 2
+	  }
+	 },
+	 {
+	  "id": "toponyme - oro lineaire 1",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_oro_lin",
+	  "filter": [
+	   "in",
+	   "txt_typo",
+	   "ORO_ILE_1",
+	   "ORO_RELIEF_1",
+	   "ORO_RELIEF_1_T"
+	  ],
+	  "layout": {
+	   "symbol-placement": "line",
+	   "text-field": "{texte}",
+	   "text-size": 20,
+	   "text-anchor": "center",
+	   "text-keep-upright": true,
+	   "text-padding": 5,
+	   "text-max-angle": 45,
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ],
+	   "visibility": "visible"
+	  },
+	  "paint": {
+	   "text-color": "#863831",
+	   "text-halo-width": 2,
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)"
+	  }
+	 },
+	 {
+	  "id": "toponyme - oro ponc monde",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_oro_ponc",
+	  "minzoom": 5,
+	  "filter": [
+	   "in",
+	   "txt_typo",
+	   "Basin",
+	   "Depression",
+	   "Desert",
+	   "Geoarea",
+	   "Gorge",
+	   "Isthmus",
+	   "Lake",
+	   "Lowland",
+	   "Pen/cape",
+	   "Plain",
+	   "Plateau",
+	   "Range/mtn",
+	   "Tundra",
+	   "Valley",
+	   "Island",
+	   "Island group"
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-size": 11,
+	   "text-allow-overlap": false,
+	   "text-padding": 1,
+	   "text-font": [
+		"Source Sans Pro Italic"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#863831",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 2
+	  }
+	 },
+	 {
+	  "id": "toponyme localite n0 typoA4 non commune",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_localite_ponc",
+	  "maxzoom": 16,
+	  "filter": [
+	   "all",
+	   [
+		"!=",
+		"symbo",
+		"COMMUNE_FUSIONNEE"
+	   ],
+	   [
+		"!=",
+		"symbo",
+		"COMMUNE_CHEF_LIEU"
+	   ],
+	   [
+		"==",
+		"txt_typo",
+		"TYPO_A_4"
+	   ]
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-size": 17,
+	   "text-allow-overlap": true,
+	   "text-anchor": "center",
+	   "text-padding": 1,
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#000000",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 3
+	  }
+	 },
+	 {
+	  "id": "toponyme - ocs lineaire 1",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_ocs_lin",
+	  "filter": [
+	   "==",
+	   "txt_typo",
+	   "OCS_FORET_1"
+	  ],
+	  "layout": {
+	   "symbol-placement": "line",
+	   "text-field": "{texte}",
+	   "text-size": {
+		"stops": [
+		 [
+		  10,
+		  18
+		 ],
+		 [
+		  12,
+		  22
+		 ]
+		]
+	   },
+	   "text-anchor": "center",
+	   "text-keep-upright": true,
+	   "text-padding": 1,
+	   "text-max-angle": 45,
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ],
+	   "visibility": "visible"
+	  },
+	  "paint": {
+	   "text-color": "#287B00",
+	   "text-halo-width": 2,
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)"
+	  }
+	 },
+	 {
+	  "id": "toponyme - ocs ponc 1",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_ocs_ponc",
+	  "filter": [
+	   "==",
+	   "txt_typo",
+	   "OCS_FORET_1"
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-size": {
+		"stops": [
+		 [
+		  10,
+		  18
+		 ],
+		 [
+		  12,
+		  22
+		 ]
+		]
+	   },
+	   "text-allow-overlap": true,
+	   "text-padding": 1,
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#287B00",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 2
+	  }
+	 },
+	 {
+	  "id": "toponyme - oro ponc 1",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_oro_ponc",
+	  "minzoom": 8,
+	  "filter": [
+	   "in",
+	   "txt_typo",
+	   "grande île",
+	   "ORO_ILE_1",
+	   "ORO_RELIEF_1",
+	   "ORO_RELIEF_1_T",
+	   "TYPO_G_3",
+	   "TYPO_G_2",
+	   "TYPO_G_1"
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-size": 21,
+	   "text-allow-overlap": true,
+	   "text-padding": 1,
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#863831",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 2
+	  }
+	 },
+	 {
+	  "id": "toponyme - hydro lineaire glacier",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_hydro_lin",
+	  "filter": [
+	   "in",
+	   "txt_typo",
+	   "ORO_GLACIER_1",
+	   "ORO_GLACIER_2"
+	  ],
+	  "layout": {
+	   "symbol-placement": "line",
+	   "text-field": "{texte}",
+	   "text-size": 15,
+	   "text-anchor": "center",
+	   "text-keep-upright": true,
+	   "text-max-angle": 45,
+	   "text-font": [
+		"Source Sans Pro Italic"
+	   ],
+	   "visibility": "visible"
+	  },
+	  "paint": {
+	   "text-color": "#447FB3",
+	   "text-halo-width": 2,
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)"
+	  }
+	 },
+	 {
+	  "id": "toponyme - hydro lineaire 1",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_hydro_lin",
+	  "filter": [
+	   "in",
+	   "txt_typo",
+	   "HYD_LIN_1",
+	   "HYD-LIN-1",
+	   "grande rivière",
+	   "HYD_SURF_1",
+	   "HYD_SURF_1_T",
+	   "TYPO_D_1",
+	   "TYPO_D_2"
+	  ],
+	  "layout": {
+	   "symbol-placement": "line",
+	   "text-field": "{texte}",
+	   "text-size": 18,
+	   "text-anchor": "center",
+	   "text-keep-upright": true,
+	   "text-max-angle": 45,
+	   "text-padding": 10,
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ],
+	   "visibility": "visible"
+	  },
+	  "paint": {
+	   "text-color": "#447FB3",
+	   "text-halo-width": 2,
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)"
+	  }
+	 },
+	 {
+	  "id": "toponyme - hydro lineaire ocean",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_hydro_lin",
+	  "filter": [
+	   "==",
+	   "txt_typo",
+	   "mer et océan"
+	  ],
+	  "layout": {
+	   "symbol-placement": "line",
+	   "text-field": "{texte}",
+	   "text-size": 30,
+	   "text-anchor": "center",
+	   "text-keep-upright": true,
+	   "text-max-angle": 45,
+	   "text-padding": 10,
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ],
+	   "visibility": "visible"
+	  },
+	  "paint": {
+	   "text-color": "#447FB3",
+	   "text-halo-width": 4,
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)"
+	  }
+	 },
+	 {
+	  "id": "toponyme - hydro ponc 1",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_hydro_ponc",
+	  "minzoom": 4,
+	  "filter": [
+	   "in",
+	   "txt_typo",
+	   "mer",
+	   "grand",
+	   "grand golfe",
+	   "HYD_SURF_1",
+	   "TYPO_D_1"
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-size": {
+		"stops": [
+		 [
+		  4,
+		  16
+		 ],
+		 [
+		  6,
+		  30
+		 ],
+		 [
+		  10,
+		  25
+		 ]
+		]
+	   },
+	   "text-allow-overlap": true,
+	   "text-padding": 10,
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#447FB3",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 4
+	  }
+	 },
+	 {
+	  "id": "toponyme localite importance 2",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_localite_ponc",
+	  "minzoom": 4,
+	  "filter": [
+	   "in",
+	   "txt_typo",
+	   "commune 2",
+	   "BAT_COMMUNE_2",
+	   "BAT_COMMUNE-2",
+	   "BAT_COMMUNE_2_T"
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "icon-image": "Localite",
+	   "icon-size": 0.25,
+	   "text-field": "{texte}",
+	   "text-size": {
+		"stops": [
+		 [
+		  4,
+		  10
+		 ],
+		 [
+		  6,
+		  17
+		 ]
+		]
+	   },
+	   "text-allow-overlap": true,
+	   "text-anchor": "bottom-left",
+	   "text-offset": [
+		0.3,
+		0.2
+	   ],
+	   "text-padding": 1,
+	   "text-transform": "uppercase",
+	   "text-font": {
+		"stops": [
+		 [
+		  1,
+		  [
+		   "Source Sans Pro Regular"
+		  ]
+		 ],
+		 [
+		  7,
+		  [
+		   "Source Sans Pro Bold"
+		  ]
+		 ],
+		 [
+		  10,
+		  [
+		   "Source Sans Pro Regular"
+		  ]
+		 ]
+		]
+	   }
+	  },
+	  "paint": {
+	   "text-color": "#000000",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 3
+	  }
+	 },
+	 {
+	  "id": "toponyme localite n0 typoA3 non commune",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_localite_ponc",
+	  "maxzoom": 16,
+	  "filter": [
+	   "all",
+	   [
+		"!=",
+		"symbo",
+		"COMMUNE_FUSIONNEE"
+	   ],
+	   [
+		"!=",
+		"symbo",
+		"COMMUNE_CHEF_LIEU"
+	   ],
+	   [
+		"==",
+		"txt_typo",
+		"TYPO_A_3"
+	   ]
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-size": 19,
+	   "text-allow-overlap": true,
+	   "text-anchor": "center",
+	   "text-padding": 1,
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#000000",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 3
+	  }
+	 },
+	 {
+	  "id": "toponyme localite n0 typoA2 non commune",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_localite_ponc",
+	  "maxzoom": 16,
+	  "filter": [
+	   "all",
+	   [
+		"!=",
+		"symbo",
+		"COMMUNE_FUSIONNEE"
+	   ],
+	   [
+		"!=",
+		"symbo",
+		"COMMUNE_CHEF_LIEU"
+	   ],
+	   [
+		"==",
+		"txt_typo",
+		"TYPO_A_2"
+	   ]
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-size": 21,
+	   "text-allow-overlap": true,
+	   "text-anchor": "center",
+	   "text-padding": 1,
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#000000",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 4
+	  }
+	 },
+	 {
+	  "id": "toponyme localite n0 typoA7 commune",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_localite_ponc",
+	  "maxzoom": 18,
+	  "filter": [
+	   "all",
+	   [
+		"in",
+		"symbo",
+		"COMMUNE_FUSIONNEE",
+		"COMMUNE_CHEF_LIEU"
+	   ],
+	   [
+		"==",
+		"txt_typo",
+		"TYPO_A_7"
+	   ]
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-size": {
+		"stops": [
+		 [
+		  15,
+		  13
+		 ],
+		 [
+		  17,
+		  16
+		 ]
+		]
+	   },
+	   "text-allow-overlap": true,
+	   "text-anchor": "center",
+	   "text-padding": 1,
+	   "text-transform": "uppercase",
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#000000",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 2
+	  }
+	 },
+	 {
+	  "id": "toponyme localite n0 typoA6 commune",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_localite_ponc",
+	  "maxzoom": 18,
+	  "filter": [
+	   "all",
+	   [
+		"in",
+		"symbo",
+		"COMMUNE_FUSIONNEE",
+		"COMMUNE_CHEF_LIEU"
+	   ],
+	   [
+		"==",
+		"txt_typo",
+		"TYPO_A_6"
+	   ]
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-size": {
+		"stops": [
+		 [
+		  15,
+		  15
+		 ],
+		 [
+		  17,
+		  18
+		 ]
+		]
+	   },
+	   "text-allow-overlap": true,
+	   "text-anchor": "center",
+	   "text-padding": 1,
+	   "text-transform": "uppercase",
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#000000",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 2
+	  }
+	 },
+	 {
+	  "id": "toponyme localite n0 typoA1 non commune",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_localite_ponc",
+	  "maxzoom": 16,
+	  "filter": [
+	   "all",
+	   [
+		"!=",
+		"symbo",
+		"COMMUNE_FUSIONNEE"
+	   ],
+	   [
+		"!=",
+		"symbo",
+		"COMMUNE_CHEF_LIEU"
+	   ],
+	   [
+		"==",
+		"txt_typo",
+		"TYPO_A_1"
+	   ]
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-size": 23,
+	   "text-allow-overlap": true,
+	   "text-anchor": "center",
+	   "text-padding": 1,
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#000000",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 4
+	  }
+	 },
+	 {
+	  "id": "toponyme localite n0 typoA4 commune",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_localite_ponc",
+	  "maxzoom": 16,
+	  "filter": [
+	   "all",
+	   [
+		"in",
+		"symbo",
+		"COMMUNE_FUSIONNEE",
+		"COMMUNE_CHEF_LIEU"
+	   ],
+	   [
+		"==",
+		"txt_typo",
+		"TYPO_A_4"
+	   ]
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-size": 17,
+	   "text-allow-overlap": true,
+	   "text-anchor": "center",
+	   "text-padding": 1,
+	   "text-transform": "uppercase",
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#000000",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 3
+	  }
+	 },
+	 {
+	  "id": "toponyme localite n0 typoA3 commune",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_localite_ponc",
+	  "maxzoom": 16,
+	  "filter": [
+	   "all",
+	   [
+		"in",
+		"symbo",
+		"COMMUNE_FUSIONNEE",
+		"COMMUNE_CHEF_LIEU"
+	   ],
+	   [
+		"==",
+		"txt_typo",
+		"TYPO_A_3"
+	   ]
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-size": 19,
+	   "text-allow-overlap": true,
+	   "text-anchor": "center",
+	   "text-padding": 1,
+	   "text-transform": "uppercase",
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#000000",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 3
+	  }
+	 },
+	 {
+	  "id": "toponyme localite n0 typoA2 commune",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_localite_ponc",
+	  "maxzoom": 16,
+	  "filter": [
+	   "all",
+	   [
+		"in",
+		"symbo",
+		"COMMUNE_FUSIONNEE",
+		"COMMUNE_CHEF_LIEU"
+	   ],
+	   [
+		"==",
+		"txt_typo",
+		"TYPO_A_2"
+	   ]
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-size": 21,
+	   "text-allow-overlap": true,
+	   "text-anchor": "center",
+	   "text-padding": 1,
+	   "text-transform": "uppercase",
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#000000",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 4
+	  }
+	 },
+	 {
+	  "id": "toponyme localite importance 1",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_localite_ponc",
+	  "minzoom": 3,
+	  "filter": [
+	   "in",
+	   "txt_typo",
+	   "commune 1",
+	   "BAT_COMMUNE_1",
+	   "BAT_COMMUNE_1_T"
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "icon-image": "Localite",
+	   "icon-size": 0.3,
+	   "text-field": "{texte}",
+	   "text-size": {
+		"stops": [
+		 [
+		  3,
+		  10
+		 ],
+		 [
+		  6,
+		  20
+		 ]
+		]
+	   },
+	   "text-allow-overlap": false,
+	   "text-anchor": "bottom-left",
+	   "text-offset": [
+		0.25,
+		-0.1
+	   ],
+	   "text-padding": 1,
+	   "text-transform": "uppercase",
+	   "text-font": {
+		"stops": [
+		 [
+		  1,
+		  [
+		   "Source Sans Pro Regular"
+		  ]
+		 ],
+		 [
+		  7,
+		  [
+		   "Source Sans Pro Bold"
+		  ]
+		 ],
+		 [
+		  10,
+		  [
+		   "Source Sans Pro Regular"
+		  ]
+		 ]
+		]
+	   }
+	  },
+	  "paint": {
+	   "text-color": "#000000",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 4
+	  }
+	 },
+	 {
+	  "id": "toponyme localite n0 typoA1 commune",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_localite_ponc",
+	  "maxzoom": 16,
+	  "filter": [
+	   "all",
+	   [
+		"in",
+		"symbo",
+		"COMMUNE_FUSIONNEE",
+		"COMMUNE_CHEF_LIEU"
+	   ],
+	   [
+		"==",
+		"txt_typo",
+		"TYPO_A_1"
+	   ]
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-size": 23,
+	   "text-allow-overlap": true,
+	   "text-anchor": "center",
+	   "text-padding": 1,
+	   "text-transform": "uppercase",
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#000000",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 4
+	  }
+	 },
+	 {
+	  "id": "toponyme - hydro ponc ocean",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_hydro_ponc",
+	  "minzoom": 1,
+	  "filter": [
+	   "==",
+	   "txt_typo",
+	   "ocean"
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "symbol-placement": "point",
+	   "text-field": "{texte}",
+	   "text-size": {
+		"stops": [
+		 [
+		  1,
+		  16
+		 ],
+		 [
+		  6,
+		  30
+		 ]
+		]
+	   },
+	   "text-allow-overlap": true,
+	   "text-anchor": "center",
+	   "text-padding": 10,
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#447FB3",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 4
+	  }
+	 },
+	 {
+	  "id": "toponyme pays 3",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_localite_ponc",
+	  "minzoom": 4,
+	  "maxzoom": 5,
+	  "filter": [
+	   "==",
+	   "txt_typo",
+	   "pays 3"
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "text-field": "{texte}",
+	   "text-size": 9,
+	   "text-allow-overlap": true,
+	   "text-anchor": "center",
+	   "text-padding": 1,
+	   "text-transform": "uppercase",
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#787878",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 4
+	  }
+	 },
+	 {
+	  "id": "toponyme pays 2",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_localite_ponc",
+	  "minzoom": 2,
+	  "maxzoom": 5,
+	  "filter": [
+	   "==",
+	   "txt_typo",
+	   "pays 2"
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "text-field": "{texte}",
+	   "text-size": 13,
+	   "text-allow-overlap": true,
+	   "text-anchor": "center",
+	   "text-padding": 2,
+	   "text-transform": "uppercase",
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#787878",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 4
+	  }
+	 },
+	 {
+	  "id": "toponyme pays 1",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_localite_ponc",
+	  "minzoom": 2,
+	  "maxzoom": 5,
+	  "filter": [
+	   "==",
+	   "txt_typo",
+	   "pays 1"
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "text-field": "{texte}",
+	   "text-size": 13,
+	   "text-allow-overlap": true,
+	   "text-anchor": "center",
+	   "text-padding": 2,
+	   "text-transform": "uppercase",
+	   "text-font": [
+		"Source Sans Pro Regular"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#787878",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 4
+	  }
+	 },
+	 {
+	  "id": "toponyme continent",
+	  "type": "symbol",
+	  "source": "plan_ign",
+	  "source-layer": "toponyme_localite_ponc",
+	  "maxzoom": 3,
+	  "filter": [
+	   "==",
+	   "txt_typo",
+	   "continent"
+	  ],
+	  "layout": {
+	   "visibility": "visible",
+	   "text-field": "{texte}",
+	   "text-size": 15,
+	   "text-allow-overlap": true,
+	   "text-anchor": "center",
+	   "text-padding": 1,
+	   "text-transform": "uppercase",
+	   "text-font": [
+		"Source Sans Pro Bold"
+	   ]
+	  },
+	  "paint": {
+	   "text-color": "#787878",
+	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
+	   "text-halo-width": 4
+	  }
+	 }
 	]
-}
+   }

--- a/components/map/styles/vector.json
+++ b/components/map/styles/vector.json
@@ -11,12 +11,8 @@
       "cadastre": {
         "type": "vector",
         "url": 
-			"https://wxs.ign.fr/parcellaire/geoportail/wmts?layer=CADASTRALPARCELS.PARCELLAIRE_EXPRESS&style=PCI vecteur&tilematrixset=PM&Service=WMTS&Request=GetTile&Version=1.0.0&Format=image/png&TileMatrix={z}&TileCol={x}&TileRow={y}"
-        },
-		"decoupage-administratif": {
-			"type": "vector",
-			"url": "https://openmaptiles.geo.data.gouv.fr/data/decoupage-administratif.json"
-		  }
+			"https://wxs.ign.fr/parcellaire/geoportail/wmts?layer=&style=normal&tilematrixset=PM&Service=WMTS&Request=GetTile&Version=1.0.0&Format=image/png&TileMatrix={z}&TileCol={x}&TileRow={y}"
+        }
     },
 
 	"transition": {

--- a/components/map/styles/vector.json
+++ b/components/map/styles/vector.json
@@ -1,14854 +1,8578 @@
 {
-  "version": 8,
-  "name": "PLAN IGN",
-  "metadata": {
-    "url": "https://wxs.ign.fr/choisirgeoportail/geoportail/tms/1.0.0/PLAN.IGN/metadata.json"
+	"version": 8,
+	"name": "PLAN IGN",
+    "glyphs":"https://wxs.ign.fr/static/vectorTiles/fonts/{fontstack}/{range}.pbf",
+	"sprite": "https://wxs.ign.fr/static/vectorTiles/styles/PLAN.IGN/sprite/PlanIgn",
+    "sources": {
+      "plan_ign": {
+        "type": "vector",
+        "url": "https://wxs.ign.fr/essentiels/geoportail/tms/1.0.0/PLAN.IGN/metadata.json/"
+      },
+      "cadastre": {
+        "type": "vector",
+        "url": 
+			"https://wxs.ign.fr/parcellaire/geoportail/wmts?layer=CADASTRALPARCELS.PARCELLAIRE_EXPRESS&style=PCI vecteur&tilematrixset=PM&Service=WMTS&Request=GetTile&Version=1.0.0&Format=image/png&TileMatrix={z}&TileCol={x}&TileRow={y}"
+        },
+		"decoupage-administratif": {
+			"type": "vector",
+			"url": "https://openmaptiles.geo.data.gouv.fr/data/decoupage-administratif.json"
+		  }
+    },
 
-  },
-  "sources": {
-    "plan_ign": {
-      "type": "vector",
-      "tiles": "https://wxs.ign.fr/essentiels/geoportail/tms/1.0.0/PLAN.IGN/{z}/{x}/{y}.pbf",
-      "scheme": "tms"
-    
-    },
-    "cadastre": {
-      "type": "vector",
-      "url": "https://wxs.ign.fr/parcellaire/geoportail/wmts?layer=CADASTRALPARCELS.PARCELLAIRE_EXPRESS&style=normal&tilematrixset=PM&Service=WMTS&Request=GetTile&Version=1.0.0&Format=image%2Fjpeg&TileMatrix={z}&TileCol={x}&TileRow={y}"
-    },
-    "decoupage-administratif": {
-      "type": "vector",
-      "url": "https://wxs.ign.fr/parcellaire/geoportail/wmts?layer=ADMINEXPRESS-COG-CARTO.LATEST&style=normal&tilematrixset=PM&Service=WMTS&Request=GetTile&Version=1.0.0&Format=image%2Fjpeg&TileMatrix={z}&TileCol={x}&TileRow={y}"
-    }
-  },
-  "sprite": "https://wxs.ign.fr/static/vectorTiles/styles/PLAN.IGN/sprite/PlanIgn",
-  "glyphs": "https://wxs.ign.fr/static/vectorTiles/styles/PLAN.IGN/sprite/PlanIgn",
-  "transition": {
-    "duration": 300,
-    "delay": 0
-   },
+	"transition": {
+		"duration": 300,
+		"delay": 0
+	},
+	"layers": [
+        {
+            "id": "bckgrd",
+             "type": "fill",
+             "source": "plan_ign",
+             "source-layer": "fond_opaque",
+             "minzoom": 0,
+             "layout": {
+                 "visibility": "visible"
+             },
+             "paint": {
+                 "fill-color": "#FFFFFF",
+                 "fill-opacity": 1
+             }
+        },
+        {
+			"id": "orographie : relief - 0m",
+			"type": "fill",
+			"source": "plan_ign",
+			"source-layer": "oro_relief",
+			"minzoom": 0,
+			"layout": {
+				"visibility": "visible"
+			},
+            "filter": ["==","symbo","HYPSO_0"],
+			"paint": {
+				"fill-color": "#D6E5BA",
+		        "fill-opacity": 1
+			}
+		},
+		{
+			"id": "orographie : relief - 100m",
+			"type": "fill",
+			"source": "plan_ign",
+			"source-layer": "oro_relief",
+			"minzoom": 0,
+			"layout": {
+				"visibility": "visible"
+			},
+            "filter": ["==","symbo","HYPSO_100"],
+			"paint": {
+				"fill-color": "#F7F2DA",
+		        "fill-opacity": 1
+			}
+		},
+		{
+			"id": "orographie : relief - 200m",
+			"type": "fill",
+			"source": "plan_ign",
+			"source-layer": "oro_relief",
+			"minzoom": 0,
+			"layout": {
+				"visibility": "visible"
+			},
+            "filter": ["==","symbo","HYPSO_200"],
+			"paint": {
+				"fill-color": "#EBDEBF",
+		        "fill-opacity": 1
+			}
+		},
+		{
+			"id": "orographie : relief - 1000m",
+			"type": "fill",
+			"source": "plan_ign",
+			"source-layer": "oro_relief",
+			"minzoom": 0,
+			"layout": {
+				"visibility": "visible"
+			},
+            "filter": ["==","symbo","HYPSO_1000"],
+			"paint": {
+				"fill-color": "#DABE97",
+		        "fill-opacity": 1
+			}
+		},
+		{
+			"id": "orographie : relief - 3000m",
+			"type": "fill",
+			"source": "plan_ign",
+			"source-layer": "oro_relief",
+			"minzoom": 0,
+			"layout": {
+				"visibility": "visible"
+			},
+            "filter": ["==","symbo","HYPSO_3000"],
+			"paint": {
+				"fill-color": "#B28773",
+		        "fill-opacity": 1
+			}
+		},
+		{
+			"id": "orographie : relief - 4000m",
+			"type": "fill",
+			"source": "plan_ign",
+			"source-layer": "oro_relief",
+			"minzoom": 0,
+			"layout": {
+				"visibility": "visible"
+			},
+            "filter": ["==","symbo","HYPSO_4000"],
+			"paint": {
+				"fill-color": "#9E6A54",
+		        "fill-opacity": 1
+			}
+		},
+		{
+			"id": "orographie : relief - 5000m",
+			"type": "fill",
+			"source": "plan_ign",
+			"source-layer": "oro_relief",
+			"minzoom": 0,
+			"layout": {
+				"visibility": "visible"
+			},
+            "filter": ["==","symbo","HYPSO_5000"],
+			"paint": {
+				"fill-color": "#773A2B",
+				"fill-opacity": 1
+			}
+		},
+		{
+			"id": "orographie : relief - glacier",
+			"type": "fill",
+			"source": "plan_ign",
+			"source-layer": "oro_relief",
+			"minzoom": 0,
+			"layout": {
+				"visibility": "visible"
+			},
+            "filter": ["==","symbo","GLACIER"],
+			"paint": {
+				"fill-color": "#FFFFFF",
+				"fill-opacity": 0.7
+			}
+		},
+        {
+            "id": "ocs - vegetation - zone boiséee, foret fermee, peupleraie",
+            "type": "fill",
+            "source": "plan_ign",
+            "source-layer": "ocs_vegetation_surf",
+            "layout": {
+                "visibility": "visible"
+            },
+            "filter": ["in","symbo",
+                                    "ZONE_BOISEE",
+                                    "ZONE_FORET_FERMEE_FEUIL",
+                                    "ZONE_FORET_FERMEE_CONI",
+                                    "ZONE_FORET_FERMEE_MIXTE",
+                                    "ZONE_PEUPLERAIE"
+            ],
+            "paint": {
+                "fill-color": "#DFE8D5",
+				"fill-outline-color": "#DFE8D5"
+            }
+        },
+        {
+            "id": "ocs - vegetation - forêt ouverte",
+            "type": "fill",
+            "source": "plan_ign",
+            "source-layer": "ocs_vegetation_surf",
+            "layout": {
+                "visibility": "visible"
+            },
+            "filter": ["in","symbo",
+									"ZONE_FORET_OUVERTE"
+            ],
+            "paint": {
+                "fill-color": "#EDF2D9",
+				"fill-outline-color": "#EDF2D9"
+            }
+        },
+        {
+            "id": "ocs - vegetation - lande ligneuse",
+            "type": "fill",
+            "source": "plan_ign",
+            "source-layer": "ocs_vegetation_surf",
+            "layout": {
+                "visibility": "visible"
+            },
+            "filter": ["==","symbo","ZONE_LANDE_LIGNEUSE"],
+            "paint": {
+                "fill-color": "#F2EECD"
+            }
+        },
+        {
+            "id": "ocs - vegetation - vigne",
+            "type": "fill",
+            "source": "plan_ign",
+            "source-layer": "ocs_vegetation_surf",
+            "layout": {
+                "visibility": "visible"
+            },
+            "filter": ["==","symbo","ZONE_VIGNE"],
+            "paint": {
+                "fill-color": "#FFEDD9"
+            }
+        },
+        {
+            "id": "ocs - vegetation - verger",
+            "type": "fill",
+            "source": "plan_ign",
+            "source-layer": "ocs_vegetation_surf",
+            "layout": {
+                "visibility": "visible"
+            },
+            "filter": ["==","symbo","ZONE_VERGER"],
+            "paint": {
+                "fill-color": "#FAE2C5"
+            }
+        },
+        {
+            "id": "ocs - vegetation - canne à sucre, bananeraie",
+            "type": "fill",
+            "source": "plan_ign",
+            "source-layer": "ocs_vegetation_surf",
+            "layout": {
+                "visibility": "visible"
+            },
+            "filter": ["==","symbo","ZONE_CANNE_BANANE"],
+            "paint": {
+                "fill-color": "#FAEDFA"
+            }
+        },
+        {
+			"id": "hydro surfacique - Estran",
+			"type": "fill",
+			"source": "plan_ign",
+			"source-layer": "hydro_surf",
+			"layout": {
+				"visibility": "visible"
+			},
+            "filter": ["==","symbo","ZONE_D_ESTRAN"],
+			"paint": {
+				"fill-color": "#C3DDE9",
+				"fill-outline-color": "#C3DDE9"
+			}
+		},
+        {
+            "id": "ocs - vegetation - mangrovre",
+            "type": "fill",
+            "source": "plan_ign",
+            "source-layer": "ocs_vegetation_surf",
+            "layout": {
+                "visibility": "visible"
+            },
+            "filter": ["==","symbo","ZONE_MANGROVE"],
+            "paint": {
+                "fill-color": {"stops": [[9, "#85CCCB"], [10, "#90CCCB"]]}
+            }
+        },
+        {
+            "id": "ocs - vegetation - marais",
+            "type": "fill",
+            "source": "plan_ign",
+            "source-layer": "ocs_vegetation_surf",
+            "layout": {
+                "visibility": "visible"
+            },
+            "filter": ["==","symbo","ZONE_MARAIS"],
+            "paint": {
+                "fill-pattern": "Marais"
+            }
+        },
+        {
+            "id": "ocs - vegetation - marais salant",
+            "type": "fill",
+            "source": "plan_ign",
+            "source-layer": "ocs_vegetation_surf",
+            "layout": {
+                "visibility": "visible"
+            },
+            "filter": ["==","symbo","ZONE_MARAIS_SALANT"],
+            "paint": {
+                "fill-pattern": "MaraisSalant"
+            }
+        },
+        {
+            "id": "ocs - Zone",
+            "type": "fill",
+            "source": "plan_ign",
+            "source-layer": "ocs_nature_sol_surf",
+            "layout": {
+                "visibility": "visible"
+            },
+            "filter": ["==","symbo","ZONE_ROCHEUSE"],
+            "paint": {
+                "fill-color": "#D0D0D0",
+				"fill-opacity": 0.3
+            }
+        },
+        {
+            "id": "ocs - Zone sable sec",
+            "type": "fill",
+            "source": "plan_ign",
+            "source-layer": "ocs_nature_sol_surf",
+            "layout": {
+                "visibility": "visible"
+            },
+            "filter": ["==","symbo","ZONE_SABLE_SEC"],
+            "paint": {
+				"fill-pattern": "Sable"
+            }
+        },
+        {
+            "id": "ocs - Zone sable humide",
+            "type": "fill",
+            "source": "plan_ign",
+            "source-layer": "ocs_nature_sol_surf",
+            "layout": {
+                "visibility": "visible"
+            },
+            "filter": ["in","symbo",
+                                    "ZONE_SABLE_HUMIDE",
+                                    "FOND_CUVETTE_HUMIDE"
+            ],
+            "paint": {
+				"fill-pattern": "SableHumide"
+            }
+        },
+        {
+            "id": "ocs - Zone graviers galets secs",
+            "type": "fill",
+            "source": "plan_ign",
+            "source-layer": "ocs_nature_sol_surf",
+            "layout": {
+                "visibility": "visible"
+            },
+            "filter": ["==","symbo","GRAVIERS_GALETS_SEC"],
+            "paint": {
+				"fill-pattern": "GravierSec"
+            }
+        },
+        {
+            "id": "ocs - Zone graviers galets humides",
+            "type": "fill",
+            "source": "plan_ign",
+            "source-layer": "ocs_nature_sol_surf",
+            "layout": {
+                "visibility": "visible"
+            },
+            "filter": ["==","symbo","GRAVIERS_GALETS_HUM"],
+            "paint": {
+				"fill-pattern": "Gravier"
+            }
+        },
+        {
+            "id": "ocs - Zone rocher hydro",
+            "type": "fill",
+            "source": "plan_ign",
+            "source-layer": "ocs_nature_sol_surf",
+            "layout": {
+                "visibility": "visible"
+            },
+            "filter": ["==","symbo","ZONE_ROCHER_HYDRO"],
+            "paint": {
+				"fill-pattern": "RocherHydro"
+            }
+        },
+        {
+            "id": "ocs - Zone glacier",
+            "type": "fill",
+            "source": "plan_ign",
+            "source-layer": "ocs_nature_sol_surf",
+            "layout": {
+                "visibility": "visible"
+            },
+            "filter": ["==","symbo","ZONE_GLACIER"],
+            "paint": {
+				"fill-pattern": "Glacier",
+				"fill-opacity": {"stops": [[10, 0.5], [12, 0.3]]}
+            }
+        },
+        {
+            "id": "zone batie",
+            "type": "fill",
+            "source": "plan_ign",
+            "source-layer": "bati_zone_surf",
+			"minzoom": 7,
+			"maxzoom": 15,
+            "layout": {
+                "visibility": "visible"
+            },
+            "filter": ["==","symbo","ZONE_BATI"],
+            "paint": {
+                "fill-color": "#E8E2D1",
+                "fill-opacity": {"stops": [[12, 1], [13, 0.9], [14, 0.5]]}
+            }
+        },
+        {
+            "id": "zone d'activité",
+            "type": "fill",
+            "source": "plan_ign",
+            "source-layer": "bati_zone_surf",
+            "layout": {
+                "visibility": "visible"
+            },
+            "filter": ["==","symbo","ZONE_INDUS_ACTI"],
+            "paint": {
+                "fill-color": "#D9D9D9"
+            }
+        },
+        {
+            "id": "oro - courbe et cuvette maitresse",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "oro_courbe",
+            "maxzoom":16,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "CNV_MAITRESSE",
+                                    "CUVETTE_MAITRESSE"
+            ],
+			"paint": {
+				"line-color": "#D9C8A9",
+                "line-width": {
+					"stops": [[13, 1.7], [15, 2]]
+				}
+			}
+        },
+        {
+            "id": "oro - courbe et cuvette normale",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "oro_courbe",
+            "maxzoom":16,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "CNV_NORMALE",
+                                    "CUVETTE_NORMALE"
+            ],
+			"paint": {
+				"line-color": "#D9C8A9",
+                "line-width": {
+					"stops": [[13, 1], [15, 1.2]]
+				}
+			}
+        },
+        {
+            "id": "oro - courbe et cuvette intercalaire",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "oro_courbe",
+            "maxzoom":16,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "CNV_INTERCALAIRE",
+                                    "CUVETTE_INTERCAL",
+                                    "CNV_SS_INTERCALAIRE"
+            ],
+			"paint": {
+				"line-color": "#D9C8A9",
+                "line-width": 0.7,
+				"line-dasharray": [20,7]
+			}
+        },
+        {
+            "id": "oro - courbe et cuvette glacier maitresse",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "oro_courbe",
+            "maxzoom":16,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "CNV_GLACIER_MAITRESSE",
+                                    "CUV_GLACIER_MAITRESSE"
+            ],
+			"paint": {
+				"line-color": "#A4BFD9",
+                "line-width": {
+					"stops": [[13, 1.7], [15, 2]]
+				}
+			}
+        },
+        {
+            "id": "oro - courbe et cuvette glacier normale",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "oro_courbe",
+            "maxzoom":16,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "CNV_GLACIER_NORMALE",
+                                    "CUV_GLACIER_NORMALE"
+            ],
+			"paint": {
+				"line-color": "#A4BFD9",
+                "line-width": {
+					"stops": [[13, 1], [15, 1.2]]
+				}
+			}
+        },
+        {
+            "id": "oro - courbe et cuvette glacier intercalaire",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "oro_courbe",
+            "maxzoom":16,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "CNV_GLACIER_INTERCAL",
+                                    "CUV_GLACIER_INTERCAL"
+            ],
+			"paint": {
+				"line-color": "#A4BFD9",
+                "line-width": {
+					"stops": [[13, 0.7], [15, 0.9]]
+				},
+				"line-dasharray": [20,7]
+			}
+        },
+        {
+            "id": "oro - courbe et cuvette rocher maitresse",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "oro_courbe",
+            "maxzoom":16,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "CNV_ROCHER_MAITRESSE",
+                                    "CUV_ROCHER_MAITRESSE"
+            ],
+			"paint": {
+				"line-color": "#AAAAAA",
+                "line-width": 1.7
+            }
+        },
+        {
+            "id": "oro - courbe et cuvette rocher normale",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "oro_courbe",
+            "maxzoom":16,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "CNV_ROCHER_NORMALE",
+                                    "CUV_ROCHER_NORMALE"
+            ],
+			"paint": {
+				"line-color": "#AAAAAA",
+                "line-width": 1
+			}
+        },
+        {
+            "id": "oro - courbe et cuvette rocher intercalaire",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "oro_courbe",
+            "maxzoom":16,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "CNV_ROCHER_INTERCAL",
+                                    "CUV_ROCHER_INTERCAL"
+            ],
+			"paint": {
+				"line-color": "#AAAAAA",
+                "line-width": {
+					"stops": [[13, 0.7], [15, 0.9]]
+				},
+				"line-dasharray": [20,7]
+			}
+        },
+        {
+            "id": "oro - courbe et cuvette bathymetrique",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "oro_courbe",
+            "maxzoom":16,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "CNV_BATHYMETRIQUE",
+                                    "CUV_BATHYMETRIQUE"
+            ],
+			"paint": {
+				"line-color": "#0000FF",
+                "line-width": 1
+			}
+        },
+        {
+            "id": "oro lin - talus",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "oro_lin",
+			"minzoom": 14,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","TALUS"],
+			"paint": {
+				"line-color": "#D9C8A9",
+                "line-width": 1
+			}
+        },
+        {
+            "id": "oro lin - talus - trait perpendiculaire",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "oro_lin",
+			"minzoom": 14,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","TALUS"],
+			"paint": {
+				"line-color": "#D9C8A9",
+		        "line-width": {
+					"stops": [[14, 7], [16, 9]]
+				},
+				"line-dasharray": [0.1,1],
+                "line-translate": [0,4]
+			}
+        },
+		{
+            "id": "toponyme - cote de courbe normale",
+            "type": "symbol",
+            "source": "plan_ign",
+            "source-layer": "oro_courbe",
+			"minzoom":13,
+            "maxzoom":16,
+            "layout": {
+                "symbol-placement": "line",
+                "text-field": "{texte}",
+                "text-size": {"stops": [[13, 10], [15, 13]]},
+                "text-anchor": "center",
+                "text-rotation-alignment":"map",
+                "text-pitch-alignment": "viewport",
+                "text-keep-upright": false,
+                "text-max-angle": 20,
+                "text-max-width": 100,
+                "text-font": ["Source Sans Pro Italic"]
+            },
+            "filter": ["all",
+                        ["!=","texte","0"],
+                        ["==","hors_zone","true"],
+                        ["in","symbo",
+                                    "CNV_MAITRESSE",
+                                    "CUVETTE_MAITRESSE"
+                        ]
+            ],
+            "paint": {
+                "text-color": "#604A2F",
+                "text-halo-width": 0.5,
+                "text-halo-color": "#FFFFFF"
+            }
+        },
+		{
+            "id": "toponyme - cote de courbe rocher",
+            "type": "symbol",
+            "source": "plan_ign",
+            "source-layer": "oro_courbe",
+			"minzoom":13,
+            "maxzoom":16,
+            "layout": {
+                "symbol-placement": "line",
+                "text-field": "{texte}",
+                "text-size": {"stops": [[13, 10], [15, 13]]},
+                "text-anchor": "center",
+                "text-rotation-alignment":"map",
+                "text-pitch-alignment": "viewport",
+                "text-keep-upright": false,
+                "text-max-angle": 20,
+                "text-max-width": 100,
+                "text-font": ["Source Sans Pro Italic"]
+            },
+            "filter": ["all",
+                        ["!=","texte","0"],
+                        ["==","hors_zone","true"],
+                        ["in","symbo",
+                                    "CNV_ROCHER_MAITRESSE",
+                                    "CUV_ROCHER_MAITRESSE"
+                        ]
+            ],
+            "paint": {
+                "text-color": "#333333",
+                "text-halo-width": 0.5,
+                "text-halo-color": "#FFFFFF"
+            }
+        },
+		{
+            "id": "toponyme - cote de courbe glacier",
+            "type": "symbol",
+            "source": "plan_ign",
+            "source-layer": "oro_courbe",
+			"minzoom":13,
+            "maxzoom":16,
+            "layout": {
+                "symbol-placement": "line",
+                "text-field": "{texte}",
+                "text-size": {"stops": [[13, 10], [15, 13]]},
+                "text-anchor": "center",
+                "text-rotation-alignment":"map",
+                "text-pitch-alignment": "viewport",
+                "text-keep-upright": false,
+                "text-max-angle": 20,
+                "text-max-width": 100,
+                "text-font": ["Source Sans Pro Italic"]
+            },
+            "filter": ["all",
+                        ["!=","texte","0"],
+                        ["==","hors_zone","true"],
+                        ["in","symbo",
+                                    "CNV_GLACIER_MAITRESSE",
+									"CUV_GLACIER_MAITRESSE"
+                        ]
+            ],
+            "paint": {
+                "text-color": "#629FD9",
+                "text-halo-width": 0.5,
+                "text-halo-color": "#FFFFFF"
+            }
+        },
+        {
+			"id": "hydro surfacique",
+			"type": "fill",
+			"source": "plan_ign",
+			"source-layer": "hydro_surf",
+			"layout": {
+				"visibility": "visible"
+			},
+            "filter": ["in","symbo",
+                                    "SURFACE_D_EAU",
+                                    "BASSIN",
+                                    "ZONE_MARINE"
+            ],
+			"paint": {
+				"fill-color": "#AAD5E9",
+				"fill-outline-color": "#AAD5E9"
+			}
+		},
+        {
+			"id": "hydro surfacique temporaire",
+			"type": "fill",
+			"source": "plan_ign",
+			"source-layer": "hydro_surf",
+			"layout": {
+				"visibility": "visible"
+			},
+            "filter": ["==","symbo","SURFACE_D_EAU_TEMP"],
+			"paint": {
+				"fill-color": "rgba(168, 203, 220, 0.5)"
+			}
+		},
+		{
+			"id": "réseau hydro  - cours d'eau souterrain",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "hydro_reseau_sou",
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+            },
+            "filter": ["in","symbo",
+									"COURS_D_EAU_SOU",
+									"COURS_D_EAU_MOY_SOU"
+			],
+			"paint": {
+				"line-color": "#AAD5E9",
+		        "line-width": {
+					"stops": [[12, 1.5], [17, 6.5]]
+                },
+                "line-dasharray": [2,2]	
+			}
+		},
+        {
+			"id": "réseau hydro - filet interieur - aqueduc souterrain",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "hydro_reseau_sou",
+			"minzoom": 12,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","AQUEDUC_SOU"],
+			"paint": {
+				"line-color": "#AAD5E9",
+		        "line-width": {
+					"stops": [[12, 1.4], [16, 3.5], [17, 5.9]]
+				},
+				"line-dasharray": [2,2]
+			}
+		},
+		{
+			"id": "réseau hydro - carre - aqueduc souterrain",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "hydro_reseau_sou",
+			"minzoom": 12,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","AQUEDUC_SOU"],
+			"paint": {
+				"line-color": "#AAD5E9",
+		        "line-width": {
+					"stops": [[12, 3.5], [16, 8.7], [17, 14.7]]
+				},
+				"line-dasharray": [1,5]
+			}
+		},
+        {
+			"id": "Ferre souterrain - voie normale",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "ferre_sou",
+            "minzoom": 10,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "VF_1_SOU",
+									"VF_2_SOU",
+                                    "VF_ELEC_1_SOU",
+                                    "VF_FERRO_ROUTIER_SOU"
+            ],
+			"paint": {
+				"line-color": "#B4B4B4",
+		        "line-width": {
+					"stops": [[10, 0.8], [17, 2.5]]
+				}
+			}
+		},
+        {
+			"id": "Ferre souterrain - trait perpendic épais",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "ferre_sou",
+			"minzoom": 10,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "VF_1_SOU",
+                                    "VF_2_SOU",
+                                    "VF_ELEC_1_SOU",
+                                    "VF_FERRO_ROUTIER_SOU"
+            ],
+			"paint": {
+				"line-color": "#B4B4B4",
+		        "line-width": {
+					"stops": [[10, 3.5], [17, 14.7]]
+				},
+				"line-dasharray": [0.1,10]
+			}
+		},
+        {
+			"id": "Ferre souterrain - voie etroite",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "ferre_sou",
+			"minzoom": 10,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "VF_ETROITE_1_SOU",
+									"VF_ETROITE_SOU"
+            ],
+			"paint": {
+				"line-color": "#B4B4B4",
+		        "line-width": {
+					"stops": [[10, 0.3], [17, 1.8]]
+				}
+			}
+		},
+        {
+			"id": "Ferre souterrain - trait perpendic fin",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "ferre_sou",
+			"minzoom": 10,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "VF_ETROITE_1_SOU",
+									"VF_ETROITE_SOU"
+            ],
+			"paint": {
+				"line-color": "#B4B4B4",
+		        "line-width": {
+					"stops": [[10, 3.5], [17, 14.7]]
+				},
+				"line-dasharray": [0.1,10]
+			}
+		},
+        {
+			"id": "Ferre souterrain - voie service",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "ferre_sou",
+			"minzoom": 14,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "VF_SERVICE_SOU",
+                                    "VF_NON_EXPLOITEE_SOU"
+            ],
+			"paint": {
+				"line-color": "#B4B4B4",
+		        "line-width": {
+					"stops": [[10, 0.3], [17, 1.8]]
+				},
+				"line-dasharray": [5,2,1,2]
+			}
+		},
+        {
+        	"id": "Ferre souterrain - funic/urbain",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "ferre_sou",
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "FUNI_CREMAILLERE_SOU",
+                                    "TRANSPORT_URBAIN_SOU"
+            ],
+			"paint": {
+				"line-color": "#B4B4B4",
+		        "line-width": {
+					"stops": [[10, 0.3], [17, 1.8]]
+				}
+			}
+		},
+        {
+			"id": "Ferre souterrain - 2 trait perpendic - funic/urbain",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "ferre_sou",
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "FUNI_CREMAILLERE_SOU",
+                                    "TRANSPORT_URBAIN_SOU"
+            ],
+			"paint": {
+				"line-color": "#B4B4B4",
+		        "line-width": {
+					"stops": [[10, 3.5], [17, 17]]
+				},
+				"line-dasharray": [0.1,0.2,0.1,10]
+			}
+		},
+        {
+			"id": "Chemin souterrain - piste cyclable",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_chemin_sou",
+			"minzoom": 13,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+			"filter": ["==","symbo","PISTE_CYCLABLE_SOU"],
+			"paint": {
+				"line-color": "#AB81CC",
+		        "line-width": {
+				"stops": [[14, 1.1], [15, 1.7], [16, 2], [17, 3.5]]
+                },
+				"line-dasharray": [6,2]
+			}
+		},
+        {
+			"id": "Chemin souterrain - filet exterieur - escalier",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_chemin_sou",
+			"minzoom": 14,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+			"filter": ["==","symbo","ESCALIER_SOU"],
+			"paint": {
+				"line-color": "#B3989A",
+		        "line-width": {
+				"stops": [[14, 1.75], [15, 3], [16, 4.2], [17, 9.5]]
+                }
+			}
+		},
+        {
+			"id": "Chemin souterrain - filet interieur - escalier",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_chemin_sou",
+			"minzoom": 14,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+			"filter": ["==","symbo","ESCALIER_SOU"],
+			"paint": {
+				"line-color": "#FFFFFF",
+		        "line-width": {
+				"stops": [[14, 1], [15, 1.9], [16, 2.7], [17, 5.8]]
+                },
+				"line-dasharray": [1,0.2]
+			}
+		},
+        {
+			"id": "Chemin souterrain - Rue pietonne",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_chemin_sou",
+			"minzoom": 14,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+			"filter": ["==","symbo","RUE_PIETONNE_SOU"],
+			"paint": {
+				"line-color": "#B3989A",
+		        "line-width": {
+				"stops": [[14, 1], [15, 1.2], [16, 1.4], [17, 2]]
+                },
+				"line-dasharray": [1,3]
+			}
+		},
+        {
+			"id": "Chemin souterrain - sentier",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_chemin_sou",
+			"minzoom": 13,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+			"filter": ["==","symbo","SENTIER_SOU"],
+			"paint": {
+				"line-color": "#B3989A",
+		        "line-width": {
+				"stops": [[14, 1], [15, 1.2], [16, 1.4], [17, 2]]
+                },
+				"line-dasharray": [4,3]
+			}
+		},
+        {
+			"id": "Chemin souterrain - chemin",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_chemin_sou",
+			"minzoom": 12,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+			"filter": ["==","symbo","CHEMIN_SOU"],
+			"paint": {
+				"line-color": "#B3989A",
+		        "line-width": {
+				"stops": [[14, 1], [15, 1.2], [16, 1.4], [17, 2]]
+                }
+			}
+		},
+        {
+			"id": "Routier souterrain - filet extérieur - route non revetu carrosable",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route_sou",
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+			"filter": ["==","symbo","NON_REVETUE_CARRO_SOU"],
+			"paint": {
+				"line-color": "#AFAFAF",
+		        "line-width": {
+				"stops": [[14, 3.2], [15, 5.4], [16, 7.7], [17, 16.8]]
+                },
+				"line-dasharray": [2,2]
+			}
+		},
+        {
+			"id": "Routier souterrain - filet extérieur - bretelle autoroute",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route_sou",
+			"minzoom": 12,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "BRET_AUTO_PEAGE_3_SOU",
+                                    "BRET_AUTO_PEAGE_2_SOU",
+                                    "BRET_AUTO_PEAGE_1_SOU",
+                                    "BRET_AUTO_LIBRE_3_SOU",
+                                    "BRET_AUTO_LIBRE_2_SOU",
+                                    "BRET_AUTO_LIBRE_1_SOU"
+            ],
+			"paint": {
+				"line-color": "rgba(222, 70, 14, 0.5)",
+				"line-width": {
+					"stops": [[12, 2.5], [14, 3.7], [15, 6.8], [16, 8.4], [17, 14]]
+                }
+			}
+		},
+        {
+			"id": "Routier souterrain - filet extérieur - route non classee restreint",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route_sou",
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","NON_CLASSEE_RESTREINT_SOU"],
+			"paint": {
+				"line-color": "#AFAFAF",
+		        "line-width": {
+				"stops": [[14, 3.2], [15, 5.4], [16, 7.7], [17, 16.8]]
+                }
+			}
+		},
+        {
+			"id": "Routier souterrain - filet extérieur - route non classee",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route_sou",
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "NON_CLASSEE_4_SOU",
+                                    "NON_CLASSEE_SOU"
+            ],
+			"paint": {
+				"line-color": "#AFAFAF",
+		        "line-width": {
+				"stops": [[14, 3.2], [15, 5.4], [16, 7.7], [17, 16.8]]
+                }
+			}
+		},
+        {
+			"id": "Routier souterrain - filet extérieur - route locale",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route_sou",
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "BRET_LOCALE_SOU",
+                                    "LOCALE_4_SOU",
+                                    "LOCALE_3_SOU",
+                                    "LOCALE_2_SOU",
+                                    "LOCALE_1_SOU"
+            ],
+			"paint": {
+				"line-color": "rgba(130, 130, 130, 0.5)",
+		        "line-width": {
+				"stops": [[9, 2], [14, 3.5], [15, 6], [16, 8.4], [17, 18.3]]
+                }
+			}
+		},
+        {
+			"id": "Routier souterrain - filet extérieur - route locale en construction",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route_sou",
+			"minzoom": 11,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","LOCALE_CONSTR_SOU"],
+			"paint": {
+				"line-color": "#C8C8C8",
+		        "line-width": {
+				"stops": [[9, 2], [14, 3.5], [15, 6], [16, 8.4], [17, 18.3]]
+                }
+			}
+		},
+        {
+			"id": "Routier souterrain - filet extérieur - route regionale",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route_sou",
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "BRET_REGIONALE_SOU",
+                                    "REGIONALE_4_SOU",
+                                    "REGIONALE_3_SOU",
+                                    "REGIONALE_2_SOU",
+                                    "REGIONALE_1_SOU"
+            ],
+			"paint": {
+				"line-color": "rgba(130, 130, 130, 0.5)",
+		        "line-width": {
+					"stops": [[6, 1.5], [9, 2.3], [14, 5], [15, 8.1], [16, 11.2], [17, 22]]
+                }					
+			}
+		},
+        {
+			"id": "Routier souterrain - filet extérieur - route regionale en construction",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route_sou",
+			"minzoom": 10,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","REGIONALE_CONSTR_SOU"],
+			"paint": {
+				"line-color": "#C8C8C8",
+		        "line-width": {
+					"stops": [[6, 1.5], [9, 2.3], [14, 5], [15, 8.1], [16, 11.2], [17, 22]]
+                }					
+			}
+		},
+        {
+			"id": "Routier souterrain - filet extérieur - route principale",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route_sou",
+			"minzoom": 7,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "BRET_PRINCIPALE_SOU",
+                                    "PRINCIPALE_4_SOU",
+                                    "PRINCIPALE_3_SOU",
+                                    "PRINCIPALE_2_SOU",
+                                    "PRINCIPALE_1_SOU"
+            ],
+			"paint": {
+				"line-color": "rgba(222, 70, 14, 0.5)",
+		        "line-width": {
+                    "stops": [[6, 1.8], [9, 2.7], [14, 5.9], [15, 9], [16, 12.2], [17, 22.5]]
+                }
+			}
+		},
+        {
+			"id": "Routier souterrain - filet extérieur - route principale en construction",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route_sou",
+			"minzoom": 10,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","PRINCIPALE_CONSTR_SOU"],
+			"paint": {
+				"line-color": "#C8C8C8",
+		        "line-width": {
+					"stops": [[6, 1.8], [9, 2.7], [14, 5.9], [15, 9], [16, 12.2], [17, 22.5]]
+                }
+			}
+		},
+        {
+			"id": "Routier souterrain - filet extérieur - autoroute",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route_sou",
+			"minzoom": 7,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "AUTOROU_PEAGE_SOU",
+                                    "AUTOROU_LIBRE_SOU"
+            ],
+			"paint": {
+				"line-color": "rgba(222, 70, 14, 0.5)",
+		        "line-width": {
+					"stops": [[6, 2.5], [9, 3.5], [14, 7.5], [15, 11], [16, 15], [17, 26]]
+                }
+			}
+		},
+        {
+			"id": "Routier souterrain - filet extérieur - autoroute en construction",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route_sou",
+			"minzoom": 10,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+			"filter": ["==","symbo","AUTOROU_CONSTR_SOU"],
+			"paint": {
+				"line-color": "#C8C8C8",
+		        "line-width": {
+					"stops": [[6, 2.5], [9, 3.5], [14, 7.5], [15, 11], [16, 15], [17, 26]]
+                }
+			}
+		},
+        {
+			"id": "Routier souterrain - filet interieur - route non revetu carrosable",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route_sou",
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+			"filter": ["==","symbo","NON_REVETUE_CARRO_SOU"],
+			"paint": {
+				"line-color": "#DCDCDC",
+		        "line-width": {
+				"stops": [[14, 2.3], [15, 4.1], [16, 6.3], [17, 13.5]]
+                }
+			}
+		},
+        {
+			"id": "Routier souterrain - filet interieur - bretelle autoroute",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route_sou",
+			"minzoom": 12,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "BRET_AUTO_PEAGE_3_SOU",
+                                    "BRET_AUTO_PEAGE_2_SOU",
+                                    "BRET_AUTO_PEAGE_1_SOU",
+                                    "BRET_AUTO_LIBRE_3_SOU",
+                                    "BRET_AUTO_LIBRE_2_SOU",
+                                    "BRET_AUTO_LIBRE_1_SOU"
+            ],
+			"paint": {
+				"line-color": "rgba(255, 255, 255, 0.5)",
+				"line-width": {
+					"stops": [[12, 1.5], [14, 2.6], [15, 5.2], [16, 6.7], [17, 10.8]]
+                }
+			}
+		},
+        {
+			"id": "Routier souterrain - filet interieur - route non classee restreint",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route_sou",
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","NON_CLASSEE_RESTREINT_SOU"],
+			"paint": {
+				"line-color": "#F2F5FF",
+		        "line-width": {
+				"stops": [[14, 2.3], [15, 4.1], [16, 6.3], [17, 13.5]]
+                }
+			}
+		},
+        {
+			"id": "Routier souterrain - filet interieur - route non classee",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route_sou",
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "NON_CLASSEE_4_SOU",
+                                    "NON_CLASSEE_SOU"
+            ],
+			"paint": {
+				"line-color": "#DCDCDC",
+		        "line-width": {
+				"stops": [[14, 2.3], [15, 4.1], [16, 6.3], [17, 13.5]]
+                }
+			}
+		},
+        {
+			"id": "Routier souterrain - filet interieur - route locale",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route_sou",
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "BRET_LOCALE_SOU",
+                                    "LOCALE_4_SOU",
+                                    "LOCALE_3_SOU",
+                                    "LOCALE_2_SOU",
+                                    "LOCALE_1_SOU"
+            ],
+			"paint": {
+				"line-color": "rgba(255, 255, 255, 0.5)",
+		        "line-width": {
+				"stops": [[9, 1.3], [14, 2.3], [15, 4.1], [16, 6.1], [17, 13.1]]
+                }
+			}
+		},
+        {
+			"id": "Routier souterrain - filet interieur - route locale en construction",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route_sou",
+			"minzoom": 11,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","LOCALE_CONSTR_SOU"],
+			"paint": {
+				"line-color": {
+                    "stops": [[12, "#FFFFFF"], [13, "#FCF4A8"], [17, "#FCF7C1"]]
+                },
+		        "line-width": {
+				"stops": [[9, 2], [14, 3.5], [15, 6], [16, 8.4], [17, 18.3]]
+                },
+				"line-dasharray": [2, 2]
 
-"layers": [
-   {
-    "id": "bckgrd",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "fond_opaque",
-    "minzoom": 0,
-    "layout": {
-     "visibility": "visible"
-    },
-    "paint": {
-     "fill-color": "#ffffff",
-     "fill-opacity": 1
-    }
-   },
-   {
-    "id": "orographie : relief - 0m",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "oro_relief",
-    "minzoom": 0,
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "HYPSO_0"
-    ],
-    "paint": {
-     "fill-color": "#D6E5BA",
-     "fill-opacity": 1
-    }
-   },
-   {
-    "id": "orographie : relief - 100m",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "oro_relief",
-    "minzoom": 0,
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "HYPSO_100"
-    ],
-    "paint": {
-     "fill-color": "#F7F2DA",
-     "fill-opacity": 1
-    }
-   },
-   {
-    "id": "orographie : relief - 200m",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "oro_relief",
-    "minzoom": 0,
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "HYPSO_200"
-    ],
-    "paint": {
-     "fill-color": "#EBDEBF",
-     "fill-opacity": 1
-    }
-   },
-   {
-    "id": "orographie : relief - 1000m",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "oro_relief",
-    "minzoom": 0,
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "HYPSO_1000"
-    ],
-    "paint": {
-     "fill-color": "#DABE97",
-     "fill-opacity": 1
-    }
-   },
-   {
-    "id": "orographie : relief - 3000m",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "oro_relief",
-    "minzoom": 0,
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "HYPSO_3000"
-    ],
-    "paint": {
-     "fill-color": "#B28773",
-     "fill-opacity": 1
-    }
-   },
-   {
-    "id": "orographie : relief - 4000m",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "oro_relief",
-    "minzoom": 0,
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "HYPSO_4000"
-    ],
-    "paint": {
-     "fill-color": "#9E6A54",
-     "fill-opacity": 1
-    }
-   },
-   {
-    "id": "orographie : relief - 5000m",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "oro_relief",
-    "minzoom": 0,
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "HYPSO_5000"
-    ],
-    "paint": {
-     "fill-color": "#773A2B",
-     "fill-opacity": 1
-    }
-   },
-   {
-    "id": "orographie : relief - glacier",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "oro_relief",
-    "minzoom": 0,
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "GLACIER"
-    ],
-    "paint": {
-     "fill-color": "#FFFFFF",
-     "fill-opacity": 0.7
-    }
-   },
-   {
-    "id": "ocs - vegetation - zone boiséee, foret fermee, peupleraie",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "ocs_vegetation_surf",
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "ZONE_BOISEE",
-     "ZONE_FORET_FERMEE_FEUIL",
-     "ZONE_FORET_FERMEE_CONI",
-     "ZONE_FORET_FERMEE_MIXTE",
-     "ZONE_PEUPLERAIE"
-    ],
-    "paint": {
-     "fill-color": "#DFE8D5",
-     "fill-outline-color": "#DFE8D5"
-    }
-   },
-   {
-    "id": "ocs - vegetation - forêt ouverte",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "ocs_vegetation_surf",
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "ZONE_FORET_OUVERTE"
-    ],
-    "paint": {
-     "fill-color": "#EDF2D9",
-     "fill-outline-color": "#EDF2D9"
-    }
-   },
-   {
-    "id": "ocs - vegetation - lande ligneuse",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "ocs_vegetation_surf",
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "ZONE_LANDE_LIGNEUSE"
-    ],
-    "paint": {
-     "fill-color": "#F2EECD"
-    }
-   },
-   {
-    "id": "ocs - vegetation - vigne",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "ocs_vegetation_surf",
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "ZONE_VIGNE"
-    ],
-    "paint": {
-     "fill-color": "#FFEDD9"
-    }
-   },
-   {
-    "id": "ocs - vegetation - verger",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "ocs_vegetation_surf",
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "ZONE_VERGER"
-    ],
-    "paint": {
-     "fill-color": "#FAE2C5"
-    }
-   },
-   {
-    "id": "ocs - vegetation - canne à sucre, bananeraie",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "ocs_vegetation_surf",
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "ZONE_CANNE_BANANE"
-    ],
-    "paint": {
-     "fill-color": "#FAEDFA"
-    }
-   },
-   {
-    "id": "hydro surfacique - Estran",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "hydro_surf",
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "ZONE_D_ESTRAN"
-    ],
-    "paint": {
-     "fill-color": "#C3DDE9",
-     "fill-outline-color": "#C3DDE9"
-    }
-   },
-   {
-    "id": "ocs - vegetation - mangrovre",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "ocs_vegetation_surf",
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "ZONE_MANGROVE"
-    ],
-    "paint": {
-     "fill-color": {
-      "stops": [
-       [
-        9,
-        "#85CCCB"
-       ],
-       [
-        10,
-        "#90CCCB"
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "ocs - vegetation - marais",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "ocs_vegetation_surf",
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "ZONE_MARAIS"
-    ],
-    "paint": {
-     "fill-pattern": "Marais"
-    }
-   },
-   {
-    "id": "ocs - vegetation - marais salant",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "ocs_vegetation_surf",
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "ZONE_MARAIS_SALANT"
-    ],
-    "paint": {
-     "fill-pattern": "MaraisSalant"
-    }
-   },
-   {
-    "id": "ocs - Zone",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "ocs_nature_sol_surf",
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "ZONE_ROCHEUSE"
-    ],
-    "paint": {
-     "fill-color": "#D0D0D0",
-     "fill-opacity": 0.3
-    }
-   },
-   {
-    "id": "ocs - Zone sable sec",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "ocs_nature_sol_surf",
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "ZONE_SABLE_SEC"
-    ],
-    "paint": {
-     "fill-pattern": "Sable"
-    }
-   },
-   {
-    "id": "ocs - Zone sable humide",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "ocs_nature_sol_surf",
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "ZONE_SABLE_HUMIDE",
-     "FOND_CUVETTE_HUMIDE"
-    ],
-    "paint": {
-     "fill-pattern": "SableHumide"
-    }
-   },
-   {
-    "id": "ocs - Zone graviers galets secs",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "ocs_nature_sol_surf",
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "GRAVIERS_GALETS_SEC"
-    ],
-    "paint": {
-     "fill-pattern": "GravierSec"
-    }
-   },
-   {
-    "id": "ocs - Zone graviers galets humides",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "ocs_nature_sol_surf",
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "GRAVIERS_GALETS_HUM"
-    ],
-    "paint": {
-     "fill-pattern": "Gravier"
-    }
-   },
-   {
-    "id": "ocs - Zone rocher hydro",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "ocs_nature_sol_surf",
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "ZONE_ROCHER_HYDRO"
-    ],
-    "paint": {
-     "fill-pattern": "RocherHydro"
-    }
-   },
-   {
-    "id": "ocs - Zone glacier",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "ocs_nature_sol_surf",
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "ZONE_GLACIER"
-    ],
-    "paint": {
-     "fill-pattern": "Glacier",
-     "fill-opacity": {
-      "stops": [
-       [
-        10,
-        0.5
-       ],
-       [
-        12,
-        0.3
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "zone batie",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "bati_zone_surf",
-    "minzoom": 7,
-    "maxzoom": 15,
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "ZONE_BATI"
-    ],
-    "paint": {
-     "fill-color": "#E8E2D1",
-     "fill-opacity": {
-      "stops": [
-       [
-        12,
-        1
-       ],
-       [
-        13,
-        0.9
-       ],
-       [
-        14,
-        0.5
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "zone d'activité",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "bati_zone_surf",
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "ZONE_INDUS_ACTI"
-    ],
-    "paint": {
-     "fill-color": "#D9D9D9"
-    }
-   },
-   {
-    "id": "oro - courbe et cuvette maitresse",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "oro_courbe",
-    "maxzoom": 16,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "CNV_MAITRESSE",
-     "CUVETTE_MAITRESSE"
-    ],
-    "paint": {
-     "line-color": "#D9C8A9",
-     "line-width": {
-      "stops": [
-       [
-        13,
-        1.7
-       ],
-       [
-        15,
-        2
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "oro - courbe et cuvette normale",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "oro_courbe",
-    "maxzoom": 16,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "CNV_NORMALE",
-     "CUVETTE_NORMALE"
-    ],
-    "paint": {
-     "line-color": "#D9C8A9",
-     "line-width": {
-      "stops": [
-       [
-        13,
-        1
-       ],
-       [
-        15,
-        1.2
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "oro - courbe et cuvette intercalaire",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "oro_courbe",
-    "maxzoom": 16,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "CNV_INTERCALAIRE",
-     "CUVETTE_INTERCAL",
-     "CNV_SS_INTERCALAIRE"
-    ],
-    "paint": {
-     "line-color": "#D9C8A9",
-     "line-width": 0.7,
-     "line-dasharray": [
-      20,
-      7
-     ]
-    }
-   },
-   {
-    "id": "oro - courbe et cuvette glacier maitresse",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "oro_courbe",
-    "maxzoom": 16,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "CNV_GLACIER_MAITRESSE",
-     "CUV_GLACIER_MAITRESSE"
-    ],
-    "paint": {
-     "line-color": "#A4BFD9",
-     "line-width": {
-      "stops": [
-       [
-        13,
-        1.7
-       ],
-       [
-        15,
-        2
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "oro - courbe et cuvette glacier normale",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "oro_courbe",
-    "maxzoom": 16,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "CNV_GLACIER_NORMALE",
-     "CUV_GLACIER_NORMALE"
-    ],
-    "paint": {
-     "line-color": "#A4BFD9",
-     "line-width": {
-      "stops": [
-       [
-        13,
-        1
-       ],
-       [
-        15,
-        1.2
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "oro - courbe et cuvette glacier intercalaire",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "oro_courbe",
-    "maxzoom": 16,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "CNV_GLACIER_INTERCAL",
-     "CUV_GLACIER_INTERCAL"
-    ],
-    "paint": {
-     "line-color": "#A4BFD9",
-     "line-width": {
-      "stops": [
-       [
-        13,
-        0.7
-       ],
-       [
-        15,
-        0.9
-       ]
-      ]
-     },
-     "line-dasharray": [
-      20,
-      7
-     ]
-    }
-   },
-   {
-    "id": "oro - courbe et cuvette rocher maitresse",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "oro_courbe",
-    "maxzoom": 16,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "CNV_ROCHER_MAITRESSE",
-     "CUV_ROCHER_MAITRESSE"
-    ],
-    "paint": {
-     "line-color": "#AAAAAA",
-     "line-width": 1.7
-    }
-   },
-   {
-    "id": "oro - courbe et cuvette rocher normale",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "oro_courbe",
-    "maxzoom": 16,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "CNV_ROCHER_NORMALE",
-     "CUV_ROCHER_NORMALE"
-    ],
-    "paint": {
-     "line-color": "#AAAAAA",
-     "line-width": 1
-    }
-   },
-   {
-    "id": "oro - courbe et cuvette rocher intercalaire",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "oro_courbe",
-    "maxzoom": 16,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "CNV_ROCHER_INTERCAL",
-     "CUV_ROCHER_INTERCAL"
-    ],
-    "paint": {
-     "line-color": "#AAAAAA",
-     "line-width": {
-      "stops": [
-       [
-        13,
-        0.7
-       ],
-       [
-        15,
-        0.9
-       ]
-      ]
-     },
-     "line-dasharray": [
-      20,
-      7
-     ]
-    }
-   },
-   {
-    "id": "oro - courbe et cuvette bathymetrique",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "oro_courbe",
-    "maxzoom": 16,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "CNV_BATHYMETRIQUE",
-     "CUV_BATHYMETRIQUE"
-    ],
-    "paint": {
-     "line-color": "#0000FF",
-     "line-width": 1
-    }
-   },
-   {
-    "id": "oro lin - talus",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "oro_lin",
-    "minzoom": 14,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "TALUS"
-    ],
-    "paint": {
-     "line-color": "#D9C8A9",
-     "line-width": 1
-    }
-   },
-   {
-    "id": "oro lin - talus - trait perpendiculaire",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "oro_lin",
-    "minzoom": 14,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "TALUS"
-    ],
-    "paint": {
-     "line-color": "#D9C8A9",
-     "line-width": {
-      "stops": [
-       [
-        14,
-        7
-       ],
-       [
-        16,
-        9
-       ]
-      ]
-     },
-     "line-dasharray": [
-      0.1,
-      1
-     ],
-     "line-translate": [
-      0,
-      4
-     ]
-    }
-   },
-   {
-    "id": "toponyme - cote de courbe normale",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "oro_courbe",
-    "minzoom": 13,
-    "maxzoom": 16,
-    "layout": {
-     "symbol-placement": "line",
-     "text-field": "{texte}",
-     "text-size": {
-      "stops": [
-       [
-        13,
-        10
-       ],
-       [
-        15,
-        13
-       ]
-      ]
-     },
-     "text-anchor": "center",
-     "text-rotation-alignment": "map",
-     "text-pitch-alignment": "viewport",
-     "text-keep-upright": false,
-     "text-max-angle": 20,
-     "text-max-width": 100,
-     "text-font": [
-      "Source Sans Pro Italic"
-     ]
-    },
-    "filter": [
-     "all",
-     [
-      "!=",
-      "texte",
-      "0"
-     ],
-     [
-      "==",
-      "hors_zone",
-      "true"
-     ],
-     [
-      "in",
-      "symbo",
-      "CNV_MAITRESSE",
-      "CUVETTE_MAITRESSE"
-     ]
-    ],
-    "paint": {
-     "text-color": "#604A2F",
-     "text-halo-width": 0.5,
-     "text-halo-color": "#FFFFFF"
-    }
-   },
-   {
-    "id": "toponyme - cote de courbe rocher",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "oro_courbe",
-    "minzoom": 13,
-    "maxzoom": 16,
-    "layout": {
-     "symbol-placement": "line",
-     "text-field": "{texte}",
-     "text-size": {
-      "stops": [
-       [
-        13,
-        10
-       ],
-       [
-        15,
-        13
-       ]
-      ]
-     },
-     "text-anchor": "center",
-     "text-rotation-alignment": "map",
-     "text-pitch-alignment": "viewport",
-     "text-keep-upright": false,
-     "text-max-angle": 20,
-     "text-max-width": 100,
-     "text-font": [
-      "Source Sans Pro Italic"
-     ]
-    },
-    "filter": [
-     "all",
-     [
-      "!=",
-      "texte",
-      "0"
-     ],
-     [
-      "==",
-      "hors_zone",
-      "true"
-     ],
-     [
-      "in",
-      "symbo",
-      "CNV_ROCHER_MAITRESSE",
-      "CUV_ROCHER_MAITRESSE"
-     ]
-    ],
-    "paint": {
-     "text-color": "#333333",
-     "text-halo-width": 0.5,
-     "text-halo-color": "#FFFFFF"
-    }
-   },
-   {
-    "id": "toponyme - cote de courbe glacier",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "oro_courbe",
-    "minzoom": 13,
-    "maxzoom": 16,
-    "layout": {
-     "symbol-placement": "line",
-     "text-field": "{texte}",
-     "text-size": {
-      "stops": [
-       [
-        13,
-        10
-       ],
-       [
-        15,
-        13
-       ]
-      ]
-     },
-     "text-anchor": "center",
-     "text-rotation-alignment": "map",
-     "text-pitch-alignment": "viewport",
-     "text-keep-upright": false,
-     "text-max-angle": 20,
-     "text-max-width": 100,
-     "text-font": [
-      "Source Sans Pro Italic"
-     ]
-    },
-    "filter": [
-     "all",
-     [
-      "!=",
-      "texte",
-      "0"
-     ],
-     [
-      "==",
-      "hors_zone",
-      "true"
-     ],
-     [
-      "in",
-      "symbo",
-      "CNV_GLACIER_MAITRESSE",
-      "CUV_GLACIER_MAITRESSE"
-     ]
-    ],
-    "paint": {
-     "text-color": "#629FD9",
-     "text-halo-width": 0.5,
-     "text-halo-color": "#FFFFFF"
-    }
-   },
-   {
-    "id": "hydro surfacique",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "hydro_surf",
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "SURFACE_D_EAU",
-     "BASSIN",
-     "ZONE_MARINE"
-    ],
-    "paint": {
-     "fill-color": "#AAD5E9",
-     "fill-outline-color": "#AAD5E9"
-    }
-   },
-   {
-    "id": "hydro surfacique temporaire",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "hydro_surf",
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "SURFACE_D_EAU_TEMP"
-    ],
-    "paint": {
-     "fill-color": "rgba(168, 203, 220, 0.5)"
-    }
-   },
-   {
-    "id": "réseau hydro  - cours d'eau souterrain",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "hydro_reseau_sou",
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "COURS_D_EAU_SOU",
-     "COURS_D_EAU_MOY_SOU"
-    ],
-    "paint": {
-     "line-color": "#AAD5E9",
-     "line-width": {
-      "stops": [
-       [
-        12,
-        1.5
-       ],
-       [
-        17,
-        6.5
-       ]
-      ]
-     },
-     "line-dasharray": [
-      2,
-      2
-     ]
-    }
-   },
-   {
-    "id": "réseau hydro - filet interieur - aqueduc souterrain",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "hydro_reseau_sou",
-    "minzoom": 12,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "AQUEDUC_SOU"
-    ],
-    "paint": {
-     "line-color": "#AAD5E9",
-     "line-width": {
-      "stops": [
-       [
-        12,
-        1.4
-       ],
-       [
-        16,
-        3.5
-       ],
-       [
-        17,
-        5.9
-       ]
-      ]
-     },
-     "line-dasharray": [
-      2,
-      2
-     ]
-    }
-   },
-   {
-    "id": "réseau hydro - carre - aqueduc souterrain",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "hydro_reseau_sou",
-    "minzoom": 12,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "AQUEDUC_SOU"
-    ],
-    "paint": {
-     "line-color": "#AAD5E9",
-     "line-width": {
-      "stops": [
-       [
-        12,
-        3.5
-       ],
-       [
-        16,
-        8.7
-       ],
-       [
-        17,
-        14.7
-       ]
-      ]
-     },
-     "line-dasharray": [
-      1,
-      5
-     ]
-    }
-   },
-   {
-    "id": "Ferre souterrain - voie normale",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "ferre_sou",
-    "minzoom": 10,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "VF_1_SOU",
-     "VF_2_SOU",
-     "VF_ELEC_1_SOU",
-     "VF_FERRO_ROUTIER_SOU"
-    ],
-    "paint": {
-     "line-color": "#B4B4B4",
-     "line-width": {
-      "stops": [
-       [
-        10,
-        0.8
-       ],
-       [
-        17,
-        2.5
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Ferre souterrain - trait perpendic épais",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "ferre_sou",
-    "minzoom": 10,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "VF_1_SOU",
-     "VF_2_SOU",
-     "VF_ELEC_1_SOU",
-     "VF_FERRO_ROUTIER_SOU"
-    ],
-    "paint": {
-     "line-color": "#B4B4B4",
-     "line-width": {
-      "stops": [
-       [
-        10,
-        3.5
-       ],
-       [
-        17,
-        14.7
-       ]
-      ]
-     },
-     "line-dasharray": [
-      0.1,
-      10
-     ]
-    }
-   },
-   {
-    "id": "Ferre souterrain - voie etroite",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "ferre_sou",
-    "minzoom": 10,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "VF_ETROITE_1_SOU",
-     "VF_ETROITE_SOU"
-    ],
-    "paint": {
-     "line-color": "#B4B4B4",
-     "line-width": {
-      "stops": [
-       [
-        10,
-        0.3
-       ],
-       [
-        17,
-        1.8
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Ferre souterrain - trait perpendic fin",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "ferre_sou",
-    "minzoom": 10,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "VF_ETROITE_1_SOU",
-     "VF_ETROITE_SOU"
-    ],
-    "paint": {
-     "line-color": "#B4B4B4",
-     "line-width": {
-      "stops": [
-       [
-        10,
-        3.5
-       ],
-       [
-        17,
-        14.7
-       ]
-      ]
-     },
-     "line-dasharray": [
-      0.1,
-      10
-     ]
-    }
-   },
-   {
-    "id": "Ferre souterrain - voie service",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "ferre_sou",
-    "minzoom": 14,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "VF_SERVICE_SOU",
-     "VF_NON_EXPLOITEE_SOU"
-    ],
-    "paint": {
-     "line-color": "#B4B4B4",
-     "line-width": {
-      "stops": [
-       [
-        10,
-        0.3
-       ],
-       [
-        17,
-        1.8
-       ]
-      ]
-     },
-     "line-dasharray": [
-      5,
-      2,
-      1,
-      2
-     ]
-    }
-   },
-   {
-    "id": "Ferre souterrain - funic/urbain",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "ferre_sou",
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "FUNI_CREMAILLERE_SOU",
-     "TRANSPORT_URBAIN_SOU"
-    ],
-    "paint": {
-     "line-color": "#B4B4B4",
-     "line-width": {
-      "stops": [
-       [
-        10,
-        0.3
-       ],
-       [
-        17,
-        1.8
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Ferre souterrain - 2 trait perpendic - funic/urbain",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "ferre_sou",
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "FUNI_CREMAILLERE_SOU",
-     "TRANSPORT_URBAIN_SOU"
-    ],
-    "paint": {
-     "line-color": "#B4B4B4",
-     "line-width": {
-      "stops": [
-       [
-        10,
-        3.5
-       ],
-       [
-        17,
-        17
-       ]
-      ]
-     },
-     "line-dasharray": [
-      0.1,
-      0.2,
-      0.1,
-      10
-     ]
-    }
-   },
-   {
-    "id": "Chemin souterrain - piste cyclable",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_chemin_sou",
-    "minzoom": 13,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "PISTE_CYCLABLE_SOU"
-    ],
-    "paint": {
-     "line-color": "#AB81CC",
-     "line-width": {
-      "stops": [
-       [
-        14,
-        1.1
-       ],
-       [
-        15,
-        1.7
-       ],
-       [
-        16,
-        2
-       ],
-       [
-        17,
-        3.5
-       ]
-      ]
-     },
-     "line-dasharray": [
-      6,
-      2
-     ]
-    }
-   },
-   {
-    "id": "Chemin souterrain - filet exterieur - escalier",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_chemin_sou",
-    "minzoom": 14,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "ESCALIER_SOU"
-    ],
-    "paint": {
-     "line-color": "#B3989A",
-     "line-width": {
-      "stops": [
-       [
-        14,
-        1.75
-       ],
-       [
-        15,
-        3
-       ],
-       [
-        16,
-        4.2
-       ],
-       [
-        17,
-        9.5
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Chemin souterrain - filet interieur - escalier",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_chemin_sou",
-    "minzoom": 14,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "ESCALIER_SOU"
-    ],
-    "paint": {
-     "line-color": "#FFFFFF",
-     "line-width": {
-      "stops": [
-       [
-        14,
-        1
-       ],
-       [
-        15,
-        1.9
-       ],
-       [
-        16,
-        2.7
-       ],
-       [
-        17,
-        5.8
-       ]
-      ]
-     },
-     "line-dasharray": [
-      1,
-      0.2
-     ]
-    }
-   },
-   {
-    "id": "Chemin souterrain - Rue pietonne",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_chemin_sou",
-    "minzoom": 14,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "RUE_PIETONNE_SOU"
-    ],
-    "paint": {
-     "line-color": "#B3989A",
-     "line-width": {
-      "stops": [
-       [
-        14,
-        1
-       ],
-       [
-        15,
-        1.2
-       ],
-       [
-        16,
-        1.4
-       ],
-       [
-        17,
-        2
-       ]
-      ]
-     },
-     "line-dasharray": [
-      1,
-      3
-     ]
-    }
-   },
-   {
-    "id": "Chemin souterrain - sentier",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_chemin_sou",
-    "minzoom": 13,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "SENTIER_SOU"
-    ],
-    "paint": {
-     "line-color": "#B3989A",
-     "line-width": {
-      "stops": [
-       [
-        14,
-        1
-       ],
-       [
-        15,
-        1.2
-       ],
-       [
-        16,
-        1.4
-       ],
-       [
-        17,
-        2
-       ]
-      ]
-     },
-     "line-dasharray": [
-      4,
-      3
-     ]
-    }
-   },
-   {
-    "id": "Chemin souterrain - chemin",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_chemin_sou",
-    "minzoom": 12,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "CHEMIN_SOU"
-    ],
-    "paint": {
-     "line-color": "#B3989A",
-     "line-width": {
-      "stops": [
-       [
-        14,
-        1
-       ],
-       [
-        15,
-        1.2
-       ],
-       [
-        16,
-        1.4
-       ],
-       [
-        17,
-        2
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier souterrain - filet extérieur - route non revetu carrosable",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route_sou",
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "NON_REVETUE_CARRO_SOU"
-    ],
-    "paint": {
-     "line-color": "#AFAFAF",
-     "line-width": {
-      "stops": [
-       [
-        14,
-        3.2
-       ],
-       [
-        15,
-        5.4
-       ],
-       [
-        16,
-        7.7
-       ],
-       [
-        17,
-        16.8
-       ]
-      ]
-     },
-     "line-dasharray": [
-      2,
-      2
-     ]
-    }
-   },
-   {
-    "id": "Routier souterrain - filet extérieur - bretelle autoroute",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route_sou",
-    "minzoom": 12,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "BRET_AUTO_PEAGE_3_SOU",
-     "BRET_AUTO_PEAGE_2_SOU",
-     "BRET_AUTO_PEAGE_1_SOU",
-     "BRET_AUTO_LIBRE_3_SOU",
-     "BRET_AUTO_LIBRE_2_SOU",
-     "BRET_AUTO_LIBRE_1_SOU"
-    ],
-    "paint": {
-     "line-color": "rgba(222, 70, 14, 0.5)",
-     "line-width": {
-      "stops": [
-       [
-        12,
-        2.5
-       ],
-       [
-        14,
-        3.7
-       ],
-       [
-        15,
-        6.8
-       ],
-       [
-        16,
-        8.4
-       ],
-       [
-        17,
-        14
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier souterrain - filet extérieur - route non classee restreint",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route_sou",
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "NON_CLASSEE_RESTREINT_SOU"
-    ],
-    "paint": {
-     "line-color": "#AFAFAF",
-     "line-width": {
-      "stops": [
-       [
-        14,
-        3.2
-       ],
-       [
-        15,
-        5.4
-       ],
-       [
-        16,
-        7.7
-       ],
-       [
-        17,
-        16.8
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier souterrain - filet extérieur - route non classee",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route_sou",
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "NON_CLASSEE_4_SOU",
-     "NON_CLASSEE_SOU"
-    ],
-    "paint": {
-     "line-color": "#AFAFAF",
-     "line-width": {
-      "stops": [
-       [
-        14,
-        3.2
-       ],
-       [
-        15,
-        5.4
-       ],
-       [
-        16,
-        7.7
-       ],
-       [
-        17,
-        16.8
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier souterrain - filet extérieur - route locale",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route_sou",
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "BRET_LOCALE_SOU",
-     "LOCALE_4_SOU",
-     "LOCALE_3_SOU",
-     "LOCALE_2_SOU",
-     "LOCALE_1_SOU"
-    ],
-    "paint": {
-     "line-color": "rgba(130, 130, 130, 0.5)",
-     "line-width": {
-      "stops": [
-       [
-        9,
-        2
-       ],
-       [
-        14,
-        3.5
-       ],
-       [
-        15,
-        6
-       ],
-       [
-        16,
-        8.4
-       ],
-       [
-        17,
-        18.3
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier souterrain - filet extérieur - route locale en construction",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route_sou",
-    "minzoom": 11,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "LOCALE_CONSTR_SOU"
-    ],
-    "paint": {
-     "line-color": "#C8C8C8",
-     "line-width": {
-      "stops": [
-       [
-        9,
-        2
-       ],
-       [
-        14,
-        3.5
-       ],
-       [
-        15,
-        6
-       ],
-       [
-        16,
-        8.4
-       ],
-       [
-        17,
-        18.3
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier souterrain - filet extérieur - route regionale",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route_sou",
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "BRET_REGIONALE_SOU",
-     "REGIONALE_4_SOU",
-     "REGIONALE_3_SOU",
-     "REGIONALE_2_SOU",
-     "REGIONALE_1_SOU"
-    ],
-    "paint": {
-     "line-color": "rgba(130, 130, 130, 0.5)",
-     "line-width": {
-      "stops": [
-       [
-        6,
-        1.5
-       ],
-       [
-        9,
-        2.3
-       ],
-       [
-        14,
-        5
-       ],
-       [
-        15,
-        8.1
-       ],
-       [
-        16,
-        11.2
-       ],
-       [
-        17,
-        22
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier souterrain - filet extérieur - route regionale en construction",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route_sou",
-    "minzoom": 10,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "REGIONALE_CONSTR_SOU"
-    ],
-    "paint": {
-     "line-color": "#C8C8C8",
-     "line-width": {
-      "stops": [
-       [
-        6,
-        1.5
-       ],
-       [
-        9,
-        2.3
-       ],
-       [
-        14,
-        5
-       ],
-       [
-        15,
-        8.1
-       ],
-       [
-        16,
-        11.2
-       ],
-       [
-        17,
-        22
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier souterrain - filet extérieur - route principale",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route_sou",
-    "minzoom": 7,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "BRET_PRINCIPALE_SOU",
-     "PRINCIPALE_4_SOU",
-     "PRINCIPALE_3_SOU",
-     "PRINCIPALE_2_SOU",
-     "PRINCIPALE_1_SOU"
-    ],
-    "paint": {
-     "line-color": "rgba(222, 70, 14, 0.5)",
-     "line-width": {
-      "stops": [
-       [
-        6,
-        1.8
-       ],
-       [
-        9,
-        2.7
-       ],
-       [
-        14,
-        5.9
-       ],
-       [
-        15,
-        9
-       ],
-       [
-        16,
-        12.2
-       ],
-       [
-        17,
-        22.5
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier souterrain - filet extérieur - route principale en construction",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route_sou",
-    "minzoom": 10,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "PRINCIPALE_CONSTR_SOU"
-    ],
-    "paint": {
-     "line-color": "#C8C8C8",
-     "line-width": {
-      "stops": [
-       [
-        6,
-        1.8
-       ],
-       [
-        9,
-        2.7
-       ],
-       [
-        14,
-        5.9
-       ],
-       [
-        15,
-        9
-       ],
-       [
-        16,
-        12.2
-       ],
-       [
-        17,
-        22.5
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier souterrain - filet extérieur - autoroute",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route_sou",
-    "minzoom": 7,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "AUTOROU_PEAGE_SOU",
-     "AUTOROU_LIBRE_SOU"
-    ],
-    "paint": {
-     "line-color": "rgba(222, 70, 14, 0.5)",
-     "line-width": {
-      "stops": [
-       [
-        6,
-        2.5
-       ],
-       [
-        9,
-        3.5
-       ],
-       [
-        14,
-        7.5
-       ],
-       [
-        15,
-        11
-       ],
-       [
-        16,
-        15
-       ],
-       [
-        17,
-        26
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier souterrain - filet extérieur - autoroute en construction",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route_sou",
-    "minzoom": 10,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "AUTOROU_CONSTR_SOU"
-    ],
-    "paint": {
-     "line-color": "#C8C8C8",
-     "line-width": {
-      "stops": [
-       [
-        6,
-        2.5
-       ],
-       [
-        9,
-        3.5
-       ],
-       [
-        14,
-        7.5
-       ],
-       [
-        15,
-        11
-       ],
-       [
-        16,
-        15
-       ],
-       [
-        17,
-        26
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier souterrain - filet interieur - route non revetu carrosable",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route_sou",
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "NON_REVETUE_CARRO_SOU"
-    ],
-    "paint": {
-     "line-color": "#DCDCDC",
-     "line-width": {
-      "stops": [
-       [
-        14,
-        2.3
-       ],
-       [
-        15,
-        4.1
-       ],
-       [
-        16,
-        6.3
-       ],
-       [
-        17,
-        13.5
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier souterrain - filet interieur - bretelle autoroute",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route_sou",
-    "minzoom": 12,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "BRET_AUTO_PEAGE_3_SOU",
-     "BRET_AUTO_PEAGE_2_SOU",
-     "BRET_AUTO_PEAGE_1_SOU",
-     "BRET_AUTO_LIBRE_3_SOU",
-     "BRET_AUTO_LIBRE_2_SOU",
-     "BRET_AUTO_LIBRE_1_SOU"
-    ],
-    "paint": {
-     "line-color": "rgba(255, 255, 255, 0.5)",
-     "line-width": {
-      "stops": [
-       [
-        12,
-        1.5
-       ],
-       [
-        14,
-        2.6
-       ],
-       [
-        15,
-        5.2
-       ],
-       [
-        16,
-        6.7
-       ],
-       [
-        17,
-        10.8
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier souterrain - filet interieur - route non classee restreint",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route_sou",
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "NON_CLASSEE_RESTREINT_SOU"
-    ],
-    "paint": {
-     "line-color": "#F2F5FF",
-     "line-width": {
-      "stops": [
-       [
-        14,
-        2.3
-       ],
-       [
-        15,
-        4.1
-       ],
-       [
-        16,
-        6.3
-       ],
-       [
-        17,
-        13.5
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier souterrain - filet interieur - route non classee",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route_sou",
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "NON_CLASSEE_4_SOU",
-     "NON_CLASSEE_SOU"
-    ],
-    "paint": {
-     "line-color": "#DCDCDC",
-     "line-width": {
-      "stops": [
-       [
-        14,
-        2.3
-       ],
-       [
-        15,
-        4.1
-       ],
-       [
-        16,
-        6.3
-       ],
-       [
-        17,
-        13.5
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier souterrain - filet interieur - route locale",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route_sou",
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "BRET_LOCALE_SOU",
-     "LOCALE_4_SOU",
-     "LOCALE_3_SOU",
-     "LOCALE_2_SOU",
-     "LOCALE_1_SOU"
-    ],
-    "paint": {
-     "line-color": "rgba(255, 255, 255, 0.5)",
-     "line-width": {
-      "stops": [
-       [
-        9,
-        1.3
-       ],
-       [
-        14,
-        2.3
-       ],
-       [
-        15,
-        4.1
-       ],
-       [
-        16,
-        6.1
-       ],
-       [
-        17,
-        13.1
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier souterrain - filet interieur - route locale en construction",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route_sou",
-    "minzoom": 11,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "LOCALE_CONSTR_SOU"
-    ],
-    "paint": {
-     "line-color": {
-      "stops": [
-       [
-        12,
-        "#FFFFFF"
-       ],
-       [
-        13,
-        "#FCF4A8"
-       ],
-       [
-        17,
-        "#FCF7C1"
-       ]
-      ]
-     },
-     "line-width": {
-      "stops": [
-       [
-        9,
-        2
-       ],
-       [
-        14,
-        3.5
-       ],
-       [
-        15,
-        6
-       ],
-       [
-        16,
-        8.4
-       ],
-       [
-        17,
-        18.3
-       ]
-      ]
-     },
-     "line-dasharray": [
-      2,
-      2
-     ]
-    }
-   },
-   {
-    "id": "Routier souterrain - filet interieur - route regionale",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route_sou",
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "BRET_REGIONALE_SOU",
-     "REGIONALE_4_SOU",
-     "REGIONALE_3_SOU",
-     "REGIONALE_2_SOU",
-     "REGIONALE_1_SOU"
-    ],
-    "paint": {
-     "line-color": "rgba(255, 255, 255, 0.5)",
-     "line-width": {
-      "stops": [
-       [
-        6,
-        1.4
-       ],
-       [
-        9,
-        1.5
-       ],
-       [
-        14,
-        3.2
-       ],
-       [
-        15,
-        5.8
-       ],
-       [
-        16,
-        8.3
-       ],
-       [
-        17,
-        16.2
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier souterrain - filet interieur - route regionale en construction",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route_sou",
-    "minzoom": 10,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "REGIONALE_CONSTR_SOU"
-    ],
-    "paint": {
-     "line-color": {
-      "stops": [
-       [
-        9,
-        "#FFFFFF"
-       ],
-       [
-        10,
-        "#FDF28B"
-       ],
-       [
-        17,
-        "#FCF6BD"
-       ]
-      ]
-     },
-     "line-width": {
-      "stops": [
-       [
-        4,
-        0.4
-       ],
-       [
-        6,
-        1.5
-       ],
-       [
-        9,
-        2.3
-       ],
-       [
-        14,
-        5
-       ],
-       [
-        15,
-        8.1
-       ],
-       [
-        16,
-        11.2
-       ],
-       [
-        17,
-        22
-       ]
-      ]
-     },
-     "line-dasharray": [
-      2,
-      2
-     ]
-    }
-   },
-   {
-    "id": "Routier souterrain - filet interieur - route principale",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route_sou",
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "BRET_PRINCIPALE_SOU",
-     "PRINCIPALE_4_SOU",
-     "PRINCIPALE_3_SOU",
-     "PRINCIPALE_2_SOU",
-     "PRINCIPALE_1_SOU"
-    ],
-    "paint": {
-     "line-color": "rgba(255, 255, 255, 0.5)",
-     "line-width": {
-      "stops": [
-       [
-        4,
-        0.5
-       ],
-       [
-        6,
-        1.8
-       ],
-       [
-        9,
-        2.1
-       ],
-       [
-        14,
-        4.4
-       ],
-       [
-        15,
-        7.3
-       ],
-       [
-        16,
-        10
-       ],
-       [
-        17,
-        18.5
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier souterrain - filet interieur - route principale en construction",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route_sou",
-    "minzoom": 10,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "PRINCIPALE_CONSTR_SOU"
-    ],
-    "paint": {
-     "line-color": {
-      "stops": [
-       [
-        9,
-        "#F3C66D"
-       ],
-       [
-        17,
-        "#F2DDB3"
-       ]
-      ]
-     },
-     "line-width": {
-      "stops": [
-       [
-        4,
-        0.5
-       ],
-       [
-        6,
-        1.8
-       ],
-       [
-        9,
-        2.7
-       ],
-       [
-        14,
-        5.9
-       ],
-       [
-        15,
-        9
-       ],
-       [
-        16,
-        12.2
-       ],
-       [
-        17,
-        22.5
-       ]
-      ]
-     },
-     "line-dasharray": [
-      2,
-      2
-     ]
-    }
-   },
-   {
-    "id": "Routier souterrain - filet interieur - autoroute",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route_sou",
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "AUTOROU_PEAGE_SOU",
-     "AUTOROU_LIBRE_SOU"
-    ],
-    "paint": {
-     "line-color": "rgba(255, 255, 255, 0.5)",
-     "line-width": {
-      "stops": [
-       [
-        4,
-        0.7
-       ],
-       [
-        6,
-        2.5
-       ],
-       [
-        9,
-        2.7
-       ],
-       [
-        14,
-        5.8
-       ],
-       [
-        15,
-        9
-       ],
-       [
-        16,
-        12
-       ],
-       [
-        17,
-        20.8
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier souterrain - axe central - autoroute",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route_sou",
-    "minzoom": 13,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "AUTOROU_PEAGE_SOU",
-     "AUTOROU_LIBRE_SOU"
-    ],
-    "paint": {
-     "line-color": "#FFFFFF",
-     "line-width": {
-      "stops": [
-       [
-        9,
-        0.6
-       ],
-       [
-        14,
-        0.7
-       ],
-       [
-        15,
-        1
-       ],
-       [
-        16,
-        1.2
-       ],
-       [
-        17,
-        2.1
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier souterrain - filet interieur - autoroute en construction",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route_sou",
-    "minzoom": 10,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "AUTOROU_CONSTR_SOU"
-    ],
-    "paint": {
-     "line-color": {
-      "stops": [
-       [
-        9,
-        "#F2BA59"
-       ],
-       [
-        17,
-        "#F2C261"
-       ]
-      ]
-     },
-     "line-width": {
-      "stops": [
-       [
-        4,
-        0.7
-       ],
-       [
-        6,
-        2.5
-       ],
-       [
-        9,
-        3.5
-       ],
-       [
-        14,
-        7.5
-       ],
-       [
-        15,
-        11
-       ],
-       [
-        16,
-        15
-       ],
-       [
-        17,
-        26
-       ]
-      ]
-     },
-     "line-dasharray": [
-      2,
-      2
-     ]
-    }
-   },
-   {
-    "id": "Routier souterrain - axe central - autoroute en construction",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route_sou",
-    "minzoom": 13,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "AUTOROU_CONSTR_SOU"
-    ],
-    "paint": {
-     "line-color": "#808080",
-     "line-width": {
-      "stops": [
-       [
-        9,
-        0.6
-       ],
-       [
-        14,
-        0.7
-       ],
-       [
-        15,
-        1
-       ],
-       [
-        16,
-        1.2
-       ],
-       [
-        17,
-        2.1
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "réseau hydro - cours d'eau temporaire",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "hydro_reseau",
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "COURS_D_EAU_TEMP",
-     "COURS_D_EAU_TEMP_MOY"
-    ],
-    "paint": {
-     "line-color": "#AAD5E9",
-     "line-width": {
-      "stops": [
-       [
-        12,
-        1.5
-       ],
-       [
-        17,
-        4
-       ]
-      ]
-     },
-     "line-dasharray": [
-      6,
-      2
-     ]
-    }
-   },
-   {
-    "id": "réseau hydro - cours d'eau",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "hydro_reseau",
-    "minzoom": 3,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "COURS_D_EAU"
-    ],
-    "paint": {
-     "line-color": "#AAD5E9",
-     "line-width": {
-      "stops": [
-       [
-        4,
-        0.3
-       ],
-       [
-        7,
-        1.5
-       ],
-       [
-        12,
-        1.5
-       ],
-       [
-        17,
-        6.5
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "réseau hydro - canal",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "hydro_reseau",
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "CANAL"
-    ],
-    "paint": {
-     "line-color": "#AAD5E9",
-     "line-width": {
-      "stops": [
-       [
-        12,
-        1.4
-       ],
-       [
-        17,
-        5.9
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "réseau hydro - filet interieur - aqueduc",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "hydro_reseau",
-    "minzoom": 12,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "AQUEDUC_AU_SOL"
-    ],
-    "paint": {
-     "line-color": "#AAD5E9",
-     "line-width": {
-      "stops": [
-       [
-        12,
-        1.4
-       ],
-       [
-        16,
-        3.5
-       ],
-       [
-        17,
-        5.9
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "réseau hydro - carre - aqueduc",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "hydro_reseau",
-    "minzoom": 12,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "AQUEDUC_AU_SOL"
-    ],
-    "paint": {
-     "line-color": "#AAD5E9",
-     "line-width": {
-      "stops": [
-       [
-        12,
-        3.5
-       ],
-       [
-        16,
-        8.7
-       ],
-       [
-        17,
-        14.7
-       ]
-      ]
-     },
-     "line-dasharray": [
-      1,
-      5
-     ]
-    }
-   },
-   {
-    "id": "réseau hydro - cours d'eau moyen ",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "hydro_reseau",
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "COURS_D_EAU_MOY"
-    ],
-    "paint": {
-     "line-color": "#AAD5E9",
-     "line-width": {
-      "stops": [
-       [
-        7,
-        2
-       ],
-       [
-        12,
-        2.5
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "réseau hydro - cours d'eau large ",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "hydro_reseau",
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "COURS_D_EAU_LAR"
-    ],
-    "paint": {
-     "line-color": "#AAD5E9",
-     "line-width": {
-      "stops": [
-       [
-        7,
-        3
-       ],
-       [
-        11,
-        5
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "parcellaire - parcelle surface",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "parcellaire_parcelle",
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "PARCELLE"
-    ],
-    "paint": {
-     "fill-color": "#FFFFD1",
-     "fill-opacity": 0.7
-    }
-   },
-   {
-    "id": "bati surfacique mairie - Zoom 14",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "bati_surf",
-    "maxzoom": 14,
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "MAIRIE",
-     "MAIRIE_ANNEXE"
-    ],
-    "paint": {
-     "fill-color": "#FFA6A6"
-    }
-   },
-   {
-    "id": "bati surfacique mairie - Zoom 15,16,17,18",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "bati_surf",
-    "minzoom": 14,
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "MAIRIE",
-     "MAIRIE_ANNEXE"
-    ],
-    "paint": {
-     "fill-color": {
-      "stops": [
-       [
-        14,
-        "#FFA6A6"
-       ],
-       [
-        15,
-        "#FFAEAE"
-       ]
-      ]
-     },
-     "fill-outline-color": "#FF7C7C"
-    }
-   },
-   {
-    "id": "bati surfacique fonctionnel industriel ou commercial - Zoom 14,15",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "bati_surf",
-    "maxzoom": 15,
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "BATI_COMMERCIAL",
-     "BATI_INDUSTRIEL",
-     "HANGAR",
-     "HANGAR_COMMERCIAL",
-     "HANGAR_INDUSTRIEL"
-    ],
-    "paint": {
-     "fill-color": "#C8C8C8"
-    }
-   },
-   {
-    "id": "bati surfacique fonctionnel industriel ou commercial - Zoom 16,17,18",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "bati_surf",
-    "minzoom": 15,
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "BATI_COMMERCIAL",
-     "BATI_INDUSTRIEL",
-     "HANGAR",
-     "HANGAR_COMMERCIAL",
-     "HANGAR_INDUSTRIEL"
-    ],
-    "paint": {
-     "fill-color": {
-      "stops": [
-       [
-        15,
-        "#D1D1D1"
-       ],
-       [
-        16,
-        "#E6E6E6"
-       ]
-      ]
-     },
-     "fill-outline-color": "#B8B8B8"
-    }
-   },
-   {
-    "id": "bati surfacique fonctionnel public - Zoom 14,15",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "bati_surf",
-    "maxzoom": 15,
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "BATI_PUBLIC",
-     "HANGAR_PUBLIC"
-    ],
-    "paint": {
-     "fill-color": "#B9B6D6"
-    }
-   },
-   {
-    "id": "bati surfacique fonctionnel public - Zoom 16,17,18",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "bati_surf",
-    "minzoom": 15,
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "BATI_PUBLIC",
-     "HANGAR_PUBLIC"
-    ],
-    "paint": {
-     "fill-color": {
-      "stops": [
-       [
-        15,
-        "#CFC5DE"
-       ],
-       [
-        16,
-        "#E4DAF3"
-       ]
-      ]
-     },
-     "fill-outline-color": "#A6A1D6"
-    }
-   },
-   {
-    "id": "bati surfacique fonctionnel sportif - bordure",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "bati_surf",
-    "minzoom": 15,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "BATI_SPORTIF"
-    ],
-    "paint": {
-     "line-color": "#BCD9AB",
-     "line-width": 4
-    }
-   },
-   {
-    "id": "bati surfacique fonctionnel sportif",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "bati_surf",
-    "minzoom": 13,
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "BATI_SPORTIF"
-    ],
-    "paint": {
-     "fill-color": {
-      "stops": [
-       [
-        14,
-        "#C9E1DD"
-       ],
-       [
-        15,
-        "#DCE6E4"
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "bati surfacique fonctionnel gare - Zoom 14,15",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "bati_surf",
-    "maxzoom": 15,
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "BATI_GARE"
-    ],
-    "paint": {
-     "fill-color": "#B3B5F5"
-    }
-   },
-   {
-    "id": "bati surfacique fonctionnel gare - Zoom 16,17,18",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "bati_surf",
-    "minzoom": 15,
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "BATI_GARE"
-    ],
-    "paint": {
-     "fill-color": {
-      "stops": [
-       [
-        15,
-        "#BFC1F5"
-       ],
-       [
-        16,
-        "#CBCDF5"
-       ]
-      ]
-     },
-     "fill-outline-color": "#9B9EF6"
-    }
-   },
-   {
-    "id": "bati surfacique quelconque - Zoom 15",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "bati_surf",
-    "minzoom": 14,
-    "maxzoom": 15,
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "BATI_QQUE"
-    ],
-    "paint": {
-     "fill-color": "#D6C6B8"
-    }
-   },
-   {
-    "id": "bati surfacique quelconque - Zoom 16,17,18",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "bati_surf",
-    "minzoom": 15,
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "BATI_QQUE"
-    ],
-    "paint": {
-     "fill-color": {
-      "stops": [
-       [
-        15,
-        "#E6E0CF"
-       ],
-       [
-        16,
-        "#F1EBD9"
-       ]
-      ]
-     },
-     "fill-outline-color": "#C3AA8E"
-    }
-   },
-   {
-    "id": "cimetiere surfacique 1",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "bati_surf",
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "CIMETIERE_SURF",
-     "CIMETIERE_MILI_SURF",
-     "NECROPOLE_NATIONALE"
-    ],
-    "paint": {
-     "fill-color": "#F0F0F0",
-     "fill-opacity": 0.5,
-     "fill-outline-color": "#818181"
-    }
-   },
-   {
-    "id": "cimetiere surfacique 2",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "bati_surf",
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "CIMETIERE_SURF",
-     "CIMETIERE_MILI_SURF",
-     "NECROPOLE_NATIONALE"
-    ],
-    "paint": {
-     "fill-pattern": "Cimetiere"
-    }
-   },
-   {
-    "id": "bati hydro surfacique - Autre",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "bati_surf",
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "ECLUSE_SURF",
-     "RESERVOIR_EAU_SURF"
-    ],
-    "paint": {
-     "fill-color": "#ADCCD9",
-     "fill-outline-color": "#336699"
-    }
-   },
-   {
-    "id": "bati hydro surfacique - Pecherie",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "bati_surf",
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "PECHERIE_SURF"
-    ],
-    "paint": {
-     "fill-color": "#BFE2F0",
-     "fill-outline-color": "#509FEF"
-    }
-   },
-   {
-    "id": "bati hydro surfacique - Barrage",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "bati_surf",
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "BARRAGE_SURF"
-    ],
-    "paint": {
-     "fill-color": "#FFFFFF",
-     "fill-outline-color": "#464646"
-    }
-   },
-   {
-    "id": "bati hydro surfacique - Chateau d'eau",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "bati_surf",
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "CHATEAU_EAU_SURF"
-    ],
-    "paint": {
-     "fill-color": "#1466B2"
-    }
-   },
-   {
-    "id": "bati infra surfacique - Silo",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "bati_surf",
-    "minzoom": 15,
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "SILO_SURF"
-    ],
-    "paint": {
-     "fill-color": "#C7A9AA",
-     "fill-outline-color": "#696969"
-    }
-   },
-   {
-    "id": "bati infra surfacique - Reservoir indus",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "bati_surf",
-    "minzoom": 14,
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "RESERVOIR_INDUS_SURF"
-    ],
-    "paint": {
-     "fill-color": "#8D9DAA",
-     "fill-outline-color": "#464646"
-    }
-   },
-   {
-    "id": "bati infra surfacique - Serre",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "bati_surf",
-    "minzoom": 13,
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "SERRE_SURF"
-    ],
-    "paint": {
-     "fill-color": "#CAD6D9",
-     "fill-outline-color": "#8C8C8C"
-    }
-   },
-   {
-    "id": "bati infra surfacique - poste electrique",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "bati_surf",
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "POSTE_ELEC_SURF"
-    ],
-    "paint": {
-     "fill-color": "#7993B6",
-     "fill-opacity": 0.3
-    }
-   },
-   {
-    "id": "bati infra surfacique - poste electrique bord",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "bati_surf",
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "POSTE_ELEC_SURF"
-    ],
-    "paint": {
-     "line-color": "#000000",
-     "line-width": {
-      "stops": [
-       [
-        12,
-        0.3
-       ],
-       [
-        17,
-        1.2
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "bati religieux surfacique - Zoom 14",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "bati_surf",
-    "maxzoom": 14,
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "CHAPELLE_SURF",
-     "EGLISE_SURF",
-     "CHRETIEN_SURF",
-     "SYNAGOGUE_SURF",
-     "MOSQUEE_SURF",
-     "AUTRE_CULTE_SURF"
-    ],
-    "paint": {
-     "fill-color": "#F7CBCB"
-    }
-   },
-   {
-    "id": "bati religieux surfacique - Zoom 15,16,17,18",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "bati_surf",
-    "minzoom": 14,
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "CHAPELLE_SURF",
-     "EGLISE_SURF",
-     "CHRETIEN_SURF",
-     "SYNAGOGUE_SURF",
-     "MOSQUEE_SURF",
-     "AUTRE_CULTE_SURF"
-    ],
-    "paint": {
-     "fill-color": {
-      "stops": [
-       [
-        14,
-        "#F7CBCB"
-       ],
-       [
-        15,
-        "#F7E1E1"
-       ]
-      ]
-     },
-     "fill-outline-color": {
-      "stops": [
-       [
-        14,
-        "#F7A8A8"
-       ],
-       [
-        15,
-        "#F7B7B7"
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "bati remarquable surfacique",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "bati_surf",
-    "minzoom": 13,
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "FORTIF_SURF",
-     "CHATEAU_SURF",
-     "TOUR_MOULIN_SURF",
-     "ARENE_THEATRE",
-     "ARC_TRIOMPHE_SURF",
-     "MONUMENT_SURF"
-    ],
-    "paint": {
-     "fill-color": "#9B9B9B",
-     "fill-outline-color": "#6E6E6E"
-    }
-   },
-   {
-    "id": "bati sportif surfacique fond",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "bati_surf",
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "TENNIS_SURF",
-     "SPORT_INDIF_SURF",
-     "FOOT_SURF",
-     "MULTI_SPORT_SURF",
-     "PISTE_SPORT_SURF",
-     "NATATION_SURF"
-    ],
-    "paint": {
-     "fill-color": "#FFFFFF",
-     "fill-outline-color": "#FFFFFF"
-    }
-   },
-   {
-    "id": "bati sportif surfacique",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "bati_surf",
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "TENNIS_SURF",
-     "SPORT_INDIF_SURF",
-     "FOOT_SURF",
-     "MULTI_SPORT_SURF",
-     "PISTE_SPORT_SURF",
-     "NATATION_SURF"
-    ],
-    "paint": {
-     "line-color": "#BCD9AB",
-     "line-width": 2
-    }
-   },
-   {
-    "id": "bati transport surfacique - piste",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "bati_surf",
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "PISTE_DUR",
-     "PISTE_HERBE"
-    ],
-    "paint": {
-     "fill-color": "#DBDBDB",
-     "fill-outline-color": "#808080"
-    }
-   },
-   {
-    "id": "bati ZAI - Autres",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "bati_zai",
-    "minzoom": 15,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "in",
-     "nature",
-     "Lycée",
-     "Université",
-     "Capitainerie",
-     "Gendarmerie",
-     "Siège d'EPCI",
-     "Musée",
-     "Collège",
-     "Maison de retraite",
-     "Etablissement thermal",
-     "Autre service déconcentré de l'Etat",
-     "Etablissement pénitentiaire",
-     "Divers public ou administratif",
-     "Autre établissement d'enseignement",
-     "Maison du parc",
-     "Palais de justice",
-     "Enseignement primaire",
-     "Office de tourisme",
-     "Hôpital",
-     "Police",
-     "Piscine",
-     "Enseignement supérieur",
-     "Poste",
-     "Caserne",
-     "Etablissement hospitalier",
-     "Etablissement extraterritorial",
-     "Science",
-     "Structure d'accueil pour personnes handicapées",
-     "Administration centrale de l'Etat",
-     "Caserne de pompiers"
-    ],
-    "paint": {
-     "fill-color": "#E3BFE2",
-     "fill-opacity": 0.5,
-     "fill-outline-color": "#E39FE1"
-    }
-   },
-   {
-    "id": "bati ZAI - Commandement",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "bati_zai",
-    "minzoom": 15,
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "in",
-     "nature",
-     "Hôtel de département",
-     "Hôtel de région",
-     "Préfecture de région",
-     "Préfecture",
-     "Sous-préfecture"
-    ],
-    "paint": {
-     "fill-color": "#FF0000",
-     "fill-opacity": 0.3,
-     "fill-outline-color": "#B40000"
-    }
-   },
-   {
-    "id": "construction linéaire - mur",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "bati_lin",
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "MUR"
-    ],
-    "paint": {
-     "line-color": "#8C8C8C",
-     "line-width": 0.3
-    }
-   },
-   {
-    "id": "construction linéaire - autre",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "bati_lin",
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "RUINE_LIN",
-     "MUR_SOUTENEMENT",
-     "FORTIF_LIN"
-    ],
-    "paint": {
-     "line-color": "#646464",
-     "line-width": 0.5
-    }
-   },
-   {
-    "id": "construction hydrographique linéaire - Barrage",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "bati_lin",
-    "minzoom": 13,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "BARRAGE_LIN"
-    ],
-    "paint": {
-     "line-color": "#646464",
-     "line-width": {
-      "stops": [
-       [
-        13,
-        1.5
-       ],
-       [
-        17,
-        5
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "construction hydrographique linéaire - Quai",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "bati_lin",
-    "minzoom": 12,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "QUAI",
-     "DIGUE"
-    ],
-    "paint": {
-     "line-color": "#828282",
-     "line-width": {
-      "stops": [
-       [
-        14,
-        1
-       ],
-       [
-        17,
-        2.5
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "construction hydrographique linéaire - Pecherie",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "bati_lin",
-    "minzoom": 12,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "PECHERIE_LIN"
-    ],
-    "paint": {
-     "line-color": "#0066CC",
-     "line-width": {
-      "stops": [
-       [
-        14,
-        1
-       ],
-       [
-        17,
-        2.5
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Chemin a niveau - piste cyclable",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_chemin",
-    "minzoom": 13,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "PISTE_CYCLABLE"
-    ],
-    "paint": {
-     "line-color": {
-      "stops": [
-       [
-        17,
-        "#9B5CCC"
-       ],
-       [
-        18,
-        "#FFFFFF"
-       ]
-      ]
-     },
-     "line-width": {
-      "stops": [
-       [
-        14,
-        1.1
-       ],
-       [
-        15,
-        1.7
-       ],
-       [
-        16,
-        2
-       ],
-       [
-        17,
-        3.5
-       ],
-       [
-        18,
-        6
-       ]
-      ]
-     },
-     "line-dasharray": [
-      6,
-      2
-     ]
-    }
-   },
-   {
-    "id": "Chemin a niveau - filet exterieur - escalier",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_chemin",
-    "minzoom": 14,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "ESCALIER"
-    ],
-    "paint": {
-     "line-color": {
-      "stops": [
-       [
-        17,
-        "#8C7274"
-       ],
-       [
-        18,
-        "#C8C8C8"
-       ]
-      ]
-     },
-     "line-width": {
-      "stops": [
-       [
-        14,
-        1.75
-       ],
-       [
-        15,
-        3
-       ],
-       [
-        16,
-        4.2
-       ],
-       [
-        17,
-        9.5
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Chemin a niveau - filet interieur - escalier",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_chemin",
-    "minzoom": 14,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "ESCALIER"
-    ],
-    "paint": {
-     "line-color": "#FFFFFF",
-     "line-width": {
-      "stops": [
-       [
-        14,
-        1
-       ],
-       [
-        15,
-        1.9
-       ],
-       [
-        16,
-        2.7
-       ],
-       [
-        17,
-        5.8
-       ]
-      ]
-     },
-     "line-dasharray": [
-      1,
-      0.2
-     ]
-    }
-   },
-   {
-    "id": "Chemin a niveau - Rue pietonne",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_chemin",
-    "minzoom": 14,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "RUE_PIETONNE"
-    ],
-    "paint": {
-     "line-color": {
-      "stops": [
-       [
-        17,
-        "#8C7274"
-       ],
-       [
-        18,
-        "#F8E5D5"
-       ]
-      ]
-     },
-     "line-width": {
-      "stops": [
-       [
-        14,
-        1
-       ],
-       [
-        15,
-        1.2
-       ],
-       [
-        16,
-        1.4
-       ],
-       [
-        17,
-        2
-       ],
-       [
-        18,
-        5
-       ]
-      ]
-     },
-     "line-dasharray": [
-      1,
-      3
-     ]
-    }
-   },
-   {
-    "id": "Chemin a niveau - sentier",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_chemin",
-    "minzoom": 13,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "SENTIER"
-    ],
-    "paint": {
-     "line-color": {
-      "stops": [
-       [
-        17,
-        "#8C7274"
-       ],
-       [
-        18,
-        "#FFFFFF"
-       ]
-      ]
-     },
-     "line-width": {
-      "stops": [
-       [
-        14,
-        1
-       ],
-       [
-        15,
-        1.2
-       ],
-       [
-        16,
-        1.4
-       ],
-       [
-        17,
-        2
-       ],
-       [
-        18,
-        6
-       ]
-      ]
-     },
-     "line-dasharray": [
-      4,
-      3
-     ]
-    }
-   },
-   {
-    "id": "Chemin a niveau - chemin",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_chemin",
-    "minzoom": 12,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "CHEMIN"
-    ],
-    "paint": {
-     "line-color": {
-      "stops": [
-       [
-        17,
-        "#8C7274"
-       ],
-       [
-        18,
-        "#FFFFFF"
-       ]
-      ]
-     },
-     "line-width": {
-      "stops": [
-       [
-        14,
-        1
-       ],
-       [
-        15,
-        1.2
-       ],
-       [
-        16,
-        1.4
-       ],
-       [
-        17,
-        2
-       ],
-       [
-        18,
-        7
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier a niveau - filet extérieur - route non revetu carrosable",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route",
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "NON_REVETUE_CARRO"
-    ],
-    "paint": {
-     "line-color": {
-      "stops": [
-       [
-        12,
-        "#646464"
-       ],
-       [
-        17,
-        "#8C8C8C"
-       ]
-      ]
-     },
-     "line-width": {
-      "stops": [
-       [
-        14,
-        3.2
-       ],
-       [
-        15,
-        5.4
-       ],
-       [
-        16,
-        7.7
-       ],
-       [
-        17,
-        16.8
-       ]
-      ]
-     },
-     "line-dasharray": [
-      2,
-      2
-     ]
-    }
-   },
-   {
-    "id": "Routier a niveau - filet interieur - route non revetu carrosable",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route",
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "NON_REVETUE_CARRO"
-    ],
-    "paint": {
-     "line-color": "#FFFFFF",
-     "line-width": {
-      "stops": [
-       [
-        14,
-        2.3
-       ],
-       [
-        15,
-        4.1
-       ],
-       [
-        16,
-        6.3
-       ],
-       [
-        17,
-        13.5
-       ],
-       [
-        18,
-        16.8
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier a niveau - filet extérieur - bretelle autoroute",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route",
-    "minzoom": 12,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "BRET_AUTO_PEAGE_3",
-     "BRET_AUTO_PEAGE_2",
-     "BRET_AUTO_PEAGE_1",
-     "BRET_AUTO_LIBRE_3",
-     "BRET_AUTO_LIBRE_2",
-     "BRET_AUTO_LIBRE_1"
-    ],
-    "paint": {
-     "line-color": {
-      "stops": [
-       [
-        9,
-        "#DE460E"
-       ],
-       [
-        17,
-        "#F18800"
-       ],
-       [
-        18,
-        "#FFFFFF"
-       ]
-      ]
-     },
-     "line-width": {
-      "stops": [
-       [
-        12,
-        2.5
-       ],
-       [
-        14,
-        3.7
-       ],
-       [
-        15,
-        6.8
-       ],
-       [
-        16,
-        8.4
-       ],
-       [
-        17,
-        14
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier a niveau - filet extérieur - route non classee restreint",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route",
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "NON_CLASSEE_RESTREINT"
-    ],
-    "paint": {
-     "line-color": {
-      "stops": [
-       [
-        17,
-        "#969696"
-       ],
-       [
-        18,
-        "#FFFFFF"
-       ]
-      ]
-     },
-     "line-width": {
-      "stops": [
-       [
-        14,
-        3.2
-       ],
-       [
-        15,
-        5.4
-       ],
-       [
-        16,
-        7.7
-       ],
-       [
-        17,
-        16.8
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier a niveau - filet extérieur - route non classee",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route",
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "NON_CLASSEE_4",
-     "NON_CLASSEE"
-    ],
-    "paint": {
-     "line-color": {
-      "stops": [
-       [
-        17,
-        "#969696"
-       ],
-       [
-        18,
-        "#FFFFFF"
-       ]
-      ]
-     },
-     "line-width": {
-      "stops": [
-       [
-        14,
-        3.2
-       ],
-       [
-        15,
-        5.4
-       ],
-       [
-        16,
-        7.7
-       ],
-       [
-        17,
-        16.8
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier a niveau - filet extérieur - route locale",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route",
-    "minzoom": 7,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "BRET_LOCALE",
-     "LOCALE_4",
-     "LOCALE_3",
-     "LOCALE_2",
-     "LOCALE_1"
-    ],
-    "paint": {
-     "line-color": {
-      "stops": [
-       [
-        12,
-        "#8C8C8C"
-       ],
-       [
-        13,
-        "#B4B4B4"
-       ],
-       [
-        17,
-        "#B4B4B4"
-       ],
-       [
-        18,
-        "#FFFFFF"
-       ]
-      ]
-     },
-     "line-width": {
-      "stops": [
-       [
-        9,
-        2
-       ],
-       [
-        14,
-        3.5
-       ],
-       [
-        15,
-        6
-       ],
-       [
-        16,
-        8.4
-       ],
-       [
-        17,
-        18.3
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier a niveau - filet extérieur - route locale en construction",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route",
-    "minzoom": 11,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "LOCALE_CONSTR"
-    ],
-    "paint": {
-     "line-color": "#C8C8C8",
-     "line-width": {
-      "stops": [
-       [
-        9,
-        2
-       ],
-       [
-        14,
-        3.5
-       ],
-       [
-        15,
-        6
-       ],
-       [
-        16,
-        8.4
-       ],
-       [
-        17,
-        18.3
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier a niveau - filet extérieur - route regionale",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route",
-    "minzoom": 8,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "BRET_REGIONALE",
-     "REGIONALE_4",
-     "REGIONALE_3",
-     "REGIONALE_2",
-     "REGIONALE_1"
-    ],
-    "paint": {
-     "line-color": {
-      "stops": [
-       [
-        9,
-        "#828282"
-       ],
-       [
-        10,
-        "#B4B4B4"
-       ],
-       [
-        17,
-        "#B4B4B4"
-       ],
-       [
-        18,
-        "#FFFFFF"
-       ]
-      ]
-     },
-     "line-width": {
-      "stops": [
-       [
-        6,
-        1.5
-       ],
-       [
-        9,
-        2.3
-       ],
-       [
-        14,
-        5
-       ],
-       [
-        15,
-        8.1
-       ],
-       [
-        16,
-        11.2
-       ],
-       [
-        17,
-        22
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier a niveau - filet extérieur - route regionale en construction",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route",
-    "minzoom": 10,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "REGIONALE_CONSTR"
-    ],
-    "paint": {
-     "line-color": "#C8C8C8",
-     "line-width": {
-      "stops": [
-       [
-        6,
-        1.5
-       ],
-       [
-        9,
-        2.3
-       ],
-       [
-        14,
-        5
-       ],
-       [
-        15,
-        8.1
-       ],
-       [
-        16,
-        11.2
-       ],
-       [
-        17,
-        22
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier a niveau - filet extérieur - route principale",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route",
-    "minzoom": 8,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "BRET_PRINCIPALE",
-     "PRINCIPALE_4",
-     "PRINCIPALE_3",
-     "PRINCIPALE_2",
-     "PRINCIPALE_1"
-    ],
-    "paint": {
-     "line-color": {
-      "stops": [
-       [
-        17,
-        "#E2A52A"
-       ],
-       [
-        18,
-        "#FFFFFF"
-       ]
-      ]
-     },
-     "line-width": {
-      "stops": [
-       [
-        6,
-        1.8
-       ],
-       [
-        9,
-        2.7
-       ],
-       [
-        14,
-        5.9
-       ],
-       [
-        15,
-        9
-       ],
-       [
-        16,
-        12.2
-       ],
-       [
-        17,
-        22.5
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier a niveau - filet extérieur - route principale en construction",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route",
-    "minzoom": 10,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "PRINCIPALE_CONSTR"
-    ],
-    "paint": {
-     "line-color": "#C8C8C8",
-     "line-width": {
-      "stops": [
-       [
-        6,
-        1.8
-       ],
-       [
-        9,
-        2.7
-       ],
-       [
-        14,
-        5.9
-       ],
-       [
-        15,
-        9
-       ],
-       [
-        16,
-        12.2
-       ],
-       [
-        17,
-        22.5
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier a niveau - filet extérieur - autoroute",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route",
-    "minzoom": 8,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "AUTOROU_PEAGE",
-     "AUTOROU_LIBRE"
-    ],
-    "paint": {
-     "line-color": {
-      "stops": [
-       [
-        9,
-        "#DE460E"
-       ],
-       [
-        17,
-        "#F18800"
-       ],
-       [
-        18,
-        "#FFFFFF"
-       ]
-      ]
-     },
-     "line-width": {
-      "stops": [
-       [
-        6,
-        2.5
-       ],
-       [
-        9,
-        3.5
-       ],
-       [
-        14,
-        7.5
-       ],
-       [
-        15,
-        11
-       ],
-       [
-        16,
-        15
-       ],
-       [
-        17,
-        26
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier a niveau - filet extérieur - autoroute en construction",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route",
-    "minzoom": 8,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "AUTOROU_CONSTR"
-    ],
-    "paint": {
-     "line-color": "#C8C8C8",
-     "line-width": {
-      "stops": [
-       [
-        6,
-        2.5
-       ],
-       [
-        9,
-        3.5
-       ],
-       [
-        14,
-        7.5
-       ],
-       [
-        15,
-        11
-       ],
-       [
-        16,
-        15
-       ],
-       [
-        17,
-        26
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier a niveau - filet interieur - bretelle autoroute",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route",
-    "minzoom": 12,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "BRET_AUTO_PEAGE_3",
-     "BRET_AUTO_PEAGE_2",
-     "BRET_AUTO_PEAGE_1",
-     "BRET_AUTO_LIBRE_3",
-     "BRET_AUTO_LIBRE_2",
-     "BRET_AUTO_LIBRE_1"
-    ],
-    "paint": {
-     "line-color": {
-      "stops": [
-       [
-        9,
-        "#F18800"
-       ],
-       [
-        17,
-        "#F2B230"
-       ]
-      ]
-     },
-     "line-width": {
-      "stops": [
-       [
-        12,
-        1.5
-       ],
-       [
-        14,
-        2.6
-       ],
-       [
-        15,
-        5.2
-       ],
-       [
-        16,
-        6.7
-       ],
-       [
-        17,
-        10.8
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier a niveau - filet interieur - route non classee restreint",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route",
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "NON_CLASSEE_RESTREINT"
-    ],
-    "paint": {
-     "line-color": "#EDF1FF",
-     "line-width": {
-      "stops": [
-       [
-        14,
-        2.3
-       ],
-       [
-        15,
-        4.1
-       ],
-       [
-        16,
-        6.3
-       ],
-       [
-        17,
-        13.5
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier a niveau - filet interieur - route non classee",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route",
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "NON_CLASSEE_4",
-     "NON_CLASSEE"
-    ],
-    "paint": {
-     "line-color": "#FFFFFF",
-     "line-width": {
-      "stops": [
-       [
-        14,
-        2.3
-       ],
-       [
-        15,
-        4.1
-       ],
-       [
-        16,
-        6.3
-       ],
-       [
-        17,
-        13.5
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier a niveau - filet interieur - route locale",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route",
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "BRET_LOCALE",
-     "LOCALE_4",
-     "LOCALE_3",
-     "LOCALE_2",
-     "LOCALE_1"
-    ],
-    "paint": {
-     "line-color": {
-      "stops": [
-       [
-        6,
-        "#F2B361"
-       ],
-       [
-        7,
-        "#FFFFFF"
-       ],
-       [
-        12,
-        "#FFFFFF"
-       ],
-       [
-        13,
-        "#FCF4A8"
-       ],
-       [
-        17,
-        "#FCF7C1"
-       ]
-      ]
-     },
-     "line-width": {
-      "stops": [
-       [
-        9,
-        1.3
-       ],
-       [
-        14,
-        2.3
-       ],
-       [
-        15,
-        4.1
-       ],
-       [
-        16,
-        6.1
-       ],
-       [
-        17,
-        13.1
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier a niveau - filet interieur - route locale en construction",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route",
-    "minzoom": 11,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "LOCALE_CONSTR"
-    ],
-    "paint": {
-     "line-color": {
-      "stops": [
-       [
-        12,
-        "#FFFFFF"
-       ],
-       [
-        13,
-        "#FCF4A8"
-       ],
-       [
-        17,
-        "#FCF7C1"
-       ],
-       [
-        18,
-        "#EDEDED"
-       ]
-      ]
-     },
-     "line-width": {
-      "stops": [
-       [
-        9,
-        2
-       ],
-       [
-        14,
-        3.5
-       ],
-       [
-        15,
-        6
-       ],
-       [
-        16,
-        8.4
-       ],
-       [
-        17,
-        18.3
-       ]
-      ]
-     },
-     "line-dasharray": [
-      2,
-      2
-     ]
-    }
-   },
-   {
-    "id": "Routier a niveau - filet interieur - route regionale",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route",
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "BRET_REGIONALE",
-     "REGIONALE_4",
-     "REGIONALE_3",
-     "REGIONALE_2",
-     "REGIONALE_1"
-    ],
-    "paint": {
-     "line-color": {
-      "stops": [
-       [
-        6,
-        "#F2A949"
-       ],
-       [
-        7,
-        "#FFFFFF"
-       ],
-       [
-        9,
-        "#FFFFFF"
-       ],
-       [
-        10,
-        "#FDF28B"
-       ],
-       [
-        17,
-        "#FCF6BD"
-       ]
-      ]
-     },
-     "line-width": {
-      "stops": [
-       [
-        4,
-        1.1
-       ],
-       [
-        6,
-        1.4
-       ],
-       [
-        9,
-        1.5
-       ],
-       [
-        14,
-        3.2
-       ],
-       [
-        15,
-        5.8
-       ],
-       [
-        16,
-        8.3
-       ],
-       [
-        17,
-        16.2
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier a niveau - filet interieur - route regionale en construction",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route",
-    "minzoom": 10,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "REGIONALE_CONSTR"
-    ],
-    "paint": {
-     "line-color": {
-      "stops": [
-       [
-        9,
-        "#FFFFFF"
-       ],
-       [
-        10,
-        "#FDF28B"
-       ],
-       [
-        17,
-        "#FCF6BD"
-       ],
-       [
-        18,
-        "#EDEDED"
-       ]
-      ]
-     },
-     "line-width": {
-      "stops": [
-       [
-        4,
-        0.4
-       ],
-       [
-        6,
-        1.5
-       ],
-       [
-        9,
-        2.3
-       ],
-       [
-        14,
-        5
-       ],
-       [
-        15,
-        8.1
-       ],
-       [
-        16,
-        11.2
-       ],
-       [
-        17,
-        22
-       ]
-      ]
-     },
-     "line-dasharray": [
-      2,
-      2
-     ]
-    }
-   },
-   {
-    "id": "Routier a niveau - filet interieur - route principale",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route",
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "BRET_PRINCIPALE",
-     "PRINCIPALE_4",
-     "PRINCIPALE_3",
-     "PRINCIPALE_2",
-     "PRINCIPALE_1"
-    ],
-    "paint": {
-     "line-color": {
-      "stops": [
-       [
-        6,
-        "#F29924"
-       ],
-       [
-        7,
-        "#F3C66D"
-       ],
-       [
-        9,
-        "#F3C66D"
-       ],
-       [
-        17,
-        "#F2DDB3"
-       ]
-      ]
-     },
-     "line-width": {
-      "stops": [
-       [
-        4,
-        0.6
-       ],
-       [
-        6,
-        1.8
-       ],
-       [
-        9,
-        2.1
-       ],
-       [
-        14,
-        4.4
-       ],
-       [
-        15,
-        7.3
-       ],
-       [
-        16,
-        10
-       ],
-       [
-        17,
-        18.5
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier a niveau - filet interieur - route principale en construction",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route",
-    "minzoom": 10,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "PRINCIPALE_CONSTR"
-    ],
-    "paint": {
-     "line-color": {
-      "stops": [
-       [
-        9,
-        "#F3C66D"
-       ],
-       [
-        17,
-        "#F2DDB3"
-       ],
-       [
-        18,
-        "#EDEDED"
-       ]
-      ]
-     },
-     "line-width": {
-      "stops": [
-       [
-        4,
-        0.5
-       ],
-       [
-        6,
-        1.8
-       ],
-       [
-        9,
-        2.7
-       ],
-       [
-        14,
-        5.9
-       ],
-       [
-        15,
-        9
-       ],
-       [
-        16,
-        12.2
-       ],
-       [
-        17,
-        22.5
-       ]
-      ]
-     },
-     "line-dasharray": [
-      2,
-      2
-     ]
-    }
-   },
-   {
-    "id": "Routier a niveau - filet interieur - autoroute",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route",
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "AUTOROU_PEAGE",
-     "AUTOROU_LIBRE"
-    ],
-    "paint": {
-     "line-color": {
-      "stops": [
-       [
-        9,
-        "#F18800"
-       ],
-       [
-        17,
-        "#F2B230"
-       ]
-      ]
-     },
-     "line-width": {
-      "stops": [
-       [
-        4,
-        0.7
-       ],
-       [
-        6,
-        2.5
-       ],
-       [
-        9,
-        2.7
-       ],
-       [
-        14,
-        5.8
-       ],
-       [
-        15,
-        9
-       ],
-       [
-        16,
-        12
-       ],
-       [
-        17,
-        20.8
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier a niveau - axe central - autoroute",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route",
-    "minzoom": 13,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "AUTOROU_PEAGE",
-     "AUTOROU_LIBRE"
-    ],
-    "paint": {
-     "line-color": "#FFFFFF",
-     "line-width": {
-      "stops": [
-       [
-        9,
-        0.6
-       ],
-       [
-        14,
-        0.7
-       ],
-       [
-        15,
-        1
-       ],
-       [
-        16,
-        1.2
-       ],
-       [
-        17,
-        2.1
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier a niveau - filet interieur - autoroute en construction",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route",
-    "minzoom": 8,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "AUTOROU_CONSTR"
-    ],
-    "paint": {
-     "line-color": {
-      "stops": [
-       [
-        9,
-        "#F18800"
-       ],
-       [
-        17,
-        "#F2B230"
-       ],
-       [
-        18,
-        "#EDEDED"
-       ]
-      ]
-     },
-     "line-width": {
-      "stops": [
-       [
-        4,
-        0.7
-       ],
-       [
-        6,
-        2.5
-       ],
-       [
-        9,
-        3.5
-       ],
-       [
-        14,
-        7.5
-       ],
-       [
-        15,
-        11
-       ],
-       [
-        16,
-        15
-       ],
-       [
-        17,
-        26
-       ]
-      ]
-     },
-     "line-dasharray": [
-      2,
-      2
-     ]
-    }
-   },
-   {
-    "id": "Routier a niveau - axe centrale - autoroute en construction",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route",
-    "minzoom": 13,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "AUTOROU_CONSTR"
-    ],
-    "paint": {
-     "line-color": "#808080",
-     "line-width": {
-      "stops": [
-       [
-        9,
-        0.6
-       ],
-       [
-        14,
-        0.7
-       ],
-       [
-        15,
-        1
-       ],
-       [
-        16,
-        1.2
-       ],
-       [
-        17,
-        2.1
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Ferre a niveau - voie normale",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "ferre",
-    "minzoom": 10,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "VF_1",
-     "VF_2",
-     "VF_3",
-     "VF_4",
-     "VF_ELEC_1",
-     "VF_ELEC_2",
-     "VF_ELEC_3",
-     "VF_ELEC_4"
-    ],
-    "paint": {
-     "line-color": "#787878",
-     "line-width": {
-      "stops": [
-       [
-        10,
-        0.8
-       ],
-       [
-        17,
-        2.5
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Ferre a niveau - voie normale trait perpendic",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "ferre",
-    "minzoom": 10,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "VF_1",
-     "VF_2",
-     "VF_3",
-     "VF_4",
-     "VF_ELEC_1",
-     "VF_ELEC_2",
-     "VF_ELEC_3",
-     "VF_ELEC_4"
-    ],
-    "paint": {
-     "line-color": "#787878",
-     "line-width": {
-      "stops": [
-       [
-        10,
-        3.5
-       ],
-       [
-        17,
-        14.7
-       ]
-      ]
-     },
-     "line-dasharray": [
-      0.1,
-      10
-     ]
-    }
-   },
-   {
-    "id": "Ferre a niveau - voie etroite",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "ferre",
-    "minzoom": 10,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "VF_ETROITE_1",
-     "VF_ETROITE_2",
-     "VF_ETROITE"
-    ],
-    "paint": {
-     "line-color": "#787878",
-     "line-width": {
-      "stops": [
-       [
-        10,
-        0.3
-       ],
-       [
-        17,
-        1.8
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Ferre a niveau - voie etroite trait perpendic",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "ferre",
-    "minzoom": 10,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "VF_ETROITE_1",
-     "VF_ETROITE_2",
-     "VF_ETROITE"
-    ],
-    "paint": {
-     "line-color": "#787878",
-     "line-width": {
-      "stops": [
-       [
-        10,
-        3.5
-       ],
-       [
-        17,
-        14.7
-       ]
-      ]
-     },
-     "line-dasharray": [
-      0.1,
-      10
-     ]
-    }
-   },
-   {
-    "id": "Ferre a niveau - voie service",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "ferre",
-    "minzoom": 14,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "VF_SERVICE",
-     "VF_NON_EXPLOITEE"
-    ],
-    "paint": {
-     "line-color": "#787878",
-     "line-width": {
-      "stops": [
-       [
-        10,
-        0.3
-       ],
-       [
-        17,
-        1.8
-       ]
-      ]
-     },
-     "line-dasharray": [
-      5,
-      2,
-      1,
-      2
-     ]
-    }
-   },
-   {
-    "id": "Ferre a niveau - voie en construction",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "ferre",
-    "minzoom": 10,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "VF_EN_CONSTR"
-    ],
-    "paint": {
-     "line-color": "#787878",
-     "line-width": {
-      "stops": [
-       [
-        10,
-        0.3
-       ],
-       [
-        17,
-        1.8
-       ]
-      ]
-     },
-     "line-dasharray": [
-      2,
-      2
-     ]
-    }
-   },
-   {
-    "id": "Ferre a niveau - voie en construction trait perpendic",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "ferre",
-    "minzoom": 10,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "VF_EN_CONSTR"
-    ],
-    "paint": {
-     "line-color": "#787878",
-     "line-width": {
-      "stops": [
-       [
-        10,
-        3.5
-       ],
-       [
-        17,
-        14.7
-       ]
-      ]
-     },
-     "line-dasharray": [
-      0.1,
-      10
-     ]
-    }
-   },
-   {
-    "id": "Ferre a niveau - funic/urbain",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "ferre",
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "FUNI_CREMAILLERE",
-     "TRANSPORT_URBAIN"
-    ],
-    "paint": {
-     "line-color": "#787878",
-     "line-width": {
-      "stops": [
-       [
-        10,
-        0.3
-       ],
-       [
-        17,
-        1.8
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Ferre a niveau - 2 trait perpendic - funic/urbain",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "ferre",
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "FUNI_CREMAILLERE",
-     "TRANSPORT_URBAIN"
-    ],
-    "paint": {
-     "line-color": "#787878",
-     "line-width": {
-      "stops": [
-       [
-        10,
-        3.5
-       ],
-       [
-        17,
-        17
-       ]
-      ]
-     },
-     "line-dasharray": [
-      0.1,
-      0.2,
-      0.1,
-      10
-     ]
-    }
-   },
-   {
-    "id": "liaison routiere - Bac Liaison Maritime",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_liaison",
-    "minzoom": 8,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "BAC_AUTO",
-     "LIAISON_MARITIME",
-     "BAC_LIAISON_MARITIME"
-    ],
-    "paint": {
-     "line-color": "#5792C2",
-     "line-width": {
-      "stops": [
-       [
-        8,
-        1
-       ],
-       [
-        13,
-        2.5
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "liaison routiere - Gue route",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_liaison",
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "GUE_ROUTE"
-    ],
-    "paint": {
-     "line-color": {
-      "stops": [
-       [
-        13,
-        "#BEBEBE"
-       ],
-       [
-        17,
-        "#646464"
-       ],
-       [
-        18,
-        "#FFFFFF"
-       ]
-      ]
-     },
-     "line-width": {
-      "stops": [
-       [
-        14,
-        2.3
-       ],
-       [
-        15,
-        4.1
-       ],
-       [
-        16,
-        6.3
-       ],
-       [
-        17,
-        13.5
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "liaison routiere - Gue chemin",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_liaison",
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "GUE_CHEMIN"
-    ],
-    "paint": {
-     "line-color": {
-      "stops": [
-       [
-        13,
-        "#BEBEBE"
-       ],
-       [
-        17,
-        "#646464"
-       ]
-      ]
-     },
-     "line-width": {
-      "stops": [
-       [
-        14,
-        1.6
-       ],
-       [
-        15,
-        2.9
-       ],
-       [
-        16,
-        4.4
-       ],
-       [
-        17,
-        6.5
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "liaison routiere - filet extérieur - Pont passerelle",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_liaison",
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "PONT_PASSERELLE",
-     "PONT_LIN",
-     "PONT_MOBILE_LIN"
-    ],
-    "paint": {
-     "line-color": {
-      "stops": [
-       [
-        17,
-        "#C8C8C8"
-       ],
-       [
-        18,
-        "#FFFFFF"
-       ]
-      ]
-     },
-     "line-width": {
-      "stops": [
-       [
-        14,
-        2.2
-       ],
-       [
-        15,
-        3.8
-       ],
-       [
-        16,
-        5.4
-       ],
-       [
-        17,
-        11.8
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "liaison routiere - filet intérieur - Pont passerelle",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_liaison",
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "PONT_PASSERELLE",
-     "PONT_LIN",
-     "PONT_MOBILE_LIN"
-    ],
-    "paint": {
-     "line-color": "#FFFFFF",
-     "line-width": {
-      "stops": [
-       [
-        14,
-        0.7
-       ],
-       [
-        15,
-        1.1
-       ],
-       [
-        16,
-        1.7
-       ],
-       [
-        17,
-        3.8
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier surfacique",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "routier_surf",
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "SURF_ROUT_PRINC",
-     "SURF_ROUT_REG",
-     "SURF_ROUT_LOC",
-     "SURF_ROUT_NON_CLA"
-    ],
-    "paint": {
-     "fill-color": "#FFFFFF",
-     "fill-outline-color": "#000000"
-    }
-   },
-   {
-    "id": "Routier surfacique - Dalle de protection",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "routier_surf",
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "DALLE_DE_PROTECTION"
-    ],
-    "paint": {
-     "fill-opacity": 0.5,
-     "fill-color": "#FFFFFF",
-     "fill-outline-color": "#000000"
-    }
-   },
-   {
-    "id": "Routier surfacique - Escalier surfacique",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "routier_surf",
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "ESCALIER_SURF"
-    ],
-    "paint": {
-     "fill-opacity": 0.8,
-     "fill-color": "#FFFFFF",
-     "fill-outline-color": "#918091"
-    }
-   },
-   {
-    "id": "Routier surfacique - Péage surfacique",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "routier_surf",
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "SURF_PEAGE"
-    ],
-    "paint": {
-     "fill-color": "#F2DAAA",
-     "fill-outline-color": "#E2A52A"
-    }
-   },
-   {
-    "id": "bati transport surfacique - bati peage",
-    "type": "fill",
-    "source": "plan_ign",
-    "source-layer": "bati_surf",
-    "minzoom": 13,
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "BATI_PEAGE"
-    ],
-    "paint": {
-     "fill-color": "#DCDCDC",
-     "fill-outline-color": "#808080"
-    }
-   },
-   {
-    "id": "réseau hydro  - cours d'eau superieur",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "hydro_reseau_sup",
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "COURS_D_EAU_SUP",
-     "COURS_D_EAU_MOY_SUP"
-    ],
-    "paint": {
-     "line-color": "#AAD5E9",
-     "line-width": {
-      "stops": [
-       [
-        12,
-        1.5
-       ],
-       [
-        17,
-        6.5
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "réseau hydro - canal superieur",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "hydro_reseau_sup",
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "CANAL_SUP"
-    ],
-    "paint": {
-     "line-color": "#AAD5E9",
-     "line-width": {
-      "stops": [
-       [
-        12,
-        1.4
-       ],
-       [
-        17,
-        5.9
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "réseau hydro - filet interieur - aqueduc superieur",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "hydro_reseau_sup",
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "AQUEDUC_SUP"
-    ],
-    "paint": {
-     "line-color": "#AAD5E9",
-     "line-width": {
-      "stops": [
-       [
-        12,
-        1.4
-       ],
-       [
-        16,
-        3.5
-       ],
-       [
-        17,
-        5.9
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "réseau hydro - carre - aqueduc superieur",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "hydro_reseau_sup",
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "AQUEDUC_SUP"
-    ],
-    "paint": {
-     "line-color": "#AAD5E9",
-     "line-width": {
-      "stops": [
-       [
-        12,
-        3.5
-       ],
-       [
-        16,
-        8.7
-       ],
-       [
-        17,
-        14.7
-       ]
-      ]
-     },
-     "line-dasharray": [
-      1,
-      5
-     ]
-    }
-   },
-   {
-    "id": "Chemin superieur - piste cyclable",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_chemin_sup",
-    "minzoom": 13,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "PISTE_CYCLABLE_SUP"
-    ],
-    "paint": {
-     "line-color": {
-      "stops": [
-       [
-        17,
-        "#9B5CCC"
-       ],
-       [
-        18,
-        "#FFFFFF"
-       ]
-      ]
-     },
-     "line-width": {
-      "stops": [
-       [
-        14,
-        1.1
-       ],
-       [
-        15,
-        1.7
-       ],
-       [
-        16,
-        2
-       ],
-       [
-        17,
-        3.5
-       ],
-       [
-        18,
-        6
-       ]
-      ]
-     },
-     "line-dasharray": [
-      6,
-      2
-     ]
-    }
-   },
-   {
-    "id": "Chemin superieur - filet exterieur - escalier",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_chemin_sup",
-    "minzoom": 14,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "ESCALIER_SUP"
-    ],
-    "paint": {
-     "line-color": {
-      "stops": [
-       [
-        17,
-        "#8C7274"
-       ],
-       [
-        18,
-        "#C8C8C8"
-       ]
-      ]
-     },
-     "line-width": {
-      "stops": [
-       [
-        14,
-        1.75
-       ],
-       [
-        15,
-        3
-       ],
-       [
-        16,
-        4.2
-       ],
-       [
-        17,
-        9.5
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Chemin superieur - filet interieur - escalier",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_chemin_sup",
-    "minzoom": 14,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "ESCALIER_SUP"
-    ],
-    "paint": {
-     "line-color": "#FFFFFF",
-     "line-width": {
-      "stops": [
-       [
-        14,
-        1
-       ],
-       [
-        15,
-        1.9
-       ],
-       [
-        16,
-        2.7
-       ],
-       [
-        17,
-        5.8
-       ]
-      ]
-     },
-     "line-dasharray": [
-      1,
-      0.2
-     ]
-    }
-   },
-   {
-    "id": "Chemin superieur - Rue pietonne",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_chemin_sup",
-    "minzoom": 14,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "RUE_PIETONNE_SUP"
-    ],
-    "paint": {
-     "line-color": {
-      "stops": [
-       [
-        17,
-        "#8C7274"
-       ],
-       [
-        18,
-        "#EBEBEB"
-       ]
-      ]
-     },
-     "line-width": {
-      "stops": [
-       [
-        14,
-        1
-       ],
-       [
-        15,
-        1.2
-       ],
-       [
-        16,
-        1.4
-       ],
-       [
-        17,
-        2
-       ],
-       [
-        18,
-        5
-       ]
-      ]
-     },
-     "line-dasharray": [
-      1,
-      3
-     ]
-    }
-   },
-   {
-    "id": "Chemin superieur - sentier",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_chemin_sup",
-    "minzoom": 13,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "SENTIER_SUP"
-    ],
-    "paint": {
-     "line-color": {
-      "stops": [
-       [
-        17,
-        "#8C7274"
-       ],
-       [
-        18,
-        "#FFFFFF"
-       ]
-      ]
-     },
-     "line-width": {
-      "stops": [
-       [
-        14,
-        1
-       ],
-       [
-        15,
-        1.2
-       ],
-       [
-        16,
-        1.4
-       ],
-       [
-        17,
-        2
-       ],
-       [
-        18,
-        6
-       ]
-      ]
-     },
-     "line-dasharray": [
-      4,
-      3
-     ]
-    }
-   },
-   {
-    "id": "Chemin superieur - chemin",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_chemin_sup",
-    "minzoom": 12,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "CHEMIN_SUP"
-    ],
-    "paint": {
-     "line-color": {
-      "stops": [
-       [
-        17,
-        "#8C7274"
-       ],
-       [
-        18,
-        "#FFFFFF"
-       ]
-      ]
-     },
-     "line-width": {
-      "stops": [
-       [
-        14,
-        1
-       ],
-       [
-        15,
-        1.2
-       ],
-       [
-        16,
-        1.4
-       ],
-       [
-        17,
-        2
-       ],
-       [
-        18,
-        7
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier superieur - filet extérieur - route non revetu carrosable",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route_sup",
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "NON_REVETUE_CARRO_SUP"
-    ],
-    "paint": {
-     "line-color": {
-      "stops": [
-       [
-        12,
-        "#646464"
-       ],
-       [
-        17,
-        "#8C8C8C"
-       ]
-      ]
-     },
-     "line-width": {
-      "stops": [
-       [
-        14,
-        3.2
-       ],
-       [
-        15,
-        5.4
-       ],
-       [
-        16,
-        7.7
-       ],
-       [
-        17,
-        16.8
-       ]
-      ]
-     },
-     "line-dasharray": [
-      2,
-      2
-     ]
-    }
-   },
-   {
-    "id": "Routier superieur - filet extérieur - bretelle autoroute",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route_sup",
-    "minzoom": 12,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "BRET_AUTO_PEAGE_3_SUP",
-     "BRET_AUTO_PEAGE_2_SUP",
-     "BRET_AUTO_PEAGE_1_SUP",
-     "BRET_AUTO_LIBRE_3_SUP",
-     "BRET_AUTO_LIBRE_2_SUP",
-     "BRET_AUTO_LIBRE_1_SUP"
-    ],
-    "paint": {
-     "line-color": {
-      "stops": [
-       [
-        9,
-        "#DE460E"
-       ],
-       [
-        17,
-        "#F18800"
-       ],
-       [
-        18,
-        "#FFFFFF"
-       ]
-      ]
-     },
-     "line-width": {
-      "stops": [
-       [
-        12,
-        2.5
-       ],
-       [
-        14,
-        3.7
-       ],
-       [
-        15,
-        6.8
-       ],
-       [
-        16,
-        8.4
-       ],
-       [
-        17,
-        14
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier superieur - filet extérieur - route non classee restreint",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route_sup",
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "NON_CLASSEE_RESTREINT_SUP"
-    ],
-    "paint": {
-     "line-color": {
-      "stops": [
-       [
-        17,
-        "#969696"
-       ],
-       [
-        18,
-        "#FFFFFF"
-       ]
-      ]
-     },
-     "line-width": {
-      "stops": [
-       [
-        14,
-        3.2
-       ],
-       [
-        15,
-        5.4
-       ],
-       [
-        16,
-        7.7
-       ],
-       [
-        17,
-        16.8
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier superieur - filet extérieur - route non classee",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route_sup",
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "NON_CLASSEE_4_SUP",
-     "NON_CLASSEE_SUP"
-    ],
-    "paint": {
-     "line-color": {
-      "stops": [
-       [
-        17,
-        "#969696"
-       ],
-       [
-        18,
-        "#FFFFFF"
-       ]
-      ]
-     },
-     "line-width": {
-      "stops": [
-       [
-        14,
-        3.2
-       ],
-       [
-        15,
-        5.4
-       ],
-       [
-        16,
-        7.7
-       ],
-       [
-        17,
-        16.8
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier superieur - filet extérieur - route locale",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route_sup",
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "BRET_LOCALE_SUP",
-     "LOCALE_4_SUP",
-     "LOCALE_3_SUP",
-     "LOCALE_2_SUP",
-     "LOCALE_1_SUP"
-    ],
-    "paint": {
-     "line-color": {
-      "stops": [
-       [
-        12,
-        "#8C8C8C"
-       ],
-       [
-        13,
-        "#B4B4B4"
-       ],
-       [
-        17,
-        "#B4B4B4"
-       ],
-       [
-        18,
-        "#FFFFFF"
-       ]
-      ]
-     },
-     "line-width": {
-      "stops": [
-       [
-        9,
-        2
-       ],
-       [
-        14,
-        3.5
-       ],
-       [
-        15,
-        6
-       ],
-       [
-        16,
-        8.4
-       ],
-       [
-        17,
-        18.3
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier superieur - filet extérieur - route locale en construction",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route_sup",
-    "minzoom": 11,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "LOCALE_CONSTR_SUP"
-    ],
-    "paint": {
-     "line-color": "#C8C8C8",
-     "line-width": {
-      "stops": [
-       [
-        9,
-        2
-       ],
-       [
-        14,
-        3.5
-       ],
-       [
-        15,
-        6
-       ],
-       [
-        16,
-        8.4
-       ],
-       [
-        17,
-        18.3
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier superieur - filet extérieur - route regionale",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route_sup",
-    "minzoom": 8,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "BRET_REGIONALE_SUP",
-     "REGIONALE_4_SUP",
-     "REGIONALE_3_SUP",
-     "REGIONALE_2_SUP",
-     "REGIONALE_1_SUP"
-    ],
-    "paint": {
-     "line-color": {
-      "stops": [
-       [
-        9,
-        "#828282"
-       ],
-       [
-        10,
-        "#B4B4B4"
-       ],
-       [
-        17,
-        "#B4B4B4"
-       ],
-       [
-        18,
-        "#FFFFFF"
-       ]
-      ]
-     },
-     "line-width": {
-      "stops": [
-       [
-        6,
-        1.5
-       ],
-       [
-        9,
-        2.3
-       ],
-       [
-        14,
-        5
-       ],
-       [
-        15,
-        8.1
-       ],
-       [
-        16,
-        11.2
-       ],
-       [
-        17,
-        22
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier superieur - filet extérieur - route regionale en construction",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route_sup",
-    "minzoom": 10,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "REGIONALE_CONSTR_SUP"
-    ],
-    "paint": {
-     "line-color": "#C8C8C8",
-     "line-width": {
-      "stops": [
-       [
-        6,
-        1.5
-       ],
-       [
-        9,
-        2.3
-       ],
-       [
-        14,
-        5
-       ],
-       [
-        15,
-        8.1
-       ],
-       [
-        16,
-        11.2
-       ],
-       [
-        17,
-        22
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier superieur - filet extérieur - route principale",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route_sup",
-    "minzoom": 8,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "BRET_PRINCIPALE_SUP",
-     "PRINCIPALE_4_SUP",
-     "PRINCIPALE_3_SUP",
-     "PRINCIPALE_2_SUP",
-     "PRINCIPALE_1_SUP"
-    ],
-    "paint": {
-     "line-color": {
-      "stops": [
-       [
-        17,
-        "#E2A52A"
-       ],
-       [
-        18,
-        "#FFFFFF"
-       ]
-      ]
-     },
-     "line-width": {
-      "stops": [
-       [
-        6,
-        1.8
-       ],
-       [
-        9,
-        2.7
-       ],
-       [
-        14,
-        5.9
-       ],
-       [
-        15,
-        9
-       ],
-       [
-        16,
-        12.2
-       ],
-       [
-        17,
-        22.5
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier superieur - filet extérieur - route principale en construction",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route_sup",
-    "minzoom": 10,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "PRINCIPALE_CONSTR_SUP"
-    ],
-    "paint": {
-     "line-color": "#C8C8C8",
-     "line-width": {
-      "stops": [
-       [
-        6,
-        1.8
-       ],
-       [
-        9,
-        2.7
-       ],
-       [
-        14,
-        5.9
-       ],
-       [
-        15,
-        9
-       ],
-       [
-        16,
-        12.2
-       ],
-       [
-        17,
-        22.5
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier superieur - filet extérieur - autoroute",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route_sup",
-    "minzoom": 8,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "AUTOROU_PEAGE_SUP",
-     "AUTOROU_LIBRE_SUP"
-    ],
-    "paint": {
-     "line-color": {
-      "stops": [
-       [
-        9,
-        "#DE460E"
-       ],
-       [
-        17,
-        "#F18800"
-       ],
-       [
-        18,
-        "#FFFFFF"
-       ]
-      ]
-     },
-     "line-width": {
-      "stops": [
-       [
-        6,
-        2.5
-       ],
-       [
-        9,
-        3.5
-       ],
-       [
-        14,
-        7.5
-       ],
-       [
-        15,
-        11
-       ],
-       [
-        16,
-        15
-       ],
-       [
-        17,
-        26
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier superieur - filet extérieur - autoroute en construction",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route_sup",
-    "minzoom": 10,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "AUTOROU_CONSTR_SUP"
-    ],
-    "paint": {
-     "line-color": "#C8C8C8",
-     "line-width": {
-      "stops": [
-       [
-        6,
-        2.5
-       ],
-       [
-        9,
-        3.5
-       ],
-       [
-        14,
-        7.5
-       ],
-       [
-        15,
-        11
-       ],
-       [
-        16,
-        15
-       ],
-       [
-        17,
-        26
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier superieur - filet interieur - route non revetu carrosable",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route_sup",
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "NON_REVETUE_CARRO_SUP"
-    ],
-    "paint": {
-     "line-color": "#FFFFFF",
-     "line-width": {
-      "stops": [
-       [
-        14,
-        2.3
-       ],
-       [
-        15,
-        4.1
-       ],
-       [
-        16,
-        6.3
-       ],
-       [
-        17,
-        13.5
-       ],
-       [
-        18,
-        16.8
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier superieur - filet interieur - bretelle autoroute",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route_sup",
-    "minzoom": 12,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "BRET_AUTO_PEAGE_3_SUP",
-     "BRET_AUTO_PEAGE_2_SUP",
-     "BRET_AUTO_PEAGE_1_SUP",
-     "BRET_AUTO_LIBRE_3_SUP",
-     "BRET_AUTO_LIBRE_2_SUP",
-     "BRET_AUTO_LIBRE_1_SUP"
-    ],
-    "paint": {
-     "line-color": {
-      "stops": [
-       [
-        9,
-        "#F18800"
-       ],
-       [
-        17,
-        "#F2B230"
-       ]
-      ]
-     },
-     "line-width": {
-      "stops": [
-       [
-        12,
-        1.5
-       ],
-       [
-        14,
-        2.6
-       ],
-       [
-        15,
-        5.2
-       ],
-       [
-        16,
-        6.7
-       ],
-       [
-        17,
-        10.8
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier superieur - filet interieur - route non classee restreint",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route_sup",
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "NON_CLASSEE_RESTREINT_SUP"
-    ],
-    "paint": {
-     "line-color": "#EDF1FF",
-     "line-width": {
-      "stops": [
-       [
-        14,
-        2.3
-       ],
-       [
-        15,
-        4.1
-       ],
-       [
-        16,
-        6.3
-       ],
-       [
-        17,
-        13.5
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier superieur - filet interieur - route non classee",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route_sup",
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "NON_CLASSEE_4_SUP",
-     "NON_CLASSEE_SUP"
-    ],
-    "paint": {
-     "line-color": "#FFFFFF",
-     "line-width": {
-      "stops": [
-       [
-        14,
-        2.3
-       ],
-       [
-        15,
-        4.1
-       ],
-       [
-        16,
-        6.3
-       ],
-       [
-        17,
-        13.5
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier superieur - filet interieur - route locale",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route_sup",
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "BRET_LOCALE_SUP",
-     "LOCALE_4_SUP",
-     "LOCALE_3_SUP",
-     "LOCALE_2_SUP",
-     "LOCALE_1_SUP"
-    ],
-    "paint": {
-     "line-color": {
-      "stops": [
-       [
-        12,
-        "#FFFFFF"
-       ],
-       [
-        13,
-        "#FCF4A8"
-       ],
-       [
-        17,
-        "#FCF7C1"
-       ]
-      ]
-     },
-     "line-width": {
-      "stops": [
-       [
-        9,
-        1.3
-       ],
-       [
-        14,
-        2.3
-       ],
-       [
-        15,
-        4.1
-       ],
-       [
-        16,
-        6.1
-       ],
-       [
-        17,
-        13.1
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier superieur - filet interieur - route locale en construction",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route_sup",
-    "minzoom": 11,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "LOCALE_CONSTR_SUP"
-    ],
-    "paint": {
-     "line-color": {
-      "stops": [
-       [
-        12,
-        "#FFFFFF"
-       ],
-       [
-        13,
-        "#FCF4A8"
-       ],
-       [
-        17,
-        "#FCF7C1"
-       ]
-      ]
-     },
-     "line-width": {
-      "stops": [
-       [
-        9,
-        2
-       ],
-       [
-        14,
-        3.5
-       ],
-       [
-        15,
-        6
-       ],
-       [
-        16,
-        8.4
-       ],
-       [
-        17,
-        18.3
-       ]
-      ]
-     },
-     "line-dasharray": [
-      2,
-      2
-     ]
-    }
-   },
-   {
-    "id": "Routier superieur - filet interieur - route regionale",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route_sup",
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "BRET_REGIONALE_SUP",
-     "REGIONALE_4_SUP",
-     "REGIONALE_3_SUP",
-     "REGIONALE_2_SUP",
-     "REGIONALE_1_SUP"
-    ],
-    "paint": {
-     "line-color": {
-      "stops": [
-       [
-        9,
-        "#FFFFFF"
-       ],
-       [
-        10,
-        "#FDF28B"
-       ],
-       [
-        17,
-        "#FCF6BD"
-       ]
-      ]
-     },
-     "line-width": {
-      "stops": [
-       [
-        6,
-        1.4
-       ],
-       [
-        9,
-        1.5
-       ],
-       [
-        14,
-        3.2
-       ],
-       [
-        15,
-        5.8
-       ],
-       [
-        16,
-        8.3
-       ],
-       [
-        17,
-        16.2
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier superieur - filet interieur - route regionale en construction",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route_sup",
-    "minzoom": 10,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "REGIONALE_CONSTR_SUP"
-    ],
-    "paint": {
-     "line-color": {
-      "stops": [
-       [
-        9,
-        "#FFFFFF"
-       ],
-       [
-        10,
-        "#FDF28B"
-       ],
-       [
-        17,
-        "#FCF6BD"
-       ]
-      ]
-     },
-     "line-width": {
-      "stops": [
-       [
-        6,
-        1.5
-       ],
-       [
-        9,
-        2.3
-       ],
-       [
-        14,
-        5
-       ],
-       [
-        15,
-        8.1
-       ],
-       [
-        16,
-        11.2
-       ],
-       [
-        17,
-        22
-       ]
-      ]
-     },
-     "line-dasharray": [
-      2,
-      2
-     ]
-    }
-   },
-   {
-    "id": "Routier superieur - filet interieur - route principale",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route_sup",
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "BRET_PRINCIPALE_SUP",
-     "PRINCIPALE_4_SUP",
-     "PRINCIPALE_3_SUP",
-     "PRINCIPALE_2_SUP",
-     "PRINCIPALE_1_SUP"
-    ],
-    "paint": {
-     "line-color": {
-      "stops": [
-       [
-        9,
-        "#F3C66D"
-       ],
-       [
-        17,
-        "#F2DDB3"
-       ]
-      ]
-     },
-     "line-width": {
-      "stops": [
-       [
-        4,
-        0.5
-       ],
-       [
-        6,
-        1.8
-       ],
-       [
-        9,
-        2.1
-       ],
-       [
-        14,
-        4.4
-       ],
-       [
-        15,
-        7.3
-       ],
-       [
-        16,
-        10
-       ],
-       [
-        17,
-        18.5
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier superieur - filet interieur - route principale en construction",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route_sup",
-    "minzoom": 10,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "PRINCIPALE_CONSTR_SUP"
-    ],
-    "paint": {
-     "line-color": {
-      "stops": [
-       [
-        9,
-        "#F3C66D"
-       ],
-       [
-        17,
-        "#F2DDB3"
-       ]
-      ]
-     },
-     "line-width": {
-      "stops": [
-       [
-        6,
-        1.8
-       ],
-       [
-        9,
-        2.7
-       ],
-       [
-        14,
-        5.9
-       ],
-       [
-        15,
-        9
-       ],
-       [
-        16,
-        12.2
-       ],
-       [
-        17,
-        22.5
-       ]
-      ]
-     },
-     "line-dasharray": [
-      2,
-      2
-     ]
-    }
-   },
-   {
-    "id": "Routier superieur - filet interieur - autoroute",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route_sup",
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "AUTOROU_PEAGE_SUP",
-     "AUTOROU_LIBRE_SUP"
-    ],
-    "paint": {
-     "line-color": {
-      "stops": [
-       [
-        9,
-        "#F18800"
-       ],
-       [
-        17,
-        "#F2B230"
-       ]
-      ]
-     },
-     "line-width": {
-      "stops": [
-       [
-        4,
-        0.7
-       ],
-       [
-        6,
-        2.5
-       ],
-       [
-        9,
-        2.7
-       ],
-       [
-        14,
-        5.8
-       ],
-       [
-        15,
-        9
-       ],
-       [
-        16,
-        12
-       ],
-       [
-        17,
-        20.8
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier superieur - axe central - autoroute",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route_sup",
-    "minzoom": 13,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "AUTOROU_PEAGE_SUP",
-     "AUTOROU_LIBRE_SUP"
-    ],
-    "paint": {
-     "line-color": "#FFFFFF",
-     "line-width": {
-      "stops": [
-       [
-        9,
-        0.6
-       ],
-       [
-        14,
-        0.7
-       ],
-       [
-        15,
-        1
-       ],
-       [
-        16,
-        1.2
-       ],
-       [
-        17,
-        2.1
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Routier superieur - filet interieur - autoroute en construction",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route_sup",
-    "minzoom": 10,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "AUTOROU_CONSTR_SUP"
-    ],
-    "paint": {
-     "line-color": {
-      "stops": [
-       [
-        9,
-        "#F18800"
-       ],
-       [
-        17,
-        "#F2B230"
-       ]
-      ]
-     },
-     "line-width": {
-      "stops": [
-       [
-        4,
-        0.7
-       ],
-       [
-        6,
-        2.5
-       ],
-       [
-        9,
-        3.5
-       ],
-       [
-        14,
-        7.5
-       ],
-       [
-        15,
-        11
-       ],
-       [
-        16,
-        15
-       ],
-       [
-        17,
-        26
-       ]
-      ]
-     },
-     "line-dasharray": [
-      2,
-      2
-     ]
-    }
-   },
-   {
-    "id": "Routier superieur - axe centrale - autoroute en construction",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "routier_route_sup",
-    "minzoom": 13,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "AUTOROU_CONSTR_SUP"
-    ],
-    "paint": {
-     "line-color": "#808080",
-     "line-width": {
-      "stops": [
-       [
-        9,
-        0.6
-       ],
-       [
-        14,
-        0.7
-       ],
-       [
-        15,
-        1
-       ],
-       [
-        16,
-        1.2
-       ],
-       [
-        17,
-        2.1
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Ferre superieur - voie normale",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "ferre_sup",
-    "minzoom": 10,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "VF_1_SUP",
-     "VF_2_SUP",
-     "VF_ELEC_1_SUP"
-    ],
-    "paint": {
-     "line-color": "#787878",
-     "line-width": {
-      "stops": [
-       [
-        10,
-        0.8
-       ],
-       [
-        17,
-        2.5
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Ferre superieur - voie normale trait perpendic",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "ferre_sup",
-    "minzoom": 10,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "VF_1_SUP",
-     "VF_2_SUP",
-     "VF_ELEC_1_SUP"
-    ],
-    "paint": {
-     "line-color": "#787878",
-     "line-width": {
-      "stops": [
-       [
-        10,
-        3.5
-       ],
-       [
-        17,
-        14.7
-       ]
-      ]
-     },
-     "line-dasharray": [
-      0.1,
-      10
-     ]
-    }
-   },
-   {
-    "id": "Ferre superieur - voie etroite",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "ferre_sup",
-    "minzoom": 10,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "VF_ETROITE_1_SUP",
-     "VF_ETROITE_SUP"
-    ],
-    "paint": {
-     "line-color": "#787878",
-     "line-width": {
-      "stops": [
-       [
-        10,
-        0.3
-       ],
-       [
-        17,
-        1.8
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Ferre superieur - voie etroite trait perpendic",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "ferre_sup",
-    "minzoom": 10,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "VF_ETROITE_1_SUP",
-     "VF_ETROITE_SUP"
-    ],
-    "paint": {
-     "line-color": "#787878",
-     "line-width": {
-      "stops": [
-       [
-        10,
-        3.5
-       ],
-       [
-        17,
-        14.7
-       ]
-      ]
-     },
-     "line-dasharray": [
-      0.1,
-      10
-     ]
-    }
-   },
-   {
-    "id": "Ferre superieur - voie service",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "ferre_sup",
-    "minzoom": 14,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "VF_SERVICE_SUP",
-     "VF_NON_EXPLOITEE_SUP"
-    ],
-    "paint": {
-     "line-color": "#787878",
-     "line-width": {
-      "stops": [
-       [
-        10,
-        0.3
-       ],
-       [
-        17,
-        1.8
-       ]
-      ]
-     },
-     "line-dasharray": [
-      5,
-      2,
-      1,
-      2
-     ]
-    }
-   },
-   {
-    "id": "Ferre superieur - voie en construction",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "ferre_sup",
-    "minzoom": 10,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "VF_EN_CONSTR_SUP"
-    ],
-    "paint": {
-     "line-color": "#787878",
-     "line-width": {
-      "stops": [
-       [
-        10,
-        0.3
-       ],
-       [
-        17,
-        1.8
-       ]
-      ]
-     },
-     "line-dasharray": [
-      2,
-      2
-     ]
-    }
-   },
-   {
-    "id": "Ferre superieur - voie en construction trait perpendic",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "ferre_sup",
-    "minzoom": 10,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "VF_EN_CONSTR_SUP"
-    ],
-    "paint": {
-     "line-color": "#787878",
-     "line-width": {
-      "stops": [
-       [
-        10,
-        3.5
-       ],
-       [
-        17,
-        14.7
-       ]
-      ]
-     },
-     "line-dasharray": [
-      0.1,
-      10
-     ]
-    }
-   },
-   {
-    "id": "Ferre superieur - funic/urbain",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "ferre_sup",
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "FUNI_CREMAILLERE_SUP",
-     "TRANSPORT_URBAIN_SUP"
-    ],
-    "paint": {
-     "line-color": "#787878",
-     "line-width": {
-      "stops": [
-       [
-        10,
-        0.3
-       ],
-       [
-        17,
-        1.8
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "Ferre superieur - 2 trait perpendic - funic/urbain",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "ferre_sup",
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "FUNI_CREMAILLERE_SUP",
-     "TRANSPORT_URBAIN_SUP"
-    ],
-    "paint": {
-     "line-color": "#787878",
-     "line-width": {
-      "stops": [
-       [
-        10,
-        3.5
-       ],
-       [
-        17,
-        17
-       ]
-      ]
-     },
-     "line-dasharray": [
-      0.1,
-      0.2,
-      0.1,
-      10
-     ]
-    }
-   },
-   {
-    "id": "Limite - cloture",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "limite_lin",
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "CLOTURE"
-    ],
-    "paint": {
-     "line-color": "#000000",
-     "line-width": {
-      "stops": [
-       [
-        13,
-        0.6
-       ],
-       [
-        17,
-        1
-       ]
-      ]
-     },
-     "line-dasharray": [
-      1.5,
-      4
-     ]
-    }
-   },
-   {
-    "id": "Limite - layon",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "limite_lin",
-    "minzoom": 14,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "LAYON"
-    ],
-    "paint": {
-     "line-color": "#B3989A",
-     "line-width": {
-      "stops": [
-       [
-        14,
-        1
-       ],
-       [
-        15,
-        1.2
-       ],
-       [
-        16,
-        1.4
-       ],
-       [
-        17,
-        2
-       ]
-      ]
-     },
-     "line-dasharray": [
-      4,
-      7
-     ]
-    }
-   },
-   {
-    "id": "Zone Règlementee - Enceinte militaire",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "limite_lin",
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "LIM_ZONE_REGLEMENTEE",
-     "LIM_ENCEINTE_MILITAIRE",
-     "LIM_ENCEINTE_MILI",
-     "LIM_CHAMP_TIR"
-    ],
-    "paint": {
-     "line-color": "rgba(226, 130, 92, 0.8)",
-     "line-width": {
-      "stops": [
-       [
-        13,
-        1.7
-       ],
-       [
-        17,
-        3.1
-       ]
-      ]
-     },
-     "line-dasharray": [
-      4,
-      1,
-      2,
-      5
-     ]
-    }
-   },
-   {
-    "id": "limite zone naturelle",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "limite_lin",
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "LIM_ZONE_NATURELLE",
-     "LIM_ZONE_NATURELLE_ILE",
-     "LIM_RESERVE_NATURELLE"
-    ],
-    "paint": {
-     "line-color": "#FFC2CB",
-     "line-width": {
-      "stops": [
-       [
-        13,
-        2
-       ],
-       [
-        17,
-        4
-       ]
-      ]
-     },
-     "line-dasharray": [
-      2,
-      1
-     ]
-    }
-   },
-   {
-    "id": "limite zone naturelle - Parc naturel 10",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "limite_lin",
-    "maxzoom": 10,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "LIM_PARC_NATUREL",
-     "LIM_PARC_NATUREL_ILE"
-    ],
-    "paint": {
-     "line-color": "#42A266",
-     "line-width": {
-      "stops": [
-       [
-        13,
-        2
-       ],
-       [
-        17,
-        4
-       ]
-      ]
-     },
-     "line-dasharray": [
-      2,
-      1
-     ]
-    }
-   },
-   {
-    "id": "limite zone naturelle - Parc naturel 11",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "limite_lin",
-    "minzoom": 10,
-    "maxzoom": 11,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "LIM_PARC_NATUREL",
-     "LIM_PARC_NATUREL_ILE"
-    ],
-    "paint": {
-     "line-color": "#42A266",
-     "line-width": {
-      "stops": [
-       [
-        13,
-        2
-       ],
-       [
-        17,
-        4
-       ]
-      ]
-     },
-     "line-dasharray": [
-      2,
-      2
-     ]
-    }
-   },
-   {
-    "id": "limite zone naturelle - Parc naturel 12",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "limite_lin",
-    "minzoom": 11,
-    "maxzoom": 12,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "LIM_PARC_NATUREL",
-     "LIM_PARC_NATUREL_ILE"
-    ],
-    "paint": {
-     "line-color": "#42A266",
-     "line-width": {
-      "stops": [
-       [
-        13,
-        2
-       ],
-       [
-        17,
-        4
-       ]
-      ]
-     },
-     "line-dasharray": [
-      2,
-      3
-     ]
-    }
-   },
-   {
-    "id": "limite zone naturelle - Parc naturel 13",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "limite_lin",
-    "minzoom": 12,
-    "maxzoom": 13,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "LIM_PARC_NATUREL",
-     "LIM_PARC_NATUREL_ILE"
-    ],
-    "paint": {
-     "line-color": "#42A266",
-     "line-width": {
-      "stops": [
-       [
-        13,
-        2
-       ],
-       [
-        17,
-        4
-       ]
-      ]
-     },
-     "line-dasharray": [
-      2,
-      4
-     ]
-    }
-   },
-   {
-    "id": "limite zone naturelle - Parc naturel 14",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "limite_lin",
-    "minzoom": 13,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "LIM_PARC_NATUREL",
-     "LIM_PARC_NATUREL_ILE"
-    ],
-    "paint": {
-     "line-color": "rgba(66, 162, 102, 0.7)",
-     "line-width": {
-      "stops": [
-       [
-        13,
-        2
-       ],
-       [
-        17,
-        4
-       ]
-      ]
-     },
-     "line-dasharray": [
-      2,
-      5
-     ]
-    }
-   },
-   {
-    "id": "limite zone naturelle - Parc marin",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "limite_lin",
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "LIM_PARC_NATUREL_MARIN"
-    ],
-    "paint": {
-     "line-color": "#2A81A2",
-     "line-width": {
-      "stops": [
-       [
-        13,
-        2
-       ],
-       [
-        17,
-        4
-       ]
-      ]
-     },
-     "line-dasharray": [
-      2,
-      1
-     ]
-    }
-   },
-   {
-    "id": "parcellaire - parcelle bordure",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "parcellaire_parcelle",
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "PARCELLE"
-    ],
-    "paint": {
-     "line-color": "#9933FF",
-     "line-width": 1
-    }
-   },
-   {
-    "id": "parcellaire - section",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "parcellaire_section",
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "SECTION"
-    ],
-    "paint": {
-     "line-color": "#287B00",
-     "line-width": 1.9,
-     "line-dasharray": [
-      2,
-      4,
-      2
-     ]
-    }
-   },
-   {
-    "id": "toponyme - parcellaire - section",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_parcellaire_section",
-    "filter": [
-     "==",
-     "txt_typo",
-     "SECTION"
-    ],
-    "layout": {
-     "symbol-placement": "line",
-     "text-offset": [
-      0,
-      0
-     ],
-     "text-field": "{texte}",
-     "text-size": 15,
-     "text-anchor": "center",
-     "text-keep-upright": true,
-     "text-max-angle": 45,
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#287B00"
-    }
-   },
-   {
-    "id": "toponyme - parcellaire - parcelle",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_parcellaire_parcelle",
-    "filter": [
-     "==",
-     "txt_typo",
-     "PARCELLE"
-    ],
-    "layout": {
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-size": 11,
-     "text-anchor": "center",
-     "text-keep-upright": true,
-     "text-max-angle": 45,
-     "text-font": [
-      "Source Sans Pro Bold"
-     ]
-    },
-    "paint": {
-     "text-color": "#9933FF",
-     "text-halo-width": 1,
-     "text-halo-color": "#FFFFFF"
-    }
-   },
-   {
-    "id": "toponyme - parcellaire - adresse",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_parcellaire_adresse_ponc",
-    "filter": [
-     "==",
-     "txt_typo",
-     "ADRESSE"
-    ],
-    "layout": {
-     "symbol-placement": "point",
-     "text-field": [
-      "concat",
-      "{numero}",
-      "{indice_de_repetition}"
-     ],
-     "text-size": 11,
-     "text-anchor": "center",
-     "text-keep-upright": true,
-     "text-max-angle": 45,
-     "text-font": [
-      "Source Sans Pro Bold"
-     ]
-    },
-    "paint": {
-     "text-color": "#695744",
-     "text-halo-width": 1,
-     "text-halo-color": "#FFFFFF"
-    }
-   },
-   {
-    "id": "limite admin - limite de commune",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "limite_lin",
-    "minzoom": 13,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "LIM_COMMUNE",
-     "LIM_CANTON",
-     "LIM_ARRONDISSEMENT"
-    ],
-    "paint": {
-     "line-color": "rgba(126, 119, 184, 0.5)",
-     "line-width": {
-      "stops": [
-       [
-        13,
-        3
-       ],
-       [
-        17,
-        5.5
-       ]
-      ]
-     },
-     "line-dasharray": [
-      4,
-      2,
-      1,
-      1,
-      1,
-      1,
-      1,
-      2
-     ]
-    }
-   },
-   {
-    "id": "limite admin - limite de département bandeau",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "limite_lin",
-    "minzoom": 8,
-    "maxzoom": 13,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "LIM_DEPARTEMENT"
-    ],
-    "paint": {
-     "line-color": "rgba(178, 175, 219, 0.4)",
-     "line-width": {
-      "stops": [
-       [
-        9,
-        4.1
-       ],
-       [
-        12,
-        6
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "limite admin - limite de département tiret",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "limite_lin",
-    "minzoom": 13,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "LIM_DEPARTEMENT"
-    ],
-    "paint": {
-     "line-color": "rgba(126, 119, 184, 0.5)",
-     "line-width": {
-      "stops": [
-       [
-        13,
-        3
-       ],
-       [
-        17,
-        5.5
-       ]
-      ]
-     },
-     "line-dasharray": [
-      4,
-      2,
-      1,
-      1,
-      1,
-      2
-     ]
-    }
-   },
-   {
-    "id": "limite admin - limite de région bandeau",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "limite_lin",
-    "minzoom": 7,
-    "maxzoom": 13,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "LIM_REGION"
-    ],
-    "paint": {
-     "line-color": "rgba(178, 175, 219, 0.5)",
-     "line-width": {
-      "stops": [
-       [
-        9,
-        4.5
-       ],
-       [
-        12,
-        6.7
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "limite admin - limite de région tiret",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "limite_lin",
-    "minzoom": 13,
-    "maxzoom": 18,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "LIM_REGION"
-    ],
-    "paint": {
-     "line-color": "rgba(126, 119, 184, 0.5)",
-     "line-width": {
-      "stops": [
-       [
-        13,
-        3
-       ],
-       [
-        17,
-        5.5
-       ]
-      ]
-     },
-     "line-dasharray": [
-      4,
-      2,
-      1,
-      2
-     ]
-    }
-   },
-   {
-    "id": "limite etat 1",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "limite_lin",
-    "minzoom": 2,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "LIM_ETAT",
-     "LIM_ETAT_ETRANGER"
-    ],
-    "paint": {
-     "line-color": "rgba(178, 175, 219, 0.6)",
-     "line-width": {
-      "stops": [
-       [
-        2,
-        2
-       ],
-       [
-        3,
-        3.5
-       ],
-       [
-        9,
-        5
-       ],
-       [
-        14,
-        13
-       ],
-       [
-        15,
-        20
-       ],
-       [
-        16,
-        24
-       ],
-       [
-        17,
-        42
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "limite etat 2",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "limite_lin",
-    "minzoom": 7,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "LIM_ETAT",
-     "LIM_ETAT_ETRANGER"
-    ],
-    "paint": {
-     "line-color": "#9F9CB8",
-     "line-width": {
-      "stops": [
-       [
-        9,
-        1.5
-       ],
-       [
-        14,
-        3.5
-       ],
-       [
-        15,
-        5.5
-       ],
-       [
-        16,
-        6.5
-       ],
-       [
-        17,
-        11
-       ]
-      ]
-     },
-     "line-dasharray": [
-      4,
-      2
-     ]
-    }
-   },
-   {
-    "id": "limite cote",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "limite_lin",
-    "minzoom": 7,
-    "maxzoom": 10,
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "LIM_COTE"
-    ],
-    "paint": {
-     "line-color": "#82A3B2",
-     "line-width": 1
-    }
-   },
-   {
-    "id": "ligne electrique",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "bati_lin",
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "LIGNE_ELECTRIQUE"
-    ],
-    "paint": {
-     "line-color": "#808080",
-     "line-width": {
-      "stops": [
-       [
-        13,
-        1
-       ],
-       [
-        17,
-        2
-       ]
-      ]
-     }
-    }
-   },
-   {
-    "id": "autre construction linéaire",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "bati_lin",
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "round",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "CABLE",
-     "REMONTEE_MEC",
-     "HYDROCARBURES",
-     "CONDUITE_MATIERES_P",
-     "SPORT_MONTAGNE_LIN",
-     "PISTE_BOBSLEIGH",
-     "PISTE_LUGE",
-     "PISTE_AERO_LIN"
-    ],
-    "paint": {
-     "line-color": "#808080",
-     "line-width": 1
-    }
-   },
-   {
-    "id": "autre construction linéaire - trait perpend cable",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "bati_lin",
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "CABLE"
-    ],
-    "paint": {
-     "line-color": "#808080",
-     "line-width": 5,
-     "line-dasharray": [
-      0.5,
-      10
-     ]
-    }
-   },
-   {
-    "id": "autre construction linéaire - trait perpend 1 remont",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "bati_lin",
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "REMONTEE_MEC"
-    ],
-    "paint": {
-     "line-color": "#808080",
-     "line-width": 6,
-     "line-dasharray": [
-      1,
-      10
-     ]
-    }
-   },
-   {
-    "id": "autre construction linéaire - trait perpend 2 remont",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "bati_lin",
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "REMONTEE_MEC"
-    ],
-    "paint": {
-     "line-color": "#BEBEBE",
-     "line-width": 6,
-     "line-dasharray": [
-      0.3,
-      0.4,
-      0.3,
-      10
-     ]
-    }
-   },
-   {
-    "id": "autre construction linéaire - trait perpend carbur",
-    "type": "line",
-    "source": "plan_ign",
-    "source-layer": "bati_lin",
-    "layout": {
-     "visibility": "visible",
-     "line-cap": "butt",
-     "line-join": "round"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "HYDROCARBURES",
-     "CONDUITE_MATIERES_P"
-    ],
-    "paint": {
-     "line-color": "#808080",
-     "line-width": 5,
-     "line-dasharray": [
-      1,
-      10
-     ]
-    }
-   },
-   {
-    "id": "routier ponctuel - peage ponctuel",
-    "type": "circle",
-    "source": "plan_ign",
-    "source-layer": "routier_ponc",
-    "minzoom": 8,
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "PEAGE_PONC"
-    ],
-    "paint": {
-     "circle-radius": {
-      "stops": [
-       [
-        9,
-        3.5
-       ],
-       [
-        12,
-        6.5
-       ]
-      ]
-     },
-     "circle-color": "#E2A52A",
-     "circle-stroke-width": 1,
-     "circle-stroke-color": "#808080"
-    }
-   },
-   {
-    "id": "routier ponctuel - barriere",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "routier_ponc",
-    "minzoom": 12,
-    "layout": {
-     "visibility": "visible",
-     "icon-image": "Barriere",
-     "icon-size": {
-      "stops": [
-       [
-        13,
-        0.25
-       ],
-       [
-        16,
-        0.45
-       ],
-       [
-        17,
-        0.7
-       ]
-      ]
-     },
-     "icon-allow-overlap": true,
-     "icon-rotate": [
-      "get",
-      "rotation"
-     ]
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "BARRIERE"
-    ],
-    "paint": {
-     "icon-color": "#969696"
-    }
-   },
-   {
-    "id": "hydro ponctuel",
-    "type": "circle",
-    "source": "plan_ign",
-    "source-layer": "hydro_ponc",
-    "minzoom": 13,
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "FONTAINE",
-     "POINT_D_EAU",
-     "SOURCE",
-     "SOURCE_CAPTEE",
-     "PERTE",
-     "RESURGENCE",
-     "CASCADE",
-     "AUTRE_HYDRO_PONC"
-    ],
-    "paint": {
-     "circle-radius": {
-      "stops": [
-       [
-        14,
-        3
-       ],
-       [
-        17,
-        7
-       ]
-      ]
-     },
-     "circle-color": "#FFFFFF",
-     "circle-opacity": 1,
-     "circle-stroke-width": {
-      "stops": [
-       [
-        14,
-        2
-       ],
-       [
-        17,
-        5
-       ]
-      ]
-     },
-     "circle-stroke-color": "#1466B2"
-    }
-   },
-   {
-    "id": "point coté",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "oro_ponc",
-    "minzoom": 11,
-    "maxzoom": 16,
-    "filter": [
-     "in",
-     "symbo",
-     "POINT_COTE",
-     "POINT_COTE_TOPO",
-     "POINT_COTE_RESEAU",
-     "POINT_RBF"
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "icon-image": "Localite",
-     "icon-size": 0.1,
-     "text-field": "{texte}",
-     "text-size": 10,
-     "text-allow-overlap": false,
-     "text-anchor": "bottom-left",
-     "text-offset": [
-      0.2,
-      0.4
-     ],
-     "text-padding": 2,
-     "text-font": [
-      "Source Sans Pro Italic"
-     ]
-    },
-    "paint": {
-     "text-color": "#505050"
-    }
-   },
-   {
-    "id": "bati ponctuel : Hopital",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "bati_ponc",
-    "layout": {
-     "visibility": "visible",
-     "icon-image": "Hopital",
-     "icon-size": 0.33
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "HOPITAL_PONC"
-    ],
-    "paint": {
-     "icon-color": "#646464"
-    }
-   },
-   {
-    "id": "bati ponctuel hydrographique",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "bati_ponc",
-    "minzoom": 14,
-    "layout": {
-     "visibility": "visible",
-     "icon-image": "Pompage",
-     "icon-size": {
-      "stops": [
-       [
-        13,
-        0.2
-       ],
-       [
-        17,
-        0.6
-       ]
-      ]
-     },
-     "icon-allow-overlap": true
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "CITERNE",
-     "LAVOIR",
-     "STATION_EPURATION",
-     "STATION_DE_POMPAGE",
-     "USINE_PRODUCTION_EAU",
-     "USINE_ELEVATRICE"
-    ],
-    "paint": {
-     "icon-color": "#1C62A6"
-    }
-   },
-   {
-    "id": "bati ponctuel hydrographique - Puits-Abreuvoir",
-    "type": "circle",
-    "source": "plan_ign",
-    "source-layer": "bati_ponc",
-    "minzoom": 13,
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "PUITS",
-     "ABREUVOIR"
-    ],
-    "paint": {
-     "circle-radius": {
-      "stops": [
-       [
-        14,
-        3
-       ],
-       [
-        17,
-        7
-       ]
-      ]
-     },
-     "circle-color": "#FFFFFF",
-     "circle-opacity": 1,
-     "circle-stroke-width": {
-      "stops": [
-       [
-        14,
-        2
-       ],
-       [
-        17,
-        5
-       ]
-      ]
-     },
-     "circle-stroke-color": "#1466B2"
-    }
-   },
-   {
-    "id": "bati ponctuel hydrographique - Phare",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "bati_ponc",
-    "minzoom": 13,
-    "layout": {
-     "visibility": "visible",
-     "icon-image": "Phare",
-     "icon-size": {
-      "stops": [
-       [
-        13,
-        0.7
-       ],
-       [
-        17,
-        1.3
-       ]
-      ]
-     }
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "PHARE"
-    ],
-    "paint": {
-     "icon-color": "#646464"
-    }
-   },
-   {
-    "id": "bati ponctuel hydrographique - Amer-Feu",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "bati_ponc",
-    "minzoom": 13,
-    "layout": {
-     "visibility": "visible",
-     "icon-image": "Feu",
-     "icon-size": {
-      "stops": [
-       [
-        13,
-        0.7
-       ],
-       [
-        17,
-        1.3
-       ]
-      ]
-     }
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "AMER",
-     "FEU",
-     "FEU_PONC",
-     "TOURELLE_LUMINEUSE"
-    ],
-    "paint": {
-     "icon-color": "#646464"
-    }
-   },
-   {
-    "id": "bati ponctuel hydrographique - Balise",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "bati_ponc",
-    "minzoom": 13,
-    "layout": {
-     "visibility": "visible",
-     "icon-image": "Balise",
-     "icon-size": {
-      "stops": [
-       [
-        13,
-        0.7
-       ],
-       [
-        17,
-        1.3
-       ]
-      ]
-     }
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "BALISE",
-     "TOURELLE"
-    ],
-    "paint": {
-     "icon-color": "#646464"
-    }
-   },
-   {
-    "id": "bati ponctuel hydrographique - Ecluse",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "bati_ponc",
-    "minzoom": 12,
-    "maxzoom": 15,
-    "layout": {
-     "visibility": "visible",
-     "icon-image": "Ecluse",
-     "icon-size": 0.2
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "ECLUSE_PONC"
-    ],
-    "paint": {
-     "icon-color": "#1C62A6"
-    }
-   },
-   {
-    "id": "bati ponctuel hydrographique - Barrage",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "bati_ponc",
-    "minzoom": 12,
-    "maxzoom": 14,
-    "layout": {
-     "visibility": "visible",
-     "icon-image": "Barrage",
-     "icon-size": 0.25
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "BARRAGE_PONC"
-    ],
-    "paint": {
-     "icon-color": "#1C62A6"
-    }
-   },
-   {
-    "id": "bati ponctuel hydrographique - Chateau d'eau",
-    "type": "circle",
-    "source": "plan_ign",
-    "source-layer": "bati_ponc",
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "CHATEAU_EAU_PONC"
-    ],
-    "paint": {
-     "circle-radius": {
-      "stops": [
-       [
-        14,
-        3
-       ],
-       [
-        17,
-        8
-       ]
-      ]
-     },
-     "circle-color": "#1466B2"
-    }
-   },
-   {
-    "id": "bati ponctuel hydrographique - Réservoir d'eau",
-    "type": "circle",
-    "source": "plan_ign",
-    "source-layer": "bati_ponc",
-    "maxzoom": 15,
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "RESERVOIR_EAU_PONC"
-    ],
-    "paint": {
-     "circle-radius": {
-      "stops": [
-       [
-        14,
-        3
-       ],
-       [
-        17,
-        8
-       ]
-      ]
-     },
-     "circle-color": "#AAD5E9",
-     "circle-opacity": 1,
-     "circle-stroke-width": {
-      "stops": [
-       [
-        14,
-        1
-       ],
-       [
-        17,
-        2.5
-       ]
-      ]
-     },
-     "circle-stroke-color": "#1466B2"
-    }
-   },
-   {
-    "id": "bati ponctuel infrastructure - Constr spé",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "bati_ponc",
-    "layout": {
-     "visibility": "visible",
-     "icon-image": "ConstrSpeciale",
-     "icon-size": {
-      "stops": [
-       [
-        13,
-        0.22
-       ],
-       [
-        17,
-        0.5
-       ]
-      ]
-     }
-    },
-    "filter": [
-     "in",
-     "symbo",
-     "ANTENNE",
-     "CONSTR_SPE_TECHNIQUE",
-     "CONSTR_INDIF_PONC",
-     "CHEMINEE",
-     "CHEVALEMENT",
-     "PUITS_GAZ",
-     "PUITS_PETROLE",
-     "PYLONE_METEO",
-     "TORCHERE",
-     "TOUR_GUET",
-     "TOUR_HERTZIENNE"
-    ],
-    "paint": {
-     "icon-color": "#646464"
-    }
-   },
-   {
-    "id": "bati ponctuel infrastructure - Silo",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "bati_ponc",
-    "maxzoom": 15,
-    "layout": {
-     "visibility": "visible",
-     "icon-image": "Silo",
-     "icon-size": {
-      "stops": [
-       [
-        13,
-        0.22
-       ],
-       [
-        17,
-        0.5
-       ]
-      ]
-     }
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "SILO_PONC"
-    ],
-    "paint": {
-     "icon-color": "#646464"
-    }
-   },
-   {
-    "id": "bati ponctuel infrastructure - Eolienne",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "bati_ponc",
-    "layout": {
-     "visibility": "visible",
-     "icon-image": "Eolienne",
-     "icon-size": {
-      "stops": [
-       [
-        13,
-        0.4
-       ],
-       [
-        17,
-        1
-       ],
-       [
-        18,
-        0.8
-       ]
-      ]
-     }
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "EOLIENNE"
-    ],
-    "paint": {
-     "icon-color": "#646464"
-    }
-   },
-   {
-    "id": "bati ponctuel infrastructure - Reservoir",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "bati_ponc",
-    "maxzoom": 15,
-    "layout": {
-     "visibility": "visible",
-     "icon-image": "Reservoir",
-     "icon-size": {
-      "stops": [
-       [
-        13,
-        0.26
-       ],
-       [
-        17,
-        0.5
-       ]
-      ]
-     }
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "RESERVOIR_PONC"
-    ],
-    "paint": {
-     "icon-color": "#646464"
-    }
-   },
-   {
-    "id": "bati ponctuel infrastructure - pylone électrique",
-    "type": "circle",
-    "source": "plan_ign",
-    "source-layer": "bati_ponc",
-    "layout": {
-     "visibility": "visible"
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "PYLONE_ELEC"
-    ],
-    "paint": {
-     "circle-radius": {
-      "stops": [
-       [
-        13,
-        1
-       ],
-       [
-        17,
-        2
-       ]
-      ]
-     },
-     "circle-color": "#000000"
-    }
-   },
-   {
-    "id": "bati ponctuel montagne - Abri",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "bati_ponc",
-    "layout": {
-     "visibility": "visible",
-     "icon-image": "Abri",
-     "icon-size": {
-      "stops": [
-       [
-        13,
-        0.4
-       ],
-       [
-        15,
-        0.6
-       ],
-       [
-        17,
-        0.9
-       ]
-      ]
-     }
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "ABRI"
-    ],
-    "paint": {
-     "icon-color": "#246138"
-    }
-   },
-   {
-    "id": "bati ponctuel montagne - Refuge Garde",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "bati_ponc",
-    "layout": {
-     "visibility": "visible",
-     "icon-image": "Refugegard",
-     "icon-size": {
-      "stops": [
-       [
-        13,
-        0.4
-       ],
-       [
-        15,
-        0.6
-       ],
-       [
-        17,
-        0.9
-       ]
-      ]
-     }
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "REFUGE_GARDE"
-    ],
-    "paint": {
-     "icon-color": "#246138"
-    }
-   },
-   {
-    "id": "bati ponctuel montagne - Refuge Non Garde",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "bati_ponc",
-    "layout": {
-     "visibility": "visible",
-     "icon-image": "Refugenongard",
-     "icon-size": {
-      "stops": [
-       [
-        13,
-        0.4
-       ],
-       [
-        15,
-        0.6
-       ],
-       [
-        17,
-        0.9
-       ]
-      ]
-     }
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "REFUGE"
-    ],
-    "paint": {
-     "icon-color": "#246138"
-    }
-   },
-   {
-    "id": "bati ponctuel transport aerien - Aeroport FXX",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "bati_ponc",
-    "layout": {
-     "visibility": "visible",
-     "icon-image": "Aeroport",
-     "icon-size": 0.5
-    },
-    "filter": [
-     "all",
-     [
-      "==",
-      "symbo",
-      "AEROPORT_PONC"
-     ],
-     [
-      "==",
-      "territoire",
-      "FXX"
-     ]
-    ],
-    "paint": {
-     "icon-color": "#646464"
-    }
-   },
-   {
-    "id": "bati ponctuel transport aerien - Aerodrome FXX",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "bati_ponc",
-    "layout": {
-     "visibility": "visible",
-     "icon-image": "Aerodrome",
-     "icon-size": 0.4
-    },
-    "filter": [
-     "all",
-     [
-      "==",
-      "symbo",
-      "AERODROME_PONC"
-     ],
-     [
-      "==",
-      "territoire",
-      "FXX"
-     ]
-    ],
-    "paint": {
-     "icon-color": "#646464"
-    }
-   },
-   {
-    "id": "bati ponctuel transport aerien - Aeroport DOM",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "bati_ponc",
-    "minzoom": 8,
-    "layout": {
-     "visibility": "visible",
-     "icon-image": "Aeroport",
-     "icon-size": 0.5
-    },
-    "filter": [
-     "all",
-     [
-      "==",
-      "symbo",
-      "AEROPORT_PONC"
-     ],
-     [
-      "!=",
-      "territoire",
-      "FXX"
-     ]
-    ],
-    "paint": {
-     "icon-color": "#646464"
-    }
-   },
-   {
-    "id": "bati ponctuel transport aerien - Aerodrome DOM",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "bati_ponc",
-    "minzoom": 8,
-    "layout": {
-     "visibility": "visible",
-     "icon-image": "Aerodrome",
-     "icon-size": 0.4
-    },
-    "filter": [
-     "all",
-     [
-      "==",
-      "symbo",
-      "AERODROME_PONC"
-     ],
-     [
-      "!=",
-      "territoire",
-      "FXX"
-     ]
-    ],
-    "paint": {
-     "icon-color": "#646464"
-    }
-   },
-   {
-    "id": "bati ponctuel transport ferroviaire",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "bati_ponc",
-    "layout": {
-     "visibility": "visible",
-     "icon-image": "Gare",
-     "icon-size": 0.33
-    },
-    "filter": [
-     "==",
-     "symbo",
-     "GARE_VOYAGEURS"
-    ],
-    "paint": {
-     "icon-color": "#787878"
-    }
-   },
-   {
-    "id": "toponyme - bornes postales haute - chemins",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_routier_borne",
-    "minzoom": 17,
-    "maxzoom": 18,
-    "filter": [
-     "in",
-     "symbo",
-     "CHEMIN",
-     "CHEMIN_SOU",
-     "CHEMIN_SUP",
-     "PISTE_CYCLABLE",
-     "PISTE_CYCLABLE_SOU",
-     "PISTE_CYCLABLE_SUP",
-     "RUE_PIETONNE",
-     "RUE_PIETONNE_SOU",
-     "RUE_PIETONNE_SUP",
-     "SENTIER",
-     "SENTIER_SOU",
-     "SENTIER_SUP",
-     "ESCALIER",
-     "ESCALIER_SUP"
-    ],
-    "layout": {
-     "symbol-placement": "line",
-     "text-field": "{borne_sur}",
-     "text-size": 11,
-     "text-anchor": "center",
-     "text-allow-overlap": true,
-     "text-offset": [
-      0,
-      -1
-     ],
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#79654F",
-     "text-halo-width": 1,
-     "text-halo-color": "#FFFFFF"
-    }
-   },
-   {
-    "id": "toponyme - bornes postales haute - non revetue, non classee",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_routier_borne",
-    "minzoom": 17,
-    "maxzoom": 18,
-    "filter": [
-     "in",
-     "symbo",
-     "NON_CLASSEE",
-     "NON_CLASSEE_4",
-     "NON_CLASSEE_4_SUP",
-     "NON_CLASSEE_RESTREINT",
-     "NON_CLASSEE_RESTREINT_SUP",
-     "NON_CLASSEE_SOU",
-     "NON_CLASSEE_SUP",
-     "NON_REVETUE_CARRO",
-     "NON_REVETUE_CARRO_SUP"
-    ],
-    "layout": {
-     "symbol-placement": "line",
-     "text-field": "{borne_sur}",
-     "text-size": 11,
-     "text-anchor": "center",
-     "text-allow-overlap": true,
-     "text-offset": [
-      0,
-      -1.3
-     ],
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#79654F",
-     "text-halo-width": 1,
-     "text-halo-color": "#FFFFFF"
-    }
-   },
-   {
-    "id": "toponyme - bornes postales haute - locales",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_routier_borne",
-    "minzoom": 17,
-    "maxzoom": 18,
-    "filter": [
-     "in",
-     "symbo",
-     "LOCALE_1",
-     "LOCALE_1_SOU",
-     "LOCALE_1_SUP",
-     "LOCALE_2",
-     "LOCALE_2_SOU",
-     "LOCALE_2_SUP",
-     "LOCALE_3",
-     "LOCALE_3_SOU",
-     "LOCALE_3_SUP",
-     "LOCALE_4",
-     "LOCALE_4_SOU",
-     "LOCALE_4_SUP",
-     "LOCALE_CONSTR",
-     "LOCALE_CONSTR_SUP"
-    ],
-    "layout": {
-     "symbol-placement": "line",
-     "text-field": "{borne_sur}",
-     "text-size": 11,
-     "text-anchor": "center",
-     "text-allow-overlap": true,
-     "text-offset": [
-      0,
-      -1.4
-     ],
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#79654F",
-     "text-halo-width": 1,
-     "text-halo-color": "#FFFFFF"
-    }
-   },
-   {
-    "id": "toponyme - bornes postales haute - regionales",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_routier_borne",
-    "minzoom": 17,
-    "maxzoom": 18,
-    "filter": [
-     "in",
-     "symbo",
-     "REGIONALE_1",
-     "REGIONALE_1_SOU",
-     "REGIONALE_1_SUP",
-     "REGIONALE_2",
-     "REGIONALE_2_SOU",
-     "REGIONALE_2_SUP",
-     "REGIONALE_3",
-     "REGIONALE_3_SOU",
-     "REGIONALE_3_SUP",
-     "REGIONALE_4",
-     "REGIONALE_4_SUP",
-     "REGIONALE_CONSTR"
-    ],
-    "layout": {
-     "symbol-placement": "line",
-     "text-field": "{borne_sur}",
-     "text-size": 11,
-     "text-anchor": "center",
-     "text-allow-overlap": true,
-     "text-offset": [
-      0,
-      -1.5
-     ],
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#79654F",
-     "text-halo-width": 1,
-     "text-halo-color": "#FFFFFF"
-    }
-   },
-   {
-    "id": "toponyme - bornes postales haute - principales",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_routier_borne",
-    "minzoom": 17,
-    "maxzoom": 18,
-    "filter": [
-     "in",
-     "symbo",
-     "PRINCIPALE_1",
-     "PRINCIPALE_1_SOU",
-     "PRINCIPALE_1_SUP",
-     "PRINCIPALE_2",
-     "PRINCIPALE_2_SOU",
-     "PRINCIPALE_2_SUP",
-     "PRINCIPALE_3",
-     "PRINCIPALE_3_SOU",
-     "PRINCIPALE_3_SUP",
-     "PRINCIPALE_4",
-     "PRINCIPALE_4_SOU",
-     "PRINCIPALE_4_SUP",
-     "PRINCIPALE_CONSTR"
-    ],
-    "layout": {
-     "symbol-placement": "line",
-     "text-field": "{borne_sur}",
-     "text-size": 11,
-     "text-anchor": "center",
-     "text-allow-overlap": true,
-     "text-offset": [
-      0,
-      -1.6
-     ],
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#79654F",
-     "text-halo-width": 1,
-     "text-halo-color": "#FFFFFF"
-    }
-   },
-   {
-    "id": "toponyme - bornes postales bas - chemins",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_routier_borne",
-    "minzoom": 17,
-    "maxzoom": 18,
-    "filter": [
-     "in",
-     "symbo",
-     "CHEMIN",
-     "CHEMIN_SOU",
-     "CHEMIN_SUP",
-     "PISTE_CYCLABLE",
-     "PISTE_CYCLABLE_SOU",
-     "PISTE_CYCLABLE_SUP",
-     "RUE_PIETONNE",
-     "RUE_PIETONNE_SOU",
-     "RUE_PIETONNE_SUP",
-     "SENTIER",
-     "SENTIER_SOU",
-     "SENTIER_SUP",
-     "ESCALIER",
-     "ESCALIER_SUP"
-    ],
-    "layout": {
-     "symbol-placement": "line",
-     "text-field": "{borne_sous}",
-     "text-size": 11,
-     "text-anchor": "center",
-     "text-allow-overlap": true,
-     "text-offset": [
-      0,
-      1
-     ],
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#79654F",
-     "text-halo-width": 1,
-     "text-halo-color": "#FFFFFF"
-    }
-   },
-   {
-    "id": "toponyme - bornes postales bas - non revetue, non classee",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_routier_borne",
-    "minzoom": 17,
-    "maxzoom": 18,
-    "filter": [
-     "in",
-     "symbo",
-     "NON_CLASSEE",
-     "NON_CLASSEE_4",
-     "NON_CLASSEE_4_SUP",
-     "NON_CLASSEE_RESTREINT",
-     "NON_CLASSEE_RESTREINT_SUP",
-     "NON_CLASSEE_SOU",
-     "NON_CLASSEE_SUP",
-     "NON_REVETUE_CARRO",
-     "NON_REVETUE_CARRO_SUP"
-    ],
-    "layout": {
-     "symbol-placement": "line",
-     "text-field": "{borne_sous}",
-     "text-size": 11,
-     "text-anchor": "center",
-     "text-allow-overlap": true,
-     "text-offset": [
-      0,
-      1.3
-     ],
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#79654F",
-     "text-halo-width": 1,
-     "text-halo-color": "#FFFFFF"
-    }
-   },
-   {
-    "id": "toponyme - bornes postales bas - locales",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_routier_borne",
-    "minzoom": 17,
-    "maxzoom": 18,
-    "filter": [
-     "in",
-     "symbo",
-     "LOCALE_1",
-     "LOCALE_1_SOU",
-     "LOCALE_1_SUP",
-     "LOCALE_2",
-     "LOCALE_2_SOU",
-     "LOCALE_2_SUP",
-     "LOCALE_3",
-     "LOCALE_3_SOU",
-     "LOCALE_3_SUP",
-     "LOCALE_4",
-     "LOCALE_4_SOU",
-     "LOCALE_4_SUP",
-     "LOCALE_CONSTR",
-     "LOCALE_CONSTR_SUP"
-    ],
-    "layout": {
-     "symbol-placement": "line",
-     "text-field": "{borne_sous}",
-     "text-size": 11,
-     "text-anchor": "center",
-     "text-allow-overlap": true,
-     "text-offset": [
-      0,
-      1.4
-     ],
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#79654F",
-     "text-halo-width": 1,
-     "text-halo-color": "#FFFFFF"
-    }
-   },
-   {
-    "id": "toponyme - bornes postales bas - regionales",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_routier_borne",
-    "minzoom": 17,
-    "maxzoom": 18,
-    "filter": [
-     "in",
-     "symbo",
-     "REGIONALE_1",
-     "REGIONALE_1_SOU",
-     "REGIONALE_1_SUP",
-     "REGIONALE_2",
-     "REGIONALE_2_SOU",
-     "REGIONALE_2_SUP",
-     "REGIONALE_3",
-     "REGIONALE_3_SOU",
-     "REGIONALE_3_SUP",
-     "REGIONALE_4",
-     "REGIONALE_4_SUP",
-     "REGIONALE_CONSTR"
-    ],
-    "layout": {
-     "symbol-placement": "line",
-     "text-field": "{borne_sous}",
-     "text-size": 11,
-     "text-anchor": "center",
-     "text-allow-overlap": true,
-     "text-offset": [
-      0,
-      1.5
-     ],
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#79654F",
-     "text-halo-width": 1,
-     "text-halo-color": "#FFFFFF"
-    }
-   },
-   {
-    "id": "toponyme - bornes postales bas - principales",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_routier_borne",
-    "minzoom": 17,
-    "maxzoom": 18,
-    "filter": [
-     "in",
-     "symbo",
-     "PRINCIPALE_1",
-     "PRINCIPALE_1_SOU",
-     "PRINCIPALE_1_SUP",
-     "PRINCIPALE_2",
-     "PRINCIPALE_2_SOU",
-     "PRINCIPALE_2_SUP",
-     "PRINCIPALE_3",
-     "PRINCIPALE_3_SOU",
-     "PRINCIPALE_3_SUP",
-     "PRINCIPALE_4",
-     "PRINCIPALE_4_SOU",
-     "PRINCIPALE_4_SUP",
-     "PRINCIPALE_CONSTR"
-    ],
-    "layout": {
-     "symbol-placement": "line",
-     "text-field": "{borne_sous}",
-     "text-size": 11,
-     "text-anchor": "center",
-     "text-allow-overlap": true,
-     "text-offset": [
-      0,
-      1.6
-     ],
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#79654F",
-     "text-halo-width": 1,
-     "text-halo-color": "#FFFFFF"
-    }
-   },
-   {
-    "id": "toponyme - courbe rocher maitresse",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_oro_ponc",
-    "filter": [
-     "==",
-     "txt_typo",
-     "ORO_COURBE_ROCHER"
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-size": 10,
-     "text-allow-overlap": false,
-     "text-padding": 30,
-     "text-rotate": {
-      "type": "identity",
-      "property": "rotation"
-     },
-     "text-font": [
-      "Source Sans Pro Italic"
-     ]
-    },
-    "paint": {
-     "text-color": "#333333",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 1
-    }
-   },
-   {
-    "id": "toponyme - courbe glacier maitresse",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_oro_ponc",
-    "filter": [
-     "==",
-     "txt_typo",
-     "ORO_COURBE_GLACIER"
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-size": 10,
-     "text-allow-overlap": false,
-     "text-padding": 30,
-     "text-rotate": {
-      "type": "identity",
-      "property": "rotation"
-     },
-     "text-font": [
-      "Source Sans Pro Italic"
-     ]
-    },
-    "paint": {
-     "text-color": "#629FD9",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 1
-    }
-   },
-   {
-    "id": "toponyme - courbe maitresse",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_oro_ponc",
-    "filter": [
-     "==",
-     "txt_typo",
-     "ORO_COURBE"
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-size": 10,
-     "text-allow-overlap": false,
-     "text-padding": 30,
-     "text-rotate": {
-      "type": "identity",
-      "property": "rotation"
-     },
-     "text-font": [
-      "Source Sans Pro Italic"
-     ]
-    },
-    "paint": {
-     "text-color": "#604A2F",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 1
-    }
-   },
-   {
-    "id": "toponyme - liaison maritime",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_routier_liaison_lin",
-    "minzoom": 8,
-    "maxzoom": 18,
-    "filter": [
-     "==",
-     "txt_typo",
-     "LIAISON_MARITIME"
-    ],
-    "layout": {
-     "symbol-placement": "line",
-     "text-field": "{texte}",
-     "text-size": 15,
-     "text-anchor": "center",
-     "text-keep-upright": true,
-     "text-max-angle": 45,
-     "text-padding": 10,
-     "text-font": [
-      "Source Sans Pro Italic"
-     ]
-    },
-    "paint": {
-     "text-color": "#5792C2",
-     "text-halo-width": 5,
-     "text-halo-color": "#AAD5E9"
-    }
-   },
-   {
-    "id": "toponyme bati station de métro + bati ponctuel metro",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_bati_ponc",
-    "minzoom": 14,
-    "filter": [
-     "all",
-     [
-      "==",
-      "txt_typo",
-      "TYPO_E_1"
-     ],
-     [
-      "==",
-      "symbo",
-      "STATION_METRO"
-     ]
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-size": 11,
-     "text-allow-overlap": false,
-     "text-offset": [
-      0.3,
-      -0.25
-     ],
-     "text-padding": 3,
-     "text-anchor": "bottom-left",
-     "text-font": [
-      "Source Sans Pro"
-     ],
-     "icon-image": "Metro",
-     "icon-size": {
-      "stops": [
-       [
-        15,
-        0.33
-       ],
-       [
-        17,
-        0.6
-       ]
-      ]
-     }
-    },
-    "paint": {
-     "text-color": "#3C3C3C",
-     "icon-color": "#646464"
-    }
-   },
-   {
-    "id": "toponyme ferre lineaire",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_ferre_lin",
-    "minzoom": 12,
-    "filter": [
-     "in",
-     "txt_typo",
-     "FER_NOM",
-     "FER_OUVRAGE"
-    ],
-    "layout": {
-     "symbol-placement": "line",
-     "text-field": "{texte}",
-     "text-size": 10,
-     "text-anchor": "center",
-     "text-offset": [
-      0,
-      -1
-     ],
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#000000",
-     "text-halo-width": 1,
-     "text-halo-color": "rgba(255, 255, 255, 1)"
-    }
-   },
-   {
-    "id": "toponyme station epuration, de pompage, usine de production eau",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_bati_ponc",
-    "minzoom": 14,
-    "filter": [
-     "==",
-     "txt_typo",
-     "station"
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{designation}",
-     "text-anchor": "left",
-     "text-offset": [
-      0.8,
-      0
-     ],
-     "text-size": 11,
-     "text-allow-overlap": false,
-     "text-padding": 1,
-     "text-font": [
-      "Source Sans Pro Italic"
-     ]
-    },
-    "paint": {
-     "text-color": "#447FB3"
-    }
-   },
-   {
-    "id": "toponyme bati ponc gare",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_bati_ponc",
-    "minzoom": 15,
-    "filter": [
-     "==",
-     "txt_typo",
-     "gore"
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{designation}",
-     "text-size": 11,
-     "text-allow-overlap": false,
-     "text-padding": 1,
-     "text-font": [
-      "Source Sans Pro Italic"
-     ]
-    },
-    "paint": {
-     "text-color": "#000000"
-    }
-   },
-   {
-    "id": "toponyme bati ponc barrage",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_bati_ponc",
-    "minzoom": 12,
-    "filter": [
-     "==",
-     "txt_typo",
-     "BARRAGE_PONC"
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-anchor": "left",
-     "text-offset": [
-      0.8,
-      0
-     ],
-     "text-size": 11,
-     "text-allow-overlap": false,
-     "text-padding": 1,
-     "text-font": [
-      "Source Sans Pro"
-     ]
-    },
-    "paint": {
-     "text-color": "#447FB3"
-    }
-   },
-   {
-    "id": "toponyme bati ponc phare - niveau 13",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_bati_ponc",
-    "maxzoom": 13,
-    "filter": [
-     "==",
-     "txt_typo",
-     "PHARE"
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-anchor": "right",
-     "text-size": 11,
-     "text-allow-overlap": false,
-     "text-padding": 1,
-     "text-font": [
-      "Source Sans Pro"
-     ]
-    },
-    "paint": {
-     "text-color": "#532A2A"
-    }
-   },
-   {
-    "id": "toponyme bati ponc phare - niveau 14à19",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_bati_ponc",
-    "minzoom": 13,
-    "filter": [
-     "all",
-     [
-      "==",
-      "symbo",
-      "PHARE"
-     ],
-     [
-      "in",
-      "txt_typo",
-      "TYPO_C_6",
-      "TYPO_C_7",
-      "TYPO_C_8",
-      "TYPO_E_GE"
-     ]
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-anchor": "right",
-     "text-size": {
-      "stops": [
-       [
-        13,
-        12
-       ],
-       [
-        18,
-        18
-       ]
-      ]
-     },
-     "text-allow-overlap": false,
-     "text-offset": [
-      -2,
-      0
-     ],
-     "text-padding": 3,
-     "text-font": [
-      "Source Sans Pro"
-     ]
-    },
-    "paint": {
-     "text-color": "#532A2A"
-    }
-   },
-   {
-    "id": "toponyme bati ponc autre",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_bati_ponc",
-    "minzoom": 12,
-    "filter": [
-     "in",
-     "txt_typo",
-     "BAT_ACTIVITE",
-     "BAT_FORTIF",
-     "BAT_VILLAGE_DETRUIT"
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-anchor": "center",
-     "text-size": 11,
-     "text-allow-overlap": false,
-     "text-padding": 1,
-     "text-font": [
-      "Source Sans Pro"
-     ]
-    },
-    "paint": {
-     "text-color": "#532A2A"
-    }
-   },
-   {
-    "id": "toponyme bati ponc aerogare",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_bati_ponc",
-    "minzoom": 14,
-    "maxzoom": 17,
-    "filter": [
-     "all",
-     [
-      "==",
-      "txt_typo",
-      "TYPO_E_GE"
-     ],
-     [
-      "==",
-      "symbo",
-      "AEROGARE"
-     ]
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-anchor": "center",
-     "text-size": {
-      "stops": [
-       [
-        12,
-        9
-       ],
-       [
-        16,
-        11
-       ]
-      ]
-     },
-     "text-allow-overlap": false,
-     "text-padding": 1,
-     "text-font": [
-      "Source Sans Pro Italic"
-     ]
-    },
-    "paint": {
-     "text-color": "#120049",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 1
-    }
-   },
-   {
-    "id": "toponyme bati ponc aeroport 12",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_bati_ponc",
-    "minzoom": 11,
-    "maxzoom": 12,
-    "filter": [
-     "==",
-     "txt_typo",
-     "AEROPORT_PONC"
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-anchor": "bottom",
-     "text-offset": [
-      0,
-      -1.3
-     ],
-     "text-size": 10.5,
-     "text-allow-overlap": false,
-     "text-padding": 1,
-     "text-font": [
-      "Source Sans Pro"
-     ]
-    },
-    "paint": {
-     "text-color": "#120049",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 2
-    }
-   },
-   {
-    "id": "toponyme bati ponc aeroport 13",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_bati_ponc",
-    "minzoom": 12,
-    "maxzoom": 13,
-    "filter": [
-     "==",
-     "txt_typo",
-     "AEROPORT_PONC"
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-anchor": "bottom",
-     "text-offset": [
-      0,
-      -2
-     ],
-     "text-size": 11,
-     "text-allow-overlap": false,
-     "text-padding": 1,
-     "text-font": [
-      "Source Sans Pro"
-     ]
-    },
-    "paint": {
-     "text-color": "#120049",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 2
-    }
-   },
-   {
-    "id": "toponyme bati ponc aeroport",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_bati_ponc",
-    "minzoom": 13,
-    "maxzoom": 17,
-    "filter": [
-     "all",
-     [
-      "==",
-      "txt_typo",
-      "TYPO_A_5"
-     ],
-     [
-      "==",
-      "symbo",
-      "AEROPORT"
-     ]
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-anchor": "center",
-     "text-size": {
-      "stops": [
-       [
-        12,
-        11
-       ],
-       [
-        16,
-        13
-       ]
-      ]
-     },
-     "text-allow-overlap": false,
-     "text-padding": 1,
-     "text-font": [
-      "Source Sans Pro"
-     ]
-    },
-    "paint": {
-     "text-color": "#120049",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 2
-    }
-   },
-   {
-    "id": "toponyme bati ponc aerodrome 12",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_bati_ponc",
-    "minzoom": 11,
-    "maxzoom": 12,
-    "filter": [
-     "==",
-     "txt_typo",
-     "AERODROME_PONC"
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-anchor": "bottom",
-     "text-offset": [
-      0,
-      -1.3
-     ],
-     "text-size": 9.5,
-     "text-allow-overlap": false,
-     "text-padding": 1,
-     "text-font": [
-      "Source Sans Pro"
-     ]
-    },
-    "paint": {
-     "text-color": "#120049",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 2
-    }
-   },
-   {
-    "id": "toponyme bati ponc aerodrome 13",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_bati_ponc",
-    "minzoom": 12,
-    "maxzoom": 13,
-    "filter": [
-     "==",
-     "txt_typo",
-     "AERODROME_PONC"
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-anchor": "bottom",
-     "text-offset": [
-      0,
-      -2
-     ],
-     "text-size": 10,
-     "text-allow-overlap": false,
-     "text-padding": 1,
-     "text-font": [
-      "Source Sans Pro"
-     ]
-    },
-    "paint": {
-     "text-color": "#120049",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 2
-    }
-   },
-   {
-    "id": "toponyme bati ponc aerodrome",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_bati_ponc",
-    "minzoom": 13,
-    "maxzoom": 17,
-    "filter": [
-     "all",
-     [
-      "==",
-      "txt_typo",
-      "TYPO_A_7"
-     ],
-     [
-      "==",
-      "symbo",
-      "AERODROME"
-     ]
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-anchor": "center",
-     "text-size": {
-      "stops": [
-       [
-        12,
-        10
-       ],
-       [
-        16,
-        12
-       ]
-      ]
-     },
-     "text-allow-overlap": false,
-     "text-padding": 1,
-     "text-font": [
-      "Source Sans Pro"
-     ]
-    },
-    "paint": {
-     "text-color": "#120049",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 2
-    }
-   },
-   {
-    "id": "toponyme - hydro ponc 5",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_hydro_ponc",
-    "filter": [
-     "in",
-     "txt_typo",
-     "TYPO_D_9",
-     "TYPO_D_10",
-     "TYPO_E_1_cyan"
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-size": {
-      "stops": [
-       [
-        15,
-        11
-       ],
-       [
-        17,
-        14
-       ]
-      ]
-     },
-     "text-allow-overlap": true,
-     "text-padding": 5,
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#447FB3",
-     "text-halo-color": "#FFFFFF",
-     "text-halo-width": 1
-    }
-   },
-   {
-    "id": "toponyme - hydro ponc glacier",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_hydro_ponc",
-    "filter": [
-     "==",
-     "txt_typo",
-     "ORO_GLACIER_2"
-    ],
-    "layout": {
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-size": 14,
-     "text-anchor": "center",
-     "text-allow-overlap": true,
-     "text-padding": 1,
-     "text-font": [
-      "Source Sans Pro Italic"
-     ]
-    },
-    "paint": {
-     "text-color": "#447FB3",
-     "text-halo-width": 2,
-     "text-halo-color": "rgba(255, 255, 255, 0.5)"
-    }
-   },
-   {
-    "id": "toponyme - limite militaire ponc 3 et 4",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_limite_ponc",
-    "filter": [
-     "in",
-     "txt_typo",
-     "LIM_MILI_3",
-     "LIM_MILI_4"
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-size": 12,
-     "text-allow-overlap": false,
-     "text-padding": 2,
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#0D2000",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 1
-    }
-   },
-   {
-    "id": "toponyme - limite parc ponc 3 et 4",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_limite_ponc",
-    "filter": [
-     "in",
-     "txt_typo",
-     "LIM_PARC_3",
-     "LIM_PARC_4",
-     "RESERVE_NATURELLE_PONC"
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-size": 13,
-     "text-allow-overlap": false,
-     "text-padding": 2,
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#287B00",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 1
-    }
-   },
-   {
-    "id": "toponyme numéro de route - départementale",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_routier_numero_lin",
-    "minzoom": 11,
-    "maxzoom": 16,
-    "filter": [
-     "==",
-     "txt_typo",
-     "Départementale"
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "line",
-     "text-field": "{texte}",
-     "text-size": 10.5,
-     "text-allow-overlap": false,
-     "text-padding": 2,
-     "text-anchor": "center",
-     "text-font": [
-      "Source Sans Pro Semibold"
-     ],
-     "text-rotation-alignment": "viewport"
-    },
-    "paint": {
-     "text-color": "#4D4D4D",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 4
-    }
-   },
-   {
-    "id": "toponyme numéro de route - nationale",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_routier_numero_lin",
-    "minzoom": 7,
-    "maxzoom": 16,
-    "filter": [
-     "==",
-     "txt_typo",
-     "Nationale"
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "line",
-     "text-field": "{texte}",
-     "text-size": 12,
-     "text-allow-overlap": false,
-     "text-padding": 0,
-     "text-anchor": "center",
-     "text-font": [
-      "Source Sans Pro Regular"
-     ],
-     "icon-image": "Ecluse",
-     "icon-rotation-alignment": "viewport",
-     "text-rotation-alignment": "viewport",
-     "icon-text-fit": "both",
-     "icon-size": 0
-    },
-    "paint": {
-     "text-color": "#F0F0F0",
-     "icon-color": "#646464",
-     "text-halo-color": "rgba(80, 80, 80, 0.5)",
-     "text-halo-width": 4
-    }
-   },
-   {
-    "id": "toponyme numéro de route - autoroute",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_routier_numero_lin",
-    "minzoom": 7,
-    "maxzoom": 16,
-    "filter": [
-     "==",
-     "txt_typo",
-     "Autoroute"
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "line",
-     "text-field": "{texte}",
-     "text-size": 15,
-     "text-allow-overlap": false,
-     "text-padding": 0,
-     "text-anchor": "center",
-     "text-font": [
-      "Source Sans Pro Regular"
-     ],
-     "icon-image": "Ecluse",
-     "icon-rotation-alignment": "viewport",
-     "text-rotation-alignment": "viewport",
-     "icon-text-fit": "both",
-     "icon-size": 0
-    },
-    "paint": {
-     "text-color": "#F0F0F0",
-     "icon-color": "#646464",
-     "text-halo-color": "rgba(80, 80, 80, 0.5)",
-     "text-halo-width": 5
-    }
-   },
-   {
-    "id": "toponyme - odonyme abrégé",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_routier_odonyme_lin",
-    "minzoom": 15,
-    "maxzoom": 17,
-    "layout": {
-     "symbol-placement": "line",
-     "text-field": "{nom_gauche}",
-     "text-size": 10,
-     "text-anchor": "center",
-     "text-max-angle": 30,
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#000000",
-     "text-halo-width": 2,
-     "text-halo-color": "rgba(255, 255, 255, 1)"
-    }
-   },
-   {
-    "id": "toponyme - odonyme desabrégé",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_routier_odonyme_lin",
-    "minzoom": 17,
-    "layout": {
-     "symbol-placement": "line",
-     "text-field": "{nom_desabrege}",
-     "text-size": 11,
-     "text-anchor": "center",
-     "text-max-angle": 30,
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#000000",
-     "text-halo-width": 2,
-     "text-halo-color": "rgba(255, 255, 255, 1)"
-    }
-   },
-   {
-    "id": "toponyme - lieu dit non habité 3",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_ocs_ponc",
-    "filter": [
-     "all",
-     [
-      "==",
-      "symbo",
-      "LIEU-DIT_NON_HABITE"
-     ],
-     [
-      "in",
-      "txt_typo",
-      "TYPO_B_10",
-      "TYPO_B_11"
-     ]
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-size": 11,
-     "text-allow-overlap": false,
-     "text-padding": 1,
-     "text-font": [
-      "Source Sans Pro Italic"
-     ]
-    },
-    "paint": {
-     "text-color": "#000000",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 1
-    }
-   },
-   {
-    "id": "toponyme - bois",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_ocs_ponc",
-    "filter": [
-     "all",
-     [
-      "==",
-      "symbo",
-      "BOIS"
-     ],
-     [
-      "in",
-      "txt_typo",
-      "TYPO_F_10",
-      "TYPO_F_11"
-     ]
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-size": 13,
-     "text-allow-overlap": false,
-     "text-padding": 1,
-     "text-font": [
-      "Source Sans Pro Italic"
-     ]
-    },
-    "paint": {
-     "text-color": "#287B00",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 1
-    }
-   },
-   {
-    "id": "toponyme - oro lineaire 4",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_oro_lin",
-    "filter": [
-     "in",
-     "txt_typo",
-     "ORO_SOMMET_3",
-     "ORO_GORGE_2"
-    ],
-    "layout": {
-     "symbol-placement": "line",
-     "text-field": "{texte}",
-     "text-size": 11,
-     "text-anchor": "center",
-     "text-keep-upright": true,
-     "text-max-angle": 45,
-     "text-padding": 1,
-     "text-font": [
-      "Source Sans Pro Italic"
-     ]
-    },
-    "paint": {
-     "text-color": "#863831",
-     "text-halo-width": 1.5,
-     "text-halo-color": "rgba(255, 255, 255, 0.5)"
-    }
-   },
-   {
-    "id": "toponyme - oro ponc 4",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_oro_ponc",
-    "filter": [
-     "in",
-     "txt_typo",
-     "ORO_SOMMET_3",
-     "ORO_GORGE_2",
-     "GROTTE",
-     "GORGE",
-     "TYPO_G_9",
-     "TYPO_G_10"
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-size": {
-      "stops": [
-       [
-        13,
-        11
-       ],
-       [
-        16,
-        16
-       ]
-      ]
-     },
-     "text-allow-overlap": true,
-     "text-padding": 1,
-     "text-font": [
-      "Source Sans Pro Italic"
-     ]
-    },
-    "paint": {
-     "text-color": "#863831",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 1.5
-    }
-   },
-   {
-    "id": "toponyme - hydro ponc 4",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_hydro_ponc",
-    "filter": [
-     "in",
-     "txt_typo",
-     "lac - étang - bassin",
-     "HYD_SURF_4",
-     "HYD_SURF_4_T",
-     "HYD_SURF_5",
-     "HYD_SURF_5_T",
-     "TYPO_D_8",
-     "SOURCE"
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-size": {
-      "stops": [
-       [
-        14,
-        13
-       ],
-       [
-        17,
-        16
-       ]
-      ]
-     },
-     "text-allow-overlap": true,
-     "text-padding": 5,
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#447FB3",
-     "text-halo-color": "#FFFFFF",
-     "text-halo-width": 1
-    }
-   },
-   {
-    "id": "toponyme quartier ",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_localite_ponc",
-    "filter": [
-     "in",
-     "txt_typo",
-     "BAT_QUARTIER",
-     "BAT_QUARTIER_T"
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-size": 11,
-     "text-allow-overlap": false,
-     "text-padding": 1,
-     "text-font": [
-      "Source Sans Pro Italic"
-     ]
-    },
-    "paint": {
-     "text-color": "#000000",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 2
-    }
-   },
-   {
-    "id": "toponyme localite n0 typoA10",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_localite_ponc",
-    "maxzoom": 18,
-    "filter": [
-     "==",
-     "txt_typo",
-     "TYPO_A_10"
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-size": {
-      "stops": [
-       [
-        15,
-        11
-       ],
-       [
-        17,
-        13.5
-       ]
-      ]
-     },
-     "text-allow-overlap": true,
-     "text-anchor": "center",
-     "text-padding": 1,
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#000000",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 2
-    }
-   },
-   {
-    "id": "toponyme - lieu dit non habité",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_ocs_ponc",
-    "filter": [
-     "all",
-     [
-      "==",
-      "symbo",
-      "LIEU-DIT_NON_HABITE"
-     ],
-     [
-      "in",
-      "txt_typo",
-      "TYPO_B_7",
-      "TYPO_B_8",
-      "TYPO_B_9"
-     ]
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-size": 12,
-     "text-allow-overlap": false,
-     "text-padding": 1,
-     "text-font": [
-      "Source Sans Pro Italic"
-     ]
-    },
-    "paint": {
-     "text-color": "#000000",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 1
-    }
-   },
-   {
-    "id": "toponyme - bois 2",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_ocs_ponc",
-    "filter": [
-     "all",
-     [
-      "==",
-      "symbo",
-      "BOIS"
-     ],
-     [
-      "in",
-      "txt_typo",
-      "TYPO_F_7",
-      "TYPO_F_8",
-      "TYPO_F_9"
-     ]
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-size": 16,
-     "text-allow-overlap": false,
-     "text-padding": 1,
-     "text-font": [
-      "Source Sans Pro Italic"
-     ]
-    },
-    "paint": {
-     "text-color": "#287B00",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 2
-    }
-   },
-   {
-    "id": "toponyme localite hameau ",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_localite_ponc",
-    "minzoom": 11,
-    "maxzoom": 13,
-    "filter": [
-     "in",
-     "txt_typo",
-     "BAT_HAMEAU",
-     "BAT_HAMEAU_T"
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "icon-image": "Localite",
-     "icon-size": 0.17,
-     "text-field": "{texte}",
-     "text-size": 11,
-     "text-allow-overlap": false,
-     "text-anchor": "bottom-left",
-     "text-offset": [
-      0.3,
-      0.1
-     ],
-     "text-padding": 1,
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#000000",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 2
-    }
-   },
-   {
-    "id": "toponyme localite importance 5",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_localite_ponc",
-    "minzoom": 9,
-    "filter": [
-     "in",
-     "txt_typo",
-     "commune 5",
-     "BAT_COMMUNE_5",
-     "BAT_COMMUNE_5_T",
-     "BAT_CHEF_LIEU_COM",
-     "BAT_CHEF_LIEU_COM_T",
-     "BAT_CHEF_LIEU_COM-T",
-     "BAT_ANCIENNE_COM",
-     "BAT_ANCIENNE_COM_T",
-     "BAT_COMMUNE_ASSOCIEE",
-     "BAT_COMMUNE_ASSOCIEE_T",
-     "Commune très petite"
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "icon-image": "Localite",
-     "icon-size": 0.21,
-     "text-field": "{texte}",
-     "text-size": 11.5,
-     "text-allow-overlap": false,
-     "text-anchor": "bottom-left",
-     "text-offset": [
-      0.3,
-      0.1
-     ],
-     "text-padding": 1,
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#000000",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 2
-    }
-   },
-   {
-    "id": "toponyme - ocs lineaire 3",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_ocs_lin",
-    "filter": [
-     "==",
-     "txt_typo",
-     "OCS_FORET_3"
-    ],
-    "layout": {
-     "symbol-placement": "line",
-     "text-field": "{texte}",
-     "text-size": {
-      "stops": [
-       [
-        10,
-        12
-       ],
-       [
-        12,
-        15
-       ]
-      ]
-     },
-     "text-anchor": "center",
-     "text-keep-upright": true,
-     "text-max-angle": 45,
-     "text-padding": 1,
-     "text-font": [
-      "Source Sans Pro Italic"
-     ]
-    },
-    "paint": {
-     "text-color": "#287B00",
-     "text-halo-width": 1,
-     "text-halo-color": "rgba(255, 255, 255, 0.5)"
-    }
-   },
-   {
-    "id": "toponyme - lieu dit non habité 1",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_ocs_ponc",
-    "filter": [
-     "all",
-     [
-      "==",
-      "symbo",
-      "LIEU-DIT_NON_HABITE"
-     ],
-     [
-      "in",
-      "txt_typo",
-      "TYPO_B_5",
-      "TYPO_B_4"
-     ]
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-size": 15,
-     "text-allow-overlap": false,
-     "text-padding": 1,
-     "text-font": [
-      "Source Sans Pro Italic"
-     ]
-    },
-    "paint": {
-     "text-color": "#000000",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 1
-    }
-   },
-   {
-    "id": "toponyme - bois 1",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_ocs_ponc",
-    "filter": [
-     "all",
-     [
-      "==",
-      "symbo",
-      "BOIS"
-     ],
-     [
-      "in",
-      "txt_typo",
-      "TYPO_F_5",
-      "TYPO_F_4"
-     ]
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-size": 19,
-     "text-allow-overlap": false,
-     "text-padding": 1,
-     "text-font": [
-      "Source Sans Pro Italic"
-     ]
-    },
-    "paint": {
-     "text-color": "#287B00",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 2
-    }
-   },
-   {
-    "id": "toponyme - bois 0",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_ocs_ponc",
-    "filter": [
-     "all",
-     [
-      "==",
-      "symbo",
-      "BOIS"
-     ],
-     [
-      "in",
-      "txt_typo",
-      "TYPO_F_3",
-      "TYPO_F_2"
-     ]
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-size": 22,
-     "text-allow-overlap": false,
-     "text-padding": 1,
-     "text-font": [
-      "Source Sans Pro Italic"
-     ]
-    },
-    "paint": {
-     "text-color": "#287B00",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 2
-    }
-   },
-   {
-    "id": "toponyme - ocs ponc 3",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_ocs_ponc",
-    "filter": [
-     "==",
-     "txt_typo",
-     "OCS_FORET_3"
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-size": {
-      "stops": [
-       [
-        10,
-        12
-       ],
-       [
-        12,
-        15
-       ]
-      ]
-     },
-     "text-allow-overlap": false,
-     "text-padding": 1,
-     "text-anchor": "center",
-     "text-font": [
-      "Source Sans Pro Italic"
-     ]
-    },
-    "paint": {
-     "text-color": "#287B00",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 1
-    }
-   },
-   {
-    "id": "toponyme - oro lineaire 3",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_oro_lin",
-    "filter": [
-     "in",
-     "txt_typo",
-     "ORO_ILE_3",
-     "ORO_RELIEF_3",
-     "ORO_RELIEF_3_T",
-     "ORO_RELIEF_4",
-     "ORO_RELIEF_4_T",
-     "ORO_CAP_2",
-     "ORO_CAP_3",
-     "ORO_SOMMET_2",
-     "ORO_COL_2",
-     "ORO_GORGE_1",
-     "ORO_GORGE-1"
-    ],
-    "layout": {
-     "symbol-placement": "line",
-     "text-field": "{texte}",
-     "text-size": 12,
-     "text-anchor": "center",
-     "text-keep-upright": true,
-     "text-max-angle": 45,
-     "text-padding": 10,
-     "text-font": [
-      "Source Sans Pro Italic"
-     ]
-    },
-    "paint": {
-     "text-color": "#863831",
-     "text-halo-width": 1.5,
-     "text-halo-color": "rgba(255, 255, 255, 0.5)"
-    }
-   },
-   {
-    "id": "toponyme - oro ponc 3",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_oro_ponc",
-    "filter": [
-     "in",
-     "txt_typo",
-     "ORO_ILE_3",
-     "ORO_RELIEF_3",
-     "ORO_RELIEF_3_T",
-     "ORO_RELIEF_4",
-     "ORO_RELIEF_4_T",
-     "ORO_CAP_2",
-     "ORO_CAP_3",
-     "ORO_SOMMET_2",
-     "ORO_COL_2",
-     "ORO_GORGE_1",
-     "ORO_GORGE-1",
-     "TYPO_G_7",
-     "TYPO_G_8"
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-size": {
-      "stops": [
-       [
-        13,
-        12
-       ],
-       [
-        16,
-        17
-       ]
-      ]
-     },
-     "text-allow-overlap": true,
-     "text-padding": 1,
-     "text-font": [
-      "Source Sans Pro Italic"
-     ]
-    },
-    "paint": {
-     "text-color": "#863831",
-     "text-halo-color": "#FFFFFF",
-     "text-halo-width": 1.5
-    }
-   },
-   {
-    "id": "toponyme - hydro lineaire 3",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_hydro_lin",
-    "filter": [
-     "in",
-     "txt_typo",
-     "HYD_LIN_3",
-     "HYD_LIN_4",
-     "HYD_LIN_5",
-     "petite rivière",
-     "canal",
-     "HYD_SURF_3",
-     "HYD_SURF_3_T",
-     "HYD_SURF_4",
-     "HYD_SURF_4_T",
-     "HYD_SURF_5",
-     "HYD_SURF_5_T",
-     "TYPO_D_5"
-    ],
-    "layout": {
-     "symbol-placement": "line",
-     "text-field": "{texte}",
-     "text-size": {
-      "stops": [
-       [
-        14,
-        12
-       ],
-       [
-        18,
-        19
-       ]
-      ]
-     },
-     "text-anchor": "center",
-     "text-keep-upright": true,
-     "text-max-angle": 45,
-     "text-padding": 10,
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#447FB3",
-     "text-halo-width": 1.5,
-     "text-halo-color": "rgba(255, 255, 255, 0.7)"
-    }
-   },
-   {
-    "id": "toponyme - hydro lineaire 4",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_hydro_lin",
-    "minzoom": 14,
-    "filter": [
-     "in",
-     "txt_typo",
-     "TYPO_D_6",
-     "TYPO_D_8",
-     "TYPO_D_9",
-     "TYPO_D_10"
-    ],
-    "layout": {
-     "symbol-placement": "line",
-     "text-field": "{texte}",
-     "text-size": {
-      "stops": [
-       [
-        14,
-        10
-       ],
-       [
-        18,
-        16
-       ]
-      ]
-     },
-     "text-anchor": "center",
-     "text-keep-upright": true,
-     "text-max-angle": 45,
-     "text-padding": 10,
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#447FB3",
-     "text-halo-width": 1.5,
-     "text-halo-color": "rgba(255, 255, 255, 0.7)"
-    }
-   },
-   {
-    "id": "toponyme - hydro ponc 3",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_hydro_ponc",
-    "filter": [
-     "in",
-     "txt_typo",
-     "petit golfe",
-     "grande baie",
-     "baie",
-     "HYD_SURF_3",
-     "TYPO_D_5",
-     "TYPO_D_6",
-     "TYPO_D_7"
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-size": {
-      "stops": [
-       [
-        15,
-        15
-       ],
-       [
-        17,
-        18
-       ]
-      ]
-     },
-     "text-allow-overlap": true,
-     "text-padding": 10,
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#447FB3",
-     "text-halo-color": "#FFFFFF",
-     "text-halo-width": 2
-    }
-   },
-   {
-    "id": "toponyme bati ponc zai zoom 16",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_bati_ponc",
-    "minzoom": 15,
-    "maxzoom": 16,
-    "filter": [
-     "==",
-     "txt_typo",
-     "zai"
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{designation}",
-     "text-size": 11,
-     "text-allow-overlap": false,
-     "text-padding": 1,
-     "text-font": [
-      "Source Sans Pro Italic"
-     ]
-    },
-    "paint": {
-     "text-color": "#000000"
-    }
-   },
-   {
-    "id": "toponyme bati ponc zai zoom 17 et 18",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_bati_ponc",
-    "minzoom": 16,
-    "filter": [
-     "==",
-     "txt_typo",
-     "zai"
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-size": 11,
-     "text-allow-overlap": false,
-     "text-padding": 1,
-     "text-font": [
-      "Source Sans Pro Italic"
-     ]
-    },
-    "paint": {
-     "text-color": "#000000"
-    }
-   },
-   {
-    "id": "toponyme localite importance 4",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_localite_ponc",
-    "minzoom": 7,
-    "filter": [
-     "in",
-     "txt_typo",
-     "commune 4",
-     "BAT_COMMUNE_4",
-     "BAT_COMMUNE_4_T"
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "icon-image": "Localite",
-     "icon-size": 0.21,
-     "text-field": "{texte}",
-     "text-size": 13,
-     "text-allow-overlap": false,
-     "text-anchor": "bottom-left",
-     "text-offset": [
-      0.3,
-      0.1
-     ],
-     "text-padding": 1,
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#000000",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 2
-    }
-   },
-   {
-    "id": "toponyme localite n0 typoA9",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_localite_ponc",
-    "maxzoom": 18,
-    "filter": [
-     "==",
-     "txt_typo",
-     "TYPO_A_9"
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-size": {
-      "stops": [
-       [
-        15,
-        11.5
-       ],
-       [
-        17,
-        14
-       ]
-      ]
-     },
-     "text-allow-overlap": true,
-     "text-anchor": "center",
-     "text-padding": 1,
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#000000",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 2
-    }
-   },
-   {
-    "id": "toponyme localite n0 typoA8",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_localite_ponc",
-    "maxzoom": 18,
-    "filter": [
-     "==",
-     "txt_typo",
-     "TYPO_A_8"
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-size": {
-      "stops": [
-       [
-        15,
-        12
-       ],
-       [
-        17,
-        15
-       ]
-      ]
-     },
-     "text-allow-overlap": true,
-     "text-anchor": "center",
-     "text-padding": 1,
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#000000",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 2
-    }
-   },
-   {
-    "id": "toponyme - limite militaire ponc 1 et 2",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_limite_ponc",
-    "filter": [
-     "in",
-     "txt_typo",
-     "LIM_MILI_1",
-     "LIM_MILI_2"
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-size": 15,
-     "text-allow-overlap": false,
-     "text-padding": 5,
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#0D2000",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 2
-    }
-   },
-   {
-    "id": "toponyme - limite parc marin",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_limite_ponc",
-    "minzoom": 8,
-    "filter": [
-     "==",
-     "txt_typo",
-     "LIM_PARC_NATUREL_MARIN"
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-size": 15,
-     "text-allow-overlap": false,
-     "text-padding": 10,
-     "text-transform": "uppercase",
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#2A81A2",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 2
-    }
-   },
-   {
-    "id": "toponyme - limite parc ponc 1 et 2",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_limite_ponc",
-    "minzoom": 8,
-    "filter": [
-     "in",
-     "txt_typo",
-     "LIM_PARC_1",
-     "LIM_PARC_2",
-     "LIM_PARC_NATUREL"
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-size": 15,
-     "text-allow-overlap": false,
-     "text-padding": 10,
-     "text-transform": "uppercase",
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#287B00",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 2
-    }
-   },
-   {
-    "id": "toponyme - ocs lineaire 2",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_ocs_lin",
-    "filter": [
-     "==",
-     "txt_typo",
-     "OCS_FORET_2"
-    ],
-    "layout": {
-     "symbol-placement": "line",
-     "text-field": "{texte}",
-     "text-size": {
-      "stops": [
-       [
-        10,
-        15
-       ],
-       [
-        12,
-        18
-       ]
-      ]
-     },
-     "text-anchor": "center",
-     "text-keep-upright": true,
-     "text-max-angle": 45,
-     "text-padding": 1,
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#287B00",
-     "text-halo-width": 2,
-     "text-halo-color": "rgba(255, 255, 255, 0.5)"
-    }
-   },
-   {
-    "id": "toponyme - ocs ponc 2",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_ocs_ponc",
-    "filter": [
-     "==",
-     "txt_typo",
-     "OCS_FORET_2"
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-size": {
-      "stops": [
-       [
-        10,
-        15
-       ],
-       [
-        12,
-        18
-       ]
-      ]
-     },
-     "text-allow-overlap": false,
-     "text-padding": 1,
-     "text-anchor": "center",
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#287B00",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 2
-    }
-   },
-   {
-    "id": "toponyme - oro lineaire 2",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_oro_lin",
-    "filter": [
-     "in",
-     "txt_typo",
-     "ORO_ILE_2",
-     "ORO_RELIEF_2",
-     "ORO_RELIEF_2_T",
-     "ORO_CAP_1",
-     "ORO_SOMMET_1"
-    ],
-    "layout": {
-     "symbol-placement": "line",
-     "text-field": "{texte}",
-     "text-size": 15,
-     "text-anchor": "center",
-     "text-keep-upright": true,
-     "text-padding": 10,
-     "text-max-angle": 45,
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#863831",
-     "text-halo-width": 2,
-     "text-halo-color": "rgba(255, 255, 255, 0.5)"
-    }
-   },
-   {
-    "id": "toponyme - oro ponc 2",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_oro_ponc",
-    "minzoom": 9,
-    "filter": [
-     "in",
-     "txt_typo",
-     "ORO_ILE_2",
-     "ORO_RELIEF_2",
-     "ORO_RELIEF_2_T",
-     "ORO_CAP_1",
-     "ORO_COL_1",
-     "sommet ou col",
-     "ORO_SOMMET_1",
-     "TYPO_G_4",
-     "TYPO_G_6"
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-size": {
-      "stops": [
-       [
-        9,
-        13
-       ],
-       [
-        10,
-        15
-       ],
-       [
-        13,
-        15
-       ],
-       [
-        16,
-        19
-       ]
-      ]
-     },
-     "text-allow-overlap": false,
-     "text-padding": 1,
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#863831",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 2
-    }
-   },
-   {
-    "id": "toponyme - oro ponc 2B",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_oro_ponc",
-    "minzoom": 8,
-    "filter": [
-     "in",
-     "txt_typo",
-     "île",
-     "cap ou pointe"
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-size": 15,
-     "text-allow-overlap": false,
-     "text-padding": 1,
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#863831",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 2
-    }
-   },
-   {
-    "id": "toponyme - hydro lineaire 2",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_hydro_lin",
-    "filter": [
-     "in",
-     "txt_typo",
-     "HYD_LIN_2",
-     "rivière moyenne",
-     "HYD_SURF_2",
-     "HYD_SURF_2_T",
-     "TYPO_D_3"
-    ],
-    "layout": {
-     "symbol-placement": "line",
-     "text-field": "{texte}",
-     "text-size": {
-      "stops": [
-       [
-        14,
-        15
-       ],
-       [
-        18,
-        21
-       ]
-      ]
-     },
-     "text-anchor": "center",
-     "text-keep-upright": true,
-     "text-max-angle": 45,
-     "text-padding": 10,
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#447FB3",
-     "text-halo-width": 2,
-     "text-halo-color": "rgba(255, 255, 255, 0.5)"
-    }
-   },
-   {
-    "id": "toponyme - hydro ponc 2",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_hydro_ponc",
-    "minzoom": 5,
-    "filter": [
-     "in",
-     "txt_typo",
-     "moyen",
-     "golfe moyen",
-     "HYD_SURF_2",
-     "TYPO_D_2",
-     "TYPO_D_3",
-     "TYPO_D_4"
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-size": {
-      "stops": [
-       [
-        5,
-        12
-       ],
-       [
-        6,
-        18
-       ],
-       [
-        10,
-        17
-       ],
-       [
-        18,
-        21
-       ]
-      ]
-     },
-     "text-allow-overlap": false,
-     "text-padding": 10,
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#447FB3",
-     "text-halo-color": "#FFFFFF",
-     "text-halo-width": 2
-    }
-   },
-   {
-    "id": "toponyme localite importance 3",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_localite_ponc",
-    "minzoom": 5,
-    "filter": [
-     "in",
-     "txt_typo",
-     "commune 3",
-     "BAT_COMMUNE_3",
-     "BAT_COMMUNE_3_T"
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "icon-image": "Localite",
-     "icon-size": 0.21,
-     "text-field": "{texte}",
-     "text-size": {
-      "stops": [
-       [
-        5,
-        10
-       ],
-       [
-        6,
-        15
-       ]
-      ]
-     },
-     "text-allow-overlap": false,
-     "text-anchor": "bottom-left",
-     "text-offset": [
-      0.3,
-      0.1
-     ],
-     "text-padding": 1,
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#000000",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 2
-    }
-   },
-   {
-    "id": "toponyme localite n0 typoA7 non commune",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_localite_ponc",
-    "maxzoom": 18,
-    "filter": [
-     "all",
-     [
-      "!=",
-      "symbo",
-      "COMMUNE_FUSIONNEE"
-     ],
-     [
-      "!=",
-      "symbo",
-      "COMMUNE_CHEF_LIEU"
-     ],
-     [
-      "==",
-      "txt_typo",
-      "TYPO_A_7"
-     ]
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-size": {
-      "stops": [
-       [
-        15,
-        13
-       ],
-       [
-        17,
-        16
-       ]
-      ]
-     },
-     "text-allow-overlap": true,
-     "text-anchor": "center",
-     "text-padding": 1,
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#000000",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 2
-    }
-   },
-   {
-    "id": "toponyme localite n0 typoA6 non commune",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_localite_ponc",
-    "maxzoom": 18,
-    "filter": [
-     "all",
-     [
-      "!=",
-      "symbo",
-      "COMMUNE_FUSIONNEE"
-     ],
-     [
-      "!=",
-      "symbo",
-      "COMMUNE_CHEF_LIEU"
-     ],
-     [
-      "==",
-      "txt_typo",
-      "TYPO_A_6"
-     ]
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-size": {
-      "stops": [
-       [
-        15,
-        15
-       ],
-       [
-        17,
-        18
-       ]
-      ]
-     },
-     "text-allow-overlap": true,
-     "text-anchor": "center",
-     "text-padding": 1,
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#000000",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 2
-    }
-   },
-   {
-    "id": "toponyme - oro lineaire 1",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_oro_lin",
-    "filter": [
-     "in",
-     "txt_typo",
-     "ORO_ILE_1",
-     "ORO_RELIEF_1",
-     "ORO_RELIEF_1_T"
-    ],
-    "layout": {
-     "symbol-placement": "line",
-     "text-field": "{texte}",
-     "text-size": 20,
-     "text-anchor": "center",
-     "text-keep-upright": true,
-     "text-padding": 5,
-     "text-max-angle": 45,
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#863831",
-     "text-halo-width": 2,
-     "text-halo-color": "rgba(255, 255, 255, 0.5)"
-    }
-   },
-   {
-    "id": "toponyme - oro ponc monde",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_oro_ponc",
-    "minzoom": 5,
-    "filter": [
-     "in",
-     "txt_typo",
-     "Basin",
-     "Depression",
-     "Desert",
-     "Geoarea",
-     "Gorge",
-     "Isthmus",
-     "Lake",
-     "Lowland",
-     "Pen/cape",
-     "Plain",
-     "Plateau",
-     "Range/mtn",
-     "Tundra",
-     "Valley",
-     "Island",
-     "Island group"
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-size": 11,
-     "text-allow-overlap": false,
-     "text-padding": 1,
-     "text-font": [
-      "Source Sans Pro Italic"
-     ]
-    },
-    "paint": {
-     "text-color": "#863831",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 2
-    }
-   },
-   {
-    "id": "toponyme localite n0 typoA4 non commune",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_localite_ponc",
-    "maxzoom": 16,
-    "filter": [
-     "all",
-     [
-      "!=",
-      "symbo",
-      "COMMUNE_FUSIONNEE"
-     ],
-     [
-      "!=",
-      "symbo",
-      "COMMUNE_CHEF_LIEU"
-     ],
-     [
-      "==",
-      "txt_typo",
-      "TYPO_A_4"
-     ]
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-size": 17,
-     "text-allow-overlap": true,
-     "text-anchor": "center",
-     "text-padding": 1,
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#000000",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 3
-    }
-   },
-   {
-    "id": "toponyme - ocs lineaire 1",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_ocs_lin",
-    "filter": [
-     "==",
-     "txt_typo",
-     "OCS_FORET_1"
-    ],
-    "layout": {
-     "symbol-placement": "line",
-     "text-field": "{texte}",
-     "text-size": {
-      "stops": [
-       [
-        10,
-        18
-       ],
-       [
-        12,
-        22
-       ]
-      ]
-     },
-     "text-anchor": "center",
-     "text-keep-upright": true,
-     "text-padding": 1,
-     "text-max-angle": 45,
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#287B00",
-     "text-halo-width": 2,
-     "text-halo-color": "rgba(255, 255, 255, 0.5)"
-    }
-   },
-   {
-    "id": "toponyme - ocs ponc 1",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_ocs_ponc",
-    "filter": [
-     "==",
-     "txt_typo",
-     "OCS_FORET_1"
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-size": {
-      "stops": [
-       [
-        10,
-        18
-       ],
-       [
-        12,
-        22
-       ]
-      ]
-     },
-     "text-allow-overlap": true,
-     "text-padding": 1,
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#287B00",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 2
-    }
-   },
-   {
-    "id": "toponyme - oro ponc 1",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_oro_ponc",
-    "minzoom": 8,
-    "filter": [
-     "in",
-     "txt_typo",
-     "grande île",
-     "ORO_ILE_1",
-     "ORO_RELIEF_1",
-     "ORO_RELIEF_1_T",
-     "TYPO_G_3",
-     "TYPO_G_2",
-     "TYPO_G_1"
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-size": 21,
-     "text-allow-overlap": true,
-     "text-padding": 1,
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#863831",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 2
-    }
-   },
-   {
-    "id": "toponyme - hydro lineaire glacier",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_hydro_lin",
-    "filter": [
-     "in",
-     "txt_typo",
-     "ORO_GLACIER_1",
-     "ORO_GLACIER_2"
-    ],
-    "layout": {
-     "symbol-placement": "line",
-     "text-field": "{texte}",
-     "text-size": 15,
-     "text-anchor": "center",
-     "text-keep-upright": true,
-     "text-max-angle": 45,
-     "text-font": [
-      "Source Sans Pro Italic"
-     ]
-    },
-    "paint": {
-     "text-color": "#447FB3",
-     "text-halo-width": 2,
-     "text-halo-color": "rgba(255, 255, 255, 0.5)"
-    }
-   },
-   {
-    "id": "toponyme - hydro lineaire 1",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_hydro_lin",
-    "filter": [
-     "in",
-     "txt_typo",
-     "HYD_LIN_1",
-     "HYD-LIN-1",
-     "grande rivière",
-     "HYD_SURF_1",
-     "HYD_SURF_1_T",
-     "TYPO_D_1",
-     "TYPO_D_2"
-    ],
-    "layout": {
-     "symbol-placement": "line",
-     "text-field": "{texte}",
-     "text-size": 18,
-     "text-anchor": "center",
-     "text-keep-upright": true,
-     "text-max-angle": 45,
-     "text-padding": 10,
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#447FB3",
-     "text-halo-width": 2,
-     "text-halo-color": "rgba(255, 255, 255, 0.5)"
-    }
-   },
-   {
-    "id": "toponyme - hydro lineaire ocean",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_hydro_lin",
-    "filter": [
-     "==",
-     "txt_typo",
-     "mer et océan"
-    ],
-    "layout": {
-     "symbol-placement": "line",
-     "text-field": "{texte}",
-     "text-size": 30,
-     "text-anchor": "center",
-     "text-keep-upright": true,
-     "text-max-angle": 45,
-     "text-padding": 10,
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#447FB3",
-     "text-halo-width": 4,
-     "text-halo-color": "rgba(255, 255, 255, 0.5)"
-    }
-   },
-   {
-    "id": "toponyme - hydro ponc 1",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_hydro_ponc",
-    "minzoom": 4,
-    "filter": [
-     "in",
-     "txt_typo",
-     "mer",
-     "grand",
-     "grand golfe",
-     "HYD_SURF_1",
-     "TYPO_D_1"
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-size": {
-      "stops": [
-       [
-        4,
-        16
-       ],
-       [
-        6,
-        30
-       ],
-       [
-        10,
-        25
-       ]
-      ]
-     },
-     "text-allow-overlap": true,
-     "text-padding": 10,
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#447FB3",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 4
-    }
-   },
-   {
-    "id": "toponyme localite importance 2",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_localite_ponc",
-    "minzoom": 4,
-    "filter": [
-     "in",
-     "txt_typo",
-     "commune 2",
-     "BAT_COMMUNE_2",
-     "BAT_COMMUNE-2",
-     "BAT_COMMUNE_2_T"
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "icon-image": "Localite",
-     "icon-size": 0.25,
-     "text-field": "{texte}",
-     "text-size": {
-      "stops": [
-       [
-        4,
-        10
-       ],
-       [
-        6,
-        17
-       ]
-      ]
-     },
-     "text-allow-overlap": true,
-     "text-anchor": "bottom-left",
-     "text-offset": [
-      0.3,
-      0.2
-     ],
-     "text-padding": 1,
-     "text-transform": "uppercase",
-     "text-font": {
-      "stops": [
-       [
-        1,
-        [
-         "Source Sans Pro Regular"
-        ]
-       ],
-       [
-        7,
-        [
-         "Source Sans Pro Bold"
-        ]
-       ],
-       [
-        10,
-        [
-         "Source Sans Pro Regular"
-        ]
-       ]
-      ]
-     }
-    },
-    "paint": {
-     "text-color": "#000000",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 3
-    }
-   },
-   {
-    "id": "toponyme localite n0 typoA3 non commune",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_localite_ponc",
-    "maxzoom": 16,
-    "filter": [
-     "all",
-     [
-      "!=",
-      "symbo",
-      "COMMUNE_FUSIONNEE"
-     ],
-     [
-      "!=",
-      "symbo",
-      "COMMUNE_CHEF_LIEU"
-     ],
-     [
-      "==",
-      "txt_typo",
-      "TYPO_A_3"
-     ]
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-size": 19,
-     "text-allow-overlap": true,
-     "text-anchor": "center",
-     "text-padding": 1,
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#000000",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 3
-    }
-   },
-   {
-    "id": "toponyme localite n0 typoA2 non commune",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_localite_ponc",
-    "maxzoom": 16,
-    "filter": [
-     "all",
-     [
-      "!=",
-      "symbo",
-      "COMMUNE_FUSIONNEE"
-     ],
-     [
-      "!=",
-      "symbo",
-      "COMMUNE_CHEF_LIEU"
-     ],
-     [
-      "==",
-      "txt_typo",
-      "TYPO_A_2"
-     ]
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-size": 21,
-     "text-allow-overlap": true,
-     "text-anchor": "center",
-     "text-padding": 1,
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#000000",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 4
-    }
-   },
-   {
-    "id": "toponyme localite n0 typoA7 commune",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_localite_ponc",
-    "maxzoom": 18,
-    "filter": [
-     "all",
-     [
-      "in",
-      "symbo",
-      "COMMUNE_FUSIONNEE",
-      "COMMUNE_CHEF_LIEU"
-     ],
-     [
-      "==",
-      "txt_typo",
-      "TYPO_A_7"
-     ]
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-size": {
-      "stops": [
-       [
-        15,
-        13
-       ],
-       [
-        17,
-        16
-       ]
-      ]
-     },
-     "text-allow-overlap": true,
-     "text-anchor": "center",
-     "text-padding": 1,
-     "text-transform": "uppercase",
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#000000",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 2
-    }
-   },
-   {
-    "id": "toponyme localite n0 typoA6 commune",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_localite_ponc",
-    "maxzoom": 18,
-    "filter": [
-     "all",
-     [
-      "in",
-      "symbo",
-      "COMMUNE_FUSIONNEE",
-      "COMMUNE_CHEF_LIEU"
-     ],
-     [
-      "==",
-      "txt_typo",
-      "TYPO_A_6"
-     ]
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-size": {
-      "stops": [
-       [
-        15,
-        15
-       ],
-       [
-        17,
-        18
-       ]
-      ]
-     },
-     "text-allow-overlap": true,
-     "text-anchor": "center",
-     "text-padding": 1,
-     "text-transform": "uppercase",
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#000000",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 2
-    }
-   },
-   {
-    "id": "toponyme localite n0 typoA1 non commune",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_localite_ponc",
-    "maxzoom": 16,
-    "filter": [
-     "all",
-     [
-      "!=",
-      "symbo",
-      "COMMUNE_FUSIONNEE"
-     ],
-     [
-      "!=",
-      "symbo",
-      "COMMUNE_CHEF_LIEU"
-     ],
-     [
-      "==",
-      "txt_typo",
-      "TYPO_A_1"
-     ]
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-size": 23,
-     "text-allow-overlap": true,
-     "text-anchor": "center",
-     "text-padding": 1,
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#000000",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 4
-    }
-   },
-   {
-    "id": "toponyme localite n0 typoA4 commune",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_localite_ponc",
-    "maxzoom": 16,
-    "filter": [
-     "all",
-     [
-      "in",
-      "symbo",
-      "COMMUNE_FUSIONNEE",
-      "COMMUNE_CHEF_LIEU"
-     ],
-     [
-      "==",
-      "txt_typo",
-      "TYPO_A_4"
-     ]
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-size": 17,
-     "text-allow-overlap": true,
-     "text-anchor": "center",
-     "text-padding": 1,
-     "text-transform": "uppercase",
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#000000",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 3
-    }
-   },
-   {
-    "id": "toponyme localite n0 typoA3 commune",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_localite_ponc",
-    "maxzoom": 16,
-    "filter": [
-     "all",
-     [
-      "in",
-      "symbo",
-      "COMMUNE_FUSIONNEE",
-      "COMMUNE_CHEF_LIEU"
-     ],
-     [
-      "==",
-      "txt_typo",
-      "TYPO_A_3"
-     ]
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-size": 19,
-     "text-allow-overlap": true,
-     "text-anchor": "center",
-     "text-padding": 1,
-     "text-transform": "uppercase",
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#000000",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 3
-    }
-   },
-   {
-    "id": "toponyme localite n0 typoA2 commune",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_localite_ponc",
-    "maxzoom": 16,
-    "filter": [
-     "all",
-     [
-      "in",
-      "symbo",
-      "COMMUNE_FUSIONNEE",
-      "COMMUNE_CHEF_LIEU"
-     ],
-     [
-      "==",
-      "txt_typo",
-      "TYPO_A_2"
-     ]
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-size": 21,
-     "text-allow-overlap": true,
-     "text-anchor": "center",
-     "text-padding": 1,
-     "text-transform": "uppercase",
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#000000",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 4
-    }
-   },
-   {
-    "id": "toponyme localite importance 1",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_localite_ponc",
-    "minzoom": 3,
-    "filter": [
-     "in",
-     "txt_typo",
-     "commune 1",
-     "BAT_COMMUNE_1",
-     "BAT_COMMUNE_1_T"
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "icon-image": "Localite",
-     "icon-size": 0.3,
-     "text-field": "{texte}",
-     "text-size": {
-      "stops": [
-       [
-        3,
-        10
-       ],
-       [
-        6,
-        20
-       ]
-      ]
-     },
-     "text-allow-overlap": false,
-     "text-anchor": "bottom-left",
-     "text-offset": [
-      0.25,
-      -0.1
-     ],
-     "text-padding": 1,
-     "text-transform": "uppercase",
-     "text-font": {
-      "stops": [
-       [
-        1,
-        [
-         "Source Sans Pro Regular"
-        ]
-       ],
-       [
-        7,
-        [
-         "Source Sans Pro Bold"
-        ]
-       ],
-       [
-        10,
-        [
-         "Source Sans Pro Regular"
-        ]
-       ]
-      ]
-     }
-    },
-    "paint": {
-     "text-color": "#000000",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 4
-    }
-   },
-   {
-    "id": "toponyme localite n0 typoA1 commune",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_localite_ponc",
-    "maxzoom": 16,
-    "filter": [
-     "all",
-     [
-      "in",
-      "symbo",
-      "COMMUNE_FUSIONNEE",
-      "COMMUNE_CHEF_LIEU"
-     ],
-     [
-      "==",
-      "txt_typo",
-      "TYPO_A_1"
-     ]
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-size": 23,
-     "text-allow-overlap": true,
-     "text-anchor": "center",
-     "text-padding": 1,
-     "text-transform": "uppercase",
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#000000",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 4
-    }
-   },
-   {
-    "id": "toponyme - hydro ponc ocean",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_hydro_ponc",
-    "minzoom": 1,
-    "filter": [
-     "==",
-     "txt_typo",
-     "ocean"
-    ],
-    "layout": {
-     "visibility": "visible",
-     "symbol-placement": "point",
-     "text-field": "{texte}",
-     "text-size": {
-      "stops": [
-       [
-        1,
-        16
-       ],
-       [
-        6,
-        30
-       ]
-      ]
-     },
-     "text-allow-overlap": true,
-     "text-anchor": "center",
-     "text-padding": 10,
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#447FB3",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 4
-    }
-   },
-   {
-    "id": "toponyme pays 3",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_localite_ponc",
-    "minzoom": 4,
-    "maxzoom": 5,
-    "filter": [
-     "==",
-     "txt_typo",
-     "pays 3"
-    ],
-    "layout": {
-     "visibility": "visible",
-     "text-field": "{texte}",
-     "text-size": 9,
-     "text-allow-overlap": true,
-     "text-anchor": "center",
-     "text-padding": 1,
-     "text-transform": "uppercase",
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#787878",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 4
-    }
-   },
-   {
-    "id": "toponyme pays 2",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_localite_ponc",
-    "minzoom": 2,
-    "maxzoom": 5,
-    "filter": [
-     "==",
-     "txt_typo",
-     "pays 2"
-    ],
-    "layout": {
-     "visibility": "visible",
-     "text-field": "{texte}",
-     "text-size": 13,
-     "text-allow-overlap": true,
-     "text-anchor": "center",
-     "text-padding": 2,
-     "text-transform": "uppercase",
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#787878",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 4
-    }
-   },
-   {
-    "id": "toponyme pays 1",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_localite_ponc",
-    "minzoom": 2,
-    "maxzoom": 5,
-    "filter": [
-     "==",
-     "txt_typo",
-     "pays 1"
-    ],
-    "layout": {
-     "visibility": "visible",
-     "text-field": "{texte}",
-     "text-size": 13,
-     "text-allow-overlap": true,
-     "text-anchor": "center",
-     "text-padding": 2,
-     "text-transform": "uppercase",
-     "text-font": [
-      "Source Sans Pro Regular"
-     ]
-    },
-    "paint": {
-     "text-color": "#787878",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 4
-    }
-   },
-   {
-    "id": "toponyme continent",
-    "type": "symbol",
-    "source": "plan_ign",
-    "source-layer": "toponyme_localite_ponc",
-    "maxzoom": 3,
-    "filter": [
-     "==",
-     "txt_typo",
-     "continent"
-    ],
-    "layout": {
-     "visibility": "visible",
-     "text-field": "{texte}",
-     "text-size": 15,
-     "text-allow-overlap": true,
-     "text-anchor": "center",
-     "text-padding": 1,
-     "text-transform": "uppercase",
-     "text-font": [
-      "Source Sans Pro Bold"
-     ]
-    },
-    "paint": {
-     "text-color": "#787878",
-     "text-halo-color": "rgba(255, 255, 255, 0.5)",
-     "text-halo-width": 4
-    }
-   }
-  ]
- }
+			}
+		},
+        {
+			"id": "Routier souterrain - filet interieur - route regionale",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route_sou",
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "BRET_REGIONALE_SOU",
+                                    "REGIONALE_4_SOU",
+                                    "REGIONALE_3_SOU",
+                                    "REGIONALE_2_SOU",
+                                    "REGIONALE_1_SOU"
+            ],
+			"paint": {
+				"line-color": "rgba(255, 255, 255, 0.5)",
+		        "line-width": {
+					"stops": [[6, 1.4], [9, 1.5], [14, 3.2], [15, 5.8], [16, 8.3], [17, 16.2]]
+                }
+			}
+		},
+        {
+			"id": "Routier souterrain - filet interieur - route regionale en construction",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route_sou",
+			"minzoom": 10,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","REGIONALE_CONSTR_SOU"],
+			"paint": {
+				"line-color": {
+                    "stops": [[9, "#FFFFFF"], [10, "#FDF28B"], [17, "#FCF6BD"]]
+                },
+		        "line-width": {
+					"stops": [[4, 0.4], [6, 1.5], [9, 2.3], [14, 5], [15, 8.1], [16, 11.2], [17, 22]]
+                },
+				"line-dasharray": [2,2]
+			}
+		},
+        {
+			"id": "Routier souterrain - filet interieur - route principale",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route_sou",
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "BRET_PRINCIPALE_SOU",
+                                    "PRINCIPALE_4_SOU",
+                                    "PRINCIPALE_3_SOU",
+                                    "PRINCIPALE_2_SOU",
+                                    "PRINCIPALE_1_SOU"
+            ],
+			"paint": {
+				"line-color": "rgba(255, 255, 255, 0.5)",
+		        "line-width": {
+					"stops": [[4, 0.5], [6, 1.8], [9, 2.1], [14, 4.4], [15, 7.3], [16, 10], [17, 18.5]]
+                }
+			}
+		},
+        {
+			"id": "Routier souterrain - filet interieur - route principale en construction",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route_sou",
+			"minzoom": 10,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+			"filter": ["==","symbo","PRINCIPALE_CONSTR_SOU"],
+			"paint": {
+				"line-color": {"stops": [[9, "#F3C66D"], [17, "#F2DDB3"]]},
+		        "line-width": {
+					"stops": [[4, 0.5], [6, 1.8], [9, 2.7], [14, 5.9], [15, 9], [16, 12.2], [17, 22.5]]
+                },
+				"line-dasharray": [2,2]
+			}
+		},
+        {
+			"id": "Routier souterrain - filet interieur - autoroute",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route_sou",
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "AUTOROU_PEAGE_SOU",
+                                    "AUTOROU_LIBRE_SOU"
+            ],
+			"paint": {
+				"line-color": "rgba(255, 255, 255, 0.5)",
+		        "line-width": {
+					"stops": [[4, 0.7], [6, 2.5], [9, 2.7], [14, 5.8], [15, 9], [16, 12], [17, 20.8]]
+                }
+			}
+		},
+        {
+			"id": "Routier souterrain - axe central - autoroute",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route_sou",
+			"minzoom": 13,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "AUTOROU_PEAGE_SOU",
+                                    "AUTOROU_LIBRE_SOU"
+            ],
+			"paint": {
+				"line-color": "#FFFFFF",
+		        "line-width": {
+					"stops": [[9, 0.6], [14, 0.7], [15, 1], [16, 1.2], [17, 2.1]]
+                }
+			}
+		},
+        {
+			"id": "Routier souterrain - filet interieur - autoroute en construction",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route_sou",
+			"minzoom": 10,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","AUTOROU_CONSTR_SOU"],
+			"paint": {
+				"line-color": {"stops": [[9, "#F2BA59"], [17, "#F2C261"]]},
+		        "line-width": {
+                    "stops": [[4, 0.7], [6, 2.5], [9, 3.5], [14, 7.5], [15, 11], [16, 15], [17, 26]]
+                },
+                "line-dasharray": [2,2]
+			}
+		},
+        {
+			"id": "Routier souterrain - axe central - autoroute en construction",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route_sou",
+			"minzoom": 13,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","AUTOROU_CONSTR_SOU"],
+			"paint": {
+				"line-color": "#808080",
+		        "line-width": {
+					"stops": [[9, 0.6], [14, 0.7], [15, 1], [16, 1.2], [17, 2.1]]
+                }
+			}
+		},
+        {
+			"id": "réseau hydro - cours d'eau temporaire",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "hydro_reseau",
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo","COURS_D_EAU_TEMP","COURS_D_EAU_TEMP_MOY"],
+			"paint": {
+				"line-color": "#AAD5E9",
+		        "line-width": {
+				"stops": [[12, 1.5], [17, 4]]
+                },
+                "line-dasharray": [6,2]
+			}
+		},
+        {
+			"id": "réseau hydro - cours d'eau",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "hydro_reseau",
+			"minzoom": 3,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","COURS_D_EAU"],
+			"paint": {
+				"line-color": "#AAD5E9",
+		        "line-width": {
+				"stops": [[4, 0.3], [7, 1.5], [12, 1.5], [17, 6.5]]
+                }
+			}
+		},
+		{
+        	"id": "réseau hydro - canal",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "hydro_reseau",
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","CANAL"],
+			"paint": {
+				"line-color": "#AAD5E9",
+		        "line-width": {
+				"stops": [[12, 1.4], [17, 5.9]]
+                }
+			}
+		},
+        {
+			"id": "réseau hydro - filet interieur - aqueduc",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "hydro_reseau",
+			"minzoom": 12,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","AQUEDUC_AU_SOL"],
+			"paint": {
+				"line-color": "#AAD5E9",
+		        "line-width": {
+				"stops": [[12, 1.4], [16, 3.5], [17, 5.9]]
+                }
+			}
+		},
+        {
+			"id": "réseau hydro - carre - aqueduc",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "hydro_reseau",
+			"minzoom": 12,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","AQUEDUC_AU_SOL"],
+			"paint": {
+				"line-color": "#AAD5E9",
+		        "line-width": {
+				"stops": [[12, 3.5], [16, 8.7], [17, 14.7]]
+                },
+			    "line-dasharray": [1,5]
+			}
+		},
+        {
+			"id": "réseau hydro - cours d'eau moyen ",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "hydro_reseau",
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+           "filter": ["==","symbo","COURS_D_EAU_MOY"],
+			"paint": {
+				"line-color": "#AAD5E9",
+		        "line-width": {
+				"stops": [[7, 2], [12, 2.5]]
+                }
+			}
+		},
+        {
+			"id": "réseau hydro - cours d'eau large ",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "hydro_reseau",
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","COURS_D_EAU_LAR"],
+			"paint": {
+				"line-color": "#AAD5E9",
+		        "line-width": {
+				"stops": [[7, 3], [11, 5]]
+                }
+			}
+		},
+		{
+			"id": "parcellaire - parcelle surface",
+			"type": "fill",
+			"source": "plan_ign",
+			"source-layer": "parcellaire_parcelle",
+			"layout": {
+				"visibility": "visible"
+			},
+            "filter": ["==","symbo","PARCELLE"],
+			"paint": {
+				"fill-color": "#FFFFD1",
+				"fill-opacity": 0.7
+			}
+		},
+		{
+			"id": "bati surfacique mairie - Zoom 14",
+			"type": "fill",
+			"source": "plan_ign",
+			"source-layer": "bati_surf",
+			"maxzoom": 14,
+			"layout": {
+				"visibility": "visible"
+			},
+			"filter": ["in","symbo",
+									"MAIRIE",
+									"MAIRIE_ANNEXE"
+			],
+			"paint": {
+				"fill-color": "#FFA6A6"
+			}
+		},
+		{
+			"id": "bati surfacique mairie - Zoom 15,16,17,18",
+			"type": "fill",
+			"source": "plan_ign",
+			"source-layer": "bati_surf",
+			"minzoom": 14,
+			"layout": {
+				"visibility": "visible"
+			},
+			"filter": ["in","symbo",
+									"MAIRIE",
+									"MAIRIE_ANNEXE"
+			],
+			"paint": {
+				"fill-color": {"stops": [[14, "#FFA6A6"], [15, "#FFAEAE"]]},
+				"fill-outline-color": "#FF7C7C"
+			}
+		},
+		{
+			"id": "bati surfacique fonctionnel industriel ou commercial - Zoom 14,15",
+			"type": "fill",
+			"source": "plan_ign",
+			"source-layer": "bati_surf",
+			"maxzoom": 15,
+			"layout": {
+				"visibility": "visible"
+			},
+            "filter": ["in","symbo",
+                                    "BATI_COMMERCIAL",
+                                    "BATI_INDUSTRIEL",
+                                    "HANGAR",
+                                    "HANGAR_COMMERCIAL",
+                                    "HANGAR_INDUSTRIEL"
+            ],
+			"paint": {
+				"fill-color": "#C8C8C8"
+			}
+		},
+		{
+			"id": "bati surfacique fonctionnel industriel ou commercial - Zoom 16,17,18",
+			"type": "fill",
+			"source": "plan_ign",
+			"source-layer": "bati_surf",
+			"minzoom": 15,
+			"layout": {
+				"visibility": "visible"
+			},
+            "filter": ["in","symbo",
+                                    "BATI_COMMERCIAL",
+                                    "BATI_INDUSTRIEL",
+                                    "HANGAR",
+                                    "HANGAR_COMMERCIAL",
+                                    "HANGAR_INDUSTRIEL"
+            ],
+			"paint": {
+				"fill-color": {
+                    "stops": [[15, "#D1D1D1"], [16, "#E6E6E6"]]
+                },
+				"fill-outline-color": "#B8B8B8"
+			}
+		},
+		{
+			"id": "bati surfacique fonctionnel public - Zoom 14,15",
+			"type": "fill",
+			"source": "plan_ign",
+			"source-layer": "bati_surf",
+			"maxzoom": 15,
+			"layout": {
+				"visibility": "visible"
+			},
+            "filter": ["in","symbo",
+                                   "BATI_PUBLIC",
+                                   "HANGAR_PUBLIC"
+            ],
+			"paint": {
+				"fill-color": "#B9B6D6"
+			}
+		},
+		{
+			"id": "bati surfacique fonctionnel public - Zoom 16,17,18",
+			"type": "fill",
+			"source": "plan_ign",
+			"source-layer": "bati_surf",
+			"minzoom": 15,
+			"layout": {
+				"visibility": "visible"
+			},
+            "filter": ["in","symbo",
+                                   "BATI_PUBLIC",
+                                   "HANGAR_PUBLIC"
+            ],
+			"paint": {
+				"fill-color": {
+                    "stops": [[15, "#CFC5DE"], [16, "#E4DAF3"]]
+                },
+				"fill-outline-color": "#A6A1D6"
+			}
+		},
+		{
+			"id": "bati surfacique fonctionnel sportif - bordure",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "bati_surf",
+			"minzoom": 15,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","BATI_SPORTIF"],
+			"paint": {
+				"line-color": "#BCD9AB",
+				"line-width": 4
+			}
+		},
+		{
+			"id": "bati surfacique fonctionnel sportif",
+			"type": "fill",
+			"source": "plan_ign",
+			"source-layer": "bati_surf",
+			"minzoom": 13,
+			"layout": {
+				"visibility": "visible"
+			},
+            "filter": ["==","symbo","BATI_SPORTIF"],
+			"paint": {
+				"fill-color": {
+                    "stops": [[14, "#C9E1DD"], [15, "#DCE6E4"]]
+                }
+			}
+		},
+		{
+			"id": "bati surfacique fonctionnel gare - Zoom 14,15",
+			"type": "fill",
+			"source": "plan_ign",
+			"source-layer": "bati_surf",
+			"maxzoom": 15,
+			"layout": {
+				"visibility": "visible"
+			},
+            "filter": ["==","symbo","BATI_GARE"],
+			"paint": {
+				"fill-color": "#B3B5F5"
+			}
+		},
+		{
+			"id": "bati surfacique fonctionnel gare - Zoom 16,17,18",
+			"type": "fill",
+			"source": "plan_ign",
+			"source-layer": "bati_surf",
+			"minzoom": 15,
+			"layout": {
+				"visibility": "visible"
+			},
+            "filter": ["==","symbo","BATI_GARE"],
+			"paint": {
+				"fill-color": {
+                    "stops": [[15, "#BFC1F5"], [16, "#CBCDF5"]]
+                },
+				"fill-outline-color": "#9B9EF6"
+			}
+		},
+		{
+			"id": "bati surfacique quelconque - Zoom 15",
+			"type": "fill",
+			"source": "plan_ign",
+			"source-layer": "bati_surf",
+			"minzoom": 14,
+			"maxzoom": 15,
+			"layout": {
+				"visibility": "visible"
+			},
+            "filter": ["==","symbo","BATI_QQUE"],
+			"paint": {
+				"fill-color": "#D6C6B8"
+			}
+		},
+		{
+			"id": "bati surfacique quelconque - Zoom 16,17,18",
+			"type": "fill",
+			"source": "plan_ign",
+			"source-layer": "bati_surf",
+			"minzoom": 15,
+			"layout": {
+				"visibility": "visible"
+			},
+            "filter": ["==","symbo","BATI_QQUE"],
+			"paint": {
+				"fill-color": {
+                    "stops": [[15, "#E6E0CF"], [16, "#F1EBD9"]]
+                },
+				"fill-outline-color": "#C3AA8E"
+			}
+		},
+		{
+			"id": "cimetiere surfacique 1",
+			"type": "fill",
+			"source": "plan_ign",
+			"source-layer": "bati_surf",
+			"layout": {
+				"visibility": "visible"
+			},
+            "filter": ["in","symbo",
+                                    "CIMETIERE_SURF",
+                                    "CIMETIERE_MILI_SURF",
+									"NECROPOLE_NATIONALE"
+            ],
+			"paint": {
+				"fill-color": "#F0F0F0",
+				"fill-opacity": 0.5,
+				"fill-outline-color": "#818181"
+			}
+		},
+		{
+			"id": "cimetiere surfacique 2",
+			"type": "fill",
+			"source": "plan_ign",
+			"source-layer": "bati_surf",
+			"layout": {
+				"visibility": "visible"
+			},
+            "filter": ["in","symbo",
+                                    "CIMETIERE_SURF",
+									"CIMETIERE_MILI_SURF",
+									"NECROPOLE_NATIONALE"
+            ],
+			"paint": {
+				"fill-pattern": "Cimetiere"
+			}
+		},
+		{
+			"id": "bati hydro surfacique - Autre",
+			"type": "fill",
+			"source": "plan_ign",
+			"source-layer": "bati_surf",
+			"layout": {
+				"visibility": "visible"
+			},
+            "filter": ["in","symbo",
+                                    "ECLUSE_SURF",
+                                    "RESERVOIR_EAU_SURF"
+            ],
+			"paint": {
+				"fill-color": "#ADCCD9",
+				"fill-outline-color": "#336699"
+			}
+		},
+		{
+			"id": "bati hydro surfacique - Pecherie",
+			"type": "fill",
+			"source": "plan_ign",
+			"source-layer": "bati_surf",
+			"layout": {
+				"visibility": "visible"
+			},
+            "filter": ["==","symbo","PECHERIE_SURF"],
+        	"paint": {
+				"fill-color": "#BFE2F0",
+				"fill-outline-color": "#509FEF"
+			}
+		},
+		{
+			"id": "bati hydro surfacique - Barrage",
+			"type": "fill",
+			"source": "plan_ign",
+			"source-layer": "bati_surf",
+			"layout": {
+				"visibility": "visible"
+			},
+            "filter": ["==","symbo","BARRAGE_SURF"],
+			"paint": {
+				"fill-color": "#FFFFFF",
+				"fill-outline-color": "#464646"
+			}
+		},
+		{
+			"id": "bati hydro surfacique - Chateau d'eau",
+			"type": "fill",
+			"source": "plan_ign",
+			"source-layer": "bati_surf",
+			"layout": {
+				"visibility": "visible"
+			},
+            "filter": ["==","symbo","CHATEAU_EAU_SURF"],
+			"paint": {
+				"fill-color": "#1466B2"
+			}
+		},
+        {
+			"id": "bati infra surfacique - Silo",
+			"type": "fill",
+			"source": "plan_ign",
+			"source-layer": "bati_surf",
+			"minzoom": 15,
+			"layout": {
+				"visibility": "visible"
+			},
+            "filter": ["==","symbo","SILO_SURF"],
+			"paint": {
+				"fill-color": "#C7A9AA",
+				"fill-outline-color": "#696969"
+			}
+		},
+		{
+			"id": "bati infra surfacique - Reservoir indus",
+			"type": "fill",
+			"source": "plan_ign",
+			"source-layer": "bati_surf",
+			"minzoom": 14,
+			"layout": {
+				"visibility": "visible"
+			},
+            "filter": ["==","symbo","RESERVOIR_INDUS_SURF"],
+			"paint": {
+				"fill-color": "#8D9DAA",
+				"fill-outline-color": "#464646"
+			}
+		},
+		{
+			"id": "bati infra surfacique - Serre",
+			"type": "fill",
+			"source": "plan_ign",
+			"source-layer": "bati_surf",
+			"minzoom": 13,
+			"layout": {
+				"visibility": "visible"
+			},
+            "filter": ["in","symbo","SERRE_SURF"],
+			"paint": {
+				"fill-color": "#CAD6D9",
+				"fill-outline-color": "#8C8C8C"
+			}
+		},
+		{
+			"id": "bati infra surfacique - poste electrique",
+			"type": "fill",
+			"source": "plan_ign",
+			"source-layer": "bati_surf",
+			"layout": {
+				"visibility": "visible"
+			},
+            "filter": ["in","symbo","POSTE_ELEC_SURF"],
+			"paint": {
+				"fill-color": "#7993B6",
+				"fill-opacity": 0.3
+			}
+		},
+		{
+			"id": "bati infra surfacique - poste electrique bord",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "bati_surf",
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","POSTE_ELEC_SURF"],
+			"paint": {
+				"line-color": "#000000",
+				"line-width": {"stops": [[12, 0.3], [17, 1.2]]}
+			}
+		},
+        {
+			"id": "bati religieux surfacique - Zoom 14",
+			"type": "fill",
+			"source": "plan_ign",
+			"source-layer": "bati_surf",
+			"maxzoom": 14,
+			"layout": {
+				"visibility": "visible"
+			},
+            "filter": ["in","symbo",
+									"CHAPELLE_SURF",
+									"EGLISE_SURF",
+									"CHRETIEN_SURF",
+                                    "SYNAGOGUE_SURF",
+                                    "MOSQUEE_SURF",
+                                    "AUTRE_CULTE_SURF"
+            ],
+			"paint": {
+				"fill-color": "#F7CBCB"
+			}
+		},
+		{
+			"id": "bati religieux surfacique - Zoom 15,16,17,18",
+			"type": "fill",
+			"source": "plan_ign",
+			"source-layer": "bati_surf",
+			"minzoom": 14,
+			"layout": {
+				"visibility": "visible"
+			},
+            "filter": ["in","symbo",
+									"CHAPELLE_SURF",
+									"EGLISE_SURF",
+									"CHRETIEN_SURF",
+                                    "SYNAGOGUE_SURF",
+                                    "MOSQUEE_SURF",
+                                    "AUTRE_CULTE_SURF"
+            ],
+			"paint": {
+				"fill-color": {"stops": [[14, "#F7CBCB"], [15, "#F7E1E1"]]},
+				"fill-outline-color": {"stops": [[14, "#F7A8A8"], [15, "#F7B7B7"]]}
+			}
+		},
+		{
+			"id": "bati remarquable surfacique",
+			"type": "fill",
+			"source": "plan_ign",
+			"source-layer": "bati_surf",
+			"minzoom": 13,
+			"layout": {
+				"visibility": "visible"
+			},
+            "filter": ["in","symbo",
+                                    "FORTIF_SURF",
+                                    "CHATEAU_SURF",
+                                    "TOUR_MOULIN_SURF",
+                                    "ARENE_THEATRE",
+                                    "ARC_TRIOMPHE_SURF",
+                                    "MONUMENT_SURF"
+            ],
+			"paint": {
+				"fill-color": "#9B9B9B",
+				"fill-outline-color": "#6E6E6E"
+			}
+		},
+		{
+			"id": "bati sportif surfacique fond",
+			"type": "fill",
+			"source": "plan_ign",
+			"source-layer": "bati_surf",
+			"layout": {
+				"visibility": "visible"
+			},
+            "filter": ["in","symbo",
+                                    "TENNIS_SURF",
+                                    "SPORT_INDIF_SURF",
+                                    "FOOT_SURF",
+									"MULTI_SPORT_SURF",
+                                    "PISTE_SPORT_SURF",
+                                    "NATATION_SURF"
+            ],
+			"paint": {
+				"fill-color": "#FFFFFF",
+				"fill-outline-color": "#FFFFFF"
+			}
+		},
+		{
+			"id": "bati sportif surfacique",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "bati_surf",
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "TENNIS_SURF",
+                                    "SPORT_INDIF_SURF",
+                                    "FOOT_SURF",
+									"MULTI_SPORT_SURF",
+                                    "PISTE_SPORT_SURF",
+                                    "NATATION_SURF"
+            ],
+			"paint": {
+				"line-color": "#BCD9AB",
+				"line-width": 2
+			}
+		},
+		{
+			"id": "bati transport surfacique - piste",
+			"type": "fill",
+			"source": "plan_ign",
+			"source-layer": "bati_surf",
+			"layout": {
+				"visibility": "visible"
+			},
+            "filter": ["in","symbo",
+                                    "PISTE_DUR",
+                                    "PISTE_HERBE"
+            ],
+			"paint": {
+                "fill-color": "#DBDBDB",
+                "fill-outline-color": "#808080"
+
+			}
+		},
+		{
+			"id": "bati ZAI - Autres",
+			"type": "fill",
+			"source": "plan_ign",
+			"source-layer": "bati_zai",
+            "minzoom":15,
+			"maxzoom": 18,   
+			"layout": {
+				"visibility": "visible"
+			},
+            "filter": ["in","nature",
+									"Lycée",
+									"Université",
+									"Capitainerie",
+									"Gendarmerie",
+									"Siège d'EPCI",
+									"Musée",
+									"Collège",
+									"Maison de retraite",
+									"Etablissement thermal",
+									"Autre service déconcentré de l'Etat",
+									"Etablissement pénitentiaire",
+									"Divers public ou administratif",
+									"Autre établissement d'enseignement",
+									"Maison du parc",
+									"Palais de justice",
+									"Enseignement primaire",
+									"Office de tourisme",
+									"Hôpital",
+									"Police",
+									"Piscine",
+									"Enseignement supérieur",
+									"Poste",
+									"Caserne",
+									"Etablissement hospitalier",
+									"Etablissement extraterritorial",
+									"Science",
+									"Structure d'accueil pour personnes handicapées",
+									"Administration centrale de l'Etat",
+									"Caserne de pompiers"
+            ],
+			"paint": {
+				"fill-color": "#E3BFE2",
+                "fill-opacity": 0.5,
+				"fill-outline-color": "#E39FE1"
+			}
+		},
+		{
+			"id": "bati ZAI - Commandement",
+			"type": "fill",
+			"source": "plan_ign",
+			"source-layer": "bati_zai",
+            "minzoom":15,
+			"layout": {
+				"visibility": "visible"
+			},
+            "filter": ["in","nature",
+                                    "Hôtel de département",
+									"Hôtel de région",
+									"Préfecture de région",
+									"Préfecture",
+									"Sous-préfecture"
+            ],
+			"paint": {
+				"fill-color": "#FF0000",
+                "fill-opacity": 0.3,
+				"fill-outline-color": "#B40000"
+			}
+		},
+        {
+			"id": "construction linéaire - mur",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "bati_lin",
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","MUR"],
+			"paint": {
+				"line-color": "#8C8C8C",
+		        "line-width": 0.3
+			}
+		},
+        {
+			"id": "construction linéaire - autre",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "bati_lin",
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "RUINE_LIN",
+                                    "MUR_SOUTENEMENT",
+                                    "FORTIF_LIN"
+            ],
+			"paint": {
+				"line-color": "#646464",
+		        "line-width": 0.5
+			}
+		},
+        {
+			"id": "construction hydrographique linéaire - Barrage",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "bati_lin",
+            "minzoom": 13,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","BARRAGE_LIN"],
+			"paint": {
+				"line-color": "#646464",
+		        "line-width": {"stops": [[13, 1.5], [17, 5]]}
+			}
+		},
+        {
+			"id": "construction hydrographique linéaire - Quai",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "bati_lin",
+            "minzoom": 12,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "QUAI",
+                                    "DIGUE"
+            ],
+			"paint": {
+				"line-color": "#828282",
+		        "line-width": {"stops": [[14, 1], [17, 2.5]]}
+			}
+		},
+      {
+			"id": "construction hydrographique linéaire - Pecherie",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "bati_lin",
+            "minzoom": 12,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","PECHERIE_LIN"],
+			"paint": {
+				"line-color": "#0066CC",
+		        "line-width": {"stops": [[14, 1], [17, 2.5]]}
+			}
+        },
+        {
+			"id": "Chemin a niveau - piste cyclable",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_chemin",
+			"minzoom": 13,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+			"filter": ["==","symbo","PISTE_CYCLABLE"],
+			"paint": {
+				"line-color": {"stops": [[17, "#9B5CCC"], [18, "#FFFFFF"]]},
+		        "line-width": {
+				"stops": [[14, 1.1], [15, 1.7], [16, 2], [17, 3.5], [18, 6]]
+                },
+				"line-dasharray": [6,2]
+			}
+		},
+        {
+        	"id": "Chemin a niveau - filet exterieur - escalier",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_chemin",
+			"minzoom": 14,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+			"filter": ["==","symbo","ESCALIER"],
+			"paint": {
+				"line-color": {"stops": [[17, "#8C7274"], [18, "#C8C8C8"]]},
+		        "line-width": {
+				"stops": [[14, 1.75], [15, 3], [16, 4.2], [17, 9.5]]
+                }
+			}
+		}, 		
+        {
+			"id": "Chemin a niveau - filet interieur - escalier",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_chemin",
+			"minzoom": 14,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+			"filter": ["==","symbo","ESCALIER"],
+			"paint": {
+				"line-color": "#FFFFFF",
+		        "line-width": {
+				"stops": [[14, 1], [15, 1.9], [16, 2.7], [17, 5.8]]
+                },
+				"line-dasharray": [1,0.2]
+			}
+		}, 		
+        {
+			"id": "Chemin a niveau - Rue pietonne",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_chemin",
+			"minzoom": 14,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+			"filter": ["==","symbo","RUE_PIETONNE"],
+			"paint": {
+				"line-color": {"stops": [[17, "#8C7274"], [18, "#F8E5D5"]]},
+		        "line-width": {
+				"stops": [[14, 1], [15, 1.2], [16, 1.4], [17, 2], [18, 5]]
+                },
+				"line-dasharray": [1,3]
+			}
+		},
+        {
+			"id": "Chemin a niveau - sentier",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_chemin",
+			"minzoom": 13,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+			"filter": ["==","symbo","SENTIER"],
+			"paint": {
+				"line-color": {"stops": [[17, "#8C7274"], [18, "#FFFFFF"]]},
+		        "line-width": {
+				"stops": [[14, 1], [15, 1.2], [16, 1.4], [17, 2], [18, 6]]
+                },
+				"line-dasharray": [4,3]
+			}
+		}, 		
+        {
+			"id": "Chemin a niveau - chemin",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_chemin",
+			"minzoom": 12,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+			"filter": ["==","symbo","CHEMIN"],
+			"paint": {
+				"line-color": {"stops": [[17, "#8C7274"], [18, "#FFFFFF"]]},
+		        "line-width": {
+				"stops": [[14, 1], [15, 1.2], [16, 1.4], [17, 2], [18, 7]]
+                }
+			}
+		},
+        {
+			"id": "Routier a niveau - filet extérieur - route non revetu carrosable",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route",
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+			"filter": ["==","symbo","NON_REVETUE_CARRO"],
+			"paint": {
+				"line-color": {"stops": [[12, "#646464"], [17, "#8C8C8C"]]},
+		        "line-width": {
+				"stops": [[14, 3.2], [15, 5.4], [16, 7.7], [17, 16.8]]
+                },
+				"line-dasharray": [2,2]
+			}
+		},
+        {
+			"id": "Routier a niveau - filet interieur - route non revetu carrosable",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route",
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+			"filter": ["==","symbo","NON_REVETUE_CARRO"],
+			"paint": {
+				"line-color": "#FFFFFF",
+		        "line-width": {
+				"stops": [[14, 2.3], [15, 4.1], [16, 6.3], [17, 13.5], [18, 16.8]]
+                }
+			}
+		},
+        {
+			"id": "Routier a niveau - filet extérieur - bretelle autoroute",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route",
+			"minzoom": 12,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "BRET_AUTO_PEAGE_3",
+                                    "BRET_AUTO_PEAGE_2",
+                                    "BRET_AUTO_PEAGE_1",
+                                    "BRET_AUTO_LIBRE_3",
+                                    "BRET_AUTO_LIBRE_2",
+                                    "BRET_AUTO_LIBRE_1"
+            ],
+			"paint": {
+				"line-color": {"stops": [[9, "#DE460E"], [17, "#F18800"], [18, "#FFFFFF"]]},
+				"line-width": {
+					"stops": [[12, 2.5], [14, 3.7], [15, 6.8], [16, 8.4], [17, 14]]
+                }
+			}
+		},
+        {
+			"id": "Routier a niveau - filet extérieur - route non classee restreint",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route",
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","NON_CLASSEE_RESTREINT"],
+			"paint": {
+				"line-color": {"stops": [[17, "#969696"], [18, "#FFFFFF"]]},
+		        "line-width": {
+				"stops": [[14, 3.2], [15, 5.4], [16, 7.7], [17, 16.8]]
+                }
+			}
+		},
+        {
+			"id": "Routier a niveau - filet extérieur - route non classee",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route",
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "NON_CLASSEE_4",
+                                    "NON_CLASSEE"
+            ],
+			"paint": {
+				"line-color": {"stops": [[17, "#969696"], [18, "#FFFFFF"]]},
+		        "line-width": {
+				"stops": [[14, 3.2], [15, 5.4], [16, 7.7], [17, 16.8]]
+                }
+			}
+		},
+        {
+			"id": "Routier a niveau - filet extérieur - route locale",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route",
+			"minzoom": 7,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "BRET_LOCALE",
+                                    "LOCALE_4",
+                                    "LOCALE_3",
+                                    "LOCALE_2",
+                                    "LOCALE_1"
+            ],
+			"paint": {
+				"line-color": {
+                    "stops": [[12, "#8C8C8C"], [13, "#B4B4B4"], [17, "#B4B4B4"], [18, "#FFFFFF"]]
+                },
+		        "line-width": {
+				"stops": [[9, 2], [14, 3.5], [15, 6], [16, 8.4], [17, 18.3]]
+                }
+			}
+		},
+        {
+			"id": "Routier a niveau - filet extérieur - route locale en construction",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route",
+			"minzoom": 11,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","LOCALE_CONSTR"],
+			"paint": {
+				"line-color": "#C8C8C8",
+		        "line-width": {
+				"stops": [[9, 2], [14, 3.5], [15, 6], [16, 8.4], [17, 18.3]]
+                }
+			}
+		},
+        {
+			"id": "Routier a niveau - filet extérieur - route regionale",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route",
+			"minzoom": 8,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "BRET_REGIONALE",
+                                    "REGIONALE_4",
+                                    "REGIONALE_3",
+                                    "REGIONALE_2",
+                                    "REGIONALE_1"
+            ],
+			"paint": {
+				"line-color": {
+                    "stops": [[9, "#828282"], [10, "#B4B4B4"], [17, "#B4B4B4"], [18, "#FFFFFF"]]
+                },
+		        "line-width": {
+					"stops": [[6, 1.5], [9, 2.3], [14, 5], [15, 8.1], [16, 11.2], [17, 22]]
+                }
+			}
+		},
+        {
+			"id": "Routier a niveau - filet extérieur - route regionale en construction",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route",
+			"minzoom": 10,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","REGIONALE_CONSTR"],
+			"paint": {
+				"line-color": "#C8C8C8",
+		        "line-width": {
+					"stops": [[6, 1.5], [9, 2.3], [14, 5], [15, 8.1], [16, 11.2], [17, 22]]
+                }
+			}
+		},
+        {
+			"id": "Routier a niveau - filet extérieur - route principale",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route",
+			"minzoom": 8,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "BRET_PRINCIPALE",
+                                    "PRINCIPALE_4",
+                                    "PRINCIPALE_3",
+                                    "PRINCIPALE_2",
+                                    "PRINCIPALE_1"
+            ],
+			"paint": {
+				"line-color": {"stops": [[17, "#E2A52A"], [18, "#FFFFFF"]]},
+		        "line-width": {
+					"stops": [[6, 1.8], [9, 2.7], [14, 5.9], [15, 9], [16, 12.2], [17, 22.5]]
+                }
+			}
+		},
+        {
+			"id": "Routier a niveau - filet extérieur - route principale en construction",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route",
+			"minzoom": 10,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","PRINCIPALE_CONSTR"],
+			"paint": {
+				"line-color": "#C8C8C8",
+		        "line-width": {
+					"stops": [[6, 1.8], [9, 2.7], [14, 5.9], [15, 9], [16, 12.2], [17, 22.5]]
+                }
+			}
+		},
+        {
+			"id": "Routier a niveau - filet extérieur - autoroute",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route",
+			"minzoom": 8,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "AUTOROU_PEAGE",
+                                    "AUTOROU_LIBRE"
+            ],
+			"paint": {
+				"line-color": {"stops": [[9, "#DE460E"], [17, "#F18800"], [18, "#FFFFFF"]]},
+		        "line-width": {
+					"stops": [[6, 2.5], [9, 3.5], [14, 7.5], [15, 11], [16, 15], [17, 26]]
+                }
+			}
+		},
+        {
+			"id": "Routier a niveau - filet extérieur - autoroute en construction",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route",
+			"minzoom": 8,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","AUTOROU_CONSTR"],
+			"paint": {
+				"line-color": "#C8C8C8",
+		        "line-width": {
+					"stops": [[6, 2.5], [9, 3.5], [14, 7.5], [15, 11], [16, 15], [17, 26]]
+                }
+			}
+		},
+        {
+			"id": "Routier a niveau - filet interieur - bretelle autoroute",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route",
+			"minzoom": 12,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "BRET_AUTO_PEAGE_3",
+                                    "BRET_AUTO_PEAGE_2",
+                                    "BRET_AUTO_PEAGE_1",
+                                    "BRET_AUTO_LIBRE_3",
+                                    "BRET_AUTO_LIBRE_2",
+                                    "BRET_AUTO_LIBRE_1"
+            ],
+			"paint": {
+				"line-color": {"stops": [[9, "#F18800"], [17, "#F2B230"]]},
+				"line-width": {
+					"stops": [[12, 1.5], [14, 2.6], [15, 5.2], [16, 6.7], [17, 10.8]]
+                }
+			}
+		},
+        {
+			"id": "Routier a niveau - filet interieur - route non classee restreint",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route",
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","NON_CLASSEE_RESTREINT"],
+			"paint": {
+				"line-color": "#EDF1FF",
+		        "line-width": {
+				"stops": [[14, 2.3], [15, 4.1], [16, 6.3], [17, 13.5]]
+                }
+			}
+		},
+        {
+			"id": "Routier a niveau - filet interieur - route non classee",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route",
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "NON_CLASSEE_4",
+                                    "NON_CLASSEE"
+            ],
+			"paint": {
+				"line-color": "#FFFFFF",
+		        "line-width": {
+				"stops": [[14, 2.3], [15, 4.1], [16, 6.3], [17, 13.5]]
+                }
+			}
+		},
+        {
+			"id": "Routier a niveau - filet interieur - route locale",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route",
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "BRET_LOCALE",
+                                    "LOCALE_4",
+                                    "LOCALE_3",
+                                    "LOCALE_2",
+                                    "LOCALE_1"
+            ],
+			"paint": {
+				"line-color": {
+                    "stops": [[6, "#F2B361"],[7, "#FFFFFF"], [12, "#FFFFFF"], [13, "#FCF4A8"], [17, "#FCF7C1"]]
+                },
+		        "line-width": {
+				"stops": [[9, 1.3], [14, 2.3], [15, 4.1], [16, 6.1], [17, 13.1]]
+                }
+			}
+		},
+        {
+			"id": "Routier a niveau - filet interieur - route locale en construction",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route",
+			"minzoom": 11,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","LOCALE_CONSTR"],
+			"paint": {
+				"line-color": {
+                    "stops": [[12, "#FFFFFF"], [13, "#FCF4A8"], [17, "#FCF7C1"], [18, "#EDEDED"]]
+                },
+		        "line-width": {
+				"stops": [[9, 2], [14, 3.5], [15, 6], [16, 8.4], [17, 18.3]]
+                },
+				"line-dasharray": [2, 2]
+			}
+		},
+        {
+			"id": "Routier a niveau - filet interieur - route regionale",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route",
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "BRET_REGIONALE",
+                                    "REGIONALE_4",
+                                    "REGIONALE_3",
+                                    "REGIONALE_2",
+                                    "REGIONALE_1"
+            ],
+			"paint": {
+				"line-color": {
+                    "stops": [[6, "#F2A949"], [7, "#FFFFFF"], [9, "#FFFFFF"], [10, "#FDF28B"], [17, "#FCF6BD"]]
+                },
+		        "line-width": {
+					"stops": [[4, 1.1], [6, 1.4], [9, 1.5], [14, 3.2], [15, 5.8], [16, 8.3], [17, 16.2]]
+                }
+			}
+		},
+        {
+			"id": "Routier a niveau - filet interieur - route regionale en construction",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route",
+			"minzoom": 10,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","REGIONALE_CONSTR"],
+			"paint": {
+				"line-color": {
+                    "stops": [[9, "#FFFFFF"], [10, "#FDF28B"], [17, "#FCF6BD"], [18, "#EDEDED"]]
+                },
+		        "line-width": {
+					"stops": [[4, 0.4], [6, 1.5], [9, 2.3], [14, 5], [15, 8.1], [16, 11.2], [17, 22]]
+                },
+				"line-dasharray": [2,2]
+			}
+		},
+        {
+			"id": "Routier a niveau - filet interieur - route principale",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route",
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "BRET_PRINCIPALE",
+                                    "PRINCIPALE_4",
+                                    "PRINCIPALE_3",
+                                    "PRINCIPALE_2",
+                                    "PRINCIPALE_1"
+            ],
+			"paint": {
+				"line-color": {"stops": [[6, "#F29924"], [7, "#F3C66D"], [9, "#F3C66D"], [17, "#F2DDB3"]]},
+		        "line-width": {
+					"stops": [[4, 0.6], [6, 1.8], [9, 2.1], [14, 4.4], [15, 7.3], [16, 10], [17, 18.5]]
+                }
+			}
+		},
+        {
+			"id": "Routier a niveau - filet interieur - route principale en construction",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route",
+			"minzoom": 10,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+			"filter": ["==","symbo","PRINCIPALE_CONSTR"],
+			"paint": {
+				"line-color": {"stops": [[9, "#F3C66D"], [17, "#F2DDB3"], [18, "#EDEDED"]]},
+		        "line-width": {
+					"stops": [[4, 0.5], [6, 1.8], [9, 2.7], [14, 5.9], [15, 9], [16, 12.2], [17, 22.5]]
+                },
+				"line-dasharray": [2,2]
+			}
+		},
+        {
+			"id": "Routier a niveau - filet interieur - autoroute",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route",
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "AUTOROU_PEAGE",
+                                    "AUTOROU_LIBRE"
+            ],
+			"paint": {
+				"line-color": {"stops": [[9, "#F18800"], [17, "#F2B230"]]},
+		        "line-width": {
+					"stops": [[4, 0.7], [6, 2.5], [9, 2.7], [14, 5.8], [15, 9], [16, 12], [17, 20.8]]
+                }
+			}
+		},
+        {
+			"id": "Routier a niveau - axe central - autoroute",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route",
+			"minzoom": 13,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "AUTOROU_PEAGE",
+                                    "AUTOROU_LIBRE"
+            ],
+			"paint": {
+				"line-color": "#FFFFFF",
+		        "line-width": {
+					"stops": [[9, 0.6], [14, 0.7], [15, 1], [16, 1.2], [17, 2.1]]
+                }
+			}
+		},
+        {
+			"id": "Routier a niveau - filet interieur - autoroute en construction",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route",
+			"minzoom": 8,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","AUTOROU_CONSTR"],
+			"paint": {
+				"line-color": {"stops": [[9, "#F18800"], [17, "#F2B230"], [18, "#EDEDED"]]},
+		        "line-width": {
+					"stops": [[4, 0.7], [6, 2.5], [9, 3.5], [14, 7.5], [15, 11], [16, 15], [17, 26]]
+                },
+                "line-dasharray": [2,2]
+			}
+		},
+        {
+			"id": "Routier a niveau - axe centrale - autoroute en construction",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route",
+			"minzoom": 13,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","AUTOROU_CONSTR"],
+			"paint": {
+				"line-color": "#808080",
+		        "line-width": {
+					"stops": [[9, 0.6], [14, 0.7], [15, 1], [16, 1.2], [17, 2.1]]
+                }
+			}
+		},
+        {
+			"id": "Ferre a niveau - voie normale",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "ferre",
+			"minzoom": 10,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "VF_1",
+                                    "VF_2",
+                                    "VF_3",
+                                    "VF_4",
+                                    "VF_ELEC_1",
+                                    "VF_ELEC_2",
+                                    "VF_ELEC_3",
+                                    "VF_ELEC_4"
+            ],
+			"paint": {
+				"line-color": "#787878",
+		        "line-width": {
+					"stops": [[10, 0.8], [17, 2.5]]
+				}
+			}
+		},
+        {
+			"id": "Ferre a niveau - voie normale trait perpendic",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "ferre",
+			"minzoom": 10,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "VF_1",
+                                    "VF_2",
+                                    "VF_3",
+                                    "VF_4",
+                                    "VF_ELEC_1",
+                                    "VF_ELEC_2",
+                                    "VF_ELEC_3",
+                                    "VF_ELEC_4"
+            ],
+			"paint": {
+				"line-color": "#787878",
+		        "line-width": {
+					"stops": [[10, 3.5], [17, 14.7]]
+				},
+				"line-dasharray": [0.1,10]
+			}
+		},
+        {
+			"id": "Ferre a niveau - voie etroite",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "ferre",
+			"minzoom": 10,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "VF_ETROITE_1",
+                                    "VF_ETROITE_2",
+									"VF_ETROITE"
+            ],
+			"paint": {
+				"line-color": "#787878",
+		        "line-width": {
+					"stops": [[10, 0.3], [17, 1.8]]
+				}
+			}
+		},
+        {
+			"id": "Ferre a niveau - voie etroite trait perpendic",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "ferre",
+			"minzoom": 10,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "VF_ETROITE_1",
+                                    "VF_ETROITE_2",
+									"VF_ETROITE"
+            ],
+			"paint": {
+				"line-color": "#787878",
+		        "line-width": {
+					"stops": [[10, 3.5], [17, 14.7]]
+				},
+				"line-dasharray": [0.1,10]
+			}
+		},
+        {
+			"id": "Ferre a niveau - voie service",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "ferre",
+			"minzoom": 14,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "VF_SERVICE",
+                                    "VF_NON_EXPLOITEE"
+            ],
+			"paint": {
+				"line-color": "#787878",
+		        "line-width": {
+					"stops": [[10, 0.3], [17, 1.8]]
+				},
+				"line-dasharray": [5,2,1,2]
+			}
+		},
+        {
+			"id": "Ferre a niveau - voie en construction",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "ferre",
+			"minzoom": 10,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","VF_EN_CONSTR"],
+			"paint": {
+				"line-color": "#787878",
+		        "line-width": {
+					"stops": [[10, 0.3], [17, 1.8]]
+				},
+                "line-dasharray": [2,2]
+			}
+		},
+       {
+			"id": "Ferre a niveau - voie en construction trait perpendic",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "ferre",
+			"minzoom": 10,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","VF_EN_CONSTR"],
+			"paint": {
+				"line-color": "#787878",
+		        "line-width": {
+					"stops": [[10, 3.5], [17, 14.7]]
+				},
+				"line-dasharray": [0.1,10]
+			}
+		},
+        {
+			"id": "Ferre a niveau - funic/urbain",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "ferre",
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "FUNI_CREMAILLERE",
+                                    "TRANSPORT_URBAIN"
+            ],
+			"paint": {
+				"line-color": "#787878",
+		        "line-width": {
+					"stops": [[10, 0.3], [17, 1.8]]
+				}
+			}
+		},
+         {
+			"id": "Ferre a niveau - 2 trait perpendic - funic/urbain",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "ferre",
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "FUNI_CREMAILLERE",
+                                    "TRANSPORT_URBAIN"
+            ],
+			"paint": {
+				"line-color": "#787878",
+		        "line-width": {
+					"stops": [[10, 3.5], [17, 17]]
+				},
+				"line-dasharray": [0.1,0.2,0.1,10]
+			}
+		},
+        {
+			"id": "liaison routiere - Bac Liaison Maritime",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_liaison",
+			"minzoom": 8,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+									"BAC_AUTO",
+									"LIAISON_MARITIME",
+									"BAC_LIAISON_MARITIME"
+			],
+			"paint": {
+				"line-color": "#5792C2",
+		        "line-width": {
+					"stops": [[8, 1], [13, 2.5]]
+                }					
+			}
+		},
+        {
+			"id": "liaison routiere - Gue route",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_liaison",
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","GUE_ROUTE"],
+			"paint": {
+				"line-color": {
+                    "stops": [[13, "#BEBEBE"], [17, "#646464"], [18, "#FFFFFF"]]
+                },
+		        "line-width": {
+				"stops": [[14, 2.3], [15, 4.1], [16, 6.3], [17, 13.5]]
+                }
+			}
+		},
+        {
+			"id": "liaison routiere - Gue chemin",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_liaison",
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","GUE_CHEMIN"],
+			"paint": {
+				"line-color": {
+                    "stops": [[13, "#BEBEBE"], [17, "#646464"]]
+                },
+		        "line-width": {
+				"stops": [[14, 1.6], [15, 2.9], [16, 4.4], [17, 6.5]]
+                }
+			}
+		},
+        {
+			"id": "liaison routiere - filet extérieur - Pont passerelle",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_liaison",
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "PONT_PASSERELLE",
+                                    "PONT_LIN",
+                                    "PONT_MOBILE_LIN"
+            ],
+			"paint": {
+				"line-color": {"stops": [[17, "#C8C8C8"], [18, "#FFFFFF"]]},
+		        "line-width": {
+				"stops": [[14, 2.2], [15, 3.8], [16, 5.4], [17, 11.8]]
+                }
+			}
+		},
+        {
+			"id": "liaison routiere - filet intérieur - Pont passerelle",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_liaison",
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "PONT_PASSERELLE",
+                                    "PONT_LIN",
+                                    "PONT_MOBILE_LIN"
+            ],
+			"paint": {
+				"line-color": "#FFFFFF",
+		        "line-width": {
+				"stops": [[14, 0.7], [15, 1.1], [16, 1.7], [17, 3.8]]
+                }
+			}
+		},
+        {
+			"id": "Routier surfacique",
+			"type": "fill",
+			"source": "plan_ign",
+			"source-layer": "routier_surf",
+			"layout": {
+				"visibility": "visible"
+			},
+            "filter": ["in","symbo",
+                                    "SURF_ROUT_PRINC",
+                                    "SURF_ROUT_REG",
+                                    "SURF_ROUT_LOC",
+                                    "SURF_ROUT_NON_CLA"],
+			"paint": {
+				"fill-color": "#FFFFFF",
+                "fill-outline-color": "#000000"
+			}
+		},
+        {
+			"id": "Routier surfacique - Dalle de protection",
+			"type": "fill",
+			"source": "plan_ign",
+			"source-layer": "routier_surf",
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible"
+			},
+            "filter": ["==","symbo","DALLE_DE_PROTECTION"],
+			"paint": {
+				"fill-opacity": 0.5,
+				"fill-color": "#FFFFFF",
+                "fill-outline-color": "#000000"
+			}
+		},
+        {
+			"id": "Routier surfacique - Escalier surfacique",
+			"type": "fill",
+			"source": "plan_ign",
+			"source-layer": "routier_surf",
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible"
+			},
+            "filter": ["==","symbo","ESCALIER_SURF"],
+			"paint": {
+				"fill-opacity": 0.8,
+				"fill-color": "#FFFFFF",
+                "fill-outline-color": "#918091"
+			}
+		},
+        {
+			"id": "Routier surfacique - Péage surfacique",
+			"type": "fill",
+			"source": "plan_ign",
+			"source-layer": "routier_surf",
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible"
+			},
+            "filter": ["==","symbo","SURF_PEAGE"],
+			"paint": {
+				"fill-color": "#F2DAAA",
+                "fill-outline-color": "#E2A52A"
+			}
+		},
+		{
+			"id": "bati transport surfacique - bati peage",
+			"type": "fill",
+			"source": "plan_ign",
+			"source-layer": "bati_surf",
+			"minzoom": 13,
+			"layout": {
+				"visibility": "visible"
+			},
+            "filter": ["==","symbo","BATI_PEAGE"],
+			"paint": {
+                "fill-color": "#DCDCDC",
+                "fill-outline-color": "#808080"
+
+			}
+		},
+		{
+			"id": "réseau hydro  - cours d'eau superieur",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "hydro_reseau_sup",
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+									"COURS_D_EAU_SUP",
+									"COURS_D_EAU_MOY_SUP"
+			],
+			"paint": {
+				"line-color": "#AAD5E9",
+		        "line-width": {
+					"stops": [[12, 1.5], [17, 6.5]]
+                }
+			}
+		},
+        {
+			"id": "réseau hydro - canal superieur",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "hydro_reseau_sup",
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","CANAL_SUP"],
+			"paint": {
+				"line-color": "#AAD5E9",
+		        "line-width": {
+				"stops": [[12, 1.4], [17, 5.9]]
+                }
+			}
+		},
+        {
+			"id": "réseau hydro - filet interieur - aqueduc superieur",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "hydro_reseau_sup",
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","AQUEDUC_SUP"],
+			"paint": {
+				"line-color": "#AAD5E9",
+		        "line-width": {
+				"stops": [[12, 1.4], [16, 3.5], [17, 5.9]]
+                }
+			}
+		},
+        {
+			"id": "réseau hydro - carre - aqueduc superieur",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "hydro_reseau_sup",
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","AQUEDUC_SUP"],
+			"paint": {
+				"line-color": "#AAD5E9",
+		        "line-width": {
+				"stops": [[12, 3.5], [16, 8.7], [17, 14.7]]
+                },
+			    "line-dasharray": [1,5]
+			}
+		},
+        {
+			"id": "Chemin superieur - piste cyclable",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_chemin_sup",
+			"minzoom": 13,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+			"filter": ["==","symbo","PISTE_CYCLABLE_SUP"],
+			"paint": {
+				"line-color": {"stops": [[17, "#9B5CCC"], [18, "#FFFFFF"]]},
+		        "line-width": {
+				"stops": [[14, 1.1], [15, 1.7], [16, 2], [17, 3.5], [18, 6]]
+                },
+				"line-dasharray": [6,2]
+			}
+		},
+        {
+			"id": "Chemin superieur - filet exterieur - escalier",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_chemin_sup",
+			"minzoom": 14,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+			"filter": ["==","symbo","ESCALIER_SUP"],
+			"paint": {
+				"line-color": {"stops": [[17, "#8C7274"], [18, "#C8C8C8"]]},
+		        "line-width": {
+				"stops": [[14, 1.75], [15, 3], [16, 4.2], [17, 9.5]]
+                }
+			}
+		},
+        {
+			"id": "Chemin superieur - filet interieur - escalier",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_chemin_sup",
+			"minzoom": 14,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+			"filter": ["==","symbo","ESCALIER_SUP"],
+			"paint": {
+				"line-color": "#FFFFFF",
+		        "line-width": {
+				"stops": [[14, 1], [15, 1.9], [16, 2.7], [17, 5.8]]
+                },
+				"line-dasharray": [1,0.2]
+			}
+		},
+        {
+			"id": "Chemin superieur - Rue pietonne",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_chemin_sup",
+			"minzoom": 14,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+			"filter": ["==","symbo","RUE_PIETONNE_SUP"],
+			"paint": {
+				"line-color": {"stops": [[17, "#8C7274"], [18, "#EBEBEB"]]},
+		        "line-width": {
+				"stops": [[14, 1], [15, 1.2], [16, 1.4], [17, 2], [18, 5]]
+                },
+				"line-dasharray": [1,3]
+			}
+		},
+        {
+			"id": "Chemin superieur - sentier",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_chemin_sup",
+			"minzoom": 13,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+			"filter": ["==","symbo","SENTIER_SUP"],
+			"paint": {
+				"line-color": {"stops": [[17, "#8C7274"], [18, "#FFFFFF"]]},
+		        "line-width": {
+				"stops": [[14, 1], [15, 1.2], [16, 1.4], [17, 2], [18, 6]]
+                },
+				"line-dasharray": [4,3]
+			}
+		},
+        {
+			"id": "Chemin superieur - chemin",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_chemin_sup",
+			"minzoom": 12,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+			"filter": ["==","symbo","CHEMIN_SUP"],
+			"paint": {
+				"line-color": {"stops": [[17, "#8C7274"], [18, "#FFFFFF"]]},
+		        "line-width": {
+				"stops": [[14, 1], [15, 1.2], [16, 1.4], [17, 2], [18, 7]]
+                }
+			}
+		},
+        {
+			"id": "Routier superieur - filet extérieur - route non revetu carrosable",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route_sup",
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+			"filter": ["==","symbo","NON_REVETUE_CARRO_SUP"],
+			"paint": {
+				"line-color": {"stops": [[12, "#646464"], [17, "#8C8C8C"]]},
+		        "line-width": {
+				"stops": [[14, 3.2], [15, 5.4], [16, 7.7], [17, 16.8]]
+                },
+				"line-dasharray": [2,2]
+			}
+		},
+        {
+			"id": "Routier superieur - filet extérieur - bretelle autoroute",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route_sup",
+			"minzoom": 12,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "BRET_AUTO_PEAGE_3_SUP",
+                                    "BRET_AUTO_PEAGE_2_SUP",
+                                    "BRET_AUTO_PEAGE_1_SUP",
+                                    "BRET_AUTO_LIBRE_3_SUP",
+                                    "BRET_AUTO_LIBRE_2_SUP",
+                                    "BRET_AUTO_LIBRE_1_SUP"
+            ],
+			"paint": {
+				"line-color": {"stops": [[9, "#DE460E"], [17, "#F18800"], [18, "#FFFFFF"]]},
+				"line-width": {
+					"stops": [[12, 2.5], [14, 3.7], [15, 6.8], [16, 8.4], [17, 14]]
+                }
+			}
+		},
+        {
+			"id": "Routier superieur - filet extérieur - route non classee restreint",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route_sup",
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","NON_CLASSEE_RESTREINT_SUP"],
+			"paint": {
+				"line-color": {"stops": [[17, "#969696"], [18, "#FFFFFF"]]},
+		        "line-width": {
+				"stops": [[14, 3.2], [15, 5.4], [16, 7.7], [17, 16.8]]
+                }
+			}
+		},
+        {
+			"id": "Routier superieur - filet extérieur - route non classee",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route_sup",
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "NON_CLASSEE_4_SUP",
+                                    "NON_CLASSEE_SUP"
+            ],
+			"paint": {
+				"line-color": {"stops": [[17, "#969696"], [18, "#FFFFFF"]]},
+		        "line-width": {
+				"stops": [[14, 3.2], [15, 5.4], [16, 7.7], [17, 16.8]]
+                }
+			}
+		},
+        {
+			"id": "Routier superieur - filet extérieur - route locale",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route_sup",
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "BRET_LOCALE_SUP",
+                                    "LOCALE_4_SUP",
+                                    "LOCALE_3_SUP",
+                                    "LOCALE_2_SUP",
+                                    "LOCALE_1_SUP"
+            ],
+			"paint": {
+				"line-color": {
+                    "stops": [[12, "#8C8C8C"], [13, "#B4B4B4"], [17, "#B4B4B4"], [18, "#FFFFFF"]]
+                },
+		        "line-width": {
+				"stops": [[9, 2], [14, 3.5], [15, 6], [16, 8.4], [17, 18.3]]
+                }
+			}
+		},
+        {
+			"id": "Routier superieur - filet extérieur - route locale en construction",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route_sup",
+			"minzoom": 11,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","LOCALE_CONSTR_SUP"],
+			"paint": {
+				"line-color": "#C8C8C8",
+		        "line-width": {
+				"stops": [[9, 2], [14, 3.5], [15, 6], [16, 8.4], [17, 18.3]]
+                }
+			}
+		},
+        {
+			"id": "Routier superieur - filet extérieur - route regionale",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route_sup",
+			"minzoom": 8,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "BRET_REGIONALE_SUP",
+                                    "REGIONALE_4_SUP",
+                                    "REGIONALE_3_SUP",
+                                    "REGIONALE_2_SUP",
+                                    "REGIONALE_1_SUP"
+            ],
+			"paint": {
+				"line-color": {
+                    "stops": [[9, "#828282"], [10, "#B4B4B4"], [17, "#B4B4B4"], [18, "#FFFFFF"]]
+                },
+		        "line-width": {
+					"stops": [[6, 1.5], [9, 2.3], [14, 5], [15, 8.1], [16, 11.2], [17, 22]]
+                }
+			}
+		},
+        {
+			"id": "Routier superieur - filet extérieur - route regionale en construction",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route_sup",
+			"minzoom": 10,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","REGIONALE_CONSTR_SUP"],
+			"paint": {
+				"line-color": "#C8C8C8",
+		        "line-width": {
+					"stops": [[6, 1.5], [9, 2.3], [14, 5], [15, 8.1], [16, 11.2], [17, 22]]
+                }					
+			}
+		},
+        {
+			"id": "Routier superieur - filet extérieur - route principale",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route_sup",
+			"minzoom": 8,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "BRET_PRINCIPALE_SUP",
+                                    "PRINCIPALE_4_SUP",
+                                    "PRINCIPALE_3_SUP",
+                                    "PRINCIPALE_2_SUP",
+                                    "PRINCIPALE_1_SUP"
+            ],
+			"paint": {
+				"line-color": {"stops": [[17, "#E2A52A"], [18, "#FFFFFF"]]},
+		        "line-width": {
+					"stops": [[6, 1.8], [9, 2.7], [14, 5.9], [15, 9], [16, 12.2], [17, 22.5]]
+                }
+			}
+		},
+        {
+			"id": "Routier superieur - filet extérieur - route principale en construction",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route_sup",
+			"minzoom": 10,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","PRINCIPALE_CONSTR_SUP"],
+			"paint": {
+				"line-color": "#C8C8C8",
+		        "line-width": {
+					"stops": [[6, 1.8], [9, 2.7], [14, 5.9], [15, 9], [16, 12.2], [17, 22.5]]
+                }
+			}
+		},
+        {
+			"id": "Routier superieur - filet extérieur - autoroute",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route_sup",
+			"minzoom": 8,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "AUTOROU_PEAGE_SUP",
+                                    "AUTOROU_LIBRE_SUP"
+            ],
+			"paint": {
+				"line-color": {"stops": [[9, "#DE460E"], [17, "#F18800"], [18, "#FFFFFF"]]},
+		        "line-width": {
+					"stops": [[6, 2.5], [9, 3.5], [14, 7.5], [15, 11], [16, 15], [17, 26]]
+                }
+			}
+		},
+        {
+			"id": "Routier superieur - filet extérieur - autoroute en construction",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route_sup",
+			"minzoom": 10,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+			"filter": ["==","symbo","AUTOROU_CONSTR_SUP"],
+			"paint": {
+				"line-color": "#C8C8C8",
+		        "line-width": {
+					"stops": [[6, 2.5], [9, 3.5], [14, 7.5], [15, 11], [16, 15], [17, 26]]
+                }
+			}
+		},
+        {
+			"id": "Routier superieur - filet interieur - route non revetu carrosable",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route_sup",
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+			"filter": ["==","symbo","NON_REVETUE_CARRO_SUP"],
+			"paint": {
+				"line-color": "#FFFFFF",
+		        "line-width": {
+				"stops": [[14, 2.3], [15, 4.1], [16, 6.3], [17, 13.5], [18, 16.8]]
+                }
+			}
+		},
+        {
+			"id": "Routier superieur - filet interieur - bretelle autoroute",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route_sup",
+			"minzoom": 12,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "BRET_AUTO_PEAGE_3_SUP",
+                                    "BRET_AUTO_PEAGE_2_SUP",
+                                    "BRET_AUTO_PEAGE_1_SUP",
+                                    "BRET_AUTO_LIBRE_3_SUP",
+                                    "BRET_AUTO_LIBRE_2_SUP",
+                                    "BRET_AUTO_LIBRE_1_SUP"
+            ],
+			"paint": {
+				"line-color": {"stops": [[9, "#F18800"], [17, "#F2B230"]]},
+				"line-width": {
+					"stops": [[12, 1.5], [14, 2.6], [15, 5.2], [16, 6.7], [17, 10.8]]
+                }
+			}
+		},
+        {
+			"id": "Routier superieur - filet interieur - route non classee restreint",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route_sup",
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","NON_CLASSEE_RESTREINT_SUP"],
+			"paint": {
+				"line-color": "#EDF1FF",
+		        "line-width": {
+				"stops": [[14, 2.3], [15, 4.1], [16, 6.3], [17, 13.5]]
+                }
+			}
+		},
+        {
+			"id": "Routier superieur - filet interieur - route non classee",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route_sup",
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "NON_CLASSEE_4_SUP",
+                                    "NON_CLASSEE_SUP"
+            ],
+			"paint": {
+				"line-color": "#FFFFFF",
+		        "line-width": {
+				"stops": [[14, 2.3], [15, 4.1], [16, 6.3], [17, 13.5]]
+                }
+			}
+		},
+        {
+			"id": "Routier superieur - filet interieur - route locale",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route_sup",
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "BRET_LOCALE_SUP",
+                                    "LOCALE_4_SUP",
+                                    "LOCALE_3_SUP",
+                                    "LOCALE_2_SUP",
+                                    "LOCALE_1_SUP"
+            ],
+			"paint": {
+				"line-color": {
+                    "stops": [[12, "#FFFFFF"], [13, "#FCF4A8"], [17, "#FCF7C1"]]
+                },
+		        "line-width": {
+				"stops": [[9, 1.3], [14, 2.3], [15, 4.1], [16, 6.1], [17, 13.1]]
+                }
+			}
+		},
+        {
+			"id": "Routier superieur - filet interieur - route locale en construction",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route_sup",
+			"minzoom": 11,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","LOCALE_CONSTR_SUP"],
+			"paint": {
+				"line-color": {
+                    "stops": [[12, "#FFFFFF"], [13, "#FCF4A8"], [17, "#FCF7C1"]]
+                },
+		        "line-width": {
+				"stops": [[9, 2], [14, 3.5], [15, 6], [16, 8.4], [17, 18.3]]
+                },
+				"line-dasharray": [2, 2]
+			}
+		},
+        {
+			"id": "Routier superieur - filet interieur - route regionale",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route_sup",
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "BRET_REGIONALE_SUP",
+                                    "REGIONALE_4_SUP",
+                                    "REGIONALE_3_SUP",
+                                    "REGIONALE_2_SUP",
+                                    "REGIONALE_1_SUP"
+            ],
+			"paint": {
+				"line-color": {
+                    "stops": [[9, "#FFFFFF"], [10, "#FDF28B"], [17, "#FCF6BD"]]
+                },
+		        "line-width": {
+					"stops": [[6, 1.4], [9, 1.5], [14, 3.2], [15, 5.8], [16, 8.3], [17, 16.2]]
+                }
+			}
+		},
+        {
+			"id": "Routier superieur - filet interieur - route regionale en construction",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route_sup",
+			"minzoom": 10,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","REGIONALE_CONSTR_SUP"],
+			"paint": {
+				"line-color": {
+                    "stops": [[9, "#FFFFFF"], [10, "#FDF28B"], [17, "#FCF6BD"]]
+                },
+		        "line-width": {
+					"stops": [[6, 1.5], [9, 2.3], [14, 5], [15, 8.1], [16, 11.2], [17, 22]]
+                },
+				"line-dasharray": [2,2]
+			}
+		},
+        {
+			"id": "Routier superieur - filet interieur - route principale",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route_sup",
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "BRET_PRINCIPALE_SUP",
+                                    "PRINCIPALE_4_SUP",
+                                    "PRINCIPALE_3_SUP",
+                                    "PRINCIPALE_2_SUP",
+                                    "PRINCIPALE_1_SUP"
+            ],
+			"paint": {
+				"line-color": {"stops": [[9, "#F3C66D"], [17, "#F2DDB3"]]},
+		        "line-width": {
+					"stops": [[4, 0.5], [6, 1.8], [9, 2.1], [14, 4.4], [15, 7.3], [16, 10], [17, 18.5]]
+                }
+			}
+		},
+        {
+			"id": "Routier superieur - filet interieur - route principale en construction",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route_sup",
+			"minzoom": 10,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+			"filter": ["==","symbo","PRINCIPALE_CONSTR_SUP"],
+			"paint": {
+				"line-color": {"stops": [[9, "#F3C66D"], [17, "#F2DDB3"]]},
+		        "line-width": {
+					"stops": [[6, 1.8], [9, 2.7], [14, 5.9], [15, 9], [16, 12.2], [17, 22.5]]
+                },
+				"line-dasharray": [2,2]
+			}
+		},
+        {
+			"id": "Routier superieur - filet interieur - autoroute",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route_sup",
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "AUTOROU_PEAGE_SUP",
+                                    "AUTOROU_LIBRE_SUP"
+            ],
+			"paint": {
+				"line-color": {"stops": [[9, "#F18800"], [17, "#F2B230"]]},
+		        "line-width": {
+					"stops": [[4, 0.7], [6, 2.5], [9, 2.7], [14, 5.8], [15, 9], [16, 12], [17, 20.8]]
+                }
+			}
+		},
+		{
+			"id": "Routier superieur - axe central - autoroute",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route_sup",
+			"minzoom": 13,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "AUTOROU_PEAGE_SUP",
+                                    "AUTOROU_LIBRE_SUP"
+            ],
+			"paint": {
+				"line-color": "#FFFFFF",
+		        "line-width": {
+					"stops": [[9, 0.6], [14, 0.7], [15, 1], [16, 1.2], [17, 2.1]]
+                }
+			}
+		},
+        {
+			"id": "Routier superieur - filet interieur - autoroute en construction",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route_sup",
+			"minzoom": 10,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","AUTOROU_CONSTR_SUP"],
+			"paint": {
+				"line-color": {"stops": [[9, "#F18800"], [17, "#F2B230"]]},
+		        "line-width": {
+					"stops": [[4, 0.7], [6, 2.5], [9, 3.5], [14, 7.5], [15, 11], [16, 15], [17, 26]]
+                },
+                "line-dasharray": [2,2]
+			}
+		},
+        {
+			"id": "Routier superieur - axe centrale - autoroute en construction",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "routier_route_sup",
+			"minzoom": 13,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","AUTOROU_CONSTR_SUP"],
+			"paint": {
+				"line-color": "#808080",
+		        "line-width": {
+					"stops": [[9, 0.6], [14, 0.7], [15, 1], [16, 1.2], [17, 2.1]]
+                }
+			}
+		},
+        {
+			"id": "Ferre superieur - voie normale",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "ferre_sup",
+			"minzoom": 10,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "VF_1_SUP",
+                                    "VF_2_SUP",
+                                    "VF_ELEC_1_SUP"
+            ],
+			"paint": {
+				"line-color": "#787878",
+		        "line-width": {
+					"stops": [[10, 0.8], [17, 2.5]]
+				}
+			}
+		},
+        {
+			"id": "Ferre superieur - voie normale trait perpendic",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "ferre_sup",
+			"minzoom": 10,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "VF_1_SUP",
+                                    "VF_2_SUP",
+                                    "VF_ELEC_1_SUP"
+            ],
+			"paint": {
+				"line-color": "#787878",
+		        "line-width": {
+					"stops": [[10, 3.5], [17, 14.7]]
+				},
+				"line-dasharray": [0.1,10]
+			}
+		},
+        {
+			"id": "Ferre superieur - voie etroite",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "ferre_sup",
+			"minzoom": 10,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "VF_ETROITE_1_SUP",
+									"VF_ETROITE_SUP"
+            ],
+			"paint": {
+				"line-color": "#787878",
+		        "line-width": {
+					"stops": [[10, 0.3], [17, 1.8]]
+				}
+			}
+		},
+        {
+			"id": "Ferre superieur - voie etroite trait perpendic",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "ferre_sup",
+			"minzoom": 10,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "VF_ETROITE_1_SUP",
+									"VF_ETROITE_SUP"
+            ],
+			"paint": {
+				"line-color": "#787878",
+		        "line-width": {
+					"stops": [[10, 3.5], [17, 14.7]]
+				},
+				"line-dasharray": [0.1,10]
+			}
+		},
+        {
+			"id": "Ferre superieur - voie service",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "ferre_sup",
+			"minzoom": 14,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "VF_SERVICE_SUP",
+                                    "VF_NON_EXPLOITEE_SUP"
+            ],
+			"paint": {
+				"line-color": "#787878",
+		        "line-width": {
+					"stops": [[10, 0.3], [17, 1.8]]
+				},
+				"line-dasharray": [5,2,1,2]
+			}
+		},
+        {
+			"id": "Ferre superieur - voie en construction",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "ferre_sup",
+			"minzoom": 10,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","VF_EN_CONSTR_SUP"],
+			"paint": {
+				"line-color": "#787878",
+		        "line-width": {
+					"stops": [[10, 0.3], [17, 1.8]]
+				},
+                "line-dasharray": [2,2]
+			}
+		},
+        {
+			"id": "Ferre superieur - voie en construction trait perpendic",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "ferre_sup",
+			"minzoom": 10,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","VF_EN_CONSTR_SUP"],
+			"paint": {
+				"line-color": "#787878",
+		        "line-width": {
+					"stops": [[10, 3.5], [17, 14.7]]
+				},
+				"line-dasharray": [0.1,10]
+			}
+		},
+        {
+			"id": "Ferre superieur - funic/urbain",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "ferre_sup",
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "FUNI_CREMAILLERE_SUP",
+                                    "TRANSPORT_URBAIN_SUP"
+            ],
+			"paint": {
+				"line-color": "#787878",
+		        "line-width": {
+					"stops": [[10, 0.3], [17, 1.8]]
+				}
+			}
+		},
+         {
+			"id": "Ferre superieur - 2 trait perpendic - funic/urbain",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "ferre_sup",
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "FUNI_CREMAILLERE_SUP",
+                                    "TRANSPORT_URBAIN_SUP"
+            ],
+			"paint": {
+				"line-color": "#787878",
+		        "line-width": {
+					"stops": [[10, 3.5], [17, 17]]
+				},
+				"line-dasharray": [0.1,0.2,0.1,10]
+			}
+		},
+		{
+			"id": "Limite - cloture",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "limite_lin",
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","CLOTURE"],
+			"paint": {
+				"line-color": "#000000",
+                "line-width": {
+					"stops": [[13, 0.6], [17, 1]]
+                },
+                "line-dasharray": [1.5, 4]
+			}
+		},
+        {
+			"id": "Limite - layon",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "limite_lin",
+			"minzoom": 14,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+			"filter": ["==","symbo","LAYON"],
+			"paint": {
+				"line-color": "#B3989A",
+		        "line-width": {
+				"stops": [[14, 1], [15, 1.2], [16, 1.4], [17, 2]]
+                },
+				"line-dasharray": [4,7]
+			}
+		},
+        {
+			"id": "Zone Règlementee - Enceinte militaire",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "limite_lin",
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "LIM_ZONE_REGLEMENTEE",
+                                    "LIM_ENCEINTE_MILITAIRE",
+                                    "LIM_ENCEINTE_MILI",
+                                    "LIM_CHAMP_TIR"
+            ],
+			"paint": {
+				"line-color": "rgba(226, 130, 92, 0.8)",
+                "line-width": {
+					"stops": [[13, 1.7], [17, 3.1]]
+                },
+                "line-dasharray": [4, 1, 2, 5]
+			}
+		},
+        {
+			"id": "limite zone naturelle",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "limite_lin",
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+            },
+            "filter": ["in","symbo",
+									"LIM_ZONE_NATURELLE",
+									"LIM_ZONE_NATURELLE_ILE",
+									"LIM_RESERVE_NATURELLE"
+			],
+			"paint": {
+				"line-color": "#FFC2CB",
+                "line-width": {
+					"stops": [[13, 2], [17, 4]]
+                },
+                "line-dasharray": [2, 1]
+			}
+		},
+        {
+			"id": "limite zone naturelle - Parc naturel 10",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "limite_lin",
+			"maxzoom": 10,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+            },
+            "filter": ["in","symbo",
+									"LIM_PARC_NATUREL",
+									"LIM_PARC_NATUREL_ILE"
+			],
+			"paint": {
+				"line-color": "#42A266",
+                "line-width": {
+					"stops": [[13, 2], [17, 4]]
+                },
+                "line-dasharray": [2, 1]
+			}
+		},
+        {
+			"id": "limite zone naturelle - Parc naturel 11",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "limite_lin",
+			"minzoom": 10,
+			"maxzoom": 11,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+            },
+            "filter": ["in","symbo",
+									"LIM_PARC_NATUREL",
+									"LIM_PARC_NATUREL_ILE"
+			],
+			"paint": {
+				"line-color": "#42A266",
+                "line-width": {
+					"stops": [[13, 2], [17, 4]]
+                },
+                "line-dasharray": [2, 2]
+			}
+		},
+        {
+			"id": "limite zone naturelle - Parc naturel 12",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "limite_lin",
+			"minzoom": 11,
+			"maxzoom": 12,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+            },
+            "filter": ["in","symbo",
+									"LIM_PARC_NATUREL",
+									"LIM_PARC_NATUREL_ILE"
+			],
+			"paint": {
+				"line-color": "#42A266",
+                "line-width": {
+					"stops": [[13, 2], [17, 4]]
+                },
+                "line-dasharray": [2, 3]
+			}
+		},
+        {
+			"id": "limite zone naturelle - Parc naturel 13",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "limite_lin",
+			"minzoom": 12,
+			"maxzoom": 13,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+            },
+            "filter": ["in","symbo",
+									"LIM_PARC_NATUREL",
+									"LIM_PARC_NATUREL_ILE"
+			],
+			"paint": {
+				"line-color": "#42A266",
+                "line-width": {
+					"stops": [[13, 2], [17, 4]]
+                },
+                "line-dasharray": [2, 4]
+			}
+		},
+        {
+			"id": "limite zone naturelle - Parc naturel 14",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "limite_lin",
+			"minzoom": 13,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+            },
+            "filter": ["in","symbo",
+									"LIM_PARC_NATUREL",
+									"LIM_PARC_NATUREL_ILE"
+			],
+			"paint": {
+				"line-color": "rgba(66, 162, 102, 0.7)",
+                "line-width": {
+					"stops": [[13, 2], [17, 4]]
+                },
+                "line-dasharray": [2, 5]
+			}
+		},
+        {
+			"id": "limite zone naturelle - Parc marin",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "limite_lin",
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","LIM_PARC_NATUREL_MARIN"],
+			"paint": {
+				"line-color": "#2A81A2",
+                "line-width": {
+					"stops": [[13, 2], [17, 4]]
+                },
+                "line-dasharray": [2, 1]
+			}
+		},
+		{
+			"id": "parcellaire - parcelle bordure",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "parcellaire_parcelle",
+			"layout": {
+				"visibility": "visible",
+				"line-cap": "round",
+				"line-join": "round"
+			},
+            "filter": ["==","symbo","PARCELLE"],
+			"paint": {
+				"line-color": "#9933FF",
+				"line-width": 1
+			}
+		},
+		{
+			"id": "parcellaire - section",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "parcellaire_section",
+			"layout": {
+				"visibility": "visible",
+				"line-cap": "butt",
+				"line-join": "round"
+			},
+            "filter": ["==","symbo","SECTION"],
+			"paint": {
+				"line-color": "#287B00",
+				"line-width": 1.9,
+				"line-dasharray": [2,4,2]
+			}
+		},
+		{
+            "id": "toponyme - parcellaire - section",
+            "type": "symbol",
+            "source": "plan_ign",
+            "source-layer": "toponyme_parcellaire_section",
+            "filter": ["==","txt_typo","SECTION"],
+            "layout": {
+                "symbol-placement": "line",
+				"text-offset": [0, 0],
+                "text-field": "{texte}",
+                "text-size": 15,
+                "text-anchor": "center",
+                "text-keep-upright": true,
+                "text-max-angle": 45,
+                "text-font": ["Source Sans Pro Regular"]
+            },
+            "paint": {
+                "text-color": "#287B00"
+            }
+        },
+		{
+            "id": "toponyme - parcellaire - parcelle",
+            "type": "symbol",
+            "source": "plan_ign",
+            "source-layer": "toponyme_parcellaire_parcelle",
+            "filter": ["==","txt_typo","PARCELLE"],
+            "layout": {
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+                "text-size": 11,
+                "text-anchor": "center",
+                "text-keep-upright": true,
+                "text-max-angle": 45,
+                "text-font": ["Source Sans Pro Bold"]
+            },
+            "paint": {
+                "text-color": "#9933FF",
+				"text-halo-width": 1,
+                "text-halo-color": "#FFFFFF"
+            }
+        },
+		{
+            "id": "toponyme - parcellaire - adresse",
+            "type": "symbol",
+            "source": "plan_ign",
+            "source-layer": "toponyme_parcellaire_adresse_ponc",
+            "filter": ["==","txt_typo","ADRESSE"],
+            "layout": {
+                "symbol-placement": "point",
+                "text-field": ["concat","{numero}","{indice_de_repetition}"],
+                "text-size": 11,
+                "text-anchor": "center",
+                "text-keep-upright": true,
+                "text-max-angle": 45,
+                "text-font": ["Source Sans Pro Bold"]
+            },
+            "paint": {
+                "text-color": "#695744",
+				"text-halo-width": 1,
+                "text-halo-color": "#FFFFFF"
+            }
+        },
+        {
+			"id": "limite admin - limite de commune",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "limite_lin",
+			"minzoom": 13,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "LIM_COMMUNE",
+                                    "LIM_CANTON",
+                                    "LIM_ARRONDISSEMENT"
+            ],
+			"paint": {
+				"line-color": "rgba(126, 119, 184, 0.5)",
+		        "line-width": {
+				"stops": [[13, 3], [17, 5.5]]
+                },
+                "line-dasharray": [4, 2, 1, 1, 1, 1, 1, 2]
+			}
+		},
+        {
+			"id": "limite admin - limite de département bandeau",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "limite_lin",
+			"minzoom": 8,
+			"maxzoom": 13,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+			"filter": ["==","symbo","LIM_DEPARTEMENT"],
+			"paint": {
+				"line-color": "rgba(178, 175, 219, 0.4)",
+		        "line-width": {
+				"stops": [[9, 4.1], [12, 6]]
+                }
+			}
+		},
+        {
+			"id": "limite admin - limite de département tiret",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "limite_lin",
+			"minzoom": 13,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+			"filter": ["==","symbo","LIM_DEPARTEMENT"],
+			"paint": {
+				"line-color": "rgba(126, 119, 184, 0.5)",
+		        "line-width": {
+				"stops": [[13, 3], [17, 5.5]]
+                },
+                "line-dasharray": [4, 2, 1, 1, 1, 2]
+			}
+		},
+        {
+			"id": "limite admin - limite de région bandeau",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "limite_lin",
+			"minzoom": 7,
+			"maxzoom": 13,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+			"filter": ["==","symbo","LIM_REGION"],
+			"paint": {
+				"line-color": "rgba(178, 175, 219, 0.5)",
+		        "line-width": {
+				"stops": [[9, 4.5], [12, 6.7]]
+                }
+			}
+		},
+        {
+			"id": "limite admin - limite de région tiret",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "limite_lin",
+			"minzoom": 13,
+			"maxzoom": 18,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+			"filter": ["==","symbo","LIM_REGION"],
+			"paint": {
+				"line-color": "rgba(126, 119, 184, 0.5)",
+		        "line-width": {
+				"stops": [[13, 3], [17, 5.5]]
+                },
+                "line-dasharray": [4, 2, 1, 2]
+			}
+		},
+        {
+			"id": "limite etat 1",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "limite_lin",
+			"minzoom": 2,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "LIM_ETAT",
+                                    "LIM_ETAT_ETRANGER"
+            ],
+			"paint": {
+				"line-color": "rgba(178, 175, 219, 0.6)",
+		        "line-width": {
+				"stops": [[2, 2], [3, 3.5], [9, 5], [14, 13], [15, 20], [16, 24], [17, 42]]
+                }
+			}
+		},
+        {
+			"id": "limite etat 2",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "limite_lin",
+			"minzoom": 7,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "LIM_ETAT",
+                                    "LIM_ETAT_ETRANGER"
+            ],
+			"paint": {
+				"line-color": "#9F9CB8",
+		        "line-width": {
+				"stops": [[9, 1.5], [14, 3.5], [15, 5.5], [16, 6.5], [17, 11]]
+                },
+                "line-dasharray": [4, 2]
+			}
+		},
+        {
+            "id": "limite cote",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "limite_lin",
+			"minzoom": 7,
+            "maxzoom":10,
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo","LIM_COTE"],
+			"paint": {
+				"line-color": "#82A3B2",
+                "line-width": 1
+			}
+        },
+        {
+			"id": "ligne electrique",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "bati_lin",
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+            },
+            "filter": ["==","symbo","LIGNE_ELECTRIQUE"],
+			"paint": {
+				"line-color": "#808080",
+		        "line-width": {
+					"stops": [[13, 1], [17, 2]]
+				}
+			}
+		},
+        {
+			"id": "autre construction linéaire",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "bati_lin",
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "round",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+									"CABLE",
+                                    "REMONTEE_MEC",
+                                    "HYDROCARBURES",
+                                    "CONDUITE_MATIERES_P",
+                                    "SPORT_MONTAGNE_LIN",
+									"PISTE_BOBSLEIGH",
+									"PISTE_LUGE",
+                                    "PISTE_AERO_LIN"
+            ],
+			"paint": {
+				"line-color": "#808080",
+		        "line-width": 1
+			}
+		},
+        {
+			"id": "autre construction linéaire - trait perpend cable",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "bati_lin",
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","CABLE"],
+			"paint": {
+				"line-color": "#808080",
+		        "line-width": 5,
+				"line-dasharray": [0.5,10]
+			}
+		},
+        {
+			"id": "autre construction linéaire - trait perpend 1 remont",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "bati_lin",
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","REMONTEE_MEC"],
+			"paint": {
+				"line-color": "#808080",
+		        "line-width": 6,
+				"line-dasharray": [1,10]
+			}
+		},
+        {
+			"id": "autre construction linéaire - trait perpend 2 remont",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "bati_lin",
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["==","symbo","REMONTEE_MEC"],
+			"paint": {
+				"line-color": "#BEBEBE",
+		        "line-width": 6,
+				"line-dasharray": [0.3,0.4,0.3,10]
+			}
+		},
+        {
+			"id": "autre construction linéaire - trait perpend carbur",
+			"type": "line",
+			"source": "plan_ign",
+			"source-layer": "bati_lin",
+			"layout": {
+				"visibility": "visible",
+                "line-cap": "butt",
+                "line-join": "round"
+			},
+            "filter": ["in","symbo",
+                                    "HYDROCARBURES",
+                                    "CONDUITE_MATIERES_P"
+            ],
+			"paint": {
+				"line-color": "#808080",
+		        "line-width": 5,
+				"line-dasharray": [1,10]
+			}
+		},
+		{
+			"id": "routier ponctuel - peage ponctuel",
+			"type": "circle",
+			"source": "plan_ign",
+			"source-layer": "routier_ponc",
+			"minzoom": 8,
+			"layout": {
+				"visibility": "visible"
+			},
+            "filter": ["==","symbo","PEAGE_PONC"],
+			"paint": {
+                "circle-radius": {
+				"stops": [[9, 3.5], [12, 6.5]]
+                },				
+                "circle-color": "#E2A52A",
+				"circle-stroke-width": 1,
+                "circle-stroke-color": "#808080"
+			}
+		},
+		{
+			"id": "routier ponctuel - barriere",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "routier_ponc",
+			"minzoom": 12,
+			"layout": {
+				"visibility": "visible",
+				"icon-image": "Barriere",
+				"icon-size": {
+				"stops": [[13, 0.25], [16, 0.45], [17, 0.7]]
+				},
+				"icon-allow-overlap": true,
+				"icon-rotate": ["get", "rotation"]
+			},
+            "filter": ["==","symbo","BARRIERE"],
+			"paint": {
+				"icon-color": "#969696"
+			}
+		},
+		{
+			"id": "hydro ponctuel",
+			"type": "circle",
+			"source": "plan_ign",
+			"source-layer": "hydro_ponc",
+			"minzoom": 13,
+			"layout": {
+				"visibility": "visible"
+			},
+            "filter": ["in","symbo",
+                                    "FONTAINE",
+                                    "POINT_D_EAU",
+                                    "SOURCE",
+                                    "SOURCE_CAPTEE",
+                                    "PERTE",
+                                    "RESURGENCE",
+                                    "CASCADE",
+									"AUTRE_HYDRO_PONC"
+            ],
+			"paint": {
+                "circle-radius": {
+				"stops": [[14, 3], [17, 7]]
+				},
+                "circle-color": "#FFFFFF",
+                "circle-opacity": 1,
+                "circle-stroke-width": {
+				"stops": [[14, 2], [17, 5]]
+				},
+                "circle-stroke-color": "#1466B2"
+			}
+		},
+		{
+			"id": "point coté",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "oro_ponc",
+			"minzoom": 11,
+			"maxzoom": 16,
+            "filter": ["in","symbo",
+                                    "POINT_COTE",
+                                    "POINT_COTE_TOPO",
+                                    "POINT_COTE_RESEAU",
+                                    "POINT_RBF"
+            ],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+				"icon-image": "Localite",
+				"icon-size": 0.1,
+                "text-field": "{texte}",
+                "text-size": 10,
+                "text-allow-overlap": false,
+				"text-anchor": "bottom-left",
+				"text-offset": [0.2, 0.4],
+                "text-padding": 2,
+                "text-font": ["Source Sans Pro Italic"]
+			},
+			"paint": {
+                "text-color": "#505050"
+			}
+		},
+		{
+			"id": "bati ponctuel : Hopital",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "bati_ponc",
+			"layout": {
+				"visibility": "visible",
+				"icon-image": "Hopital",
+				"icon-size": 0.33
+			},
+            "filter": ["==","symbo","HOPITAL_PONC"],
+			"paint": {
+				"icon-color": "#646464"
+			}
+		},
+		{
+			"id": "bati ponctuel hydrographique",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "bati_ponc",
+			"minzoom": 14,
+			"layout": {
+				"visibility": "visible",
+				"icon-image": "Pompage",
+				"icon-size": { "stops": [[13, 0.2], [17, 0.6]] },
+				"icon-allow-overlap": true
+			},
+            "filter": ["in","symbo",
+                                    "CITERNE",
+                                    "LAVOIR",
+                                    "STATION_EPURATION",
+                                    "STATION_DE_POMPAGE",
+									"USINE_PRODUCTION_EAU",
+									"USINE_ELEVATRICE"
+            ],
+			"paint": {
+				"icon-color": "#1C62A6"
+			}
+		},
+		{
+			"id": "bati ponctuel hydrographique - Puits-Abreuvoir",
+			"type": "circle",
+			"source": "plan_ign",
+			"source-layer": "bati_ponc",
+			"minzoom": 13,
+			"layout": {
+				"visibility": "visible"
+			},
+            "filter": ["in","symbo",
+                                    "PUITS",
+                                    "ABREUVOIR"
+            ],
+			"paint": {
+                "circle-radius": {
+				"stops": [[14, 3], [17, 7]]
+				},
+                "circle-color": "#FFFFFF",
+                "circle-opacity": 1,
+                "circle-stroke-width": {
+				"stops": [[14, 2], [17, 5]]
+				},
+                "circle-stroke-color": "#1466B2"
+			}
+		},
+		{
+			"id": "bati ponctuel hydrographique - Phare",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "bati_ponc",
+			"minzoom": 13,
+			"layout": {
+				"visibility": "visible",
+				"icon-image": "Phare",
+				"icon-size": { "stops": [[13, 0.7], [17, 1.3]] }
+			},
+            "filter": ["==","symbo","PHARE"],
+			"paint": {
+				"icon-color": "#646464"
+			}
+		},
+		{
+			"id": "bati ponctuel hydrographique - Amer-Feu",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "bati_ponc",
+			"minzoom": 13,
+			"layout": {
+				"visibility": "visible",
+				"icon-image": "Feu",
+				"icon-size": { "stops": [[13, 0.7], [17, 1.3]] }
+			},
+            "filter": ["in","symbo",
+                                    "AMER",
+                                    "FEU",
+                                    "FEU_PONC",
+									"TOURELLE_LUMINEUSE"
+            ],
+			"paint": {
+				"icon-color": "#646464"
+			}
+		},
+		{
+			"id": "bati ponctuel hydrographique - Balise",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "bati_ponc",
+			"minzoom": 13,
+			"layout": {
+				"visibility": "visible",
+				"icon-image": "Balise",
+				"icon-size": { "stops": [[13, 0.7], [17, 1.3]] }
+			},
+            "filter": ["in","symbo",
+									"BALISE",
+									"TOURELLE"
+			],
+			"paint": {
+				"icon-color": "#646464"
+			}
+		},
+		{
+			"id": "bati ponctuel hydrographique - Ecluse",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "bati_ponc",
+			"minzoom": 12,
+			"maxzoom": 15,
+			"layout": {
+				"visibility": "visible",
+				"icon-image": "Ecluse",
+				"icon-size": 0.2
+			},
+            "filter": ["==","symbo","ECLUSE_PONC"],
+			"paint": {
+				"icon-color": "#1C62A6"
+			}
+		},
+		{
+			"id": "bati ponctuel hydrographique - Barrage",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "bati_ponc",
+			"minzoom": 12,
+			"maxzoom": 14,
+			"layout": {
+				"visibility": "visible",
+				"icon-image": "Barrage",
+				"icon-size": 0.25
+			},
+            "filter": ["==","symbo","BARRAGE_PONC"],
+			"paint": {
+				"icon-color": "#1C62A6"
+			}
+		},
+		{
+			"id": "bati ponctuel hydrographique - Chateau d'eau",
+			"type": "circle",
+			"source": "plan_ign",
+			"source-layer": "bati_ponc",
+			"layout": {
+				"visibility": "visible"
+			},
+            "filter": ["==","symbo","CHATEAU_EAU_PONC"],
+			"paint": {
+                "circle-radius": {
+				"stops": [[14, 3], [17, 8]]
+				},
+                "circle-color": "#1466B2"
+			}			
+		},
+		{
+			"id": "bati ponctuel hydrographique - Réservoir d'eau",
+			"type": "circle",
+			"source": "plan_ign",
+			"source-layer": "bati_ponc",
+			"maxzoom": 15,
+			"layout": {
+				"visibility": "visible"
+			},
+            "filter": ["==","symbo","RESERVOIR_EAU_PONC"],
+			"paint": {
+                "circle-radius": {
+				"stops": [[14, 3], [17, 8]]
+				},
+                "circle-color": "#AAD5E9",
+                "circle-opacity": 1,
+                "circle-stroke-width": {
+				"stops": [[14, 1], [17, 2.5]]
+				},
+                "circle-stroke-color": "#1466B2"
+			}
+		},
+		{
+			"id": "bati ponctuel infrastructure - Constr spé",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "bati_ponc",
+			"layout": {
+				"visibility": "visible",
+				"icon-image": "ConstrSpeciale",
+				"icon-size": { "stops": [[13, 0.22], [17, 0.5]] }
+			},
+            "filter": ["in","symbo",
+                                    "ANTENNE",
+                                    "CONSTR_SPE_TECHNIQUE",
+                                    "CONSTR_INDIF_PONC",
+									"CHEMINEE",
+									"CHEVALEMENT",
+									"PUITS_GAZ",
+									"PUITS_PETROLE",
+									"PYLONE_METEO",
+									"TORCHERE",
+									"TOUR_GUET",
+									"TOUR_HERTZIENNE"
+            ],
+			"paint": {
+				"icon-color": "#646464"
+			}
+		},
+		{
+			"id": "bati ponctuel infrastructure - Silo",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "bati_ponc",
+			"maxzoom": 15,
+			"layout": {
+				"visibility": "visible",
+				"icon-image": "Silo",
+				"icon-size": { "stops": [[13, 0.22], [17, 0.5]] }
+			},
+            "filter": ["==","symbo","SILO_PONC"],
+			"paint": {
+				"icon-color": "#646464"
+			}
+		},
+		{
+			"id": "bati ponctuel infrastructure - Eolienne",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "bati_ponc",
+			"layout": {
+				"visibility": "visible",
+				"icon-image": "Eolienne",
+				"icon-size": { "stops": [[13, 0.4], [17, 1], [18, 0.8]] }
+			},
+            "filter": ["==","symbo","EOLIENNE"],
+			"paint": {
+				"icon-color": "#646464"
+			}
+		},
+		{
+			"id": "bati ponctuel infrastructure - Reservoir",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "bati_ponc",
+			"maxzoom": 15,
+			"layout": {
+				"visibility": "visible",
+				"icon-image": "Reservoir",
+				"icon-size": { "stops": [[13, 0.26], [17, 0.5]] }
+			},
+            "filter": ["==","symbo","RESERVOIR_PONC"],
+			"paint": {
+				"icon-color": "#646464"
+			}
+		},
+		{
+			"id": "bati ponctuel infrastructure - pylone électrique",
+			"type": "circle",
+			"source": "plan_ign",
+			"source-layer": "bati_ponc",
+			"layout": {
+				"visibility": "visible"
+			},
+            "filter": ["==","symbo","PYLONE_ELEC"],
+			"paint": {
+                "circle-radius" : {
+					"stops": [[13, 1], [17, 2]]
+				},
+                "circle-color" : "#000000"
+			}
+		},
+		{
+			"id": "bati ponctuel montagne - Abri",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "bati_ponc",
+			"layout": {
+				"visibility": "visible",
+				"icon-image": "Abri",
+				"icon-size": { "stops": [[13, 0.4], [15, 0.6], [17, 0.9]] }
+			},
+            "filter": ["==","symbo","ABRI"],
+			"paint": {
+				"icon-color": "#246138"
+			}
+		},
+		{
+			"id": "bati ponctuel montagne - Refuge Garde",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "bati_ponc",
+			"layout": {
+				"visibility": "visible",
+				"icon-image": "Refugegard",
+				"icon-size": { "stops": [[13, 0.4], [15, 0.6], [17, 0.9]] }
+			},
+            "filter": ["==","symbo","REFUGE_GARDE"],
+			"paint": {
+				"icon-color": "#246138"
+			}
+		},
+		{
+			"id": "bati ponctuel montagne - Refuge Non Garde",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "bati_ponc",
+			"layout": {
+				"visibility": "visible",
+				"icon-image": "Refugenongard",
+				"icon-size": { "stops": [[13, 0.4], [15, 0.6], [17, 0.9]] }
+			},
+            "filter": ["==","symbo","REFUGE"],
+			"paint": {
+				"icon-color": "#246138"
+			}
+		},
+		{
+			"id": "bati ponctuel transport aerien - Aeroport FXX",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "bati_ponc",
+			"layout": {
+				"visibility": "visible",
+                "icon-image": "Aeroport",
+				"icon-size": 0.5
+			},
+            "filter": ["all",
+                        ["==","symbo","AEROPORT_PONC"],
+                        ["==","territoire","FXX"]
+            ],
+			"paint": {
+                "icon-color": "#646464"
+            }
+		},
+		{
+			"id": "bati ponctuel transport aerien - Aerodrome FXX",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "bati_ponc",
+			"layout": {
+				"visibility": "visible",
+                "icon-image": "Aerodrome",
+				"icon-size": 0.4
+			},
+            "filter": ["all",
+                        ["==","symbo","AERODROME_PONC"],
+                        ["==","territoire","FXX"]
+            ],
+			"paint": {
+                "icon-color": "#646464"
+            }
+		},
+		{
+			"id": "bati ponctuel transport aerien - Aeroport DOM",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "bati_ponc",
+			"minzoom": 8,
+			"layout": {
+				"visibility": "visible",
+                "icon-image": "Aeroport",
+				"icon-size": 0.5
+			},
+            "filter": ["all",
+                        ["==","symbo","AEROPORT_PONC"],
+                        ["!=","territoire","FXX"]
+            ],
+			"paint": {
+                "icon-color": "#646464"
+            }
+		},
+		{
+			"id": "bati ponctuel transport aerien - Aerodrome DOM",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "bati_ponc",
+			"minzoom": 8,
+			"layout": {
+				"visibility": "visible",
+                "icon-image": "Aerodrome",
+				"icon-size": 0.4
+			},
+            "filter": ["all",
+                        ["==","symbo","AERODROME_PONC"],
+                        ["!=","territoire","FXX"]
+            ],
+			"paint": {
+                "icon-color": "#646464"
+            }
+		},
+		{
+			"id": "bati ponctuel transport ferroviaire",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "bati_ponc",
+			"layout": {
+				"visibility": "visible",
+                "icon-image": "Gare",
+				"icon-size" : 0.33
+			},
+            "filter": ["==","symbo","GARE_VOYAGEURS"],
+			"paint": {
+                "icon-color": "#787878"
+            }
+		},
+		{
+            "id": "toponyme - bornes postales haute - chemins",
+            "type": "symbol",
+            "source": "plan_ign",
+            "source-layer": "toponyme_routier_borne",
+			"minzoom": 17,
+			"maxzoom": 18,
+            "filter": ["in","symbo",
+                                        "CHEMIN",
+                                        "CHEMIN_SOU",
+                                        "CHEMIN_SUP",
+                                        "PISTE_CYCLABLE",
+                                        "PISTE_CYCLABLE_SOU",
+                                        "PISTE_CYCLABLE_SUP",
+                                        "RUE_PIETONNE",
+                                        "RUE_PIETONNE_SOU",
+                                        "RUE_PIETONNE_SUP",
+                                        "SENTIER",
+                                        "SENTIER_SOU",
+                                        "SENTIER_SUP",
+                                        "ESCALIER",
+                                        "ESCALIER_SUP"],
+            "layout": {
+                "symbol-placement": "line",
+                "text-field": "{borne_sur}",
+                "text-size": 11,
+                "text-anchor": "center",
+                "text-allow-overlap": true,
+                "text-offset": [
+                  0,
+                  -1
+                ],
+                "text-font": ["Source Sans Pro Regular"]
+            },
+            "paint": {
+                "text-color": "#79654F",
+                "text-halo-width": 1,
+                "text-halo-color": "#FFFFFF"
+            }
+        },
+		{
+            "id": "toponyme - bornes postales haute - non revetue, non classee",
+            "type": "symbol",
+            "source": "plan_ign",
+            "source-layer": "toponyme_routier_borne",
+			"minzoom": 17,
+			"maxzoom": 18,
+            "filter": ["in","symbo",
+                                        "NON_CLASSEE",
+                                        "NON_CLASSEE_4",
+                                        "NON_CLASSEE_4_SUP",
+                                        "NON_CLASSEE_RESTREINT",
+                                        "NON_CLASSEE_RESTREINT_SUP",
+                                        "NON_CLASSEE_SOU",
+                                        "NON_CLASSEE_SUP",
+                                        "NON_REVETUE_CARRO",
+                                        "NON_REVETUE_CARRO_SUP"],
+            "layout": {
+                "symbol-placement": "line",
+                "text-field": "{borne_sur}",
+                "text-size": 11,
+                "text-anchor": "center",
+                "text-allow-overlap": true,
+                "text-offset": [
+                  0,
+                  -1.3
+                ],
+                "text-font": ["Source Sans Pro Regular"]
+            },
+            "paint": {
+                "text-color": "#79654F",
+                "text-halo-width": 1,
+                "text-halo-color": "#FFFFFF"
+            }
+        },
+		{
+            "id": "toponyme - bornes postales haute - locales",
+            "type": "symbol",
+            "source": "plan_ign",
+            "source-layer": "toponyme_routier_borne",
+			"minzoom": 17,
+			"maxzoom": 18,
+            "filter": ["in","symbo",
+                                        "LOCALE_1",
+                                        "LOCALE_1_SOU",
+                                        "LOCALE_1_SUP",
+                                        "LOCALE_2",
+                                        "LOCALE_2_SOU",
+                                        "LOCALE_2_SUP",
+                                        "LOCALE_3",
+                                        "LOCALE_3_SOU",
+                                        "LOCALE_3_SUP",
+                                        "LOCALE_4",
+                                        "LOCALE_4_SOU",
+                                        "LOCALE_4_SUP",
+                                        "LOCALE_CONSTR",
+                                        "LOCALE_CONSTR_SUP"],
+            "layout": {
+                "symbol-placement": "line",
+                "text-field": "{borne_sur}",
+                "text-size": 11,
+                "text-anchor": "center",
+                "text-allow-overlap": true,
+                "text-offset": [
+                  0,
+                  -1.4
+                ],
+                "text-font": ["Source Sans Pro Regular"]
+            },
+            "paint": {
+                "text-color": "#79654F",
+                "text-halo-width": 1,
+                "text-halo-color": "#FFFFFF"
+            }
+        },
+		{
+            "id": "toponyme - bornes postales haute - regionales",
+            "type": "symbol",
+            "source": "plan_ign",
+            "source-layer": "toponyme_routier_borne",
+			"minzoom": 17,
+			"maxzoom": 18,
+            "filter": ["in","symbo",
+                                        "REGIONALE_1",
+                                        "REGIONALE_1_SOU",
+                                        "REGIONALE_1_SUP",
+                                        "REGIONALE_2",
+                                        "REGIONALE_2_SOU",
+                                        "REGIONALE_2_SUP",
+                                        "REGIONALE_3",
+                                        "REGIONALE_3_SOU",
+                                        "REGIONALE_3_SUP",
+                                        "REGIONALE_4",
+                                        "REGIONALE_4_SUP",
+                                        "REGIONALE_CONSTR"],
+            "layout": {
+                "symbol-placement": "line",
+                "text-field": "{borne_sur}",
+                "text-size": 11,
+                "text-anchor": "center",
+                "text-allow-overlap": true,
+                "text-offset": [
+                  0,
+                  -1.5
+                ],
+                "text-font": ["Source Sans Pro Regular"]
+            },
+            "paint": {
+                "text-color": "#79654F",
+                "text-halo-width": 1,
+                "text-halo-color": "#FFFFFF"
+            }
+        },
+		{
+            "id": "toponyme - bornes postales haute - principales",
+            "type": "symbol",
+            "source": "plan_ign",
+            "source-layer": "toponyme_routier_borne",
+			"minzoom": 17,
+			"maxzoom": 18,
+            "filter": ["in","symbo",
+                                        "PRINCIPALE_1",
+										"PRINCIPALE_1_SOU",
+                                        "PRINCIPALE_1_SUP",
+                                        "PRINCIPALE_2",
+                                        "PRINCIPALE_2_SOU",
+                                        "PRINCIPALE_2_SUP",
+                                        "PRINCIPALE_3",
+                                        "PRINCIPALE_3_SOU",
+                                        "PRINCIPALE_3_SUP",
+                                        "PRINCIPALE_4",
+										"PRINCIPALE_4_SOU",
+                                        "PRINCIPALE_4_SUP",
+                                        "PRINCIPALE_CONSTR"],
+            "layout": {
+                "symbol-placement": "line",
+                "text-field": "{borne_sur}",
+                "text-size": 11,
+                "text-anchor": "center",
+                "text-allow-overlap": true,
+                "text-offset": [
+                  0,
+                  -1.6
+                ],
+                "text-font": ["Source Sans Pro Regular"]
+            },
+            "paint": {
+                "text-color": "#79654F",
+                "text-halo-width": 1,
+                "text-halo-color": "#FFFFFF"
+            }
+        },
+		{
+            "id": "toponyme - bornes postales bas - chemins",
+            "type": "symbol",
+            "source": "plan_ign",
+            "source-layer": "toponyme_routier_borne",
+			"minzoom": 17,
+			"maxzoom": 18,
+            "filter": ["in","symbo",
+                                        "CHEMIN",
+                                        "CHEMIN_SOU",
+                                        "CHEMIN_SUP",
+                                        "PISTE_CYCLABLE",
+                                        "PISTE_CYCLABLE_SOU",
+                                        "PISTE_CYCLABLE_SUP",
+                                        "RUE_PIETONNE",
+                                        "RUE_PIETONNE_SOU",
+                                        "RUE_PIETONNE_SUP", 
+                                        "SENTIER",
+                                        "SENTIER_SOU",
+                                        "SENTIER_SUP",
+                                        "ESCALIER",
+                                        "ESCALIER_SUP"],
+            "layout": {
+                "symbol-placement": "line",
+                "text-field": "{borne_sous}",
+                "text-size": 11,
+                "text-anchor": "center",
+                "text-allow-overlap": true,
+                "text-offset": [
+                  0,
+                  1
+                ],
+                "text-font": ["Source Sans Pro Regular"]
+            },
+            "paint": {
+                "text-color": "#79654F",
+                "text-halo-width": 1,
+                "text-halo-color": "#FFFFFF"
+            }
+        },
+		{
+            "id": "toponyme - bornes postales bas - non revetue, non classee",
+            "type": "symbol",
+            "source": "plan_ign",
+            "source-layer": "toponyme_routier_borne",
+			"minzoom": 17,
+			"maxzoom": 18,
+            "filter": ["in","symbo",
+                                        "NON_CLASSEE",
+                                        "NON_CLASSEE_4",
+                                        "NON_CLASSEE_4_SUP",
+										"NON_CLASSEE_RESTREINT",
+                                        "NON_CLASSEE_RESTREINT_SUP",
+                                        "NON_CLASSEE_SOU",
+                                        "NON_CLASSEE_SUP",
+                                        "NON_REVETUE_CARRO",
+                                        "NON_REVETUE_CARRO_SUP"],
+            "layout": {
+                "symbol-placement": "line",
+                "text-field": "{borne_sous}",
+                "text-size": 11,
+                "text-anchor": "center",
+                "text-allow-overlap": true,
+                "text-offset": [
+                  0,
+                  1.3
+                ],
+                "text-font": ["Source Sans Pro Regular"]
+            },
+            "paint": {
+                "text-color": "#79654F",
+                "text-halo-width": 1,
+                "text-halo-color": "#FFFFFF"
+            }
+        },
+		{
+            "id": "toponyme - bornes postales bas - locales",
+            "type": "symbol",
+            "source": "plan_ign",
+            "source-layer": "toponyme_routier_borne",
+			"minzoom": 17,
+			"maxzoom": 18,
+            "filter": ["in","symbo",
+                                        "LOCALE_1",
+                                        "LOCALE_1_SOU",
+                                        "LOCALE_1_SUP",
+                                        "LOCALE_2",
+                                        "LOCALE_2_SOU",
+                                        "LOCALE_2_SUP",
+                                        "LOCALE_3",
+                                        "LOCALE_3_SOU",
+                                        "LOCALE_3_SUP",
+                                        "LOCALE_4",
+                                        "LOCALE_4_SOU",
+                                        "LOCALE_4_SUP",
+                                        "LOCALE_CONSTR",
+										"LOCALE_CONSTR_SUP"],
+            "layout": {
+                "symbol-placement": "line",
+                "text-field": "{borne_sous}",
+                "text-size": 11,
+                "text-anchor": "center",
+                "text-allow-overlap": true,
+                "text-offset": [
+                  0,
+                  1.4
+                ],
+                "text-font": ["Source Sans Pro Regular"]
+            },
+            "paint": {
+                "text-color": "#79654F",
+                "text-halo-width": 1,
+                "text-halo-color": "#FFFFFF"
+            }
+        },
+		{
+            "id": "toponyme - bornes postales bas - regionales",
+            "type": "symbol",
+            "source": "plan_ign",
+            "source-layer": "toponyme_routier_borne",
+			"minzoom": 17,
+			"maxzoom": 18,
+            "filter": ["in","symbo",
+                                        "REGIONALE_1",
+                                        "REGIONALE_1_SOU",
+                                        "REGIONALE_1_SUP",
+                                        "REGIONALE_2",
+                                        "REGIONALE_2_SOU",
+                                        "REGIONALE_2_SUP",
+                                        "REGIONALE_3",
+                                        "REGIONALE_3_SOU",
+                                        "REGIONALE_3_SUP",
+                                        "REGIONALE_4",
+                                        "REGIONALE_4_SUP",
+                                        "REGIONALE_CONSTR"],
+            "layout": {
+                "symbol-placement": "line",
+                "text-field": "{borne_sous}",
+                "text-size": 11,
+                "text-anchor": "center",
+                "text-allow-overlap": true,
+                "text-offset": [
+                  0,
+                  1.5
+                ],
+                "text-font": ["Source Sans Pro Regular"]
+            },
+            "paint": {
+                "text-color": "#79654F",
+                "text-halo-width": 1,
+                "text-halo-color": "#FFFFFF"
+            }
+        },
+		{
+            "id": "toponyme - bornes postales bas - principales",
+            "type": "symbol",
+            "source": "plan_ign",
+            "source-layer": "toponyme_routier_borne",
+			"minzoom": 17,
+			"maxzoom": 18,
+            "filter": ["in","symbo",
+                                        "PRINCIPALE_1",
+										"PRINCIPALE_1_SOU",
+                                        "PRINCIPALE_1_SUP",
+                                        "PRINCIPALE_2",
+                                        "PRINCIPALE_2_SOU",
+                                        "PRINCIPALE_2_SUP",
+                                        "PRINCIPALE_3",
+                                        "PRINCIPALE_3_SOU",
+                                        "PRINCIPALE_3_SUP",
+                                        "PRINCIPALE_4",
+										"PRINCIPALE_4_SOU",
+                                        "PRINCIPALE_4_SUP",
+                                        "PRINCIPALE_CONSTR"],
+            "layout": {
+                "symbol-placement": "line",
+                "text-field": "{borne_sous}",
+                "text-size": 11,
+                "text-anchor": "center",
+                "text-allow-overlap": true,
+                "text-offset": [
+                  0,
+                  1.6
+                ],
+                "text-font": ["Source Sans Pro Regular"]
+            },
+            "paint": {
+                "text-color": "#79654F",
+                "text-halo-width": 1,
+                "text-halo-color": "#FFFFFF"
+            }
+        },
+		{
+            "id": "toponyme - courbe rocher maitresse",
+            "type": "symbol",
+            "source": "plan_ign",
+            "source-layer": "toponyme_oro_ponc",
+            "filter": ["==","txt_typo","ORO_COURBE_ROCHER"],
+            "layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+                "text-size": 10,
+                "text-allow-overlap": false,
+                "text-padding": 30,
+                "text-rotate": { "type": "identity", "property": "rotation" },
+                "text-font": ["Source Sans Pro Italic"]
+			},
+			"paint": {
+                "text-color": "#333333",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 1
+			}
+        },
+		{
+            "id": "toponyme - courbe glacier maitresse",
+            "type": "symbol",
+            "source": "plan_ign",
+            "source-layer": "toponyme_oro_ponc",
+            "filter": ["==","txt_typo","ORO_COURBE_GLACIER"],
+            "layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+                "text-size": 10,
+                "text-allow-overlap": false,
+                "text-padding": 30,
+                "text-rotate": { "type": "identity", "property": "rotation" },
+                "text-font": ["Source Sans Pro Italic"]
+			},
+			"paint": {
+                "text-color": "#629FD9",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 1
+			}
+        },
+		{
+            "id": "toponyme - courbe maitresse",
+            "type": "symbol",
+            "source": "plan_ign",
+            "source-layer": "toponyme_oro_ponc",
+            "filter": ["==","txt_typo","ORO_COURBE"],
+            "layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+                "text-size": 10,
+                "text-allow-overlap": false,
+                "text-padding": 30,
+                "text-rotate": { "type": "identity", "property": "rotation" },
+                "text-font": ["Source Sans Pro Italic"]
+			},
+			"paint": {
+                "text-color": "#604A2F",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 1
+			}
+        },
+		{
+            "id": "toponyme - liaison maritime",
+            "type": "symbol",
+            "source": "plan_ign",
+            "source-layer": "toponyme_routier_liaison_lin",
+			"minzoom": 8,
+			"maxzoom": 18,
+            "filter": ["==","txt_typo","LIAISON_MARITIME"],
+            "layout": {
+                "symbol-placement": "line",
+                "text-field": "{texte}",
+                "text-size": 15,
+                "text-anchor": "center",
+                "text-keep-upright": true,
+                "text-max-angle": 45,
+                "text-padding": 10,
+                "text-font": ["Source Sans Pro Italic"]
+            },
+            "paint": {
+                "text-color": "#5792C2",
+                "text-halo-width": 5,
+                "text-halo-color": "#AAD5E9"
+            }
+        },
+		{
+			"id": "toponyme bati station de métro + bati ponctuel metro",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_bati_ponc",
+            "minzoom":14,
+            "filter": ["all",
+                        ["==","txt_typo","TYPO_E_1"],
+                        ["==","symbo","STATION_METRO"]
+                      ],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+                "text-size": 11,
+                "text-allow-overlap": false,
+				"text-offset": [0.30, -0.25],
+                "text-padding": 3,
+				"text-anchor": "bottom-left",
+                "text-font": ["Source Sans Pro"],
+				"icon-image": "Metro",
+				"icon-size": { "stops": [[15, 0.33], [17, 0.6]] }
+			},
+			"paint": {
+                "text-color": "#3C3C3C",
+				"icon-color": "#646464"
+			}
+		},
+		{
+            "id": "toponyme ferre lineaire",
+            "type": "symbol",
+            "source": "plan_ign",
+            "source-layer": "toponyme_ferre_lin",
+			"minzoom":12,
+			"filter": ["in","txt_typo",
+                                    "FER_NOM",
+                                    "FER_OUVRAGE"
+			],
+            "layout": {
+                "symbol-placement": "line",
+                "text-field": "{texte}",
+                "text-size": 10,
+                "text-anchor": "center",
+				"text-offset": [0,-1],
+                "text-font": ["Source Sans Pro Regular"]
+            },
+            "paint": {
+                "text-color": "#000000",
+                "text-halo-width": 1,
+                "text-halo-color": "rgba(255, 255, 255, 1)"
+            }
+        },
+		{
+			"id": "toponyme station epuration, de pompage, usine de production eau",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_bati_ponc",
+			"minzoom":14,
+            "filter": ["==","txt_typo","station"],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{designation}",
+				"text-anchor": "left",
+				"text-offset": [0.8, 0],
+                "text-size": 11,
+                "text-allow-overlap": false,
+                "text-padding": 1,
+                "text-font": ["Source Sans Pro Italic"]
+			},
+			"paint": {
+                "text-color": "#447FB3"
+			}
+		},
+		{
+			"id": "toponyme bati ponc gare",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_bati_ponc",
+            "minzoom":15,
+            "filter": ["==","txt_typo","gore"],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{designation}",
+                "text-size": 11,
+                "text-allow-overlap": false,
+                "text-padding": 1,
+                "text-font": ["Source Sans Pro Italic"]
+			},
+			"paint": {
+                "text-color": "#000000"
+			}
+		},
+		{
+			"id": "toponyme bati ponc barrage",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_bati_ponc",
+            "minzoom":12,
+            "filter": ["==","txt_typo","BARRAGE_PONC"],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+				"text-anchor": "left",
+				"text-offset": [0.8, 0],
+                "text-size": 11,
+                "text-allow-overlap": false,
+                "text-padding": 1,
+                "text-font": ["Source Sans Pro"]
+			},
+			"paint": {
+                "text-color": "#447FB3"
+			}
+		},
+		{
+			"id": "toponyme bati ponc phare - niveau 13",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_bati_ponc",
+            "maxzoom":13,
+            "filter": ["==","txt_typo","PHARE"],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+				"text-anchor": "right",
+                "text-size": 11,
+                "text-allow-overlap": false,
+                "text-padding": 1,
+                "text-font": ["Source Sans Pro"]
+			},
+			"paint": {
+                "text-color": "#532A2A"
+			}
+		},		
+		{
+			"id": "toponyme bati ponc phare - niveau 14à19",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_bati_ponc",
+            "minzoom":13,
+            "filter": ["all",
+						["==","symbo","PHARE"],
+						["in","txt_typo",
+										"TYPO_C_6",
+										"TYPO_C_7",
+										"TYPO_C_8",
+										"TYPO_E_GE"]
+			],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+				"text-anchor": "right",
+                "text-size": { "stops": [[13, 12], [18, 18]] },
+                "text-allow-overlap": false,
+				"text-offset": [-2.00, 0],
+                "text-padding": 3,
+				"text-anchor": "right",
+                "text-font": ["Source Sans Pro"]
+			},
+			"paint": {
+                "text-color": "#532A2A"
+			}
+		},			
+		{
+			"id": "toponyme bati ponc autre",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_bati_ponc",
+            "minzoom":12,
+            "filter": ["in","txt_typo",
+                                        "BAT_ACTIVITE",
+                                        "BAT_FORTIF",
+                                        "BAT_VILLAGE_DETRUIT"],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+				"text-anchor": "center",
+                "text-size": 11,
+                "text-allow-overlap": false,
+                "text-padding": 1,
+                "text-font": ["Source Sans Pro"]
+			},
+			"paint": {
+                "text-color": "#532A2A"
+			}
+		},
+		{
+			"id": "toponyme bati ponc aerogare",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_bati_ponc",
+            "minzoom":14,
+			"maxzoom":17,
+            "filter": ["all",
+                        ["==","txt_typo","TYPO_E_GE"],
+                        ["==","symbo","AEROGARE"]
+                      ],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+				"text-anchor": "center",
+                "text-size": {"stops": [[12, 9], [16, 11]]},
+                "text-allow-overlap": false,
+                "text-padding": 1,
+                "text-font": ["Source Sans Pro Italic"]
+			},
+			"paint": {
+                "text-color": "#120049",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 1
+			}
+		},
+		{
+			"id": "toponyme bati ponc aeroport 12",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_bati_ponc",
+            "minzoom":11,
+			"maxzoom":12,
+            "filter": ["==","txt_typo","AEROPORT_PONC"],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+				"text-anchor": "bottom",
+				"text-offset": [0, -1.3],
+                "text-size": 10.5,
+                "text-allow-overlap": false,
+                "text-padding": 1,
+                "text-font": ["Source Sans Pro"]
+			},
+			"paint": {
+                "text-color": "#120049",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 2
+			}
+		},
+		{
+			"id": "toponyme bati ponc aeroport 13",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_bati_ponc",
+            "minzoom":12,
+			"maxzoom":13,
+            "filter": ["==","txt_typo","AEROPORT_PONC"],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+				"text-anchor": "bottom",
+				"text-offset": [0, -2],
+                "text-size": 11,
+                "text-allow-overlap": false,
+                "text-padding": 1,
+                "text-font": ["Source Sans Pro"]
+			},
+			"paint": {
+                "text-color": "#120049",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 2
+			}
+		},
+		{
+			"id": "toponyme bati ponc aeroport",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_bati_ponc",
+            "minzoom":13,
+			"maxzoom":17,
+            "filter": ["all",
+                        ["==","txt_typo","TYPO_A_5"],
+                        ["==","symbo","AEROPORT"]
+                      ],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+				"text-anchor": "center",
+                "text-size": {"stops": [[12, 11], [16, 13]]},
+                "text-allow-overlap": false,
+                "text-padding": 1,
+                "text-font": ["Source Sans Pro"]
+			},
+			"paint": {
+                "text-color": "#120049",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 2
+			}
+		},
+		{
+			"id": "toponyme bati ponc aerodrome 12",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_bati_ponc",
+            "minzoom":11,
+			"maxzoom":12,
+            "filter": ["==","txt_typo","AERODROME_PONC"],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+				"text-anchor": "bottom",
+				"text-offset": [0, -1.3],
+                "text-size": 9.5,
+                "text-allow-overlap": false,
+                "text-padding": 1,
+                "text-font": ["Source Sans Pro"]
+			},
+			"paint": {
+                "text-color": "#120049",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 2
+			}
+		},
+		{
+			"id": "toponyme bati ponc aerodrome 13",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_bati_ponc",
+            "minzoom":12,
+			"maxzoom":13,
+            "filter": ["==","txt_typo","AERODROME_PONC"],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+				"text-anchor": "bottom",
+				"text-offset": [0, -2],
+                "text-size": 10,
+                "text-allow-overlap": false,
+                "text-padding": 1,
+                "text-font": ["Source Sans Pro"]
+			},
+			"paint": {
+                "text-color": "#120049",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 2
+			}
+		},
+		{
+			"id": "toponyme bati ponc aerodrome",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_bati_ponc",
+            "minzoom":13,
+			"maxzoom":17,
+            "filter": ["all",
+                        ["==","txt_typo","TYPO_A_7"],
+                        ["==","symbo","AERODROME"]
+                      ],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+				"text-anchor": "center",
+                "text-size": {"stops": [[12, 10], [16, 12]]},
+                "text-allow-overlap": false,
+                "text-padding": 1,
+                "text-font": ["Source Sans Pro"]
+			},
+			"paint": {
+                "text-color": "#120049",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 2
+			}
+		},
+		{
+			"id": "toponyme - hydro ponc 5",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_hydro_ponc",
+            "filter": ["in","txt_typo",
+                                    "TYPO_D_9",
+                                    "TYPO_D_10",
+                                    "TYPO_E_1_cyan"
+            ],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+                "text-size": {"stops": [[15, 11], [17, 14]]},
+                "text-allow-overlap": true,
+                "text-padding": 5,
+                "text-font": ["Source Sans Pro Regular"]
+			},
+			"paint": {
+                "text-color": "#447FB3",
+                "text-halo-color": "#FFFFFF",
+                "text-halo-width": 1
+			}
+		},
+		{
+            "id": "toponyme - hydro ponc glacier",
+            "type": "symbol",
+            "source": "plan_ign",
+            "source-layer": "toponyme_hydro_ponc",
+            "filter": ["==","txt_typo","ORO_GLACIER_2"],
+            "layout": {
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+                "text-size": 14,
+                "text-anchor": "center",
+                "text-allow-overlap": true,
+                "text-padding": 1,
+                "text-font": ["Source Sans Pro Italic"]
+            },
+            "paint": {
+                "text-color": "#447FB3",
+                "text-halo-width": 2,
+                "text-halo-color": "rgba(255, 255, 255, 0.5)"
+            }
+        },
+		{
+			"id": "toponyme - limite militaire ponc 3 et 4",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_limite_ponc",
+            "filter": ["in","txt_typo",
+                                    "LIM_MILI_3",
+                                    "LIM_MILI_4"
+            ],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+                "text-size": 12,
+                "text-allow-overlap": false,
+                "text-padding": 2,
+                "text-font": ["Source Sans Pro Regular"]
+			},
+			"paint": {
+                "text-color": "#0D2000",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 1
+			}
+		},
+		{
+			"id": "toponyme - limite parc ponc 3 et 4",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_limite_ponc",
+            "filter": ["in","txt_typo",
+                                    "LIM_PARC_3",
+                                    "LIM_PARC_4",
+									"RESERVE_NATURELLE_PONC"
+            ],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+                "text-size": 13,
+                "text-allow-overlap": false,
+                "text-padding": 2,
+                "text-font": ["Source Sans Pro Regular"]
+			},
+			"paint": {
+                "text-color": "#287B00",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 1
+			}
+		},
+        {
+            "id": "toponyme numéro de route - départementale",
+            "type": "symbol",
+            "source": "plan_ign",
+            "source-layer": "toponyme_routier_numero_lin",
+            "minzoom":11,
+            "maxzoom":16,
+            "filter": ["==","txt_typo","Départementale"],
+            "layout": {
+                "visibility": "visible",
+                "symbol-placement": "line",
+                "text-field": "{texte}",
+                "text-size": 10.5,
+                "text-allow-overlap": false,
+                "text-padding": 2,
+                "text-anchor": "center",
+                "text-font": ["Source Sans Pro Semibold"],
+                "text-rotation-alignment": "viewport"
+            },
+            "paint": {
+                "text-color": "#4D4D4D",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 4
+            }
+        },
+        {
+            "id": "toponyme numéro de route - nationale",
+            "type": "symbol",
+            "source": "plan_ign",
+            "source-layer": "toponyme_routier_numero_lin",
+            "minzoom":7,
+            "maxzoom":16,
+            "filter": ["==","txt_typo","Nationale"],
+            "layout": {
+                "visibility": "visible",
+                "symbol-placement": "line",
+                "text-field": "{texte}",
+                "text-size": 12,
+                "text-allow-overlap": false,
+                "text-padding": 0,
+                "text-anchor": "center",
+                "text-font": ["Source Sans Pro Regular"],
+                "icon-image": "Ecluse",
+                "icon-rotation-alignment": "viewport",
+                "text-rotation-alignment": "viewport",
+                "icon-text-fit": "both",
+                "icon-size": 0
+            },
+            "paint": {
+                "text-color": "#F0F0F0",
+                "icon-color": "#646464",
+                "text-halo-color": "rgba(80, 80, 80, 0.5)",
+                "text-halo-width": 4
+            }
+        },      
+        {
+            "id": "toponyme numéro de route - autoroute",
+            "type": "symbol",
+            "source": "plan_ign",
+            "source-layer": "toponyme_routier_numero_lin",
+            "minzoom":7,
+            "maxzoom":16,
+            "filter": ["==","txt_typo","Autoroute"],
+            "layout": {
+                "visibility": "visible",
+                "symbol-placement": "line",
+                "text-field": "{texte}",
+                "text-size": 15,
+                "text-allow-overlap": false,
+                "text-padding": 0,
+                "text-anchor": "center",
+                "text-font": ["Source Sans Pro Regular"],
+                "icon-image": "Ecluse",
+                "icon-rotation-alignment": "viewport",
+                "text-rotation-alignment": "viewport",
+                "icon-text-fit": "both",
+                "icon-size": 0
+            },
+            "paint": {
+                "text-color": "#F0F0F0",
+                "icon-color": "#646464",
+                "text-halo-color": "rgba(80, 80, 80, 0.5)",
+                "text-halo-width": 5
+            }
+        },
+		{
+            "id": "toponyme - odonyme abrégé",
+            "type": "symbol",
+            "source": "plan_ign",
+            "source-layer": "toponyme_routier_odonyme_lin",
+			"minzoom": 15,
+            "maxzoom":17,
+            "layout": {
+                "symbol-placement": "line",
+                "text-field": "{nom_gauche}",
+                "text-size": 10,
+                "text-anchor": "center",
+                "text-max-angle": 30,
+                "text-font": ["Source Sans Pro Regular"]
+            },
+            "paint": {
+                "text-color": "#000000",
+                "text-halo-width": 2,
+                "text-halo-color": "rgba(255, 255, 255, 1)"
+            }
+        },
+		{
+            "id": "toponyme - odonyme desabrégé",
+            "type": "symbol",
+            "source": "plan_ign",
+            "source-layer": "toponyme_routier_odonyme_lin",
+			"minzoom": 17,
+            "layout": {
+                "symbol-placement": "line",
+                "text-field": "{nom_desabrege}",
+                "text-size": 11,
+                "text-anchor": "center",
+                "text-max-angle": 30,
+                "text-font": ["Source Sans Pro Regular"]
+            },
+            "paint": {
+                "text-color": "#000000",
+                "text-halo-width": 2,
+                "text-halo-color": "rgba(255, 255, 255, 1)"
+            }
+        },
+		{
+			"id": "toponyme - lieu dit non habité 3",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_ocs_ponc",
+            "filter": ["all",
+                        ["==","symbo","LIEU-DIT_NON_HABITE"],
+                        ["in","txt_typo",
+                                    "TYPO_B_10",
+                                    "TYPO_B_11"
+                        ]
+            ],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+                "text-size": 11,
+                "text-allow-overlap": false,
+                "text-padding": 1,
+                "text-font": ["Source Sans Pro Italic"]
+			},
+			"paint": {
+                "text-color": "#000000",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 1
+			}
+		},
+		{
+			"id": "toponyme - bois",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_ocs_ponc",
+            "filter": ["all",
+                        ["==","symbo","BOIS"],
+                        ["in","txt_typo",
+                                    "TYPO_F_10",
+                                    "TYPO_F_11"
+                        ]
+            ],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+                "text-size": 13,
+                "text-allow-overlap": false,
+                "text-padding": 1,
+                "text-font": ["Source Sans Pro Italic"]
+			},
+			"paint": {
+                "text-color": "#287B00",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 1
+			}
+		},
+		{
+            "id": "toponyme - oro lineaire 4",
+            "type": "symbol",
+            "source": "plan_ign",
+            "source-layer": "toponyme_oro_lin",
+            "filter": ["in","txt_typo",
+                                    "ORO_SOMMET_3",
+                                    "ORO_GORGE_2"
+            ],
+            "layout": {
+                "symbol-placement": "line",
+                "text-field": "{texte}",
+                "text-size": 11,
+                "text-anchor": "center",
+                "text-keep-upright": true,
+                "text-max-angle": 45,
+                "text-padding": 1,
+                "text-font": ["Source Sans Pro Italic"]
+            },
+            "paint": {
+                "text-color": "#863831",
+                "text-halo-width": 1.5,
+                "text-halo-color": "rgba(255, 255, 255, 0.5)"
+            }
+        },
+		{
+			"id": "toponyme - oro ponc 4",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_oro_ponc",
+            "filter": ["in","txt_typo",
+                                    "ORO_SOMMET_3",
+                                    "ORO_GORGE_2",
+                                    "GROTTE",
+                                    "GORGE",
+                                    "TYPO_G_9",
+                                    "TYPO_G_10"
+            ],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+                "text-size": {"stops": [[13, 11], [16, 16]]},
+                "text-allow-overlap": true,
+                "text-padding": 1,
+                "text-font": ["Source Sans Pro Italic"]
+			},
+			"paint": {
+                "text-color": "#863831",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 1.5
+			}
+		},
+		{
+			"id": "toponyme - hydro ponc 4",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_hydro_ponc",
+            "filter": ["in","txt_typo",
+                                    "lac - étang - bassin",
+                                    "HYD_SURF_4",
+                                    "HYD_SURF_4_T",
+                                    "HYD_SURF_5",
+                                    "HYD_SURF_5_T",
+                                    "TYPO_D_8",
+                                    "SOURCE"
+            ],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+                "text-size": {"stops": [[14, 13], [17, 16]]},
+                "text-allow-overlap": true,
+                "text-padding": 5,
+                "text-font": ["Source Sans Pro Regular"]
+			},
+			"paint": {
+                "text-color": "#447FB3",
+                "text-halo-color": "#FFFFFF",
+                "text-halo-width": 1
+			}
+		},
+		{
+			"id": "toponyme quartier ",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_localite_ponc",
+            "filter": ["in","txt_typo",
+                                    "BAT_QUARTIER",
+                                    "BAT_QUARTIER_T"
+            ],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+                "text-size": 11,
+                "text-allow-overlap": false,
+                "text-padding": 1,
+                "text-font": ["Source Sans Pro Italic"]
+			},
+			"paint": {
+                "text-color": "#000000",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 2
+			}
+		},
+		{
+			"id": "toponyme localite n0 typoA10",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_localite_ponc",
+            "maxzoom": 18,
+            "filter": ["==","txt_typo","TYPO_A_10"],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+                "text-size": {"stops": [[15, 11], [17, 13.5]]},
+                "text-allow-overlap": true,
+				"text-anchor": "center",
+                "text-padding": 1,
+                "text-font": ["Source Sans Pro Regular"]
+			},
+			"paint": {
+                "text-color": "#000000",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 2
+			}
+		},
+		{
+			"id": "toponyme - lieu dit non habité",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_ocs_ponc",
+            "filter": ["all",
+                        ["==","symbo","LIEU-DIT_NON_HABITE"],
+                        ["in","txt_typo",
+                                    "TYPO_B_7",
+                                    "TYPO_B_8",
+                                    "TYPO_B_9"
+                        ]
+            ],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+                "text-size": 12,
+                "text-allow-overlap": false,
+                "text-padding": 1,
+                "text-font": ["Source Sans Pro Italic"]
+			},
+			"paint": {
+                "text-color": "#000000",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 1
+			}
+		},
+		{
+			"id": "toponyme - bois 2",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_ocs_ponc",
+            "filter": ["all",
+                        ["==","symbo","BOIS"],
+                        ["in","txt_typo",
+                                    "TYPO_F_7",
+                                    "TYPO_F_8",
+                                    "TYPO_F_9"
+                        ]
+            ],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+                "text-size": 16,
+                "text-allow-overlap": false,
+                "text-padding": 1,
+                "text-font": ["Source Sans Pro Italic"]
+			},
+			"paint": {
+                "text-color": "#287B00",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 2
+			}
+		},
+		{
+			"id": "toponyme localite hameau ",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_localite_ponc",
+			"minzoom": 11,
+			"maxzoom": 13,
+            "filter": ["in","txt_typo",
+                                    "BAT_HAMEAU",
+                                    "BAT_HAMEAU_T"
+            ],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+				"icon-image": "Localite",
+				"icon-size": 0.17,
+                "text-field": "{texte}",
+                "text-size": 11,
+                "text-allow-overlap": false,
+				"text-anchor": "bottom-left",
+				"text-offset": [0.30, 0.10],
+                "text-padding": 1,
+                "text-font": ["Source Sans Pro Regular"]
+			},
+			"paint": {
+                "text-color": "#000000",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 2
+			}
+		},
+		{
+			"id": "toponyme localite importance 5",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_localite_ponc",
+			"minzoom": 9,
+            "filter": ["in","txt_typo",
+                                    "commune 5",
+                                    "BAT_COMMUNE_5",
+                                    "BAT_COMMUNE_5_T",
+                                    "BAT_CHEF_LIEU_COM",
+                                    "BAT_CHEF_LIEU_COM_T",
+									"BAT_CHEF_LIEU_COM-T",
+									"BAT_ANCIENNE_COM",
+									"BAT_ANCIENNE_COM_T",
+									"BAT_COMMUNE_ASSOCIEE",
+									"BAT_COMMUNE_ASSOCIEE_T",
+                                    "Commune très petite"
+            ],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+				"icon-image": "Localite",
+				"icon-size": 0.21,
+                "text-field": "{texte}",
+                "text-size": 11.5,
+                "text-allow-overlap": false,
+				"text-anchor": "bottom-left",
+				"text-offset": [0.30, 0.10],
+                "text-padding": 1,
+                "text-font": ["Source Sans Pro Regular"]
+			},
+			"paint": {
+                "text-color": "#000000",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 2
+			}
+		},
+		{
+            "id": "toponyme - ocs lineaire 3",
+            "type": "symbol",
+            "source": "plan_ign",
+            "source-layer": "toponyme_ocs_lin",
+            "filter": ["==","txt_typo","OCS_FORET_3"],
+            "layout": {
+                "symbol-placement": "line",
+                "text-field": "{texte}",
+                "text-size": {"stops": [[10, 12], [12, 15]]},
+                "text-anchor": "center",
+                "text-keep-upright": true,
+                "text-max-angle": 45,
+                "text-padding": 1,
+                "text-font": ["Source Sans Pro Italic"]
+            },
+            "paint": {
+                "text-color": "#287B00",
+                "text-halo-width": 1,
+                "text-halo-color": "rgba(255, 255, 255, 0.5)"
+            }
+        },
+		{
+			"id": "toponyme - lieu dit non habité 1",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_ocs_ponc",
+            "filter": ["all",
+                        ["==","symbo","LIEU-DIT_NON_HABITE"],
+                        ["in","txt_typo",
+                            "TYPO_B_5",
+                            "TYPO_B_4"
+                            
+                        ]
+            ],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+                "text-size": 15,
+                "text-allow-overlap": false,
+                "text-padding": 1,
+                "text-font": ["Source Sans Pro Italic"]
+			},
+			"paint": {
+                "text-color": "#000000",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 1
+			}
+		},
+		{
+			"id": "toponyme - bois 1",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_ocs_ponc",
+            "filter": ["all",
+                        ["==","symbo","BOIS"],
+                        ["in","txt_typo",
+                            "TYPO_F_5",
+                            "TYPO_F_4"                            
+                        ]
+            ],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+                "text-size": 19,
+                "text-allow-overlap": false,
+                "text-padding": 1,
+                "text-font": ["Source Sans Pro Italic"]
+			},
+			"paint": {
+                "text-color": "#287B00",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 2
+			}
+		},
+		{
+			"id": "toponyme - bois 0",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_ocs_ponc",
+            "filter": ["all",
+                        ["==","symbo","BOIS"],
+                        ["in","txt_typo",
+                            "TYPO_F_3",
+                            "TYPO_F_2"
+                        ]
+            ],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+                "text-size": 22,
+                "text-allow-overlap": false,
+                "text-padding": 1,
+                "text-font": ["Source Sans Pro Italic"]
+			},
+			"paint": {
+                "text-color": "#287B00",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 2
+			}
+		},
+		{
+			"id": "toponyme - ocs ponc 3",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_ocs_ponc",
+            "filter": ["==","txt_typo","OCS_FORET_3"],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+                "text-size": {"stops": [[10, 12], [12, 15]]},
+                "text-allow-overlap": false,
+                "text-padding": 1,
+				"text-anchor": "center",
+                "text-font": ["Source Sans Pro Italic"]
+			},
+			"paint": {
+                "text-color": "#287B00",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 1
+			}
+		},
+		{
+            "id": "toponyme - oro lineaire 3",
+            "type": "symbol",
+            "source": "plan_ign",
+            "source-layer": "toponyme_oro_lin",
+            "filter": ["in","txt_typo",
+                                    "ORO_ILE_3",
+                                    "ORO_RELIEF_3",
+                                    "ORO_RELIEF_3_T",
+                                    "ORO_RELIEF_4",
+                                    "ORO_RELIEF_4_T",
+                                    "ORO_CAP_2",
+                                    "ORO_CAP_3",
+                                    "ORO_SOMMET_2",
+                                    "ORO_COL_2",
+                                    "ORO_GORGE_1",
+									"ORO_GORGE-1"
+            ],
+            "layout": {
+                "symbol-placement": "line",
+                "text-field": "{texte}",
+                "text-size": 12,
+                "text-anchor": "center",
+                "text-keep-upright": true,
+                "text-max-angle": 45,
+                "text-padding": 10,
+                "text-font": ["Source Sans Pro Italic"]
+            },
+            "paint": {
+                "text-color": "#863831",
+                "text-halo-width": 1.5,
+                "text-halo-color": "rgba(255, 255, 255, 0.5)"
+            }
+        },
+		{
+			"id": "toponyme - oro ponc 3",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_oro_ponc",
+            "filter": ["in","txt_typo",
+                                    "ORO_ILE_3",
+                                    "ORO_RELIEF_3",
+                                    "ORO_RELIEF_3_T",
+                                    "ORO_RELIEF_4",
+                                    "ORO_RELIEF_4_T",
+                                    "ORO_CAP_2",
+                                    "ORO_CAP_3",
+                                    "ORO_SOMMET_2",
+                                    "ORO_COL_2",
+                                    "ORO_GORGE_1",
+									"ORO_GORGE-1",
+                                    "TYPO_G_7",
+                                    "TYPO_G_8"
+            ],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+                "text-size": {"stops": [[13, 12], [16, 17]]},
+                "text-allow-overlap": true,
+                "text-padding": 1,
+                "text-font": ["Source Sans Pro Italic"]
+			},
+			"paint": {
+                "text-color": "#863831",
+                "text-halo-color": "#FFFFFF",
+                "text-halo-width": 1.5
+			}
+		},
+		{
+            "id": "toponyme - hydro lineaire 3",
+            "type": "symbol",
+            "source": "plan_ign",
+            "source-layer": "toponyme_hydro_lin",
+            "filter": ["in","txt_typo",
+                                    "HYD_LIN_3",
+                                    "HYD_LIN_4",
+                                    "HYD_LIN_5",
+                                    "petite rivière",
+                                    "canal",
+                                    "HYD_SURF_3",
+                                    "HYD_SURF_3_T",
+                                    "HYD_SURF_4",
+                                    "HYD_SURF_4_T",
+                                    "HYD_SURF_5",
+                                    "HYD_SURF_5_T",
+                                    "TYPO_D_5"
+            ],
+            "layout": {
+                "symbol-placement": "line",
+                "text-field": "{texte}",
+                "text-size": {"stops": [[14, 12], [18, 19]]},
+                "text-anchor": "center",
+                "text-keep-upright": true,
+                "text-max-angle": 45,
+                "text-padding": 10,
+                "text-font": ["Source Sans Pro Regular"]
+            },
+            "paint": {
+                "text-color": "#447FB3",
+                "text-halo-width": 1.5,
+                "text-halo-color": "rgba(255, 255, 255, 0.7)"
+            }
+        },
+		{
+            "id": "toponyme - hydro lineaire 4",
+            "type": "symbol",
+            "source": "plan_ign",
+            "source-layer": "toponyme_hydro_lin",
+			"minzoom":14,
+            "filter": ["in","txt_typo",
+                                    "TYPO_D_6",
+                                    "TYPO_D_8",
+                                    "TYPO_D_9",
+                                    "TYPO_D_10"
+            ],
+            "layout": {
+                "symbol-placement": "line",
+                "text-field": "{texte}",
+                "text-size": {"stops": [[14, 10], [18, 16]]},
+                "text-anchor": "center",
+                "text-keep-upright": true,
+                "text-max-angle": 45,
+                "text-padding": 10,
+                "text-font": ["Source Sans Pro Regular"]
+            },
+            "paint": {
+                "text-color": "#447FB3",
+                "text-halo-width": 1.5,
+                "text-halo-color": "rgba(255, 255, 255, 0.7)"
+            }
+        },
+		{
+			"id": "toponyme - hydro ponc 3",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_hydro_ponc",
+            "filter": ["in","txt_typo",
+                                    "petit golfe",
+                                    "grande baie",
+                                    "baie",
+                                    "HYD_SURF_3",
+                                    "TYPO_D_5",
+                                    "TYPO_D_6",
+                                    "TYPO_D_7"
+            ],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+                "text-size": {"stops": [[15, 15], [17, 18]]},
+                "text-allow-overlap": true,
+                "text-padding": 10,
+                "text-font": ["Source Sans Pro Regular"]
+			},
+			"paint": {
+                "text-color": "#447FB3",
+                "text-halo-color": "#FFFFFF",
+                "text-halo-width": 2
+			}
+		},
+		{
+			"id": "toponyme bati ponc zai zoom 16",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_bati_ponc",
+            "minzoom":15,
+            "maxzoom":16,
+            "filter": ["==","txt_typo","zai"],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{designation}",
+                "text-size": 11,
+                "text-allow-overlap": false,
+                "text-padding": 1,
+                "text-font": ["Source Sans Pro Italic"]
+			},
+			"paint": {
+                "text-color": "#000000"
+			}
+		},
+		{
+			"id": "toponyme bati ponc zai zoom 17 et 18",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_bati_ponc",
+            "minzoom":16,
+            "filter": ["==","txt_typo","zai"],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+                "text-size": 11,
+                "text-allow-overlap": false,
+                "text-padding": 1,
+                "text-font": ["Source Sans Pro Italic"]
+			},
+			"paint": {
+                "text-color": "#000000"
+			}
+		},
+		{
+			"id": "toponyme localite importance 4",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_localite_ponc",
+			"minzoom": 7,
+            "filter": ["in","txt_typo",
+                                    "commune 4",
+                                    "BAT_COMMUNE_4",
+                                    "BAT_COMMUNE_4_T"
+             ],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+				"icon-image": "Localite",
+				"icon-size": 0.21,
+                "text-field": "{texte}",
+                "text-size": 13,
+                "text-allow-overlap": false,
+				"text-anchor": "bottom-left",
+				"text-offset": [0.30, 0.10],
+                "text-padding": 1,
+                "text-font": ["Source Sans Pro Regular"]
+			},
+			"paint": {
+                "text-color": "#000000",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 2
+			}
+		},
+		{
+			"id": "toponyme localite n0 typoA9",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_localite_ponc",
+            "maxzoom": 18,
+            "filter": ["==","txt_typo","TYPO_A_9"],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+                "text-size": {"stops": [[15, 11.5], [17, 14]]},
+                "text-allow-overlap": true,
+				"text-anchor": "center",
+                "text-padding": 1,
+                "text-font": ["Source Sans Pro Regular"]
+			},
+			"paint": {
+                "text-color": "#000000",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 2
+			}
+		},
+		{
+			"id": "toponyme localite n0 typoA8",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_localite_ponc",
+            "maxzoom": 18,
+            "filter": ["==","txt_typo","TYPO_A_8"],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+                "text-size": {"stops": [[15, 12], [17, 15]]},
+                "text-allow-overlap": true,
+				"text-anchor": "center",
+                "text-padding": 1,
+                "text-font": ["Source Sans Pro Regular"]
+			},
+			"paint": {
+                "text-color": "#000000",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 2
+			}
+		},
+		{
+			"id": "toponyme - limite militaire ponc 1 et 2",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_limite_ponc",
+            "filter": ["in","txt_typo",
+                                    "LIM_MILI_1",
+                                    "LIM_MILI_2"
+            ],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+                "text-size": 15,
+                "text-allow-overlap": false,
+                "text-padding": 5,
+                "text-font": ["Source Sans Pro Regular"]
+			},
+			"paint": {
+                "text-color": "#0D2000",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 2
+			}
+		},
+		{
+			"id": "toponyme - limite parc marin",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_limite_ponc",
+			"minzoom": 8,
+            "filter": ["==","txt_typo","LIM_PARC_NATUREL_MARIN"],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+                "text-size": 15,
+                "text-allow-overlap": false,
+                "text-padding": 10,
+                "text-transform": "uppercase",
+                "text-font": ["Source Sans Pro Regular"]
+			},
+			"paint": {
+                "text-color": "#2A81A2",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 2
+			}
+		},
+		{
+			"id": "toponyme - limite parc ponc 1 et 2",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_limite_ponc",
+			"minzoom":8,
+            "filter": ["in","txt_typo",
+                                    "LIM_PARC_1",
+                                    "LIM_PARC_2",
+                                    "LIM_PARC_NATUREL"
+            ],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+                "text-size": 15,
+                "text-allow-overlap": false,
+                "text-padding": 10,
+                "text-transform": "uppercase",
+                "text-font": ["Source Sans Pro Regular"]
+			},
+			"paint": {
+                "text-color": "#287B00",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 2
+			}
+		},
+		{
+            "id": "toponyme - ocs lineaire 2",
+            "type": "symbol",
+            "source": "plan_ign",
+            "source-layer": "toponyme_ocs_lin",
+            "filter": ["==","txt_typo","OCS_FORET_2"],
+            "layout": {
+                "symbol-placement": "line",
+                "text-field": "{texte}",
+                "text-size": {"stops": [[10, 15], [12, 18]]},
+                "text-anchor": "center",
+                "text-keep-upright": true,
+                "text-max-angle": 45,
+                "text-padding": 1,
+                "text-font": ["Source Sans Pro Regular"]
+            },
+            "paint": {
+                "text-color": "#287B00",
+                "text-halo-width": 2,
+                "text-halo-color": "rgba(255, 255, 255, 0.5)"
+            }
+        },
+		{
+			"id": "toponyme - ocs ponc 2",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_ocs_ponc",
+            "filter": ["==","txt_typo","OCS_FORET_2"],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+                "text-size": {"stops": [[10, 15], [12, 18]]},
+                "text-allow-overlap": false,
+                "text-padding": 1,
+				"text-anchor": "center",
+                "text-font": ["Source Sans Pro Regular"]
+			},
+			"paint": {
+                "text-color": "#287B00",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 2
+			}
+		},
+		{
+            "id": "toponyme - oro lineaire 2",
+            "type": "symbol",
+            "source": "plan_ign",
+            "source-layer": "toponyme_oro_lin",
+            "filter": ["in","txt_typo",
+                                    "ORO_ILE_2",
+                                    "ORO_RELIEF_2",
+                                    "ORO_RELIEF_2_T",
+                                    "ORO_CAP_1",
+                                    "ORO_SOMMET_1"
+            ],
+            "layout": {
+                "symbol-placement": "line",
+                "text-field": "{texte}",
+                "text-size": 15,
+                "text-anchor": "center",
+                "text-keep-upright": true,
+				"text-padding": 10,
+                "text-max-angle": 45,
+                "text-font": ["Source Sans Pro Regular"]
+            },
+            "paint": {
+                "text-color": "#863831",
+                "text-halo-width": 2,
+                "text-halo-color": "rgba(255, 255, 255, 0.5)"
+            }
+        },
+		{
+			"id": "toponyme - oro ponc 2",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_oro_ponc",
+			"minzoom":9,
+            "filter": ["in","txt_typo",
+                                    "ORO_ILE_2",
+                                    "ORO_RELIEF_2",
+                                    "ORO_RELIEF_2_T",
+                                    "ORO_CAP_1",
+                                    "ORO_COL_1",
+                                    "sommet ou col",
+                                    "ORO_SOMMET_1",
+                                    "TYPO_G_4",
+                                    "TYPO_G_6"
+            ],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+                "text-size": {"stops": [[9, 13], [10, 15], [13, 15], [16, 19]]},
+                "text-allow-overlap": false,
+                "text-padding": 1,
+                "text-font": ["Source Sans Pro Regular"]
+			},
+			"paint": {
+                "text-color": "#863831",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 2
+			}
+		},
+		{
+			"id": "toponyme - oro ponc 2B",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_oro_ponc",
+			"minzoom":8,
+            "filter": ["in","txt_typo",
+                                    "île",
+                                    "cap ou pointe"
+            ],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+                "text-size": 15,
+                "text-allow-overlap": false,
+                "text-padding": 1,
+                "text-font": ["Source Sans Pro Regular"]
+			},
+			"paint": {
+                "text-color": "#863831",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 2
+			}
+		},
+		{
+            "id": "toponyme - hydro lineaire 2",
+            "type": "symbol",
+            "source": "plan_ign",
+            "source-layer": "toponyme_hydro_lin",
+            "filter": ["in","txt_typo",
+                                    "HYD_LIN_2",
+                                    "rivière moyenne",
+                                    "HYD_SURF_2",
+                                    "HYD_SURF_2_T",
+                                    "TYPO_D_3"
+            ],
+            "layout": {
+                "symbol-placement": "line",
+                "text-field": "{texte}",
+                "text-size": {"stops": [[14, 15], [18, 21]]},
+                "text-anchor": "center",
+                "text-keep-upright": true,
+                "text-max-angle": 45,
+                "text-padding": 10,
+                "text-font": ["Source Sans Pro Regular"]
+            },
+            "paint": {
+                "text-color": "#447FB3",
+                "text-halo-width": 2,
+                "text-halo-color": "rgba(255, 255, 255, 0.5)"
+            }
+        },
+		{
+			"id": "toponyme - hydro ponc 2",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_hydro_ponc",
+			"minzoom": 5,
+            "filter": ["in","txt_typo",
+                                    "moyen",
+                                    "golfe moyen",
+                                    "HYD_SURF_2",
+                                    "TYPO_D_2",
+                                    "TYPO_D_3",
+                                    "TYPO_D_4"
+            ],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+                "text-size": {"stops": [[5, 12], [6, 18], [10, 17], [18, 21]]},
+                "text-allow-overlap": false,
+                "text-padding": 10,
+                "text-font": ["Source Sans Pro Regular"]
+			},
+			"paint": {
+                "text-color": "#447FB3",
+                "text-halo-color": "#FFFFFF",
+                "text-halo-width": 2
+			}
+		},
+		{
+			"id": "toponyme localite importance 3",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_localite_ponc",
+			"minzoom": 5,
+            "filter": ["in","txt_typo",
+                                    "commune 3",
+                                    "BAT_COMMUNE_3",
+                                    "BAT_COMMUNE_3_T"
+            ],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+				"icon-image": "Localite",
+				"icon-size": 0.21,
+                "text-field": "{texte}",
+                "text-size": {"stops": [[5, 10], [6, 15]]},
+                "text-allow-overlap": false,
+				"text-anchor": "bottom-left",
+				"text-offset": [0.30, 0.10],
+                "text-padding": 1,
+                "text-font": ["Source Sans Pro Regular"]
+			},
+			"paint": {
+                "text-color": "#000000",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 2
+			}
+		},
+		{
+			"id": "toponyme localite n0 typoA7 non commune",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_localite_ponc",
+            "maxzoom": 18,
+            "filter": ["all",
+						["!=","symbo","COMMUNE_FUSIONNEE"],
+						["!=","symbo","COMMUNE_CHEF_LIEU"],
+						["==","txt_typo","TYPO_A_7"]
+            ],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+                "text-size": {"stops": [[15, 13], [17, 16]]},
+                "text-allow-overlap": true,
+				"text-anchor": "center",
+                "text-padding": 1,
+                "text-font": ["Source Sans Pro Regular"]
+			},
+			"paint": {
+                "text-color": "#000000",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 2
+			}
+		},
+		{
+			"id": "toponyme localite n0 typoA6 non commune",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_localite_ponc",
+            "maxzoom": 18,
+            "filter": ["all",
+						["!=","symbo","COMMUNE_FUSIONNEE"],
+						["!=","symbo","COMMUNE_CHEF_LIEU"],
+						["==","txt_typo","TYPO_A_6"]
+            ],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+                "text-size": {"stops": [[15, 15], [17, 18]]},
+                "text-allow-overlap": true,
+				"text-anchor": "center",
+                "text-padding": 1,
+                "text-font": ["Source Sans Pro Regular"]
+			},
+			"paint": {
+                "text-color": "#000000",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 2
+			}
+		},
+		{
+            "id": "toponyme - oro lineaire 1",
+            "type": "symbol",
+            "source": "plan_ign",
+            "source-layer": "toponyme_oro_lin",
+            "filter": ["in","txt_typo",
+                                    "ORO_ILE_1",
+                                    "ORO_RELIEF_1",
+                                    "ORO_RELIEF_1_T"
+            ],
+            "layout": {
+                "symbol-placement": "line",
+                "text-field": "{texte}",
+                "text-size": 20,
+                "text-anchor": "center",
+                "text-keep-upright": true,
+                "text-padding": 5,
+                "text-max-angle": 45,
+                "text-font": ["Source Sans Pro Regular"]
+            },
+            "paint": {
+                "text-color": "#863831",
+                "text-halo-width": 2,
+                "text-halo-color": "rgba(255, 255, 255, 0.5)"
+            }
+        },
+		{
+			"id": "toponyme - oro ponc monde",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_oro_ponc",
+            "minzoom": 5,
+            "filter": ["in","txt_typo",
+                                    "Basin",
+                                    "Depression",
+                                    "Desert",
+                                    "Geoarea",
+                                    "Gorge",
+                                    "Isthmus",
+                                    "Lake",
+                                    "Lowland",
+                                    "Pen/cape",
+                                    "Plain",
+                                    "Plateau",
+                                    "Range/mtn",
+                                    "Tundra",
+                                    "Valley",
+                                    "Island",
+                                    "Island group"
+            ],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+                "text-size": 11,
+                "text-allow-overlap": false,
+                "text-padding": 1,
+                "text-font": ["Source Sans Pro Italic"]
+			},
+			"paint": {
+                "text-color": "#863831",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 2
+			}
+		},
+		{
+			"id": "toponyme localite n0 typoA4 non commune",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_localite_ponc",
+            "maxzoom": 16,
+            "filter": ["all",
+						["!=","symbo","COMMUNE_FUSIONNEE"],
+						["!=","symbo","COMMUNE_CHEF_LIEU"],
+						["==","txt_typo","TYPO_A_4"]
+            ],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+                "text-size": 17,
+                "text-allow-overlap": true,
+				"text-anchor": "center",
+                "text-padding": 1,
+                "text-font": ["Source Sans Pro Regular"]
+			},
+			"paint": {
+                "text-color": "#000000",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 3
+			}
+		},
+		{
+            "id": "toponyme - ocs lineaire 1",
+            "type": "symbol",
+            "source": "plan_ign",
+            "source-layer": "toponyme_ocs_lin",
+            "filter": ["==","txt_typo","OCS_FORET_1"],
+            "layout": {
+                "symbol-placement": "line",
+                "text-field": "{texte}",
+                "text-size": {"stops": [[10, 18], [12, 22]]},
+                "text-anchor": "center",
+                "text-keep-upright": true,
+                "text-padding": 1,
+                "text-max-angle": 45,
+                "text-font": ["Source Sans Pro Regular"]
+            },
+            "paint": {
+                "text-color": "#287B00",
+                "text-halo-width": 2,
+                "text-halo-color": "rgba(255, 255, 255, 0.5)"
+            }
+        },
+		{
+			"id": "toponyme - ocs ponc 1",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_ocs_ponc",
+            "filter": ["==","txt_typo","OCS_FORET_1"],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+                "text-size": {"stops": [[10, 18], [12, 22]]},
+                "text-allow-overlap": true,
+                "text-padding": 1,
+                "text-font": ["Source Sans Pro Regular"]
+			},
+			"paint": {
+                "text-color": "#287B00",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 2
+			}
+		},
+		{
+			"id": "toponyme - oro ponc 1",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_oro_ponc",
+			"minzoom":8,
+            "filter": ["in","txt_typo",
+                                    "grande île",
+                                    "ORO_ILE_1",
+                                    "ORO_RELIEF_1",
+                                    "ORO_RELIEF_1_T",
+                                    "TYPO_G_3",
+                                    "TYPO_G_2",
+                                    "TYPO_G_1"
+            ],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+                "text-size": 21,
+                "text-allow-overlap": true,
+                "text-padding": 1,
+                "text-font": ["Source Sans Pro Regular"]
+			},
+			"paint": {
+                "text-color": "#863831",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 2
+			}
+		},
+		{
+            "id": "toponyme - hydro lineaire glacier",
+            "type": "symbol",
+            "source": "plan_ign",
+            "source-layer": "toponyme_hydro_lin",
+            "filter": ["in","txt_typo",
+                                    "ORO_GLACIER_1",
+                                    "ORO_GLACIER_2"
+            ],
+            "layout": {
+                "symbol-placement": "line",
+                "text-field": "{texte}",
+                "text-size": 15,
+                "text-anchor": "center",
+                "text-keep-upright": true,
+                "text-max-angle": 45,
+                "text-font": ["Source Sans Pro Italic"]
+            },
+            "paint": {
+                "text-color": "#447FB3",
+                "text-halo-width": 2,
+                "text-halo-color": "rgba(255, 255, 255, 0.5)"
+            }
+        },
+		{
+            "id": "toponyme - hydro lineaire 1",
+            "type": "symbol",
+            "source": "plan_ign",
+            "source-layer": "toponyme_hydro_lin",
+            "filter": ["in","txt_typo",
+                                    "HYD_LIN_1",
+									"HYD-LIN-1",
+                                    "grande rivière",
+                                    "HYD_SURF_1",
+                                    "HYD_SURF_1_T",
+                                    "TYPO_D_1",
+                                    "TYPO_D_2"
+            ],
+            "layout": {
+                "symbol-placement": "line",
+                "text-field": "{texte}",
+                "text-size": 18,
+                "text-anchor": "center",
+                "text-keep-upright": true,
+                "text-max-angle": 45,
+                "text-padding": 10,
+                "text-font": ["Source Sans Pro Regular"]
+            },
+            "paint": {
+                "text-color": "#447FB3",
+                "text-halo-width": 2,
+                "text-halo-color": "rgba(255, 255, 255, 0.5)"
+            }
+        },
+		{
+            "id": "toponyme - hydro lineaire ocean",
+            "type": "symbol",
+            "source": "plan_ign",
+            "source-layer": "toponyme_hydro_lin",
+            "filter": ["==","txt_typo","mer et océan"],
+            "layout": {
+                "symbol-placement": "line",
+                "text-field": "{texte}",
+                "text-size": 30,
+                "text-anchor": "center",
+                "text-keep-upright": true,
+                "text-max-angle": 45,
+                "text-padding": 10,
+                "text-font": ["Source Sans Pro Regular"]
+            },
+            "paint": {
+                "text-color": "#447FB3",
+                "text-halo-width": 4,
+                "text-halo-color": "rgba(255, 255, 255, 0.5)"
+            }
+        },
+		{
+			"id": "toponyme - hydro ponc 1",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_hydro_ponc",
+			"minzoom": 4,
+            "filter": ["in","txt_typo",
+                                    "mer",
+                                    "grand",
+                                    "grand golfe",
+                                    "HYD_SURF_1",
+                                    "TYPO_D_1"
+            ],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+                "text-size": {"stops": [[4, 16], [6, 30], [10, 25]]},
+                "text-allow-overlap": true,
+                "text-padding": 10,
+                "text-font": ["Source Sans Pro Regular"]
+			},
+			"paint": {
+                "text-color": "#447FB3",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 4
+			}
+		},
+		{
+			"id": "toponyme localite importance 2",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_localite_ponc",
+			"minzoom": 4,
+            "filter": ["in","txt_typo",
+                                    "commune 2",
+                                    "BAT_COMMUNE_2",
+									"BAT_COMMUNE-2",
+                                    "BAT_COMMUNE_2_T"
+            ],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+				"icon-image": "Localite",
+				"icon-size": 0.25,
+                "text-field": "{texte}",
+                "text-size": {"stops": [[4, 10], [6, 17]]},
+                "text-allow-overlap": true,
+				"text-anchor": "bottom-left",
+				"text-offset": [0.30, 0.2],
+                "text-padding": 1,
+                "text-transform": "uppercase",
+                "text-font": {"stops": [[1, ["Source Sans Pro Regular"]], [7, ["Source Sans Pro Bold"]], [10, ["Source Sans Pro Regular"]]]}
+			},
+			"paint": {
+                "text-color": "#000000",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 3
+			}
+		},
+		{
+			"id": "toponyme localite n0 typoA3 non commune",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_localite_ponc",
+            "maxzoom": 16,
+            "filter": ["all",
+						["!=","symbo","COMMUNE_FUSIONNEE"],
+						["!=","symbo","COMMUNE_CHEF_LIEU"],
+						["==","txt_typo","TYPO_A_3"]
+            ],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+                "text-size": 19,
+                "text-allow-overlap": true,
+				"text-anchor": "center",
+                "text-padding": 1,
+                "text-font": ["Source Sans Pro Regular"]
+			},
+			"paint": {
+                "text-color": "#000000",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 3
+			}
+		},
+		{
+			"id": "toponyme localite n0 typoA2 non commune",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_localite_ponc",
+            "maxzoom": 16,
+            "filter": ["all",
+						["!=","symbo","COMMUNE_FUSIONNEE"],
+						["!=","symbo","COMMUNE_CHEF_LIEU"],
+						["==","txt_typo","TYPO_A_2"]
+            ],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+                "text-size": 21,
+                "text-allow-overlap": true,
+				"text-anchor": "center",
+                "text-padding": 1,
+                "text-font": ["Source Sans Pro Regular"]
+			},
+			"paint": {
+                "text-color": "#000000",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 4
+			}
+		},
+		{
+			"id": "toponyme localite n0 typoA7 commune",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_localite_ponc",
+            "maxzoom": 18,
+            "filter": ["all",
+						["in","symbo","COMMUNE_FUSIONNEE","COMMUNE_CHEF_LIEU"],
+						["==","txt_typo","TYPO_A_7"]
+            ],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+                "text-size": {"stops": [[15, 13], [17, 16]]},
+                "text-allow-overlap": true,
+				"text-anchor": "center",
+                "text-padding": 1,
+				"text-transform": "uppercase",
+                "text-font": ["Source Sans Pro Regular"]
+			},
+			"paint": {
+                "text-color": "#000000",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 2
+			}
+		},
+		{
+			"id": "toponyme localite n0 typoA6 commune",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_localite_ponc",
+            "maxzoom": 18,
+            "filter": ["all",
+						["in","symbo","COMMUNE_FUSIONNEE","COMMUNE_CHEF_LIEU"],
+						["==","txt_typo","TYPO_A_6"]
+            ],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+                "text-size": {"stops": [[15, 15], [17, 18]]},
+                "text-allow-overlap": true,
+				"text-anchor": "center",
+                "text-padding": 1,
+				"text-transform": "uppercase",
+                "text-font": ["Source Sans Pro Regular"]
+			},
+			"paint": {
+                "text-color": "#000000",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 2
+			}
+		},
+		{
+			"id": "toponyme localite n0 typoA1 non commune",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_localite_ponc",
+            "maxzoom": 16,
+            "filter": ["all",
+						["!=","symbo","COMMUNE_FUSIONNEE"],
+						["!=","symbo","COMMUNE_CHEF_LIEU"],
+						["==","txt_typo","TYPO_A_1"]
+            ],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+                "text-size": 23,
+                "text-allow-overlap": true,
+				"text-anchor": "center",
+                "text-padding": 1,
+                "text-font": ["Source Sans Pro Regular"]
+			},
+			"paint": {
+                "text-color": "#000000",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 4
+			}
+		},
+		{
+			"id": "toponyme localite n0 typoA4 commune",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_localite_ponc",
+            "maxzoom": 16,
+            "filter": ["all",
+						["in","symbo","COMMUNE_FUSIONNEE","COMMUNE_CHEF_LIEU"],
+						["==","txt_typo","TYPO_A_4"]
+            ],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+                "text-size": 17,
+                "text-allow-overlap": true,
+				"text-anchor": "center",
+                "text-padding": 1,
+                "text-transform": "uppercase",
+                "text-font": ["Source Sans Pro Regular"]
+			},
+			"paint": {
+                "text-color": "#000000",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 3
+			}
+		},
+		{
+			"id": "toponyme localite n0 typoA3 commune",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_localite_ponc",
+            "maxzoom": 16,
+            "filter": ["all",
+						["in","symbo","COMMUNE_FUSIONNEE","COMMUNE_CHEF_LIEU"],
+						["==","txt_typo","TYPO_A_3"]
+            ],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+                "text-size": 19,
+                "text-allow-overlap": true,
+				"text-anchor": "center",
+                "text-padding": 1,
+                "text-transform": "uppercase",
+                "text-font": ["Source Sans Pro Regular"]
+			},
+			"paint": {
+                "text-color": "#000000",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 3
+			}
+		},
+		{
+			"id": "toponyme localite n0 typoA2 commune",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_localite_ponc",
+            "maxzoom": 16,
+            "filter": ["all",
+						["in","symbo","COMMUNE_FUSIONNEE","COMMUNE_CHEF_LIEU"],
+						["==","txt_typo","TYPO_A_2"]
+            ],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+                "text-size": 21,
+                "text-allow-overlap": true,
+				"text-anchor": "center",
+                "text-padding": 1,
+                "text-transform": "uppercase",
+                "text-font": ["Source Sans Pro Regular"]
+			},
+			"paint": {
+                "text-color": "#000000",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 4
+			}
+		},
+		{
+			"id": "toponyme localite importance 1",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_localite_ponc",
+			"minzoom": 3,
+            "filter": ["in","txt_typo",
+                                    "commune 1",
+                                    "BAT_COMMUNE_1",
+                                    "BAT_COMMUNE_1_T"
+            ],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+				"icon-image": "Localite",
+				"icon-size": 0.3,
+                "text-field": "{texte}",
+                "text-size": {"stops": [[3, 10], [6, 20]]},
+                "text-allow-overlap": false,
+				"text-anchor": "bottom-left",
+				"text-offset": [0.25, -0.10],
+                "text-padding": 1,
+                "text-transform": "uppercase",
+                "text-font": {"stops": [[1, ["Source Sans Pro Regular"]], [7, ["Source Sans Pro Bold"]], [10, ["Source Sans Pro Regular"]]]}
+			},
+			"paint": {
+                "text-color": "#000000",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 4
+			}
+		},
+		{
+			"id": "toponyme localite n0 typoA1 commune",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_localite_ponc",
+            "maxzoom": 16,
+            "filter": ["all",
+						["in","symbo","COMMUNE_FUSIONNEE","COMMUNE_CHEF_LIEU"],
+						["==","txt_typo","TYPO_A_1"]
+            ],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+                "text-size": 23,
+                "text-allow-overlap": true,
+				"text-anchor": "center",
+                "text-padding": 1,
+                "text-transform": "uppercase",
+                "text-font": ["Source Sans Pro Regular"]
+			},
+			"paint": {
+                "text-color": "#000000",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 4
+			}
+		},
+		{
+			"id": "toponyme - hydro ponc ocean",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_hydro_ponc",
+			"minzoom": 1,
+            "filter": ["==","txt_typo","ocean"],
+			"layout": {
+				"visibility": "visible",
+                "symbol-placement": "point",
+                "text-field": "{texte}",
+                "text-size": {"stops": [[1, 16], [6, 30]]},
+                "text-allow-overlap": true,
+				"text-anchor": "center",
+                "text-padding": 10,
+                "text-font": ["Source Sans Pro Regular"]
+			},
+			"paint": {
+                "text-color": "#447FB3",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 4
+			}
+		},
+    	{
+			"id": "toponyme pays 3",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_localite_ponc",
+			"minzoom": 4,
+			"maxzoom": 5,
+            "filter": ["==","txt_typo","pays 3"],
+			"layout": {
+				"visibility": "visible",
+                "text-field": "{texte}",
+                "text-size": 9,
+                "text-allow-overlap": true,
+				"text-anchor": "center",
+                "text-padding": 1,
+                "text-transform": "uppercase",
+                "text-font": ["Source Sans Pro Regular"]
+			},
+			"paint": {
+                "text-color": "#787878",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 4
+			}
+		},
+    	{
+			"id": "toponyme pays 2",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_localite_ponc",
+			"minzoom": 2,
+			"maxzoom": 5,
+            "filter": ["==","txt_typo","pays 2"],
+			"layout": {
+				"visibility": "visible",
+                "text-field": "{texte}",
+                "text-size": 13,
+                "text-allow-overlap": true,
+				"text-anchor": "center",
+                "text-padding": 2,
+                "text-transform": "uppercase",
+                "text-font": ["Source Sans Pro Regular"]
+			},
+			"paint": {
+                "text-color": "#787878",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 4
+			}
+		},
+        {
+			"id": "toponyme pays 1",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_localite_ponc",
+			"minzoom": 2,
+			"maxzoom": 5,
+            "filter": ["==","txt_typo","pays 1"],    
+			"layout": {
+				"visibility": "visible",
+                "text-field": "{texte}",
+                "text-size": 13,
+                "text-allow-overlap": true,
+				"text-anchor": "center",
+                "text-padding": 2,
+                "text-transform": "uppercase",
+                "text-font": ["Source Sans Pro Regular"]
+			},
+			"paint": {
+                "text-color": "#787878",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 4
+			}
+		},
+        {
+			"id": "toponyme continent",
+			"type": "symbol",
+			"source": "plan_ign",
+			"source-layer": "toponyme_localite_ponc",
+			"maxzoom": 3,
+            "filter": ["==","txt_typo","continent"],
+			"layout": {
+				"visibility": "visible",
+                "text-field": "{texte}",
+                "text-size": 15,
+                "text-allow-overlap": true,
+				"text-anchor": "center",
+                "text-padding": 1,
+                "text-transform": "uppercase",
+                "text-font": ["Source Sans Pro Bold"]
+			},
+			"paint": {
+                "text-color": "#787878",
+                "text-halo-color": "rgba(255, 255, 255, 0.5)",
+                "text-halo-width": 4
+			}
+		}
+	]
+}

--- a/components/map/styles/vector.json
+++ b/components/map/styles/vector.json
@@ -519,7 +519,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "bati_zone_surf",
 		 "minzoom": 7,
-		 "maxzoom": 15,
+		 "maxzoom": 21,
 		 "layout": {
 		  "visibility": "visible"
 		 },
@@ -570,7 +570,7 @@
 		 "type": "line",
 		 "source": "plan_ign",
 		 "source-layer": "oro_courbe",
-		 "maxzoom": 16,
+		 "maxzoom": 21,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -603,7 +603,7 @@
 		 "type": "line",
 		 "source": "plan_ign",
 		 "source-layer": "oro_courbe",
-		 "maxzoom": 16,
+		 "maxzoom": 21,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -636,7 +636,7 @@
 		 "type": "line",
 		 "source": "plan_ign",
 		 "source-layer": "oro_courbe",
-		 "maxzoom": 16,
+		 "maxzoom": 21,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "butt",
@@ -663,7 +663,7 @@
 		 "type": "line",
 		 "source": "plan_ign",
 		 "source-layer": "oro_courbe",
-		 "maxzoom": 16,
+		 "maxzoom": 21,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -696,7 +696,7 @@
 		 "type": "line",
 		 "source": "plan_ign",
 		 "source-layer": "oro_courbe",
-		 "maxzoom": 16,
+		 "maxzoom": 21,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -729,7 +729,7 @@
 		 "type": "line",
 		 "source": "plan_ign",
 		 "source-layer": "oro_courbe",
-		 "maxzoom": 16,
+		 "maxzoom": 21,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "butt",
@@ -766,7 +766,7 @@
 		 "type": "line",
 		 "source": "plan_ign",
 		 "source-layer": "oro_courbe",
-		 "maxzoom": 16,
+		 "maxzoom": 21,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -788,7 +788,7 @@
 		 "type": "line",
 		 "source": "plan_ign",
 		 "source-layer": "oro_courbe",
-		 "maxzoom": 16,
+		 "maxzoom": 21,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -810,7 +810,7 @@
 		 "type": "line",
 		 "source": "plan_ign",
 		 "source-layer": "oro_courbe",
-		 "maxzoom": 16,
+		 "maxzoom": 21,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "butt",
@@ -847,7 +847,7 @@
 		 "type": "line",
 		 "source": "plan_ign",
 		 "source-layer": "oro_courbe",
-		 "maxzoom": 16,
+		 "maxzoom": 21,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -870,7 +870,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "oro_lin",
 		 "minzoom": 14,
-		 "maxzoom": 18,
+		 "maxzoom": 21,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -892,7 +892,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "oro_lin",
 		 "minzoom": 14,
-		 "maxzoom": 18,
+		 "maxzoom": 21,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "butt",
@@ -933,7 +933,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "oro_courbe",
 		 "minzoom": 13,
-		 "maxzoom": 16,
+		 "maxzoom": 21,
 		 "layout": {
 		  "symbol-placement": "line",
 		  "text-field": "{texte}",
@@ -991,7 +991,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "oro_courbe",
 		 "minzoom": 13,
-		 "maxzoom": 16,
+		 "maxzoom": 21,
 		 "layout": {
 		  "symbol-placement": "line",
 		  "text-field": "{texte}",
@@ -1049,7 +1049,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "oro_courbe",
 		 "minzoom": 13,
-		 "maxzoom": 16,
+		 "maxzoom": 21,
 		 "layout": {
 		  "symbol-placement": "line",
 		  "text-field": "{texte}",
@@ -1143,7 +1143,7 @@
 		 "type": "line",
 		 "source": "plan_ign",
 		 "source-layer": "hydro_reseau_sou",
-		 "maxzoom": 18,
+		 "maxzoom": 21,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "butt",
@@ -1181,7 +1181,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "hydro_reseau_sou",
 		 "minzoom": 12,
-		 "maxzoom": 18,
+		 "maxzoom": 21,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "butt",
@@ -1262,7 +1262,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "ferre_sou",
 		 "minzoom": 10,
-		 "maxzoom": 18,
+		 "maxzoom": 21,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -1298,7 +1298,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "ferre_sou",
 		 "minzoom": 10,
-		 "maxzoom": 18,
+		 "maxzoom": 21,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "butt",
@@ -1338,7 +1338,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "ferre_sou",
 		 "minzoom": 10,
-		 "maxzoom": 18,
+		 "maxzoom": 21,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -1372,7 +1372,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "ferre_sou",
 		 "minzoom": 10,
-		 "maxzoom": 18,
+		 "maxzoom": 21,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "butt",
@@ -1410,7 +1410,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "ferre_sou",
 		 "minzoom": 14,
-		 "maxzoom": 18,
+		 "maxzoom": 21,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -1449,7 +1449,7 @@
 		 "type": "line",
 		 "source": "plan_ign",
 		 "source-layer": "ferre_sou",
-		 "maxzoom": 18,
+		 "maxzoom": 21,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -1482,7 +1482,7 @@
 		 "type": "line",
 		 "source": "plan_ign",
 		 "source-layer": "ferre_sou",
-		 "maxzoom": 18,
+		 "maxzoom": 21,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "butt",
@@ -1522,7 +1522,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "routier_chemin_sou",
 		 "minzoom": 13,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -1567,7 +1567,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "routier_chemin_sou",
 		 "minzoom": 14,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "butt",
@@ -1608,7 +1608,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "routier_chemin_sou",
 		 "minzoom": 14,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "butt",
@@ -1653,7 +1653,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "routier_chemin_sou",
 		 "minzoom": 14,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -1698,7 +1698,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "routier_chemin_sou",
 		 "minzoom": 13,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -1743,7 +1743,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "routier_chemin_sou",
 		 "minzoom": 12,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -1783,7 +1783,7 @@
 		 "type": "line",
 		 "source": "plan_ign",
 		 "source-layer": "routier_route_sou",
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -1828,7 +1828,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "routier_route_sou",
 		 "minzoom": 12,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -1877,7 +1877,7 @@
 		 "type": "line",
 		 "source": "plan_ign",
 		 "source-layer": "routier_route_sou",
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -1917,7 +1917,7 @@
 		 "type": "line",
 		 "source": "plan_ign",
 		 "source-layer": "routier_route_sou",
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -1958,7 +1958,7 @@
 		 "type": "line",
 		 "source": "plan_ign",
 		 "source-layer": "routier_route_sou",
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -2007,7 +2007,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "routier_route_sou",
 		 "minzoom": 11,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -2051,7 +2051,7 @@
 		 "type": "line",
 		 "source": "plan_ign",
 		 "source-layer": "routier_route_sou",
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -2104,7 +2104,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "routier_route_sou",
 		 "minzoom": 10,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -2153,7 +2153,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "routier_route_sou",
 		 "minzoom": 7,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -2206,7 +2206,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "routier_route_sou",
 		 "minzoom": 10,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -2255,7 +2255,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "routier_route_sou",
 		 "minzoom": 7,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -2305,7 +2305,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "routier_route_sou",
 		 "minzoom": 10,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -2353,7 +2353,7 @@
 		 "type": "line",
 		 "source": "plan_ign",
 		 "source-layer": "routier_route_sou",
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -2394,7 +2394,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "routier_route_sou",
 		 "minzoom": 12,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -2443,7 +2443,7 @@
 		 "type": "line",
 		 "source": "plan_ign",
 		 "source-layer": "routier_route_sou",
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -2483,7 +2483,7 @@
 		 "type": "line",
 		 "source": "plan_ign",
 		 "source-layer": "routier_route_sou",
-		 "maxzoom": 18,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -2524,7 +2524,7 @@
 		 "type": "line",
 		 "source": "plan_ign",
 		 "source-layer": "routier_route_sou",
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -2573,7 +2573,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "routier_route_sou",
 		 "minzoom": 11,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "butt",
@@ -2636,7 +2636,7 @@
 		 "type": "line",
 		 "source": "plan_ign",
 		 "source-layer": "routier_route_sou",
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -2689,7 +2689,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "routier_route_sou",
 		 "minzoom": 10,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "butt",
@@ -2760,7 +2760,7 @@
 		 "type": "line",
 		 "source": "plan_ign",
 		 "source-layer": "routier_route_sou",
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -2817,7 +2817,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "routier_route_sou",
 		 "minzoom": 10,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "butt",
@@ -2884,7 +2884,7 @@
 		 "type": "line",
 		 "source": "plan_ign",
 		 "source-layer": "routier_route_sou",
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -2938,7 +2938,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "routier_route_sou",
 		 "minzoom": 13,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -2984,7 +2984,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "routier_route_sou",
 		 "minzoom": 10,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "butt",
@@ -3052,7 +3052,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "routier_route_sou",
 		 "minzoom": 13,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -3409,7 +3409,7 @@
 		 "type": "fill",
 		 "source": "plan_ign",
 		 "source-layer": "bati_surf",
-		 "maxzoom": 15,
+		 "maxzoom": 21,
 		 "layout": {
 		  "visibility": "visible"
 		 },
@@ -3465,7 +3465,7 @@
 		 "type": "fill",
 		 "source": "plan_ign",
 		 "source-layer": "bati_surf",
-		 "maxzoom": 15,
+		 "maxzoom": 21,
 		 "layout": {
 		  "visibility": "visible"
 		 },
@@ -3484,7 +3484,7 @@
 		 "type": "fill",
 		 "source": "plan_ign",
 		 "source-layer": "bati_surf",
-		 "minzoom": 15,
+		 "minzoom": 21,
 		 "layout": {
 		  "visibility": "visible"
 		 },
@@ -3565,7 +3565,7 @@
 		 "type": "fill",
 		 "source": "plan_ign",
 		 "source-layer": "bati_surf",
-		 "maxzoom": 15,
+		 "maxzoom": 21,
 		 "layout": {
 		  "visibility": "visible"
 		 },
@@ -3614,7 +3614,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "bati_surf",
 		 "minzoom": 14,
-		 "maxzoom": 15,
+		 "maxzoom": 21,
 		 "layout": {
 		  "visibility": "visible"
 		 },
@@ -4041,7 +4041,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "bati_zai",
 		 "minzoom": 15,
-		 "maxzoom": 18,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible"
 		 },
@@ -4579,7 +4579,7 @@
 		 "type": "line",
 		 "source": "plan_ign",
 		 "source-layer": "routier_route",
-		 "maxzoom": 18,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -4910,7 +4910,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "routier_route",
 		 "minzoom": 11,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -5026,7 +5026,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "routier_route",
 		 "minzoom": 10,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -5138,7 +5138,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "routier_route",
 		 "minzoom": 10,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -5251,7 +5251,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "routier_route",
 		 "minzoom": 8,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -5300,7 +5300,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "routier_route",
 		 "minzoom": 12,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -5360,7 +5360,7 @@
 		 "type": "line",
 		 "source": "plan_ign",
 		 "source-layer": "routier_route",
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -5400,7 +5400,7 @@
 		 "type": "line",
 		 "source": "plan_ign",
 		 "source-layer": "routier_route",
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -5441,7 +5441,7 @@
 		 "type": "line",
 		 "source": "plan_ign",
 		 "source-layer": "routier_route",
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -5579,7 +5579,7 @@
 		 "type": "line",
 		 "source": "plan_ign",
 		 "source-layer": "routier_route",
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -5733,7 +5733,7 @@
 		 "type": "line",
 		 "source": "plan_ign",
 		 "source-layer": "routier_route",
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -5879,7 +5879,7 @@
 		 "type": "line",
 		 "source": "plan_ign",
 		 "source-layer": "routier_route",
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -5944,7 +5944,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "routier_route",
 		 "minzoom": 13,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -6061,7 +6061,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "routier_route",
 		 "minzoom": 13,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -6299,7 +6299,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "ferre",
 		 "minzoom": 10,
-		 "maxzoom": 18,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -6336,7 +6336,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "ferre",
 		 "minzoom": 10,
-		 "maxzoom": 18,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "butt",
@@ -6443,7 +6443,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "routier_liaison",
 		 "minzoom": 8,
-		 "maxzoom": 18,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -6531,7 +6531,7 @@
 		 "type": "line",
 		 "source": "plan_ign",
 		 "source-layer": "routier_liaison",
-		 "maxzoom": 18,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "butt",
@@ -6634,7 +6634,7 @@
 		 "type": "line",
 		 "source": "plan_ign",
 		 "source-layer": "routier_liaison",
-		 "maxzoom": 18,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "butt",
@@ -6697,7 +6697,7 @@
 		 "type": "fill",
 		 "source": "plan_ign",
 		 "source-layer": "routier_surf",
-		 "maxzoom": 18,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible"
 		 },
@@ -6717,7 +6717,7 @@
 		 "type": "fill",
 		 "source": "plan_ign",
 		 "source-layer": "routier_surf",
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible"
 		 },
@@ -6737,7 +6737,7 @@
 		 "type": "fill",
 		 "source": "plan_ign",
 		 "source-layer": "routier_surf",
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible"
 		 },
@@ -7239,7 +7239,7 @@
 		 "type": "line",
 		 "source": "plan_ign",
 		 "source-layer": "routier_route_sup",
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "butt",
@@ -7526,7 +7526,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "routier_route_sup",
 		 "minzoom": 11,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "butt",
@@ -7642,7 +7642,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "routier_route_sup",
 		 "minzoom": 10,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "butt",
@@ -7754,7 +7754,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "routier_route_sup",
 		 "minzoom": 10,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "butt",
@@ -7867,7 +7867,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "routier_route_sup",
 		 "minzoom": 10,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "butt",
@@ -7959,7 +7959,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "routier_route_sup",
 		 "minzoom": 12,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "butt",
@@ -8019,7 +8019,7 @@
 		 "type": "line",
 		 "source": "plan_ign",
 		 "source-layer": "routier_route_sup",
-		 "maxzoom": 18,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "butt",
@@ -8059,7 +8059,7 @@
 		 "type": "line",
 		 "source": "plan_ign",
 		 "source-layer": "routier_route_sup",
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "butt",
@@ -8100,7 +8100,7 @@
 		 "type": "line",
 		 "source": "plan_ign",
 		 "source-layer": "routier_route_sup",
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "butt",
@@ -8164,7 +8164,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "routier_route_sup",
 		 "minzoom": 11,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "butt",
@@ -8227,7 +8227,7 @@
 		 "type": "line",
 		 "source": "plan_ign",
 		 "source-layer": "routier_route_sup",
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "butt",
@@ -8295,7 +8295,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "routier_route_sup",
 		 "minzoom": 10,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "butt",
@@ -8362,7 +8362,7 @@
 		 "type": "line",
 		 "source": "plan_ign",
 		 "source-layer": "routier_route_sup",
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "butt",
@@ -8430,7 +8430,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "routier_route_sup",
 		 "minzoom": 10,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "butt",
@@ -8493,7 +8493,7 @@
 		 "type": "line",
 		 "source": "plan_ign",
 		 "source-layer": "routier_route_sup",
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "butt",
@@ -8558,7 +8558,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "routier_route_sup",
 		 "minzoom": 13,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "butt",
@@ -8604,7 +8604,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "routier_route_sup",
 		 "minzoom": 10,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "butt",
@@ -8672,7 +8672,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "routier_route_sup",
 		 "minzoom": 13,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "butt",
@@ -8898,7 +8898,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "ferre_sup",
 		 "minzoom": 10,
-		 "maxzoom": 18,
+		 "maxzoom": 21,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -8935,7 +8935,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "ferre_sup",
 		 "minzoom": 10,
-		 "maxzoom": 18,
+		 "maxzoom": 21,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "butt",
@@ -9077,7 +9077,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "limite_lin",
 		 "minzoom": 14,
-		 "maxzoom": 18,
+		 "maxzoom": 21,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "round",
@@ -9161,7 +9161,7 @@
 		 "type": "line",
 		 "source": "plan_ign",
 		 "source-layer": "limite_lin",
-		 "maxzoom": 18,
+		 "maxzoom": 21,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "butt",
@@ -9237,7 +9237,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "limite_lin",
 		 "minzoom": 10,
-		 "maxzoom": 11,
+		 "maxzoom": 21,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "butt",
@@ -9275,7 +9275,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "limite_lin",
 		 "minzoom": 11,
-		 "maxzoom": 12,
+		 "maxzoom": 21,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "butt",
@@ -9313,7 +9313,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "limite_lin",
 		 "minzoom": 12,
-		 "maxzoom": 13,
+		 "maxzoom": 21,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "butt",
@@ -9351,7 +9351,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "limite_lin",
 		 "minzoom": 13,
-		 "maxzoom": 18,
+		 "maxzoom": 21,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "butt",
@@ -9388,7 +9388,7 @@
 		 "type": "line",
 		 "source": "plan_ign",
 		 "source-layer": "limite_lin",
-		 "maxzoom": 18,
+		 "maxzoom": 21,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "butt",
@@ -9560,7 +9560,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "limite_lin",
 		 "minzoom": 13,
-		 "maxzoom": 18,
+		 "maxzoom": 21,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "butt",
@@ -9605,7 +9605,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "limite_lin",
 		 "minzoom": 8,
-		 "maxzoom": 13,
+		 "maxzoom": 21,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "butt",
@@ -9638,7 +9638,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "limite_lin",
 		 "minzoom": 13,
-		 "maxzoom": 18,
+		 "maxzoom": 21,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "butt",
@@ -9679,7 +9679,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "limite_lin",
 		 "minzoom": 7,
-		 "maxzoom": 13,
+		 "maxzoom": 21,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "butt",
@@ -9712,7 +9712,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "limite_lin",
 		 "minzoom": 13,
-		 "maxzoom": 18,
+		 "maxzoom": 21,
 		 "layout": {
 		  "visibility": "visible",
 		  "line-cap": "butt",
@@ -10155,7 +10155,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "oro_ponc",
 		 "minzoom": 11,
-		 "maxzoom": 16,
+		 "maxzoom": 21,
 		 "filter": [
 		  "in",
 		  "symbo",
@@ -10390,7 +10390,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "bati_ponc",
 		 "minzoom": 12,
-		 "maxzoom": 15,
+		 "maxzoom": 21,
 		 "layout": {
 		  "visibility": "visible",
 		  "icon-image": "Ecluse",
@@ -10460,7 +10460,7 @@
 		 "type": "circle",
 		 "source": "plan_ign",
 		 "source-layer": "bati_ponc",
-		 "maxzoom": 15,
+		 "maxzoom": 21,
 		 "layout": {
 		  "visibility": "visible"
 		 },
@@ -10544,7 +10544,7 @@
 		 "type": "symbol",
 		 "source": "plan_ign",
 		 "source-layer": "bati_ponc",
-		 "maxzoom": 15,
+		 "maxzoom": 21,
 		 "layout": {
 		  "visibility": "visible",
 		  "icon-image": "Silo",
@@ -10609,7 +10609,7 @@
 		 "type": "symbol",
 		 "source": "plan_ign",
 		 "source-layer": "bati_ponc",
-		 "maxzoom": 15,
+		 "maxzoom": 21,
 		 "layout": {
 		  "visibility": "visible",
 		  "icon-image": "Reservoir",
@@ -10901,7 +10901,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "toponyme_routier_borne",
 		 "minzoom": 17,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "filter": [
 		  "in",
 		  "symbo",
@@ -10947,7 +10947,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "toponyme_routier_borne",
 		 "minzoom": 17,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "filter": [
 		  "in",
 		  "symbo",
@@ -10988,7 +10988,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "toponyme_routier_borne",
 		 "minzoom": 17,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "filter": [
 		  "in",
 		  "symbo",
@@ -11034,7 +11034,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "toponyme_routier_borne",
 		 "minzoom": 17,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "filter": [
 		  "in",
 		  "symbo",
@@ -11078,7 +11078,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "toponyme_routier_borne",
 		 "minzoom": 17,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "filter": [
 		  "in",
 		  "symbo",
@@ -11123,7 +11123,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "toponyme_routier_borne",
 		 "minzoom": 17,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "filter": [
 		  "in",
 		  "symbo",
@@ -11169,7 +11169,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "toponyme_routier_borne",
 		 "minzoom": 17,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "filter": [
 		  "in",
 		  "symbo",
@@ -11210,7 +11210,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "toponyme_routier_borne",
 		 "minzoom": 17,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "filter": [
 		  "in",
 		  "symbo",
@@ -11256,7 +11256,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "toponyme_routier_borne",
 		 "minzoom": 17,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "filter": [
 		  "in",
 		  "symbo",
@@ -11300,7 +11300,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "toponyme_routier_borne",
 		 "minzoom": 17,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "filter": [
 		  "in",
 		  "symbo",
@@ -11438,7 +11438,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "toponyme_routier_liaison_lin",
 		 "minzoom": 8,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "filter": [
 		  "==",
 		  "txt_typo",
@@ -11641,7 +11641,7 @@
 		 "type": "symbol",
 		 "source": "plan_ign",
 		 "source-layer": "toponyme_bati_ponc",
-		 "maxzoom": 13,
+		 "maxzoom": 21,
 		 "filter": [
 		  "==",
 		  "txt_typo",
@@ -11751,7 +11751,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "toponyme_bati_ponc",
 		 "minzoom": 14,
-		 "maxzoom": 17,
+		 "maxzoom": 21,
 		 "filter": [
 		  "all",
 		  [
@@ -11800,7 +11800,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "toponyme_bati_ponc",
 		 "minzoom": 11,
-		 "maxzoom": 12,
+		 "maxzoom": 21,
 		 "filter": [
 		  "==",
 		  "txt_typo",
@@ -11834,7 +11834,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "toponyme_bati_ponc",
 		 "minzoom": 12,
-		 "maxzoom": 13,
+		 "maxzoom": 21,
 		 "filter": [
 		  "==",
 		  "txt_typo",
@@ -11868,7 +11868,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "toponyme_bati_ponc",
 		 "minzoom": 13,
-		 "maxzoom": 17,
+		 "maxzoom": 21,
 		 "filter": [
 		  "all",
 		  [
@@ -11917,7 +11917,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "toponyme_bati_ponc",
 		 "minzoom": 11,
-		 "maxzoom": 12,
+		 "maxzoom": 21,
 		 "filter": [
 		  "==",
 		  "txt_typo",
@@ -11951,7 +11951,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "toponyme_bati_ponc",
 		 "minzoom": 12,
-		 "maxzoom": 13,
+		 "maxzoom": 21,
 		 "filter": [
 		  "==",
 		  "txt_typo",
@@ -11985,7 +11985,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "toponyme_bati_ponc",
 		 "minzoom": 13,
-		 "maxzoom": 17,
+		 "maxzoom": 21,
 		 "filter": [
 		  "all",
 		  [
@@ -12159,7 +12159,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "toponyme_routier_numero_lin",
 		 "minzoom": 11,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "filter": [
 		  "==",
 		  "txt_typo",
@@ -12190,7 +12190,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "toponyme_routier_numero_lin",
 		 "minzoom": 7,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "filter": [
 		  "==",
 		  "txt_typo",
@@ -12226,7 +12226,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "toponyme_routier_numero_lin",
 		 "minzoom": 7,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "filter": [
 		  "==",
 		  "txt_typo",
@@ -12262,7 +12262,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "toponyme_routier_odonyme_lin",
 		 "minzoom": 15,
-		 "maxzoom": 20,
+		 "maxzoom": 22,
 		 "layout": {
 		  "symbol-placement": "line",
 		  "text-field": "{nom_gauche}",
@@ -12323,7 +12323,7 @@
 		  ]
 		 ],
 		 "layout": {
-		  "visibility": "visible",
+		  "visibility": "none",
 		  "symbol-placement": "point",
 		  "text-field": "{texte}",
 		  "text-size": 11,
@@ -12525,7 +12525,7 @@
 		 "type": "symbol",
 		 "source": "plan_ign",
 		 "source-layer": "toponyme_localite_ponc",
-		 "maxzoom": 18,
+		 "maxzoom": 21,
 		 "filter": [
 		  "==",
 		  "txt_typo",
@@ -12640,7 +12640,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "toponyme_localite_ponc",
 		 "minzoom": 11,
-		 "maxzoom": 13,
+		 "maxzoom": 21,
 		 "filter": [
 		  "in",
 		  "txt_typo",
@@ -13137,7 +13137,7 @@
 		 "source": "plan_ign",
 		 "source-layer": "toponyme_bati_ponc",
 		 "minzoom": 15,
-		 "maxzoom": 16,
+		 "maxzoom": 21,
 		 "filter": [
 		  "==",
 		  "txt_typo",
@@ -13226,7 +13226,7 @@
 		 "type": "symbol",
 		 "source": "plan_ign",
 		 "source-layer": "toponyme_localite_ponc",
-		 "maxzoom": 18,
+		 "maxzoom": 21,
 		 "filter": [
 		  "==",
 		  "txt_typo",
@@ -13266,7 +13266,7 @@
 		 "type": "symbol",
 		 "source": "plan_ign",
 		 "source-layer": "toponyme_localite_ponc",
-		 "maxzoom": 18,
+		 "maxzoom": 21,
 		 "filter": [
 		  "==",
 		  "txt_typo",
@@ -13734,7 +13734,7 @@
 		 "type": "symbol",
 		 "source": "plan_ign",
 		 "source-layer": "toponyme_localite_ponc",
-		 "maxzoom": 18,
+		 "maxzoom": 21,
 		 "filter": [
 		  "all",
 		  [
@@ -13787,7 +13787,7 @@
 		 "type": "symbol",
 		 "source": "plan_ign",
 		 "source-layer": "toponyme_localite_ponc",
-		 "maxzoom": 18,
+		 "maxzoom": 21,
 		 "filter": [
 		  "all",
 		  [
@@ -13914,7 +13914,7 @@
 		 "type": "symbol",
 		 "source": "plan_ign",
 		 "source-layer": "toponyme_localite_ponc",
-		 "maxzoom": 16,
+		 "maxzoom": 21,
 		 "filter": [
 		  "all",
 		  [
@@ -14277,7 +14277,7 @@
 		 "type": "symbol",
 		 "source": "plan_ign",
 		 "source-layer": "toponyme_localite_ponc",
-		 "maxzoom": 16,
+		 "maxzoom": 21,
 		 "filter": [
 		  "all",
 		  [
@@ -14319,7 +14319,7 @@
 		 "type": "symbol",
 		 "source": "plan_ign",
 		 "source-layer": "toponyme_localite_ponc",
-		 "maxzoom": 16,
+		 "maxzoom": 21,
 		 "filter": [
 		  "all",
 		  [
@@ -14361,7 +14361,7 @@
 		 "type": "symbol",
 		 "source": "plan_ign",
 		 "source-layer": "toponyme_localite_ponc",
-		 "maxzoom": 18,
+		 "maxzoom": 21,
 		 "filter": [
 		  "all",
 		  [
@@ -14411,7 +14411,7 @@
 		 "type": "symbol",
 		 "source": "plan_ign",
 		 "source-layer": "toponyme_localite_ponc",
-		 "maxzoom": 18,
+		 "maxzoom": 21,
 		 "filter": [
 		  "all",
 		  [
@@ -14461,7 +14461,7 @@
 		 "type": "symbol",
 		 "source": "plan_ign",
 		 "source-layer": "toponyme_localite_ponc",
-		 "maxzoom": 16,
+		 "maxzoom": 21,
 		 "filter": [
 		  "all",
 		  [
@@ -14503,7 +14503,7 @@
 		 "type": "symbol",
 		 "source": "plan_ign",
 		 "source-layer": "toponyme_localite_ponc",
-		 "maxzoom": 16,
+		 "maxzoom": 21,
 		 "filter": [
 		  "all",
 		  [
@@ -14542,7 +14542,7 @@
 		 "type": "symbol",
 		 "source": "plan_ign",
 		 "source-layer": "toponyme_localite_ponc",
-		 "maxzoom": 16,
+		 "maxzoom": 21,
 		 "filter": [
 		  "all",
 		  [
@@ -14581,7 +14581,7 @@
 		 "type": "symbol",
 		 "source": "plan_ign",
 		 "source-layer": "toponyme_localite_ponc",
-		 "maxzoom": 16,
+		 "maxzoom": 21,
 		 "filter": [
 		  "all",
 		  [
@@ -14688,7 +14688,7 @@
 		 "type": "symbol",
 		 "source": "plan_ign",
 		 "source-layer": "toponyme_localite_ponc",
-		 "maxzoom": 16,
+		 "maxzoom": 21,
 		 "filter": [
 		  "all",
 		  [

--- a/components/map/styles/vector.json
+++ b/components/map/styles/vector.json
@@ -3751,6 +3751,9 @@
 		  "symbol-placement": "line",
 		  "symbol-spacing": 350,
 		  "text-field": "{name:latin} {name:nonlatin}",
+		  "text-font": [
+			"Open Sans Regular"
+		  ],
 		  "text-letter-spacing": 0.2,
 		  "text-max-width": 5,
 		  "text-rotation-alignment": "map",
@@ -3777,6 +3780,9 @@
 		  "symbol-placement": "line",
 		  "symbol-spacing": 350,
 		  "text-field": "{name:latin}\n{name:nonlatin}",
+		  "text-font": [
+			"Open Sans Regular"
+		  ],
 		  "text-letter-spacing": 0.2,
 		  "text-max-width": 5,
 		  "text-rotation-alignment": "map",
@@ -3810,6 +3816,9 @@
 		  "symbol-placement": "point",
 		  "symbol-spacing": 350,
 		  "text-field": "{name:latin}",
+		  "text-font": [
+			"Open Sans Regular"
+		  ],
 		  "text-letter-spacing": 0.2,
 		  "text-max-width": 5,
 		  "text-rotation-alignment": "map",
@@ -3843,6 +3852,9 @@
 		  "symbol-placement": "point",
 		  "symbol-spacing": 350,
 		  "text-field": "{name:latin}\n{name:nonlatin}",
+		  "text-font": [
+			"Open Sans Regular"
+		  ],
 		  "text-letter-spacing": 0.2,
 		  "text-max-width": 5,
 		  "text-rotation-alignment": "map",
@@ -3900,6 +3912,9 @@
 		  "icon-image": "{class}_11",
 		  "text-anchor": "top",
 		  "text-field": "{name:latin}\n{name:nonlatin}",
+		  "text-font": [
+			"Open Sans Regular"
+		  ],
 		  "text-max-width": 9,
 		  "text-offset": [
 			0,
@@ -3955,6 +3970,9 @@
 		  "icon-image": "{class}_11",
 		  "text-anchor": "top",
 		  "text-field": "{name:latin}\n{name:nonlatin}",
+		  "text-font": [
+			"Open Sans Regular"
+		  ],
 		  "text-max-width": 9,
 		  "text-offset": [
 			0,
@@ -4009,6 +4027,9 @@
 		  "icon-image": "{class}_11",
 		  "text-anchor": "top",
 		  "text-field": "{name:latin}\n{name:nonlatin}",
+		  "text-font": [
+			"Open Sans Regular"
+		  ],
 		  "text-max-width": 9,
 		  "text-offset": [
 			0,
@@ -4060,6 +4081,9 @@
 		  "text-allow-overlap": false,
 		  "text-anchor": "top",
 		  "text-field": "{name:latin}\n{name:nonlatin}",
+		  "text-font": [
+			"Open Sans Regular"
+		  ],
 		  "text-ignore-placement": false,
 		  "text-max-width": 9,
 		  "text-offset": [
@@ -4193,6 +4217,9 @@
 		  "icon-size": 1,
 		  "text-anchor": "top",
 		  "text-field": "{name:latin}\n{name:nonlatin}",
+		  "text-font": [
+			"Open Sans Regular"
+		  ],
 		  "text-max-width": 9,
 		  "text-offset": [
 			0,

--- a/components/map/styles/vector.json
+++ b/components/map/styles/vector.json
@@ -1,4246 +1,14854 @@
 {
   "version": 8,
-  "name": "OSM Bright",
+  "name": "PLAN IGN",
   "metadata": {
-    "mapbox:type": "template",
-    "mapbox:groups": {
-      "1444849364238.8171": {
-        "collapsed": false,
-        "name": "Buildings"
-      },
-      "1444849354174.1904": {
-        "collapsed": true,
-        "name": "Tunnels"
-      },
-      "1444849388993.3071": {
-        "collapsed": false,
-        "name": "Land"
-      },
-      "1444849382550.77": {
-        "collapsed": false,
-        "name": "Water"
-      },
-      "1444849345966.4436": {
-        "collapsed": false,
-        "name": "Roads"
-      },
-      "1444849334699.1902": {
-        "collapsed": true,
-        "name": "Bridges"
-      }
-    },
-    "mapbox:autocomposite": false,
-    "openmaptiles:version": "3.x",
-    "openmaptiles:mapbox:owner": "openmaptiles",
-    "openmaptiles:mapbox:source:url": "mapbox://openmaptiles.4qljc88t"
+    "url": "https://wxs.ign.fr/choisirgeoportail/geoportail/tms/1.0.0/PLAN.IGN/metadata.json"
+
   },
   "sources": {
-    "openmaptiles": {
+    "plan_ign": {
       "type": "vector",
-      "url": "https://openmaptiles.geo.data.gouv.fr/data/france-vector.json"
+      "tiles": "https://wxs.ign.fr/essentiels/geoportail/tms/1.0.0/PLAN.IGN/{z}/{x}/{y}.pbf",
+      "scheme": "tms"
+    
     },
     "cadastre": {
       "type": "vector",
-      "url": "https://openmaptiles.geo.data.gouv.fr/data/cadastre.json"
+      "url": "https://wxs.ign.fr/parcellaire/geoportail/wmts?layer=CADASTRALPARCELS.PARCELLAIRE_EXPRESS&style=normal&tilematrixset=PM&Service=WMTS&Request=GetTile&Version=1.0.0&Format=image%2Fjpeg&TileMatrix={z}&TileCol={x}&TileRow={y}"
     },
     "decoupage-administratif": {
       "type": "vector",
-      "url": "https://openmaptiles.geo.data.gouv.fr/data/decoupage-administratif.json"
+      "url": "https://wxs.ign.fr/parcellaire/geoportail/wmts?layer=ADMINEXPRESS-COG-CARTO.LATEST&style=normal&tilematrixset=PM&Service=WMTS&Request=GetTile&Version=1.0.0&Format=image%2Fjpeg&TileMatrix={z}&TileCol={x}&TileRow={y}"
     }
   },
-  "sprite": "https://openmaptiles.github.io/osm-bright-gl-style/sprite",
-  "glyphs": "https://openmaptiles.geo.data.gouv.fr/fonts/{fontstack}/{range}.pbf",
-  "layers": [
-    {
-      "id": "background",
-      "type": "background",
-      "paint": {
-        "background-color": "#f8f4f0"
-      }
-    },
-    {
-      "filter": [
-        "==",
-        "subclass",
-        "glacier"
-      ],
-      "id": "landcover-glacier",
-      "layout": {
-        "visibility": "visible"
-      },
-      "metadata": {
-        "mapbox:group": "1444849388993.3071"
-      },
-      "paint": {
-        "fill-color": "#fff",
-        "fill-opacity": {
-          "base": 1,
-          "stops": [
-            [
-              0,
-              0.9
-            ],
-            [
-              10,
-              0.3
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "landcover",
-      "type": "fill"
-    },
-    {
-      "filter": [
-        "==",
-        "class",
-        "residential"
-      ],
-      "id": "landuse-residential",
-      "metadata": {
-        "mapbox:group": "1444849388993.3071"
-      },
-      "paint": {
-        "fill-color": {
-          "base": 1,
-          "stops": [
-            [
-              12,
-              "hsla(30, 19%, 90%, 0.4)"
-            ],
-            [
-              16,
-              "hsla(30, 19%, 90%, 0.2)"
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "landuse",
-      "type": "fill"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "Polygon"
-        ],
-        [
-          "==",
-          "class",
-          "commercial"
-        ]
-      ],
-      "id": "landuse-commercial",
-      "metadata": {
-        "mapbox:group": "1444849388993.3071"
-      },
-      "paint": {
-        "fill-color": "hsla(0, 60%, 87%, 0.23)"
-      },
-      "source": "openmaptiles",
-      "source-layer": "landuse",
-      "type": "fill"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "Polygon"
-        ],
-        [
-          "==",
-          "class",
-          "industrial"
-        ]
-      ],
-      "id": "landuse-industrial",
-      "metadata": {
-        "mapbox:group": "1444849388993.3071"
-      },
-      "paint": {
-        "fill-color": "hsla(49, 100%, 88%, 0.34)"
-      },
-      "source": "openmaptiles",
-      "source-layer": "landuse",
-      "type": "fill"
-    },
-    {
-      "filter": [
-        "==",
-        "class",
-        "cemetery"
-      ],
-      "id": "landuse-cemetery",
-      "metadata": {
-        "mapbox:group": "1444849388993.3071"
-      },
-      "paint": {
-        "fill-color": "#e0e4dd"
-      },
-      "source": "openmaptiles",
-      "source-layer": "landuse",
-      "type": "fill"
-    },
-    {
-      "filter": [
-        "==",
-        "class",
-        "hospital"
-      ],
-      "id": "landuse-hospital",
-      "metadata": {
-        "mapbox:group": "1444849388993.3071"
-      },
-      "paint": {
-        "fill-color": "#fde"
-      },
-      "source": "openmaptiles",
-      "source-layer": "landuse",
-      "type": "fill"
-    },
-    {
-      "filter": [
-        "==",
-        "class",
-        "school"
-      ],
-      "id": "landuse-school",
-      "metadata": {
-        "mapbox:group": "1444849388993.3071"
-      },
-      "paint": {
-        "fill-color": "#f0e8f8"
-      },
-      "source": "openmaptiles",
-      "source-layer": "landuse",
-      "type": "fill"
-    },
-    {
-      "filter": [
-        "==",
-        "class",
-        "railway"
-      ],
-      "id": "landuse-railway",
-      "metadata": {
-        "mapbox:group": "1444849388993.3071"
-      },
-      "paint": {
-        "fill-color": "hsla(30, 19%, 90%, 0.4)"
-      },
-      "source": "openmaptiles",
-      "source-layer": "landuse",
-      "type": "fill"
-    },
-    {
-      "filter": [
-        "==",
-        "class",
-        "wood"
-      ],
-      "id": "landcover-wood",
-      "metadata": {
-        "mapbox:group": "1444849388993.3071"
-      },
-      "paint": {
-        "fill-antialias": {
-          "base": 1,
-          "stops": [
-            [
-              0,
-              false
-            ],
-            [
-              9,
-              true
-            ]
-          ]
-        },
-        "fill-color": "#6a4",
-        "fill-opacity": 0.1,
-        "fill-outline-color": "hsla(0, 0%, 0%, 0.03)"
-      },
-      "source": "openmaptiles",
-      "source-layer": "landcover",
-      "type": "fill"
-    },
-    {
-      "filter": [
-        "==",
-        "class",
-        "grass"
-      ],
-      "id": "landcover-grass",
-      "metadata": {
-        "mapbox:group": "1444849388993.3071"
-      },
-      "paint": {
-        "fill-color": "#d8e8c8",
-        "fill-opacity": 1
-      },
-      "source": "openmaptiles",
-      "source-layer": "landcover",
-      "type": "fill"
-    },
-    {
-      "filter": [
-        "==",
-        "class",
-        "public_park"
-      ],
-      "id": "landcover-grass-park",
-      "metadata": {
-        "mapbox:group": "1444849388993.3071"
-      },
-      "paint": {
-        "fill-color": "#d8e8c8",
-        "fill-opacity": 0.8
-      },
-      "source": "openmaptiles",
-      "source-layer": "park",
-      "type": "fill"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "in",
-          "class",
-          "river",
-          "stream",
-          "canal"
-        ],
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ]
-      ],
-      "id": "waterway_tunnel",
-      "layout": {
-        "line-cap": "round"
-      },
-      "minzoom": 14,
-      "paint": {
-        "line-color": "#a0c8f0",
-        "line-dasharray": [
-          2,
-          4
-        ],
-        "line-width": {
-          "base": 1.3,
-          "stops": [
-            [
-              13,
-              0.5
-            ],
-            [
-              20,
-              6
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "waterway",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "!in",
-        "class",
-        "canal",
-        "river",
-        "stream"
-      ],
-      "id": "waterway-other",
-      "layout": {
-        "line-cap": "round"
-      },
-      "metadata": {
-        "mapbox:group": "1444849382550.77"
-      },
-      "paint": {
-        "line-color": "#a0c8f0",
-        "line-width": {
-          "base": 1.3,
-          "stops": [
-            [
-              13,
-              0.5
-            ],
-            [
-              20,
-              2
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "waterway",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "in",
-          "class",
-          "canal",
-          "stream"
-        ],
-        [
-          "!=",
-          "brunnel",
-          "tunnel"
-        ]
-      ],
-      "id": "waterway-stream-canal",
-      "layout": {
-        "line-cap": "round"
-      },
-      "metadata": {
-        "mapbox:group": "1444849382550.77"
-      },
-      "paint": {
-        "line-color": "#a0c8f0",
-        "line-width": {
-          "base": 1.3,
-          "stops": [
-            [
-              13,
-              0.5
-            ],
-            [
-              20,
-              6
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "waterway",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "river"
-        ],
-        [
-          "!=",
-          "brunnel",
-          "tunnel"
-        ]
-      ],
-      "id": "waterway-river",
-      "layout": {
-        "line-cap": "round"
-      },
-      "metadata": {
-        "mapbox:group": "1444849382550.77"
-      },
-      "paint": {
-        "line-color": "#a0c8f0",
-        "line-width": {
-          "base": 1.2,
-          "stops": [
-            [
-              10,
-              0.8
-            ],
-            [
-              20,
-              6
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "waterway",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "==",
-        "$type",
-        "Polygon"
-      ],
-      "id": "water-offset",
-      "layout": {
-        "visibility": "visible"
-      },
-      "maxzoom": 8,
-      "metadata": {
-        "mapbox:group": "1444849382550.77"
-      },
-      "paint": {
-        "fill-color": "#a0c8f0",
-        "fill-opacity": 1,
-        "fill-translate": {
-          "base": 1,
-          "stops": [
-            [
-              6,
-              [
-                2,
-                0
-              ]
-            ],
-            [
-              8,
-              [
-                0,
-                0
-              ]
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "water",
-      "type": "fill"
-    },
-    {
-      "id": "water",
-      "layout": {
-        "visibility": "visible"
-      },
-      "metadata": {
-        "mapbox:group": "1444849382550.77"
-      },
-      "paint": {
-        "fill-color": "hsl(210, 67%, 85%)"
-      },
-      "source": "openmaptiles",
-      "source-layer": "water",
-      "type": "fill"
-    },
-    {
-      "filter": [
-        "==",
-        "subclass",
-        "ice_shelf"
-      ],
-      "id": "landcover-ice-shelf",
-      "layout": {
-        "visibility": "visible"
-      },
-      "metadata": {
-        "mapbox:group": "1444849382550.77"
-      },
-      "paint": {
-        "fill-color": "#fff",
-        "fill-opacity": {
-          "base": 1,
-          "stops": [
-            [
-              0,
-              0.9
-            ],
-            [
-              10,
-              0.3
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "landcover",
-      "type": "fill"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "sand"
-        ]
-      ],
-      "id": "landcover-sand",
-      "layout": {
-        "visibility": "visible"
-      },
-      "metadata": {
-        "mapbox:group": "1444849382550.77"
-      },
-      "paint": {
-        "fill-color": "rgba(245, 238, 188, 1)",
-        "fill-opacity": 1
-      },
-      "source": "openmaptiles",
-      "source-layer": "landcover",
-      "type": "fill"
-    },
-    {
-      "id": "building",
-      "metadata": {
-        "mapbox:group": "1444849364238.8171"
-      },
-      "paint": {
-        "fill-antialias": true,
-        "fill-color": {
-          "base": 1,
-          "stops": [
-            [
-              15.5,
-              "#f2eae2"
-            ],
-            [
-              16,
-              "#dfdbd7"
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "building",
-      "type": "fill"
-    },
-    {
-      "id": "building-top",
-      "layout": {
-        "visibility": "visible"
-      },
-      "metadata": {
-        "mapbox:group": "1444849364238.8171"
-      },
-      "paint": {
-        "fill-color": "#f2eae2",
-        "fill-opacity": {
-          "base": 1,
-          "stops": [
-            [
-              13,
-              0
-            ],
-            [
-              16,
-              1
-            ]
-          ]
-        },
-        "fill-outline-color": "#dfdbd7",
-        "fill-translate": {
-          "base": 1,
-          "stops": [
-            [
-              14,
-              [
-                0,
-                0
-              ]
-            ],
-            [
-              16,
-              [
-                -2,
-                -2
-              ]
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "building",
-      "type": "fill"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ],
-        [
-          "in",
-          "class",
-          "service",
-          "track"
-        ]
-      ],
-      "id": "tunnel-service-track-casing",
-      "layout": {
-        "line-join": "round"
-      },
-      "metadata": {
-        "mapbox:group": "1444849354174.1904"
-      },
-      "paint": {
-        "line-color": "#cfcdca",
-        "line-dasharray": [
-          0.5,
-          0.25
-        ],
-        "line-width": {
-          "base": 1.2,
-          "stops": [
-            [
-              15,
-              1
-            ],
-            [
-              16,
-              4
-            ],
-            [
-              20,
-              11
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ],
-        [
-          "==",
-          "class",
-          "minor"
-        ]
-      ],
-      "id": "tunnel-minor-casing",
-      "layout": {
-        "line-join": "round"
-      },
-      "metadata": {
-        "mapbox:group": "1444849354174.1904"
-      },
-      "paint": {
-        "line-color": "#cfcdca",
-        "line-opacity": {
-          "stops": [
-            [
-              12,
-              0
-            ],
-            [
-              12.5,
-              1
-            ]
-          ]
-        },
-        "line-width": {
-          "base": 1.2,
-          "stops": [
-            [
-              12,
-              0.5
-            ],
-            [
-              13,
-              1
-            ],
-            [
-              14,
-              4
-            ],
-            [
-              20,
-              15
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ],
-        [
-          "in",
-          "class",
-          "secondary",
-          "tertiary"
-        ]
-      ],
-      "id": "tunnel-secondary-tertiary-casing",
-      "layout": {
-        "line-join": "round"
-      },
-      "metadata": {
-        "mapbox:group": "1444849354174.1904"
-      },
-      "paint": {
-        "line-color": "#e9ac77",
-        "line-opacity": 1,
-        "line-width": {
-          "base": 1.2,
-          "stops": [
-            [
-              8,
-              1.5
-            ],
-            [
-              20,
-              17
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ],
-        [
-          "in",
-          "class",
-          "primary",
-          "trunk"
-        ]
-      ],
-      "id": "tunnel-trunk-primary-casing",
-      "layout": {
-        "line-join": "round"
-      },
-      "metadata": {
-        "mapbox:group": "1444849354174.1904"
-      },
-      "paint": {
-        "line-color": "#e9ac77",
-        "line-width": {
-          "base": 1.2,
-          "stops": [
-            [
-              5,
-              0.4
-            ],
-            [
-              6,
-              0.6
-            ],
-            [
-              7,
-              1.5
-            ],
-            [
-              20,
-              22
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ],
-        [
-          "==",
-          "class",
-          "motorway"
-        ]
-      ],
-      "id": "tunnel-motorway-casing",
-      "layout": {
-        "line-join": "round",
-        "visibility": "visible"
-      },
-      "metadata": {
-        "mapbox:group": "1444849354174.1904"
-      },
-      "paint": {
-        "line-color": "#e9ac77",
-        "line-dasharray": [
-          0.5,
-          0.25
-        ],
-        "line-width": {
-          "base": 1.2,
-          "stops": [
-            [
-              5,
-              0.4
-            ],
-            [
-              6,
-              0.6
-            ],
-            [
-              7,
-              1.5
-            ],
-            [
-              20,
-              22
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "LineString"
-        ],
-        [
-          "all",
-          [
-            "==",
-            "brunnel",
-            "tunnel"
-          ],
-          [
-            "==",
-            "class",
-            "path"
-          ]
-        ]
-      ],
-      "id": "tunnel-path",
-      "metadata": {
-        "mapbox:group": "1444849354174.1904"
-      },
-      "paint": {
-        "line-color": "#cba",
-        "line-dasharray": [
-          1.5,
-          0.75
-        ],
-        "line-width": {
-          "base": 1.2,
-          "stops": [
-            [
-              15,
-              1.2
-            ],
-            [
-              20,
-              4
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ],
-        [
-          "in",
-          "class",
-          "service",
-          "track"
-        ]
-      ],
-      "id": "tunnel-service-track",
-      "layout": {
-        "line-join": "round"
-      },
-      "metadata": {
-        "mapbox:group": "1444849354174.1904"
-      },
-      "paint": {
-        "line-color": "#fff",
-        "line-width": {
-          "base": 1.2,
-          "stops": [
-            [
-              15.5,
-              0
-            ],
-            [
-              16,
-              2
-            ],
-            [
-              20,
-              7.5
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ],
-        [
-          "==",
-          "class",
-          "minor_road"
-        ]
-      ],
-      "id": "tunnel-minor",
-      "layout": {
-        "line-join": "round"
-      },
-      "metadata": {
-        "mapbox:group": "1444849354174.1904"
-      },
-      "paint": {
-        "line-color": "#fff",
-        "line-opacity": 1,
-        "line-width": {
-          "base": 1.2,
-          "stops": [
-            [
-              13.5,
-              0
-            ],
-            [
-              14,
-              2.5
-            ],
-            [
-              20,
-              11.5
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ],
-        [
-          "in",
-          "class",
-          "secondary",
-          "tertiary"
-        ]
-      ],
-      "id": "tunnel-secondary-tertiary",
-      "layout": {
-        "line-join": "round"
-      },
-      "metadata": {
-        "mapbox:group": "1444849354174.1904"
-      },
-      "paint": {
-        "line-color": "#fff4c6",
-        "line-width": {
-          "base": 1.2,
-          "stops": [
-            [
-              6.5,
-              0
-            ],
-            [
-              7,
-              0.5
-            ],
-            [
-              20,
-              10
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ],
-        [
-          "in",
-          "class",
-          "primary",
-          "trunk"
-        ]
-      ],
-      "id": "tunnel-trunk-primary",
-      "layout": {
-        "line-join": "round"
-      },
-      "metadata": {
-        "mapbox:group": "1444849354174.1904"
-      },
-      "paint": {
-        "line-color": "#fff4c6",
-        "line-width": {
-          "base": 1.2,
-          "stops": [
-            [
-              6.5,
-              0
-            ],
-            [
-              7,
-              0.5
-            ],
-            [
-              20,
-              18
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ],
-        [
-          "==",
-          "class",
-          "motorway"
-        ]
-      ],
-      "id": "tunnel-motorway",
-      "layout": {
-        "line-join": "round",
-        "visibility": "visible"
-      },
-      "metadata": {
-        "mapbox:group": "1444849354174.1904"
-      },
-      "paint": {
-        "line-color": "#ffdaa6",
-        "line-width": {
-          "base": 1.2,
-          "stops": [
-            [
-              6.5,
-              0
-            ],
-            [
-              7,
-              0.5
-            ],
-            [
-              20,
-              18
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ],
-        [
-          "==",
-          "class",
-          "rail"
-        ]
-      ],
-      "id": "tunnel-railway",
-      "metadata": {
-        "mapbox:group": "1444849354174.1904"
-      },
-      "paint": {
-        "line-color": "#bbb",
-        "line-dasharray": [
-          2,
-          2
-        ],
-        "line-width": {
-          "base": 1.4,
-          "stops": [
-            [
-              14,
-              0.4
-            ],
-            [
-              15,
-              0.75
-            ],
-            [
-              20,
-              2
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "in",
-          "class",
-          "ferry"
-        ]
-      ],
-      "id": "ferry",
-      "layout": {
-        "line-join": "round",
-        "visibility": "visible"
-      },
-      "paint": {
-        "line-color": "rgba(108, 159, 182, 1)",
-        "line-dasharray": [
-          2,
-          2
-        ],
-        "line-width": 1.1
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "in",
-          "class",
-          "taxiway"
-        ]
-      ],
-      "id": "aeroway-taxiway-casing",
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round",
-        "visibility": "visible"
-      },
-      "metadata": {
-        "mapbox:group": "1444849345966.4436"
-      },
-      "minzoom": 12,
-      "paint": {
-        "line-color": "rgba(153, 153, 153, 1)",
-        "line-opacity": 1,
-        "line-width": {
-          "base": 1.5,
-          "stops": [
-            [
-              11,
-              2
-            ],
-            [
-              17,
-              12
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "aeroway",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "in",
-          "class",
-          "runway"
-        ]
-      ],
-      "id": "aeroway-runway-casing",
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round",
-        "visibility": "visible"
-      },
-      "metadata": {
-        "mapbox:group": "1444849345966.4436"
-      },
-      "minzoom": 12,
-      "paint": {
-        "line-color": "rgba(153, 153, 153, 1)",
-        "line-opacity": 1,
-        "line-width": {
-          "base": 1.5,
-          "stops": [
-            [
-              11,
-              5
-            ],
-            [
-              17,
-              55
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "aeroway",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "Polygon"
-        ],
-        [
-          "in",
-          "class",
-          "runway",
-          "taxiway"
-        ]
-      ],
-      "id": "aeroway-area",
-      "layout": {
-        "visibility": "visible"
-      },
-      "metadata": {
-        "mapbox:group": "1444849345966.4436"
-      },
-      "minzoom": 4,
-      "paint": {
-        "fill-color": "rgba(255, 255, 255, 1)",
-        "fill-opacity": {
-          "base": 1,
-          "stops": [
-            [
-              13,
-              0
-            ],
-            [
-              14,
-              1
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "aeroway",
-      "type": "fill"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "in",
-          "class",
-          "taxiway"
-        ],
-        [
-          "==",
-          "$type",
-          "LineString"
-        ]
-      ],
-      "id": "aeroway-taxiway",
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round",
-        "visibility": "visible"
-      },
-      "metadata": {
-        "mapbox:group": "1444849345966.4436"
-      },
-      "minzoom": 4,
-      "paint": {
-        "line-color": "rgba(255, 255, 255, 1)",
-        "line-opacity": {
-          "base": 1,
-          "stops": [
-            [
-              11,
-              0
-            ],
-            [
-              12,
-              1
-            ]
-          ]
-        },
-        "line-width": {
-          "base": 1.5,
-          "stops": [
-            [
-              11,
-              1
-            ],
-            [
-              17,
-              10
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "aeroway",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "in",
-          "class",
-          "runway"
-        ],
-        [
-          "==",
-          "$type",
-          "LineString"
-        ]
-      ],
-      "id": "aeroway-runway",
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round",
-        "visibility": "visible"
-      },
-      "metadata": {
-        "mapbox:group": "1444849345966.4436"
-      },
-      "minzoom": 4,
-      "paint": {
-        "line-color": "rgba(255, 255, 255, 1)",
-        "line-opacity": {
-          "base": 1,
-          "stops": [
-            [
-              11,
-              0
-            ],
-            [
-              12,
-              1
-            ]
-          ]
-        },
-        "line-width": {
-          "base": 1.5,
-          "stops": [
-            [
-              11,
-              4
-            ],
-            [
-              17,
-              50
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "aeroway",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "Polygon"
-        ],
-        [
-          "==",
-          "class",
-          "pier"
-        ]
-      ],
-      "id": "road_area_pier",
-      "layout": {
-        "visibility": "visible"
-      },
-      "metadata": {},
-      "paint": {
-        "fill-antialias": true,
-        "fill-color": "#f8f4f0"
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "fill"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "LineString"
-        ],
-        [
-          "in",
-          "class",
-          "pier"
-        ]
-      ],
-      "id": "road_pier",
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
-      "metadata": {},
-      "paint": {
-        "line-color": "#f8f4f0",
-        "line-width": {
-          "base": 1.2,
-          "stops": [
-            [
-              15,
-              1
-            ],
-            [
-              17,
-              4
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "Polygon"
-        ],
-        [
-          "!in",
-          "class",
-          "pier"
-        ]
-      ],
-      "id": "highway-area",
-      "layout": {
-        "visibility": "visible"
-      },
-      "metadata": {
-        "mapbox:group": "1444849345966.4436"
-      },
-      "paint": {
-        "fill-antialias": false,
-        "fill-color": "hsla(0, 0%, 89%, 0.56)",
-        "fill-opacity": 0.9,
-        "fill-outline-color": "#cfcdca"
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "fill"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "!in",
-          "brunnel",
-          "bridge",
-          "tunnel"
-        ],
-        [
-          "==",
-          "class",
-          "motorway_link"
-        ]
-      ],
-      "id": "highway-motorway-link-casing",
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
-      "metadata": {
-        "mapbox:group": "1444849345966.4436"
-      },
-      "minzoom": 12,
-      "paint": {
-        "line-color": "#e9ac77",
-        "line-opacity": 1,
-        "line-width": {
-          "base": 1.2,
-          "stops": [
-            [
-              12,
-              1
-            ],
-            [
-              13,
-              3
-            ],
-            [
-              14,
-              4
-            ],
-            [
-              20,
-              15
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "!in",
-          "brunnel",
-          "bridge",
-          "tunnel"
-        ],
-        [
-          "in",
-          "class",
-          "primary_link",
-          "secondary_link",
-          "tertiary_link",
-          "trunk_link"
-        ]
-      ],
-      "id": "highway-link-casing",
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round",
-        "visibility": "visible"
-      },
-      "metadata": {
-        "mapbox:group": "1444849345966.4436"
-      },
-      "minzoom": 13,
-      "paint": {
-        "line-color": "#e9ac77",
-        "line-opacity": 1,
-        "line-width": {
-          "base": 1.2,
-          "stops": [
-            [
-              12,
-              1
-            ],
-            [
-              13,
-              3
-            ],
-            [
-              14,
-              4
-            ],
-            [
-              20,
-              15
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "LineString"
-        ],
-        [
-          "all",
-          [
-            "!=",
-            "brunnel",
-            "tunnel"
-          ],
-          [
-            "in",
-            "class",
-            "minor",
-            "service",
-            "track"
-          ]
-        ]
-      ],
-      "id": "highway-minor-casing",
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
-      "metadata": {
-        "mapbox:group": "1444849345966.4436"
-      },
-      "paint": {
-        "line-color": "#cfcdca",
-        "line-opacity": {
-          "stops": [
-            [
-              12,
-              0
-            ],
-            [
-              12.5,
-              1
-            ]
-          ]
-        },
-        "line-width": {
-          "base": 1.2,
-          "stops": [
-            [
-              12,
-              0.5
-            ],
-            [
-              13,
-              1
-            ],
-            [
-              14,
-              4
-            ],
-            [
-              20,
-              15
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "!in",
-          "brunnel",
-          "bridge",
-          "tunnel"
-        ],
-        [
-          "in",
-          "class",
-          "secondary",
-          "tertiary"
-        ]
-      ],
-      "id": "highway-secondary-tertiary-casing",
-      "layout": {
-        "line-cap": "butt",
-        "line-join": "round",
-        "visibility": "visible"
-      },
-      "metadata": {
-        "mapbox:group": "1444849345966.4436"
-      },
-      "paint": {
-        "line-color": "#e9ac77",
-        "line-opacity": 1,
-        "line-width": {
-          "base": 1.2,
-          "stops": [
-            [
-              8,
-              1.5
-            ],
-            [
-              20,
-              17
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "!in",
-          "brunnel",
-          "bridge",
-          "tunnel"
-        ],
-        [
-          "in",
-          "class",
-          "primary"
-        ]
-      ],
-      "id": "highway-primary-casing",
-      "layout": {
-        "line-cap": "butt",
-        "line-join": "round",
-        "visibility": "visible"
-      },
-      "metadata": {
-        "mapbox:group": "1444849345966.4436"
-      },
-      "minzoom": 5,
-      "paint": {
-        "line-color": "#e9ac77",
-        "line-opacity": {
-          "stops": [
-            [
-              7,
-              0
-            ],
-            [
-              8,
-              1
-            ]
-          ]
-        },
-        "line-width": {
-          "base": 1.2,
-          "stops": [
-            [
-              7,
-              0
-            ],
-            [
-              8,
-              0.6
-            ],
-            [
-              9,
-              1.5
-            ],
-            [
-              20,
-              22
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "!in",
-          "brunnel",
-          "bridge",
-          "tunnel"
-        ],
-        [
-          "in",
-          "class",
-          "trunk"
-        ]
-      ],
-      "id": "highway-trunk-casing",
-      "layout": {
-        "line-cap": "butt",
-        "line-join": "round",
-        "visibility": "visible"
-      },
-      "metadata": {
-        "mapbox:group": "1444849345966.4436"
-      },
-      "minzoom": 5,
-      "paint": {
-        "line-color": "#e9ac77",
-        "line-opacity": {
-          "stops": [
-            [
-              5,
-              0
-            ],
-            [
-              6,
-              1
-            ]
-          ]
-        },
-        "line-width": {
-          "base": 1.2,
-          "stops": [
-            [
-              5,
-              0
-            ],
-            [
-              6,
-              0.6
-            ],
-            [
-              7,
-              1.5
-            ],
-            [
-              20,
-              22
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "!in",
-          "brunnel",
-          "bridge",
-          "tunnel"
-        ],
-        [
-          "==",
-          "class",
-          "motorway"
-        ]
-      ],
-      "id": "highway-motorway-casing",
-      "layout": {
-        "line-cap": "butt",
-        "line-join": "round",
-        "visibility": "visible"
-      },
-      "metadata": {
-        "mapbox:group": "1444849345966.4436"
-      },
-      "minzoom": 4,
-      "paint": {
-        "line-color": "#e9ac77",
-        "line-opacity": {
-          "stops": [
-            [
-              4,
-              0
-            ],
-            [
-              5,
-              1
-            ]
-          ]
-        },
-        "line-width": {
-          "base": 1.2,
-          "stops": [
-            [
-              4,
-              0
-            ],
-            [
-              5,
-              0.4
-            ],
-            [
-              6,
-              0.6
-            ],
-            [
-              7,
-              1.5
-            ],
-            [
-              20,
-              22
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "LineString"
-        ],
-        [
-          "all",
-          [
-            "!in",
-            "brunnel",
-            "bridge",
-            "tunnel"
-          ],
-          [
-            "==",
-            "class",
-            "path"
-          ]
-        ]
-      ],
-      "id": "highway-path",
-      "metadata": {
-        "mapbox:group": "1444849345966.4436"
-      },
-      "paint": {
-        "line-color": "#cba",
-        "line-dasharray": [
-          1.5,
-          0.75
-        ],
-        "line-width": {
-          "base": 1.2,
-          "stops": [
-            [
-              15,
-              1.2
-            ],
-            [
-              20,
-              4
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "!in",
-          "brunnel",
-          "bridge",
-          "tunnel"
-        ],
-        [
-          "==",
-          "class",
-          "motorway_link"
-        ]
-      ],
-      "id": "highway-motorway-link",
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
-      "metadata": {
-        "mapbox:group": "1444849345966.4436"
-      },
-      "minzoom": 12,
-      "paint": {
-        "line-color": "#fc8",
-        "line-width": {
-          "base": 1.2,
-          "stops": [
-            [
-              12.5,
-              0
-            ],
-            [
-              13,
-              1.5
-            ],
-            [
-              14,
-              2.5
-            ],
-            [
-              20,
-              11.5
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "!in",
-          "brunnel",
-          "bridge",
-          "tunnel"
-        ],
-        [
-          "in",
-          "class",
-          "primary_link",
-          "secondary_link",
-          "tertiary_link",
-          "trunk_link"
-        ]
-      ],
-      "id": "highway-link",
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round",
-        "visibility": "visible"
-      },
-      "metadata": {
-        "mapbox:group": "1444849345966.4436"
-      },
-      "minzoom": 13,
-      "paint": {
-        "line-color": "#fea",
-        "line-width": {
-          "base": 1.2,
-          "stops": [
-            [
-              12.5,
-              0
-            ],
-            [
-              13,
-              1.5
-            ],
-            [
-              14,
-              2.5
-            ],
-            [
-              20,
-              11.5
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "LineString"
-        ],
-        [
-          "all",
-          [
-            "!=",
-            "brunnel",
-            "tunnel"
-          ],
-          [
-            "in",
-            "class",
-            "minor",
-            "service",
-            "track"
-          ]
-        ]
-      ],
-      "id": "highway-minor",
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
-      "metadata": {
-        "mapbox:group": "1444849345966.4436"
-      },
-      "paint": {
-        "line-color": "#fff",
-        "line-opacity": 1,
-        "line-width": {
-          "base": 1.2,
-          "stops": [
-            [
-              13.5,
-              0
-            ],
-            [
-              14,
-              2.5
-            ],
-            [
-              20,
-              11.5
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "!in",
-          "brunnel",
-          "bridge",
-          "tunnel"
-        ],
-        [
-          "in",
-          "class",
-          "secondary",
-          "tertiary"
-        ]
-      ],
-      "id": "highway-secondary-tertiary",
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round",
-        "visibility": "visible"
-      },
-      "metadata": {
-        "mapbox:group": "1444849345966.4436"
-      },
-      "paint": {
-        "line-color": "#fea",
-        "line-width": {
-          "base": 1.2,
-          "stops": [
-            [
-              6.5,
-              0
-            ],
-            [
-              8,
-              0.5
-            ],
-            [
-              20,
-              13
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "LineString"
-        ],
-        [
-          "all",
-          [
-            "!in",
-            "brunnel",
-            "bridge",
-            "tunnel"
-          ],
-          [
-            "in",
-            "class",
-            "primary"
-          ]
-        ]
-      ],
-      "id": "highway-primary",
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round",
-        "visibility": "visible"
-      },
-      "metadata": {
-        "mapbox:group": "1444849345966.4436"
-      },
-      "paint": {
-        "line-color": "#fea",
-        "line-width": {
-          "base": 1.2,
-          "stops": [
-            [
-              8.5,
-              0
-            ],
-            [
-              9,
-              0.5
-            ],
-            [
-              20,
-              18
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "LineString"
-        ],
-        [
-          "all",
-          [
-            "!in",
-            "brunnel",
-            "bridge",
-            "tunnel"
-          ],
-          [
-            "in",
-            "class",
-            "trunk"
-          ]
-        ]
-      ],
-      "id": "highway-trunk",
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round",
-        "visibility": "visible"
-      },
-      "metadata": {
-        "mapbox:group": "1444849345966.4436"
-      },
-      "paint": {
-        "line-color": "#fea",
-        "line-width": {
-          "base": 1.2,
-          "stops": [
-            [
-              6.5,
-              0
-            ],
-            [
-              7,
-              0.5
-            ],
-            [
-              20,
-              18
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "LineString"
-        ],
-        [
-          "all",
-          [
-            "!in",
-            "brunnel",
-            "bridge",
-            "tunnel"
-          ],
-          [
-            "==",
-            "class",
-            "motorway"
-          ]
-        ]
-      ],
-      "id": "highway-motorway",
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round",
-        "visibility": "visible"
-      },
-      "metadata": {
-        "mapbox:group": "1444849345966.4436"
-      },
-      "minzoom": 5,
-      "paint": {
-        "line-color": "#fc8",
-        "line-width": {
-          "base": 1.2,
-          "stops": [
-            [
-              6.5,
-              0
-            ],
-            [
-              7,
-              0.5
-            ],
-            [
-              20,
-              18
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "LineString"
-        ],
-        [
-          "all",
-          [
-            "==",
-            "class",
-            "transit"
-          ],
-          [
-            "!in",
-            "brunnel",
-            "tunnel"
-          ]
-        ]
-      ],
-      "id": "railway-transit",
-      "layout": {
-        "visibility": "visible"
-      },
-      "metadata": {
-        "mapbox:group": "1444849345966.4436"
-      },
-      "paint": {
-        "line-color": "hsla(0, 0%, 73%, 0.77)",
-        "line-width": {
-          "base": 1.4,
-          "stops": [
-            [
-              14,
-              0.4
-            ],
-            [
-              20,
-              1
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "LineString"
-        ],
-        [
-          "all",
-          [
-            "==",
-            "class",
-            "transit"
-          ],
-          [
-            "!in",
-            "brunnel",
-            "tunnel"
-          ]
-        ]
-      ],
-      "id": "railway-transit-hatching",
-      "layout": {
-        "visibility": "visible"
-      },
-      "metadata": {
-        "mapbox:group": "1444849345966.4436"
-      },
-      "paint": {
-        "line-color": "hsla(0, 0%, 73%, 0.68)",
-        "line-dasharray": [
-          0.2,
-          8
-        ],
-        "line-width": {
-          "base": 1.4,
-          "stops": [
-            [
-              14.5,
-              0
-            ],
-            [
-              15,
-              2
-            ],
-            [
-              20,
-              6
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "LineString"
-        ],
-        [
-          "all",
-          [
-            "==",
-            "class",
-            "rail"
-          ],
-          [
-            "has",
-            "service"
-          ]
-        ]
-      ],
-      "id": "railway-service",
-      "metadata": {
-        "mapbox:group": "1444849345966.4436"
-      },
-      "paint": {
-        "line-color": "hsla(0, 0%, 73%, 0.77)",
-        "line-width": {
-          "base": 1.4,
-          "stops": [
-            [
-              14,
-              0.4
-            ],
-            [
-              20,
-              1
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "LineString"
-        ],
-        [
-          "all",
-          [
-            "==",
-            "class",
-            "rail"
-          ],
-          [
-            "has",
-            "service"
-          ]
-        ]
-      ],
-      "id": "railway-service-hatching",
-      "layout": {
-        "visibility": "visible"
-      },
-      "metadata": {
-        "mapbox:group": "1444849345966.4436"
-      },
-      "paint": {
-        "line-color": "hsla(0, 0%, 73%, 0.68)",
-        "line-dasharray": [
-          0.2,
-          8
-        ],
-        "line-width": {
-          "base": 1.4,
-          "stops": [
-            [
-              14.5,
-              0
-            ],
-            [
-              15,
-              2
-            ],
-            [
-              20,
-              6
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "LineString"
-        ],
-        [
-          "all",
-          [
-            "!has",
-            "service"
-          ],
-          [
-            "!in",
-            "brunnel",
-            "bridge",
-            "tunnel"
-          ],
-          [
-            "==",
-            "class",
-            "rail"
-          ]
-        ]
-      ],
-      "id": "railway",
-      "metadata": {
-        "mapbox:group": "1444849345966.4436"
-      },
-      "paint": {
-        "line-color": "#bbb",
-        "line-width": {
-          "base": 1.4,
-          "stops": [
-            [
-              14,
-              0.4
-            ],
-            [
-              15,
-              0.75
-            ],
-            [
-              20,
-              2
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "LineString"
-        ],
-        [
-          "all",
-          [
-            "!has",
-            "service"
-          ],
-          [
-            "!in",
-            "brunnel",
-            "bridge",
-            "tunnel"
-          ],
-          [
-            "==",
-            "class",
-            "rail"
-          ]
-        ]
-      ],
-      "id": "railway-hatching",
-      "metadata": {
-        "mapbox:group": "1444849345966.4436"
-      },
-      "paint": {
-        "line-color": "#bbb",
-        "line-dasharray": [
-          0.2,
-          8
-        ],
-        "line-width": {
-          "base": 1.4,
-          "stops": [
-            [
-              14.5,
-              0
-            ],
-            [
-              15,
-              3
-            ],
-            [
-              20,
-              8
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ],
-        [
-          "==",
-          "class",
-          "motorway_link"
-        ]
-      ],
-      "id": "bridge-motorway-link-casing",
-      "layout": {
-        "line-join": "round"
-      },
-      "metadata": {
-        "mapbox:group": "1444849334699.1902"
-      },
-      "paint": {
-        "line-color": "#e9ac77",
-        "line-opacity": 1,
-        "line-width": {
-          "base": 1.2,
-          "stops": [
-            [
-              12,
-              1
-            ],
-            [
-              13,
-              3
-            ],
-            [
-              14,
-              4
-            ],
-            [
-              20,
-              15
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ],
-        [
-          "in",
-          "class",
-          "primary_link",
-          "secondary_link",
-          "tertiary_link",
-          "trunk_link"
-        ]
-      ],
-      "id": "bridge-link-casing",
-      "layout": {
-        "line-join": "round"
-      },
-      "metadata": {
-        "mapbox:group": "1444849334699.1902"
-      },
-      "paint": {
-        "line-color": "#e9ac77",
-        "line-opacity": 1,
-        "line-width": {
-          "base": 1.2,
-          "stops": [
-            [
-              12,
-              1
-            ],
-            [
-              13,
-              3
-            ],
-            [
-              14,
-              4
-            ],
-            [
-              20,
-              15
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ],
-        [
-          "in",
-          "class",
-          "secondary",
-          "tertiary"
-        ]
-      ],
-      "id": "bridge-secondary-tertiary-casing",
-      "layout": {
-        "line-join": "round"
-      },
-      "metadata": {
-        "mapbox:group": "1444849334699.1902"
-      },
-      "paint": {
-        "line-color": "#e9ac77",
-        "line-opacity": 1,
-        "line-width": {
-          "base": 1.2,
-          "stops": [
-            [
-              8,
-              1.5
-            ],
-            [
-              20,
-              28
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ],
-        [
-          "in",
-          "class",
-          "primary",
-          "trunk"
-        ]
-      ],
-      "id": "bridge-trunk-primary-casing",
-      "layout": {
-        "line-join": "round"
-      },
-      "metadata": {
-        "mapbox:group": "1444849334699.1902"
-      },
-      "paint": {
-        "line-color": "hsl(28, 76%, 67%)",
-        "line-width": {
-          "base": 1.2,
-          "stops": [
-            [
-              5,
-              0.4
-            ],
-            [
-              6,
-              0.6
-            ],
-            [
-              7,
-              1.5
-            ],
-            [
-              20,
-              26
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ],
-        [
-          "==",
-          "class",
-          "motorway"
-        ]
-      ],
-      "id": "bridge-motorway-casing",
-      "layout": {
-        "line-join": "round"
-      },
-      "metadata": {
-        "mapbox:group": "1444849334699.1902"
-      },
-      "paint": {
-        "line-color": "#e9ac77",
-        "line-width": {
-          "base": 1.2,
-          "stops": [
-            [
-              5,
-              0.4
-            ],
-            [
-              6,
-              0.6
-            ],
-            [
-              7,
-              1.5
-            ],
-            [
-              20,
-              22
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "LineString"
-        ],
-        [
-          "all",
-          [
-            "==",
-            "brunnel",
-            "bridge"
-          ],
-          [
-            "==",
-            "class",
-            "path"
-          ]
-        ]
-      ],
-      "id": "bridge-path-casing",
-      "metadata": {
-        "mapbox:group": "1444849334699.1902"
-      },
-      "paint": {
-        "line-color": "#f8f4f0",
-        "line-width": {
-          "base": 1.2,
-          "stops": [
-            [
-              15,
-              1.2
-            ],
-            [
-              20,
-              18
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "LineString"
-        ],
-        [
-          "all",
-          [
-            "==",
-            "brunnel",
-            "bridge"
-          ],
-          [
-            "==",
-            "class",
-            "path"
-          ]
-        ]
-      ],
-      "id": "bridge-path",
-      "metadata": {
-        "mapbox:group": "1444849334699.1902"
-      },
-      "paint": {
-        "line-color": "#cba",
-        "line-dasharray": [
-          1.5,
-          0.75
-        ],
-        "line-width": {
-          "base": 1.2,
-          "stops": [
-            [
-              15,
-              1.2
-            ],
-            [
-              20,
-              4
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ],
-        [
-          "==",
-          "class",
-          "motorway_link"
-        ]
-      ],
-      "id": "bridge-motorway-link",
-      "layout": {
-        "line-join": "round"
-      },
-      "metadata": {
-        "mapbox:group": "1444849334699.1902"
-      },
-      "paint": {
-        "line-color": "#fc8",
-        "line-width": {
-          "base": 1.2,
-          "stops": [
-            [
-              12.5,
-              0
-            ],
-            [
-              13,
-              1.5
-            ],
-            [
-              14,
-              2.5
-            ],
-            [
-              20,
-              11.5
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ],
-        [
-          "in",
-          "class",
-          "primary_link",
-          "secondary_link",
-          "tertiary_link",
-          "trunk_link"
-        ]
-      ],
-      "id": "bridge-link",
-      "layout": {
-        "line-join": "round"
-      },
-      "metadata": {
-        "mapbox:group": "1444849334699.1902"
-      },
-      "paint": {
-        "line-color": "#fea",
-        "line-width": {
-          "base": 1.2,
-          "stops": [
-            [
-              12.5,
-              0
-            ],
-            [
-              13,
-              1.5
-            ],
-            [
-              14,
-              2.5
-            ],
-            [
-              20,
-              11.5
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ],
-        [
-          "in",
-          "class",
-          "secondary",
-          "tertiary"
-        ]
-      ],
-      "id": "bridge-secondary-tertiary",
-      "layout": {
-        "line-join": "round"
-      },
-      "metadata": {
-        "mapbox:group": "1444849334699.1902"
-      },
-      "paint": {
-        "line-color": "#fea",
-        "line-width": {
-          "base": 1.2,
-          "stops": [
-            [
-              6.5,
-              0
-            ],
-            [
-              7,
-              0.5
-            ],
-            [
-              20,
-              20
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ],
-        [
-          "in",
-          "class",
-          "primary",
-          "trunk"
-        ]
-      ],
-      "id": "bridge-trunk-primary",
-      "layout": {
-        "line-join": "round"
-      },
-      "metadata": {
-        "mapbox:group": "1444849334699.1902"
-      },
-      "paint": {
-        "line-color": "#fea",
-        "line-width": {
-          "base": 1.2,
-          "stops": [
-            [
-              6.5,
-              0
-            ],
-            [
-              7,
-              0.5
-            ],
-            [
-              20,
-              18
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ],
-        [
-          "==",
-          "class",
-          "motorway"
-        ]
-      ],
-      "id": "bridge-motorway",
-      "layout": {
-        "line-join": "round"
-      },
-      "metadata": {
-        "mapbox:group": "1444849334699.1902"
-      },
-      "paint": {
-        "line-color": "#fc8",
-        "line-width": {
-          "base": 1.2,
-          "stops": [
-            [
-              6.5,
-              0
-            ],
-            [
-              7,
-              0.5
-            ],
-            [
-              20,
-              18
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ],
-        [
-          "==",
-          "class",
-          "rail"
-        ]
-      ],
-      "id": "bridge-railway",
-      "metadata": {
-        "mapbox:group": "1444849334699.1902"
-      },
-      "paint": {
-        "line-color": "#bbb",
-        "line-width": {
-          "base": 1.4,
-          "stops": [
-            [
-              14,
-              0.4
-            ],
-            [
-              15,
-              0.75
-            ],
-            [
-              20,
-              2
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ],
-        [
-          "==",
-          "class",
-          "rail"
-        ]
-      ],
-      "id": "bridge-railway-hatching",
-      "metadata": {
-        "mapbox:group": "1444849334699.1902"
-      },
-      "paint": {
-        "line-color": "#bbb",
-        "line-dasharray": [
-          0.2,
-          8
-        ],
-        "line-width": {
-          "base": 1.4,
-          "stops": [
-            [
-              14.5,
-              0
-            ],
-            [
-              15,
-              3
-            ],
-            [
-              20,
-              8
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "==",
-        "class",
-        "cable_car"
-      ],
-      "id": "cablecar",
-      "layout": {
-        "line-cap": "round",
-        "visibility": "visible"
-      },
-      "minzoom": 13,
-      "paint": {
-        "line-color": "hsl(0, 0%, 70%)",
-        "line-width": {
-          "base": 1,
-          "stops": [
-            [
-              11,
-              1
-            ],
-            [
-              19,
-              2.5
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "==",
-        "class",
-        "cable_car"
-      ],
-      "id": "cablecar-dash",
-      "layout": {
-        "line-cap": "round",
-        "visibility": "visible"
-      },
-      "minzoom": 13,
-      "paint": {
-        "line-color": "hsl(0, 0%, 70%)",
-        "line-dasharray": [
-          2,
-          3
-        ],
-        "line-width": {
-          "base": 1,
-          "stops": [
-            [
-              11,
-              3
-            ],
-            [
-              19,
-              5.5
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          ">=",
-          "admin_level",
-          4
-        ],
-        [
-          "<=",
-          "admin_level",
-          8
-        ],
-        [
-          "!=",
-          "maritime",
-          1
-        ]
-      ],
-      "id": "boundary-land-level-4",
-      "layout": {
-        "line-join": "round"
-      },
-      "paint": {
-        "line-color": "#9e9cab",
-        "line-dasharray": [
-          3,
-          1,
-          1,
-          1
-        ],
-        "line-width": {
-          "base": 1.4,
-          "stops": [
-            [
-              4,
-              0.4
-            ],
-            [
-              5,
-              1
-            ],
-            [
-              12,
-              3
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "boundary",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "admin_level",
-          2
-        ],
-        [
-          "!=",
-          "maritime",
-          1
-        ],
-        [
-          "!=",
-          "disputed",
-          1
-        ]
-      ],
-      "id": "boundary-land-level-2",
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
-      "paint": {
-        "line-color": "hsl(248, 7%, 66%)",
-        "line-width": {
-          "base": 1,
-          "stops": [
-            [
-              0,
-              0.6
-            ],
-            [
-              4,
-              1.4
-            ],
-            [
-              5,
-              2
-            ],
-            [
-              12,
-              8
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "boundary",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "!=",
-          "maritime",
-          1
-        ],
-        [
-          "==",
-          "disputed",
-          1
-        ]
-      ],
-      "id": "boundary-land-disputed",
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
-      "paint": {
-        "line-color": "hsl(248, 7%, 70%)",
-        "line-dasharray": [
-          1,
-          3
-        ],
-        "line-width": {
-          "base": 1,
-          "stops": [
-            [
-              0,
-              0.6
-            ],
-            [
-              4,
-              1.4
-            ],
-            [
-              5,
-              2
-            ],
-            [
-              12,
-              8
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "boundary",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "in",
-          "admin_level",
-          2,
-          4
-        ],
-        [
-          "==",
-          "maritime",
-          1
-        ]
-      ],
-      "id": "boundary-water",
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
-      "paint": {
-        "line-color": "rgba(154, 189, 214, 1)",
-        "line-opacity": {
-          "stops": [
-            [
-              6,
-              0.6
-            ],
-            [
-              10,
-              1
-            ]
-          ]
-        },
-        "line-width": {
-          "base": 1,
-          "stops": [
-            [
-              0,
-              0.6
-            ],
-            [
-              4,
-              1.4
-            ],
-            [
-              5,
-              2
-            ],
-            [
-              12,
-              8
-            ]
-          ]
-        }
-      },
-      "source": "openmaptiles",
-      "source-layer": "boundary",
-      "type": "line"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "LineString"
-        ],
-        [
-          "has",
-          "name"
-        ]
-      ],
-      "id": "waterway-name",
-      "layout": {
-        "symbol-placement": "line",
-        "symbol-spacing": 350,
-        "text-field": "{name:latin} {name:nonlatin}",
-        "text-font": [
-          "Noto Sans Italic"
-        ],
-        "text-letter-spacing": 0.2,
-        "text-max-width": 5,
-        "text-rotation-alignment": "map",
-        "text-size": 14
-      },
-      "minzoom": 13,
-      "paint": {
-        "text-color": "#74aee9",
-        "text-halo-color": "rgba(255,255,255,0.7)",
-        "text-halo-width": 1.5
-      },
-      "source": "openmaptiles",
-      "source-layer": "waterway",
-      "type": "symbol"
-    },
-    {
-      "filter": [
-        "==",
-        "$type",
-        "LineString"
-      ],
-      "id": "water-name-lakeline",
-      "layout": {
-        "symbol-placement": "line",
-        "symbol-spacing": 350,
-        "text-field": "{name:latin}\n{name:nonlatin}",
-        "text-font": [
-          "Noto Sans Italic"
-        ],
-        "text-letter-spacing": 0.2,
-        "text-max-width": 5,
-        "text-rotation-alignment": "map",
-        "text-size": 14
-      },
-      "paint": {
-        "text-color": "#74aee9",
-        "text-halo-color": "rgba(255,255,255,0.7)",
-        "text-halo-width": 1.5
-      },
-      "source": "openmaptiles",
-      "source-layer": "water_name",
-      "type": "symbol"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "Point"
-        ],
-        [
-          "==",
-          "class",
-          "ocean"
-        ]
-      ],
-      "id": "water-name-ocean",
-      "layout": {
-        "symbol-placement": "point",
-        "symbol-spacing": 350,
-        "text-field": "{name:latin}",
-        "text-font": [
-          "Noto Sans Italic"
-        ],
-        "text-letter-spacing": 0.2,
-        "text-max-width": 5,
-        "text-rotation-alignment": "map",
-        "text-size": 14
-      },
-      "paint": {
-        "text-color": "#74aee9",
-        "text-halo-color": "rgba(255,255,255,0.7)",
-        "text-halo-width": 1.5
-      },
-      "source": "openmaptiles",
-      "source-layer": "water_name",
-      "type": "symbol"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "Point"
-        ],
-        [
-          "!in",
-          "class",
-          "ocean"
-        ]
-      ],
-      "id": "water-name-other",
-      "layout": {
-        "symbol-placement": "point",
-        "symbol-spacing": 350,
-        "text-field": "{name:latin}\n{name:nonlatin}",
-        "text-font": [
-          "Noto Sans Italic"
-        ],
-        "text-letter-spacing": 0.2,
-        "text-max-width": 5,
-        "text-rotation-alignment": "map",
-        "text-size": {
-          "stops": [
-            [
-              0,
-              10
-            ],
-            [
-              6,
-              14
-            ]
-          ]
-        },
-        "visibility": "visible"
-      },
-      "paint": {
-        "text-color": "#74aee9",
-        "text-halo-color": "rgba(255,255,255,0.7)",
-        "text-halo-width": 1.5
-      },
-      "source": "openmaptiles",
-      "source-layer": "water_name",
-      "type": "symbol"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "Point"
-        ],
-        [
-          ">=",
-          "rank",
-          25
-        ],
-        [
-          "any",
-          [
-            "!has",
-            "level"
-          ],
-          [
-            "==",
-            "level",
-            0
-          ]
-        ]
-      ],
-      "id": "poi-level-3",
-      "layout": {
-        "icon-image": "{class}_11",
-        "text-anchor": "top",
-        "text-field": "{name:latin}\n{name:nonlatin}",
-        "text-font": [
-          "Noto Sans Regular"
-        ],
-        "text-max-width": 9,
-        "text-offset": [
-          0,
-          0.6
-        ],
-        "text-padding": 2,
-        "text-size": 12
-      },
-      "minzoom": 16,
-      "paint": {
-        "text-color": "#666",
-        "text-halo-blur": 0.5,
-        "text-halo-color": "#ffffff",
-        "text-halo-width": 1
-      },
-      "source": "openmaptiles",
-      "source-layer": "poi",
-      "type": "symbol"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "Point"
-        ],
-        [
-          "<=",
-          "rank",
-          24
-        ],
-        [
-          ">=",
-          "rank",
-          15
-        ],
-        [
-          "any",
-          [
-            "!has",
-            "level"
-          ],
-          [
-            "==",
-            "level",
-            0
-          ]
-        ]
-      ],
-      "id": "poi-level-2",
-      "layout": {
-        "icon-image": "{class}_11",
-        "text-anchor": "top",
-        "text-field": "{name:latin}\n{name:nonlatin}",
-        "text-font": [
-          "Noto Sans Regular"
-        ],
-        "text-max-width": 9,
-        "text-offset": [
-          0,
-          0.6
-        ],
-        "text-padding": 2,
-        "text-size": 12
-      },
-      "minzoom": 15,
-      "paint": {
-        "text-color": "#666",
-        "text-halo-blur": 0.5,
-        "text-halo-color": "#ffffff",
-        "text-halo-width": 1
-      },
-      "source": "openmaptiles",
-      "source-layer": "poi",
-      "type": "symbol"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "Point"
-        ],
-        [
-          "<=",
-          "rank",
-          14
-        ],
-        [
-          "has",
-          "name"
-        ],
-        [
-          "any",
-          [
-            "!has",
-            "level"
-          ],
-          [
-            "==",
-            "level",
-            0
-          ]
-        ]
-      ],
-      "id": "poi-level-1",
-      "layout": {
-        "icon-image": "{class}_11",
-        "text-anchor": "top",
-        "text-field": "{name:latin}\n{name:nonlatin}",
-        "text-font": [
-          "Noto Sans Regular"
-        ],
-        "text-max-width": 9,
-        "text-offset": [
-          0,
-          0.6
-        ],
-        "text-padding": 2,
-        "text-size": 12
-      },
-      "minzoom": 14,
-      "paint": {
-        "text-color": "#666",
-        "text-halo-blur": 0.5,
-        "text-halo-color": "#ffffff",
-        "text-halo-width": 1
-      },
-      "source": "openmaptiles",
-      "source-layer": "poi",
-      "type": "symbol"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "Point"
-        ],
-        [
-          "has",
-          "name"
-        ],
-        [
-          "==",
-          "class",
-          "railway"
-        ],
-        [
-          "==",
-          "subclass",
-          "station"
-        ]
-      ],
-      "id": "poi-railway",
-      "layout": {
-        "icon-allow-overlap": false,
-        "icon-ignore-placement": false,
-        "icon-image": "{class}_11",
-        "icon-optional": false,
-        "text-allow-overlap": false,
-        "text-anchor": "top",
-        "text-field": "{name:latin}\n{name:nonlatin}",
-        "text-font": [
-          "Noto Sans Regular"
-        ],
-        "text-ignore-placement": false,
-        "text-max-width": 9,
-        "text-offset": [
-          0,
-          0.6
-        ],
-        "text-optional": true,
-        "text-padding": 2,
-        "text-size": 12
-      },
-      "minzoom": 13,
-      "paint": {
-        "text-color": "#666",
-        "text-halo-blur": 0.5,
-        "text-halo-color": "#ffffff",
-        "text-halo-width": 1
-      },
-      "source": "openmaptiles",
-      "source-layer": "poi",
-      "type": "symbol"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "oneway",
-          1
-        ],
-        [
-          "in",
-          "class",
-          "motorway",
-          "trunk",
-          "primary",
-          "secondary",
-          "tertiary",
-          "minor",
-          "service"
-        ]
-      ],
-      "id": "road_oneway",
-      "layout": {
-        "icon-image": "oneway",
-        "icon-padding": 2,
-        "icon-rotate": 90,
-        "icon-rotation-alignment": "map",
-        "icon-size": {
-          "stops": [
-            [
-              15,
-              0.5
-            ],
-            [
-              19,
-              1
-            ]
-          ]
-        },
-        "symbol-placement": "line",
-        "symbol-spacing": 75
-      },
-      "minzoom": 15,
-      "paint": {
-        "icon-opacity": 0.5
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "symbol"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "==",
-          "oneway",
-          -1
-        ],
-        [
-          "in",
-          "class",
-          "motorway",
-          "trunk",
-          "primary",
-          "secondary",
-          "tertiary",
-          "minor",
-          "service"
-        ]
-      ],
-      "id": "road_oneway_opposite",
-      "layout": {
-        "icon-image": "oneway",
-        "icon-padding": 2,
-        "icon-rotate": -90,
-        "icon-rotation-alignment": "map",
-        "icon-size": {
-          "stops": [
-            [
-              15,
-              0.5
-            ],
-            [
-              19,
-              1
-            ]
-          ]
-        },
-        "symbol-placement": "line",
-        "symbol-spacing": 75
-      },
-      "minzoom": 15,
-      "paint": {
-        "icon-opacity": 0.5
-      },
-      "source": "openmaptiles",
-      "source-layer": "transportation",
-      "type": "symbol"
-    },
-    {
-      "filter": [
-        "all",
-        [
-          "has",
-          "iata"
-        ]
-      ],
-      "id": "airport-label-major",
-      "layout": {
-        "icon-image": "airport_11",
-        "icon-size": 1,
-        "text-anchor": "top",
-        "text-field": "{name:latin}\n{name:nonlatin}",
-        "text-font": [
-          "Noto Sans Regular"
-        ],
-        "text-max-width": 9,
-        "text-offset": [
-          0,
-          0.6
-        ],
-        "text-optional": true,
-        "text-padding": 2,
-        "text-size": 12,
-        "visibility": "visible"
-      },
-      "minzoom": 10,
-      "paint": {
-        "text-color": "#666",
-        "text-halo-blur": 0.5,
-        "text-halo-color": "#ffffff",
-        "text-halo-width": 1
-      },
-      "source": "openmaptiles",
-      "source-layer": "aerodrome_label",
-      "type": "symbol"
+  "sprite": "https://wxs.ign.fr/static/vectorTiles/styles/PLAN.IGN/sprite/PlanIgn",
+  "glyphs": "https://wxs.ign.fr/static/vectorTiles/styles/PLAN.IGN/sprite/PlanIgn",
+  "transition": {
+    "duration": 300,
+    "delay": 0
+   },
+
+"layers": [
+   {
+    "id": "bckgrd",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "fond_opaque",
+    "minzoom": 0,
+    "layout": {
+     "visibility": "visible"
+    },
+    "paint": {
+     "fill-color": "#ffffff",
+     "fill-opacity": 1
     }
-  ],
-  "id": "osm-bright"
-}
+   },
+   {
+    "id": "orographie : relief - 0m",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "oro_relief",
+    "minzoom": 0,
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "HYPSO_0"
+    ],
+    "paint": {
+     "fill-color": "#D6E5BA",
+     "fill-opacity": 1
+    }
+   },
+   {
+    "id": "orographie : relief - 100m",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "oro_relief",
+    "minzoom": 0,
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "HYPSO_100"
+    ],
+    "paint": {
+     "fill-color": "#F7F2DA",
+     "fill-opacity": 1
+    }
+   },
+   {
+    "id": "orographie : relief - 200m",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "oro_relief",
+    "minzoom": 0,
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "HYPSO_200"
+    ],
+    "paint": {
+     "fill-color": "#EBDEBF",
+     "fill-opacity": 1
+    }
+   },
+   {
+    "id": "orographie : relief - 1000m",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "oro_relief",
+    "minzoom": 0,
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "HYPSO_1000"
+    ],
+    "paint": {
+     "fill-color": "#DABE97",
+     "fill-opacity": 1
+    }
+   },
+   {
+    "id": "orographie : relief - 3000m",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "oro_relief",
+    "minzoom": 0,
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "HYPSO_3000"
+    ],
+    "paint": {
+     "fill-color": "#B28773",
+     "fill-opacity": 1
+    }
+   },
+   {
+    "id": "orographie : relief - 4000m",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "oro_relief",
+    "minzoom": 0,
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "HYPSO_4000"
+    ],
+    "paint": {
+     "fill-color": "#9E6A54",
+     "fill-opacity": 1
+    }
+   },
+   {
+    "id": "orographie : relief - 5000m",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "oro_relief",
+    "minzoom": 0,
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "HYPSO_5000"
+    ],
+    "paint": {
+     "fill-color": "#773A2B",
+     "fill-opacity": 1
+    }
+   },
+   {
+    "id": "orographie : relief - glacier",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "oro_relief",
+    "minzoom": 0,
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "GLACIER"
+    ],
+    "paint": {
+     "fill-color": "#FFFFFF",
+     "fill-opacity": 0.7
+    }
+   },
+   {
+    "id": "ocs - vegetation - zone boiséee, foret fermee, peupleraie",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "ocs_vegetation_surf",
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "ZONE_BOISEE",
+     "ZONE_FORET_FERMEE_FEUIL",
+     "ZONE_FORET_FERMEE_CONI",
+     "ZONE_FORET_FERMEE_MIXTE",
+     "ZONE_PEUPLERAIE"
+    ],
+    "paint": {
+     "fill-color": "#DFE8D5",
+     "fill-outline-color": "#DFE8D5"
+    }
+   },
+   {
+    "id": "ocs - vegetation - forêt ouverte",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "ocs_vegetation_surf",
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "ZONE_FORET_OUVERTE"
+    ],
+    "paint": {
+     "fill-color": "#EDF2D9",
+     "fill-outline-color": "#EDF2D9"
+    }
+   },
+   {
+    "id": "ocs - vegetation - lande ligneuse",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "ocs_vegetation_surf",
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "ZONE_LANDE_LIGNEUSE"
+    ],
+    "paint": {
+     "fill-color": "#F2EECD"
+    }
+   },
+   {
+    "id": "ocs - vegetation - vigne",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "ocs_vegetation_surf",
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "ZONE_VIGNE"
+    ],
+    "paint": {
+     "fill-color": "#FFEDD9"
+    }
+   },
+   {
+    "id": "ocs - vegetation - verger",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "ocs_vegetation_surf",
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "ZONE_VERGER"
+    ],
+    "paint": {
+     "fill-color": "#FAE2C5"
+    }
+   },
+   {
+    "id": "ocs - vegetation - canne à sucre, bananeraie",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "ocs_vegetation_surf",
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "ZONE_CANNE_BANANE"
+    ],
+    "paint": {
+     "fill-color": "#FAEDFA"
+    }
+   },
+   {
+    "id": "hydro surfacique - Estran",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "hydro_surf",
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "ZONE_D_ESTRAN"
+    ],
+    "paint": {
+     "fill-color": "#C3DDE9",
+     "fill-outline-color": "#C3DDE9"
+    }
+   },
+   {
+    "id": "ocs - vegetation - mangrovre",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "ocs_vegetation_surf",
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "ZONE_MANGROVE"
+    ],
+    "paint": {
+     "fill-color": {
+      "stops": [
+       [
+        9,
+        "#85CCCB"
+       ],
+       [
+        10,
+        "#90CCCB"
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "ocs - vegetation - marais",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "ocs_vegetation_surf",
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "ZONE_MARAIS"
+    ],
+    "paint": {
+     "fill-pattern": "Marais"
+    }
+   },
+   {
+    "id": "ocs - vegetation - marais salant",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "ocs_vegetation_surf",
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "ZONE_MARAIS_SALANT"
+    ],
+    "paint": {
+     "fill-pattern": "MaraisSalant"
+    }
+   },
+   {
+    "id": "ocs - Zone",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "ocs_nature_sol_surf",
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "ZONE_ROCHEUSE"
+    ],
+    "paint": {
+     "fill-color": "#D0D0D0",
+     "fill-opacity": 0.3
+    }
+   },
+   {
+    "id": "ocs - Zone sable sec",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "ocs_nature_sol_surf",
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "ZONE_SABLE_SEC"
+    ],
+    "paint": {
+     "fill-pattern": "Sable"
+    }
+   },
+   {
+    "id": "ocs - Zone sable humide",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "ocs_nature_sol_surf",
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "ZONE_SABLE_HUMIDE",
+     "FOND_CUVETTE_HUMIDE"
+    ],
+    "paint": {
+     "fill-pattern": "SableHumide"
+    }
+   },
+   {
+    "id": "ocs - Zone graviers galets secs",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "ocs_nature_sol_surf",
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "GRAVIERS_GALETS_SEC"
+    ],
+    "paint": {
+     "fill-pattern": "GravierSec"
+    }
+   },
+   {
+    "id": "ocs - Zone graviers galets humides",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "ocs_nature_sol_surf",
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "GRAVIERS_GALETS_HUM"
+    ],
+    "paint": {
+     "fill-pattern": "Gravier"
+    }
+   },
+   {
+    "id": "ocs - Zone rocher hydro",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "ocs_nature_sol_surf",
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "ZONE_ROCHER_HYDRO"
+    ],
+    "paint": {
+     "fill-pattern": "RocherHydro"
+    }
+   },
+   {
+    "id": "ocs - Zone glacier",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "ocs_nature_sol_surf",
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "ZONE_GLACIER"
+    ],
+    "paint": {
+     "fill-pattern": "Glacier",
+     "fill-opacity": {
+      "stops": [
+       [
+        10,
+        0.5
+       ],
+       [
+        12,
+        0.3
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "zone batie",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "bati_zone_surf",
+    "minzoom": 7,
+    "maxzoom": 15,
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "ZONE_BATI"
+    ],
+    "paint": {
+     "fill-color": "#E8E2D1",
+     "fill-opacity": {
+      "stops": [
+       [
+        12,
+        1
+       ],
+       [
+        13,
+        0.9
+       ],
+       [
+        14,
+        0.5
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "zone d'activité",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "bati_zone_surf",
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "ZONE_INDUS_ACTI"
+    ],
+    "paint": {
+     "fill-color": "#D9D9D9"
+    }
+   },
+   {
+    "id": "oro - courbe et cuvette maitresse",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "oro_courbe",
+    "maxzoom": 16,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "CNV_MAITRESSE",
+     "CUVETTE_MAITRESSE"
+    ],
+    "paint": {
+     "line-color": "#D9C8A9",
+     "line-width": {
+      "stops": [
+       [
+        13,
+        1.7
+       ],
+       [
+        15,
+        2
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "oro - courbe et cuvette normale",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "oro_courbe",
+    "maxzoom": 16,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "CNV_NORMALE",
+     "CUVETTE_NORMALE"
+    ],
+    "paint": {
+     "line-color": "#D9C8A9",
+     "line-width": {
+      "stops": [
+       [
+        13,
+        1
+       ],
+       [
+        15,
+        1.2
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "oro - courbe et cuvette intercalaire",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "oro_courbe",
+    "maxzoom": 16,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "CNV_INTERCALAIRE",
+     "CUVETTE_INTERCAL",
+     "CNV_SS_INTERCALAIRE"
+    ],
+    "paint": {
+     "line-color": "#D9C8A9",
+     "line-width": 0.7,
+     "line-dasharray": [
+      20,
+      7
+     ]
+    }
+   },
+   {
+    "id": "oro - courbe et cuvette glacier maitresse",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "oro_courbe",
+    "maxzoom": 16,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "CNV_GLACIER_MAITRESSE",
+     "CUV_GLACIER_MAITRESSE"
+    ],
+    "paint": {
+     "line-color": "#A4BFD9",
+     "line-width": {
+      "stops": [
+       [
+        13,
+        1.7
+       ],
+       [
+        15,
+        2
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "oro - courbe et cuvette glacier normale",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "oro_courbe",
+    "maxzoom": 16,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "CNV_GLACIER_NORMALE",
+     "CUV_GLACIER_NORMALE"
+    ],
+    "paint": {
+     "line-color": "#A4BFD9",
+     "line-width": {
+      "stops": [
+       [
+        13,
+        1
+       ],
+       [
+        15,
+        1.2
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "oro - courbe et cuvette glacier intercalaire",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "oro_courbe",
+    "maxzoom": 16,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "CNV_GLACIER_INTERCAL",
+     "CUV_GLACIER_INTERCAL"
+    ],
+    "paint": {
+     "line-color": "#A4BFD9",
+     "line-width": {
+      "stops": [
+       [
+        13,
+        0.7
+       ],
+       [
+        15,
+        0.9
+       ]
+      ]
+     },
+     "line-dasharray": [
+      20,
+      7
+     ]
+    }
+   },
+   {
+    "id": "oro - courbe et cuvette rocher maitresse",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "oro_courbe",
+    "maxzoom": 16,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "CNV_ROCHER_MAITRESSE",
+     "CUV_ROCHER_MAITRESSE"
+    ],
+    "paint": {
+     "line-color": "#AAAAAA",
+     "line-width": 1.7
+    }
+   },
+   {
+    "id": "oro - courbe et cuvette rocher normale",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "oro_courbe",
+    "maxzoom": 16,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "CNV_ROCHER_NORMALE",
+     "CUV_ROCHER_NORMALE"
+    ],
+    "paint": {
+     "line-color": "#AAAAAA",
+     "line-width": 1
+    }
+   },
+   {
+    "id": "oro - courbe et cuvette rocher intercalaire",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "oro_courbe",
+    "maxzoom": 16,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "CNV_ROCHER_INTERCAL",
+     "CUV_ROCHER_INTERCAL"
+    ],
+    "paint": {
+     "line-color": "#AAAAAA",
+     "line-width": {
+      "stops": [
+       [
+        13,
+        0.7
+       ],
+       [
+        15,
+        0.9
+       ]
+      ]
+     },
+     "line-dasharray": [
+      20,
+      7
+     ]
+    }
+   },
+   {
+    "id": "oro - courbe et cuvette bathymetrique",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "oro_courbe",
+    "maxzoom": 16,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "CNV_BATHYMETRIQUE",
+     "CUV_BATHYMETRIQUE"
+    ],
+    "paint": {
+     "line-color": "#0000FF",
+     "line-width": 1
+    }
+   },
+   {
+    "id": "oro lin - talus",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "oro_lin",
+    "minzoom": 14,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "TALUS"
+    ],
+    "paint": {
+     "line-color": "#D9C8A9",
+     "line-width": 1
+    }
+   },
+   {
+    "id": "oro lin - talus - trait perpendiculaire",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "oro_lin",
+    "minzoom": 14,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "TALUS"
+    ],
+    "paint": {
+     "line-color": "#D9C8A9",
+     "line-width": {
+      "stops": [
+       [
+        14,
+        7
+       ],
+       [
+        16,
+        9
+       ]
+      ]
+     },
+     "line-dasharray": [
+      0.1,
+      1
+     ],
+     "line-translate": [
+      0,
+      4
+     ]
+    }
+   },
+   {
+    "id": "toponyme - cote de courbe normale",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "oro_courbe",
+    "minzoom": 13,
+    "maxzoom": 16,
+    "layout": {
+     "symbol-placement": "line",
+     "text-field": "{texte}",
+     "text-size": {
+      "stops": [
+       [
+        13,
+        10
+       ],
+       [
+        15,
+        13
+       ]
+      ]
+     },
+     "text-anchor": "center",
+     "text-rotation-alignment": "map",
+     "text-pitch-alignment": "viewport",
+     "text-keep-upright": false,
+     "text-max-angle": 20,
+     "text-max-width": 100,
+     "text-font": [
+      "Source Sans Pro Italic"
+     ]
+    },
+    "filter": [
+     "all",
+     [
+      "!=",
+      "texte",
+      "0"
+     ],
+     [
+      "==",
+      "hors_zone",
+      "true"
+     ],
+     [
+      "in",
+      "symbo",
+      "CNV_MAITRESSE",
+      "CUVETTE_MAITRESSE"
+     ]
+    ],
+    "paint": {
+     "text-color": "#604A2F",
+     "text-halo-width": 0.5,
+     "text-halo-color": "#FFFFFF"
+    }
+   },
+   {
+    "id": "toponyme - cote de courbe rocher",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "oro_courbe",
+    "minzoom": 13,
+    "maxzoom": 16,
+    "layout": {
+     "symbol-placement": "line",
+     "text-field": "{texte}",
+     "text-size": {
+      "stops": [
+       [
+        13,
+        10
+       ],
+       [
+        15,
+        13
+       ]
+      ]
+     },
+     "text-anchor": "center",
+     "text-rotation-alignment": "map",
+     "text-pitch-alignment": "viewport",
+     "text-keep-upright": false,
+     "text-max-angle": 20,
+     "text-max-width": 100,
+     "text-font": [
+      "Source Sans Pro Italic"
+     ]
+    },
+    "filter": [
+     "all",
+     [
+      "!=",
+      "texte",
+      "0"
+     ],
+     [
+      "==",
+      "hors_zone",
+      "true"
+     ],
+     [
+      "in",
+      "symbo",
+      "CNV_ROCHER_MAITRESSE",
+      "CUV_ROCHER_MAITRESSE"
+     ]
+    ],
+    "paint": {
+     "text-color": "#333333",
+     "text-halo-width": 0.5,
+     "text-halo-color": "#FFFFFF"
+    }
+   },
+   {
+    "id": "toponyme - cote de courbe glacier",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "oro_courbe",
+    "minzoom": 13,
+    "maxzoom": 16,
+    "layout": {
+     "symbol-placement": "line",
+     "text-field": "{texte}",
+     "text-size": {
+      "stops": [
+       [
+        13,
+        10
+       ],
+       [
+        15,
+        13
+       ]
+      ]
+     },
+     "text-anchor": "center",
+     "text-rotation-alignment": "map",
+     "text-pitch-alignment": "viewport",
+     "text-keep-upright": false,
+     "text-max-angle": 20,
+     "text-max-width": 100,
+     "text-font": [
+      "Source Sans Pro Italic"
+     ]
+    },
+    "filter": [
+     "all",
+     [
+      "!=",
+      "texte",
+      "0"
+     ],
+     [
+      "==",
+      "hors_zone",
+      "true"
+     ],
+     [
+      "in",
+      "symbo",
+      "CNV_GLACIER_MAITRESSE",
+      "CUV_GLACIER_MAITRESSE"
+     ]
+    ],
+    "paint": {
+     "text-color": "#629FD9",
+     "text-halo-width": 0.5,
+     "text-halo-color": "#FFFFFF"
+    }
+   },
+   {
+    "id": "hydro surfacique",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "hydro_surf",
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "SURFACE_D_EAU",
+     "BASSIN",
+     "ZONE_MARINE"
+    ],
+    "paint": {
+     "fill-color": "#AAD5E9",
+     "fill-outline-color": "#AAD5E9"
+    }
+   },
+   {
+    "id": "hydro surfacique temporaire",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "hydro_surf",
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "SURFACE_D_EAU_TEMP"
+    ],
+    "paint": {
+     "fill-color": "rgba(168, 203, 220, 0.5)"
+    }
+   },
+   {
+    "id": "réseau hydro  - cours d'eau souterrain",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "hydro_reseau_sou",
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "COURS_D_EAU_SOU",
+     "COURS_D_EAU_MOY_SOU"
+    ],
+    "paint": {
+     "line-color": "#AAD5E9",
+     "line-width": {
+      "stops": [
+       [
+        12,
+        1.5
+       ],
+       [
+        17,
+        6.5
+       ]
+      ]
+     },
+     "line-dasharray": [
+      2,
+      2
+     ]
+    }
+   },
+   {
+    "id": "réseau hydro - filet interieur - aqueduc souterrain",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "hydro_reseau_sou",
+    "minzoom": 12,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "AQUEDUC_SOU"
+    ],
+    "paint": {
+     "line-color": "#AAD5E9",
+     "line-width": {
+      "stops": [
+       [
+        12,
+        1.4
+       ],
+       [
+        16,
+        3.5
+       ],
+       [
+        17,
+        5.9
+       ]
+      ]
+     },
+     "line-dasharray": [
+      2,
+      2
+     ]
+    }
+   },
+   {
+    "id": "réseau hydro - carre - aqueduc souterrain",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "hydro_reseau_sou",
+    "minzoom": 12,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "AQUEDUC_SOU"
+    ],
+    "paint": {
+     "line-color": "#AAD5E9",
+     "line-width": {
+      "stops": [
+       [
+        12,
+        3.5
+       ],
+       [
+        16,
+        8.7
+       ],
+       [
+        17,
+        14.7
+       ]
+      ]
+     },
+     "line-dasharray": [
+      1,
+      5
+     ]
+    }
+   },
+   {
+    "id": "Ferre souterrain - voie normale",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "ferre_sou",
+    "minzoom": 10,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "VF_1_SOU",
+     "VF_2_SOU",
+     "VF_ELEC_1_SOU",
+     "VF_FERRO_ROUTIER_SOU"
+    ],
+    "paint": {
+     "line-color": "#B4B4B4",
+     "line-width": {
+      "stops": [
+       [
+        10,
+        0.8
+       ],
+       [
+        17,
+        2.5
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Ferre souterrain - trait perpendic épais",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "ferre_sou",
+    "minzoom": 10,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "VF_1_SOU",
+     "VF_2_SOU",
+     "VF_ELEC_1_SOU",
+     "VF_FERRO_ROUTIER_SOU"
+    ],
+    "paint": {
+     "line-color": "#B4B4B4",
+     "line-width": {
+      "stops": [
+       [
+        10,
+        3.5
+       ],
+       [
+        17,
+        14.7
+       ]
+      ]
+     },
+     "line-dasharray": [
+      0.1,
+      10
+     ]
+    }
+   },
+   {
+    "id": "Ferre souterrain - voie etroite",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "ferre_sou",
+    "minzoom": 10,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "VF_ETROITE_1_SOU",
+     "VF_ETROITE_SOU"
+    ],
+    "paint": {
+     "line-color": "#B4B4B4",
+     "line-width": {
+      "stops": [
+       [
+        10,
+        0.3
+       ],
+       [
+        17,
+        1.8
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Ferre souterrain - trait perpendic fin",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "ferre_sou",
+    "minzoom": 10,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "VF_ETROITE_1_SOU",
+     "VF_ETROITE_SOU"
+    ],
+    "paint": {
+     "line-color": "#B4B4B4",
+     "line-width": {
+      "stops": [
+       [
+        10,
+        3.5
+       ],
+       [
+        17,
+        14.7
+       ]
+      ]
+     },
+     "line-dasharray": [
+      0.1,
+      10
+     ]
+    }
+   },
+   {
+    "id": "Ferre souterrain - voie service",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "ferre_sou",
+    "minzoom": 14,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "VF_SERVICE_SOU",
+     "VF_NON_EXPLOITEE_SOU"
+    ],
+    "paint": {
+     "line-color": "#B4B4B4",
+     "line-width": {
+      "stops": [
+       [
+        10,
+        0.3
+       ],
+       [
+        17,
+        1.8
+       ]
+      ]
+     },
+     "line-dasharray": [
+      5,
+      2,
+      1,
+      2
+     ]
+    }
+   },
+   {
+    "id": "Ferre souterrain - funic/urbain",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "ferre_sou",
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "FUNI_CREMAILLERE_SOU",
+     "TRANSPORT_URBAIN_SOU"
+    ],
+    "paint": {
+     "line-color": "#B4B4B4",
+     "line-width": {
+      "stops": [
+       [
+        10,
+        0.3
+       ],
+       [
+        17,
+        1.8
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Ferre souterrain - 2 trait perpendic - funic/urbain",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "ferre_sou",
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "FUNI_CREMAILLERE_SOU",
+     "TRANSPORT_URBAIN_SOU"
+    ],
+    "paint": {
+     "line-color": "#B4B4B4",
+     "line-width": {
+      "stops": [
+       [
+        10,
+        3.5
+       ],
+       [
+        17,
+        17
+       ]
+      ]
+     },
+     "line-dasharray": [
+      0.1,
+      0.2,
+      0.1,
+      10
+     ]
+    }
+   },
+   {
+    "id": "Chemin souterrain - piste cyclable",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_chemin_sou",
+    "minzoom": 13,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "PISTE_CYCLABLE_SOU"
+    ],
+    "paint": {
+     "line-color": "#AB81CC",
+     "line-width": {
+      "stops": [
+       [
+        14,
+        1.1
+       ],
+       [
+        15,
+        1.7
+       ],
+       [
+        16,
+        2
+       ],
+       [
+        17,
+        3.5
+       ]
+      ]
+     },
+     "line-dasharray": [
+      6,
+      2
+     ]
+    }
+   },
+   {
+    "id": "Chemin souterrain - filet exterieur - escalier",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_chemin_sou",
+    "minzoom": 14,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "ESCALIER_SOU"
+    ],
+    "paint": {
+     "line-color": "#B3989A",
+     "line-width": {
+      "stops": [
+       [
+        14,
+        1.75
+       ],
+       [
+        15,
+        3
+       ],
+       [
+        16,
+        4.2
+       ],
+       [
+        17,
+        9.5
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Chemin souterrain - filet interieur - escalier",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_chemin_sou",
+    "minzoom": 14,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "ESCALIER_SOU"
+    ],
+    "paint": {
+     "line-color": "#FFFFFF",
+     "line-width": {
+      "stops": [
+       [
+        14,
+        1
+       ],
+       [
+        15,
+        1.9
+       ],
+       [
+        16,
+        2.7
+       ],
+       [
+        17,
+        5.8
+       ]
+      ]
+     },
+     "line-dasharray": [
+      1,
+      0.2
+     ]
+    }
+   },
+   {
+    "id": "Chemin souterrain - Rue pietonne",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_chemin_sou",
+    "minzoom": 14,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "RUE_PIETONNE_SOU"
+    ],
+    "paint": {
+     "line-color": "#B3989A",
+     "line-width": {
+      "stops": [
+       [
+        14,
+        1
+       ],
+       [
+        15,
+        1.2
+       ],
+       [
+        16,
+        1.4
+       ],
+       [
+        17,
+        2
+       ]
+      ]
+     },
+     "line-dasharray": [
+      1,
+      3
+     ]
+    }
+   },
+   {
+    "id": "Chemin souterrain - sentier",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_chemin_sou",
+    "minzoom": 13,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "SENTIER_SOU"
+    ],
+    "paint": {
+     "line-color": "#B3989A",
+     "line-width": {
+      "stops": [
+       [
+        14,
+        1
+       ],
+       [
+        15,
+        1.2
+       ],
+       [
+        16,
+        1.4
+       ],
+       [
+        17,
+        2
+       ]
+      ]
+     },
+     "line-dasharray": [
+      4,
+      3
+     ]
+    }
+   },
+   {
+    "id": "Chemin souterrain - chemin",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_chemin_sou",
+    "minzoom": 12,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "CHEMIN_SOU"
+    ],
+    "paint": {
+     "line-color": "#B3989A",
+     "line-width": {
+      "stops": [
+       [
+        14,
+        1
+       ],
+       [
+        15,
+        1.2
+       ],
+       [
+        16,
+        1.4
+       ],
+       [
+        17,
+        2
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier souterrain - filet extérieur - route non revetu carrosable",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route_sou",
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "NON_REVETUE_CARRO_SOU"
+    ],
+    "paint": {
+     "line-color": "#AFAFAF",
+     "line-width": {
+      "stops": [
+       [
+        14,
+        3.2
+       ],
+       [
+        15,
+        5.4
+       ],
+       [
+        16,
+        7.7
+       ],
+       [
+        17,
+        16.8
+       ]
+      ]
+     },
+     "line-dasharray": [
+      2,
+      2
+     ]
+    }
+   },
+   {
+    "id": "Routier souterrain - filet extérieur - bretelle autoroute",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route_sou",
+    "minzoom": 12,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "BRET_AUTO_PEAGE_3_SOU",
+     "BRET_AUTO_PEAGE_2_SOU",
+     "BRET_AUTO_PEAGE_1_SOU",
+     "BRET_AUTO_LIBRE_3_SOU",
+     "BRET_AUTO_LIBRE_2_SOU",
+     "BRET_AUTO_LIBRE_1_SOU"
+    ],
+    "paint": {
+     "line-color": "rgba(222, 70, 14, 0.5)",
+     "line-width": {
+      "stops": [
+       [
+        12,
+        2.5
+       ],
+       [
+        14,
+        3.7
+       ],
+       [
+        15,
+        6.8
+       ],
+       [
+        16,
+        8.4
+       ],
+       [
+        17,
+        14
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier souterrain - filet extérieur - route non classee restreint",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route_sou",
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "NON_CLASSEE_RESTREINT_SOU"
+    ],
+    "paint": {
+     "line-color": "#AFAFAF",
+     "line-width": {
+      "stops": [
+       [
+        14,
+        3.2
+       ],
+       [
+        15,
+        5.4
+       ],
+       [
+        16,
+        7.7
+       ],
+       [
+        17,
+        16.8
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier souterrain - filet extérieur - route non classee",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route_sou",
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "NON_CLASSEE_4_SOU",
+     "NON_CLASSEE_SOU"
+    ],
+    "paint": {
+     "line-color": "#AFAFAF",
+     "line-width": {
+      "stops": [
+       [
+        14,
+        3.2
+       ],
+       [
+        15,
+        5.4
+       ],
+       [
+        16,
+        7.7
+       ],
+       [
+        17,
+        16.8
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier souterrain - filet extérieur - route locale",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route_sou",
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "BRET_LOCALE_SOU",
+     "LOCALE_4_SOU",
+     "LOCALE_3_SOU",
+     "LOCALE_2_SOU",
+     "LOCALE_1_SOU"
+    ],
+    "paint": {
+     "line-color": "rgba(130, 130, 130, 0.5)",
+     "line-width": {
+      "stops": [
+       [
+        9,
+        2
+       ],
+       [
+        14,
+        3.5
+       ],
+       [
+        15,
+        6
+       ],
+       [
+        16,
+        8.4
+       ],
+       [
+        17,
+        18.3
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier souterrain - filet extérieur - route locale en construction",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route_sou",
+    "minzoom": 11,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "LOCALE_CONSTR_SOU"
+    ],
+    "paint": {
+     "line-color": "#C8C8C8",
+     "line-width": {
+      "stops": [
+       [
+        9,
+        2
+       ],
+       [
+        14,
+        3.5
+       ],
+       [
+        15,
+        6
+       ],
+       [
+        16,
+        8.4
+       ],
+       [
+        17,
+        18.3
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier souterrain - filet extérieur - route regionale",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route_sou",
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "BRET_REGIONALE_SOU",
+     "REGIONALE_4_SOU",
+     "REGIONALE_3_SOU",
+     "REGIONALE_2_SOU",
+     "REGIONALE_1_SOU"
+    ],
+    "paint": {
+     "line-color": "rgba(130, 130, 130, 0.5)",
+     "line-width": {
+      "stops": [
+       [
+        6,
+        1.5
+       ],
+       [
+        9,
+        2.3
+       ],
+       [
+        14,
+        5
+       ],
+       [
+        15,
+        8.1
+       ],
+       [
+        16,
+        11.2
+       ],
+       [
+        17,
+        22
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier souterrain - filet extérieur - route regionale en construction",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route_sou",
+    "minzoom": 10,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "REGIONALE_CONSTR_SOU"
+    ],
+    "paint": {
+     "line-color": "#C8C8C8",
+     "line-width": {
+      "stops": [
+       [
+        6,
+        1.5
+       ],
+       [
+        9,
+        2.3
+       ],
+       [
+        14,
+        5
+       ],
+       [
+        15,
+        8.1
+       ],
+       [
+        16,
+        11.2
+       ],
+       [
+        17,
+        22
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier souterrain - filet extérieur - route principale",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route_sou",
+    "minzoom": 7,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "BRET_PRINCIPALE_SOU",
+     "PRINCIPALE_4_SOU",
+     "PRINCIPALE_3_SOU",
+     "PRINCIPALE_2_SOU",
+     "PRINCIPALE_1_SOU"
+    ],
+    "paint": {
+     "line-color": "rgba(222, 70, 14, 0.5)",
+     "line-width": {
+      "stops": [
+       [
+        6,
+        1.8
+       ],
+       [
+        9,
+        2.7
+       ],
+       [
+        14,
+        5.9
+       ],
+       [
+        15,
+        9
+       ],
+       [
+        16,
+        12.2
+       ],
+       [
+        17,
+        22.5
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier souterrain - filet extérieur - route principale en construction",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route_sou",
+    "minzoom": 10,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "PRINCIPALE_CONSTR_SOU"
+    ],
+    "paint": {
+     "line-color": "#C8C8C8",
+     "line-width": {
+      "stops": [
+       [
+        6,
+        1.8
+       ],
+       [
+        9,
+        2.7
+       ],
+       [
+        14,
+        5.9
+       ],
+       [
+        15,
+        9
+       ],
+       [
+        16,
+        12.2
+       ],
+       [
+        17,
+        22.5
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier souterrain - filet extérieur - autoroute",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route_sou",
+    "minzoom": 7,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "AUTOROU_PEAGE_SOU",
+     "AUTOROU_LIBRE_SOU"
+    ],
+    "paint": {
+     "line-color": "rgba(222, 70, 14, 0.5)",
+     "line-width": {
+      "stops": [
+       [
+        6,
+        2.5
+       ],
+       [
+        9,
+        3.5
+       ],
+       [
+        14,
+        7.5
+       ],
+       [
+        15,
+        11
+       ],
+       [
+        16,
+        15
+       ],
+       [
+        17,
+        26
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier souterrain - filet extérieur - autoroute en construction",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route_sou",
+    "minzoom": 10,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "AUTOROU_CONSTR_SOU"
+    ],
+    "paint": {
+     "line-color": "#C8C8C8",
+     "line-width": {
+      "stops": [
+       [
+        6,
+        2.5
+       ],
+       [
+        9,
+        3.5
+       ],
+       [
+        14,
+        7.5
+       ],
+       [
+        15,
+        11
+       ],
+       [
+        16,
+        15
+       ],
+       [
+        17,
+        26
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier souterrain - filet interieur - route non revetu carrosable",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route_sou",
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "NON_REVETUE_CARRO_SOU"
+    ],
+    "paint": {
+     "line-color": "#DCDCDC",
+     "line-width": {
+      "stops": [
+       [
+        14,
+        2.3
+       ],
+       [
+        15,
+        4.1
+       ],
+       [
+        16,
+        6.3
+       ],
+       [
+        17,
+        13.5
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier souterrain - filet interieur - bretelle autoroute",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route_sou",
+    "minzoom": 12,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "BRET_AUTO_PEAGE_3_SOU",
+     "BRET_AUTO_PEAGE_2_SOU",
+     "BRET_AUTO_PEAGE_1_SOU",
+     "BRET_AUTO_LIBRE_3_SOU",
+     "BRET_AUTO_LIBRE_2_SOU",
+     "BRET_AUTO_LIBRE_1_SOU"
+    ],
+    "paint": {
+     "line-color": "rgba(255, 255, 255, 0.5)",
+     "line-width": {
+      "stops": [
+       [
+        12,
+        1.5
+       ],
+       [
+        14,
+        2.6
+       ],
+       [
+        15,
+        5.2
+       ],
+       [
+        16,
+        6.7
+       ],
+       [
+        17,
+        10.8
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier souterrain - filet interieur - route non classee restreint",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route_sou",
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "NON_CLASSEE_RESTREINT_SOU"
+    ],
+    "paint": {
+     "line-color": "#F2F5FF",
+     "line-width": {
+      "stops": [
+       [
+        14,
+        2.3
+       ],
+       [
+        15,
+        4.1
+       ],
+       [
+        16,
+        6.3
+       ],
+       [
+        17,
+        13.5
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier souterrain - filet interieur - route non classee",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route_sou",
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "NON_CLASSEE_4_SOU",
+     "NON_CLASSEE_SOU"
+    ],
+    "paint": {
+     "line-color": "#DCDCDC",
+     "line-width": {
+      "stops": [
+       [
+        14,
+        2.3
+       ],
+       [
+        15,
+        4.1
+       ],
+       [
+        16,
+        6.3
+       ],
+       [
+        17,
+        13.5
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier souterrain - filet interieur - route locale",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route_sou",
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "BRET_LOCALE_SOU",
+     "LOCALE_4_SOU",
+     "LOCALE_3_SOU",
+     "LOCALE_2_SOU",
+     "LOCALE_1_SOU"
+    ],
+    "paint": {
+     "line-color": "rgba(255, 255, 255, 0.5)",
+     "line-width": {
+      "stops": [
+       [
+        9,
+        1.3
+       ],
+       [
+        14,
+        2.3
+       ],
+       [
+        15,
+        4.1
+       ],
+       [
+        16,
+        6.1
+       ],
+       [
+        17,
+        13.1
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier souterrain - filet interieur - route locale en construction",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route_sou",
+    "minzoom": 11,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "LOCALE_CONSTR_SOU"
+    ],
+    "paint": {
+     "line-color": {
+      "stops": [
+       [
+        12,
+        "#FFFFFF"
+       ],
+       [
+        13,
+        "#FCF4A8"
+       ],
+       [
+        17,
+        "#FCF7C1"
+       ]
+      ]
+     },
+     "line-width": {
+      "stops": [
+       [
+        9,
+        2
+       ],
+       [
+        14,
+        3.5
+       ],
+       [
+        15,
+        6
+       ],
+       [
+        16,
+        8.4
+       ],
+       [
+        17,
+        18.3
+       ]
+      ]
+     },
+     "line-dasharray": [
+      2,
+      2
+     ]
+    }
+   },
+   {
+    "id": "Routier souterrain - filet interieur - route regionale",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route_sou",
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "BRET_REGIONALE_SOU",
+     "REGIONALE_4_SOU",
+     "REGIONALE_3_SOU",
+     "REGIONALE_2_SOU",
+     "REGIONALE_1_SOU"
+    ],
+    "paint": {
+     "line-color": "rgba(255, 255, 255, 0.5)",
+     "line-width": {
+      "stops": [
+       [
+        6,
+        1.4
+       ],
+       [
+        9,
+        1.5
+       ],
+       [
+        14,
+        3.2
+       ],
+       [
+        15,
+        5.8
+       ],
+       [
+        16,
+        8.3
+       ],
+       [
+        17,
+        16.2
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier souterrain - filet interieur - route regionale en construction",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route_sou",
+    "minzoom": 10,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "REGIONALE_CONSTR_SOU"
+    ],
+    "paint": {
+     "line-color": {
+      "stops": [
+       [
+        9,
+        "#FFFFFF"
+       ],
+       [
+        10,
+        "#FDF28B"
+       ],
+       [
+        17,
+        "#FCF6BD"
+       ]
+      ]
+     },
+     "line-width": {
+      "stops": [
+       [
+        4,
+        0.4
+       ],
+       [
+        6,
+        1.5
+       ],
+       [
+        9,
+        2.3
+       ],
+       [
+        14,
+        5
+       ],
+       [
+        15,
+        8.1
+       ],
+       [
+        16,
+        11.2
+       ],
+       [
+        17,
+        22
+       ]
+      ]
+     },
+     "line-dasharray": [
+      2,
+      2
+     ]
+    }
+   },
+   {
+    "id": "Routier souterrain - filet interieur - route principale",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route_sou",
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "BRET_PRINCIPALE_SOU",
+     "PRINCIPALE_4_SOU",
+     "PRINCIPALE_3_SOU",
+     "PRINCIPALE_2_SOU",
+     "PRINCIPALE_1_SOU"
+    ],
+    "paint": {
+     "line-color": "rgba(255, 255, 255, 0.5)",
+     "line-width": {
+      "stops": [
+       [
+        4,
+        0.5
+       ],
+       [
+        6,
+        1.8
+       ],
+       [
+        9,
+        2.1
+       ],
+       [
+        14,
+        4.4
+       ],
+       [
+        15,
+        7.3
+       ],
+       [
+        16,
+        10
+       ],
+       [
+        17,
+        18.5
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier souterrain - filet interieur - route principale en construction",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route_sou",
+    "minzoom": 10,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "PRINCIPALE_CONSTR_SOU"
+    ],
+    "paint": {
+     "line-color": {
+      "stops": [
+       [
+        9,
+        "#F3C66D"
+       ],
+       [
+        17,
+        "#F2DDB3"
+       ]
+      ]
+     },
+     "line-width": {
+      "stops": [
+       [
+        4,
+        0.5
+       ],
+       [
+        6,
+        1.8
+       ],
+       [
+        9,
+        2.7
+       ],
+       [
+        14,
+        5.9
+       ],
+       [
+        15,
+        9
+       ],
+       [
+        16,
+        12.2
+       ],
+       [
+        17,
+        22.5
+       ]
+      ]
+     },
+     "line-dasharray": [
+      2,
+      2
+     ]
+    }
+   },
+   {
+    "id": "Routier souterrain - filet interieur - autoroute",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route_sou",
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "AUTOROU_PEAGE_SOU",
+     "AUTOROU_LIBRE_SOU"
+    ],
+    "paint": {
+     "line-color": "rgba(255, 255, 255, 0.5)",
+     "line-width": {
+      "stops": [
+       [
+        4,
+        0.7
+       ],
+       [
+        6,
+        2.5
+       ],
+       [
+        9,
+        2.7
+       ],
+       [
+        14,
+        5.8
+       ],
+       [
+        15,
+        9
+       ],
+       [
+        16,
+        12
+       ],
+       [
+        17,
+        20.8
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier souterrain - axe central - autoroute",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route_sou",
+    "minzoom": 13,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "AUTOROU_PEAGE_SOU",
+     "AUTOROU_LIBRE_SOU"
+    ],
+    "paint": {
+     "line-color": "#FFFFFF",
+     "line-width": {
+      "stops": [
+       [
+        9,
+        0.6
+       ],
+       [
+        14,
+        0.7
+       ],
+       [
+        15,
+        1
+       ],
+       [
+        16,
+        1.2
+       ],
+       [
+        17,
+        2.1
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier souterrain - filet interieur - autoroute en construction",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route_sou",
+    "minzoom": 10,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "AUTOROU_CONSTR_SOU"
+    ],
+    "paint": {
+     "line-color": {
+      "stops": [
+       [
+        9,
+        "#F2BA59"
+       ],
+       [
+        17,
+        "#F2C261"
+       ]
+      ]
+     },
+     "line-width": {
+      "stops": [
+       [
+        4,
+        0.7
+       ],
+       [
+        6,
+        2.5
+       ],
+       [
+        9,
+        3.5
+       ],
+       [
+        14,
+        7.5
+       ],
+       [
+        15,
+        11
+       ],
+       [
+        16,
+        15
+       ],
+       [
+        17,
+        26
+       ]
+      ]
+     },
+     "line-dasharray": [
+      2,
+      2
+     ]
+    }
+   },
+   {
+    "id": "Routier souterrain - axe central - autoroute en construction",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route_sou",
+    "minzoom": 13,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "AUTOROU_CONSTR_SOU"
+    ],
+    "paint": {
+     "line-color": "#808080",
+     "line-width": {
+      "stops": [
+       [
+        9,
+        0.6
+       ],
+       [
+        14,
+        0.7
+       ],
+       [
+        15,
+        1
+       ],
+       [
+        16,
+        1.2
+       ],
+       [
+        17,
+        2.1
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "réseau hydro - cours d'eau temporaire",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "hydro_reseau",
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "COURS_D_EAU_TEMP",
+     "COURS_D_EAU_TEMP_MOY"
+    ],
+    "paint": {
+     "line-color": "#AAD5E9",
+     "line-width": {
+      "stops": [
+       [
+        12,
+        1.5
+       ],
+       [
+        17,
+        4
+       ]
+      ]
+     },
+     "line-dasharray": [
+      6,
+      2
+     ]
+    }
+   },
+   {
+    "id": "réseau hydro - cours d'eau",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "hydro_reseau",
+    "minzoom": 3,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "COURS_D_EAU"
+    ],
+    "paint": {
+     "line-color": "#AAD5E9",
+     "line-width": {
+      "stops": [
+       [
+        4,
+        0.3
+       ],
+       [
+        7,
+        1.5
+       ],
+       [
+        12,
+        1.5
+       ],
+       [
+        17,
+        6.5
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "réseau hydro - canal",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "hydro_reseau",
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "CANAL"
+    ],
+    "paint": {
+     "line-color": "#AAD5E9",
+     "line-width": {
+      "stops": [
+       [
+        12,
+        1.4
+       ],
+       [
+        17,
+        5.9
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "réseau hydro - filet interieur - aqueduc",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "hydro_reseau",
+    "minzoom": 12,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "AQUEDUC_AU_SOL"
+    ],
+    "paint": {
+     "line-color": "#AAD5E9",
+     "line-width": {
+      "stops": [
+       [
+        12,
+        1.4
+       ],
+       [
+        16,
+        3.5
+       ],
+       [
+        17,
+        5.9
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "réseau hydro - carre - aqueduc",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "hydro_reseau",
+    "minzoom": 12,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "AQUEDUC_AU_SOL"
+    ],
+    "paint": {
+     "line-color": "#AAD5E9",
+     "line-width": {
+      "stops": [
+       [
+        12,
+        3.5
+       ],
+       [
+        16,
+        8.7
+       ],
+       [
+        17,
+        14.7
+       ]
+      ]
+     },
+     "line-dasharray": [
+      1,
+      5
+     ]
+    }
+   },
+   {
+    "id": "réseau hydro - cours d'eau moyen ",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "hydro_reseau",
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "COURS_D_EAU_MOY"
+    ],
+    "paint": {
+     "line-color": "#AAD5E9",
+     "line-width": {
+      "stops": [
+       [
+        7,
+        2
+       ],
+       [
+        12,
+        2.5
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "réseau hydro - cours d'eau large ",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "hydro_reseau",
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "COURS_D_EAU_LAR"
+    ],
+    "paint": {
+     "line-color": "#AAD5E9",
+     "line-width": {
+      "stops": [
+       [
+        7,
+        3
+       ],
+       [
+        11,
+        5
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "parcellaire - parcelle surface",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "parcellaire_parcelle",
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "PARCELLE"
+    ],
+    "paint": {
+     "fill-color": "#FFFFD1",
+     "fill-opacity": 0.7
+    }
+   },
+   {
+    "id": "bati surfacique mairie - Zoom 14",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "bati_surf",
+    "maxzoom": 14,
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "MAIRIE",
+     "MAIRIE_ANNEXE"
+    ],
+    "paint": {
+     "fill-color": "#FFA6A6"
+    }
+   },
+   {
+    "id": "bati surfacique mairie - Zoom 15,16,17,18",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "bati_surf",
+    "minzoom": 14,
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "MAIRIE",
+     "MAIRIE_ANNEXE"
+    ],
+    "paint": {
+     "fill-color": {
+      "stops": [
+       [
+        14,
+        "#FFA6A6"
+       ],
+       [
+        15,
+        "#FFAEAE"
+       ]
+      ]
+     },
+     "fill-outline-color": "#FF7C7C"
+    }
+   },
+   {
+    "id": "bati surfacique fonctionnel industriel ou commercial - Zoom 14,15",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "bati_surf",
+    "maxzoom": 15,
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "BATI_COMMERCIAL",
+     "BATI_INDUSTRIEL",
+     "HANGAR",
+     "HANGAR_COMMERCIAL",
+     "HANGAR_INDUSTRIEL"
+    ],
+    "paint": {
+     "fill-color": "#C8C8C8"
+    }
+   },
+   {
+    "id": "bati surfacique fonctionnel industriel ou commercial - Zoom 16,17,18",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "bati_surf",
+    "minzoom": 15,
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "BATI_COMMERCIAL",
+     "BATI_INDUSTRIEL",
+     "HANGAR",
+     "HANGAR_COMMERCIAL",
+     "HANGAR_INDUSTRIEL"
+    ],
+    "paint": {
+     "fill-color": {
+      "stops": [
+       [
+        15,
+        "#D1D1D1"
+       ],
+       [
+        16,
+        "#E6E6E6"
+       ]
+      ]
+     },
+     "fill-outline-color": "#B8B8B8"
+    }
+   },
+   {
+    "id": "bati surfacique fonctionnel public - Zoom 14,15",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "bati_surf",
+    "maxzoom": 15,
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "BATI_PUBLIC",
+     "HANGAR_PUBLIC"
+    ],
+    "paint": {
+     "fill-color": "#B9B6D6"
+    }
+   },
+   {
+    "id": "bati surfacique fonctionnel public - Zoom 16,17,18",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "bati_surf",
+    "minzoom": 15,
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "BATI_PUBLIC",
+     "HANGAR_PUBLIC"
+    ],
+    "paint": {
+     "fill-color": {
+      "stops": [
+       [
+        15,
+        "#CFC5DE"
+       ],
+       [
+        16,
+        "#E4DAF3"
+       ]
+      ]
+     },
+     "fill-outline-color": "#A6A1D6"
+    }
+   },
+   {
+    "id": "bati surfacique fonctionnel sportif - bordure",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "bati_surf",
+    "minzoom": 15,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "BATI_SPORTIF"
+    ],
+    "paint": {
+     "line-color": "#BCD9AB",
+     "line-width": 4
+    }
+   },
+   {
+    "id": "bati surfacique fonctionnel sportif",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "bati_surf",
+    "minzoom": 13,
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "BATI_SPORTIF"
+    ],
+    "paint": {
+     "fill-color": {
+      "stops": [
+       [
+        14,
+        "#C9E1DD"
+       ],
+       [
+        15,
+        "#DCE6E4"
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "bati surfacique fonctionnel gare - Zoom 14,15",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "bati_surf",
+    "maxzoom": 15,
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "BATI_GARE"
+    ],
+    "paint": {
+     "fill-color": "#B3B5F5"
+    }
+   },
+   {
+    "id": "bati surfacique fonctionnel gare - Zoom 16,17,18",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "bati_surf",
+    "minzoom": 15,
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "BATI_GARE"
+    ],
+    "paint": {
+     "fill-color": {
+      "stops": [
+       [
+        15,
+        "#BFC1F5"
+       ],
+       [
+        16,
+        "#CBCDF5"
+       ]
+      ]
+     },
+     "fill-outline-color": "#9B9EF6"
+    }
+   },
+   {
+    "id": "bati surfacique quelconque - Zoom 15",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "bati_surf",
+    "minzoom": 14,
+    "maxzoom": 15,
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "BATI_QQUE"
+    ],
+    "paint": {
+     "fill-color": "#D6C6B8"
+    }
+   },
+   {
+    "id": "bati surfacique quelconque - Zoom 16,17,18",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "bati_surf",
+    "minzoom": 15,
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "BATI_QQUE"
+    ],
+    "paint": {
+     "fill-color": {
+      "stops": [
+       [
+        15,
+        "#E6E0CF"
+       ],
+       [
+        16,
+        "#F1EBD9"
+       ]
+      ]
+     },
+     "fill-outline-color": "#C3AA8E"
+    }
+   },
+   {
+    "id": "cimetiere surfacique 1",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "bati_surf",
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "CIMETIERE_SURF",
+     "CIMETIERE_MILI_SURF",
+     "NECROPOLE_NATIONALE"
+    ],
+    "paint": {
+     "fill-color": "#F0F0F0",
+     "fill-opacity": 0.5,
+     "fill-outline-color": "#818181"
+    }
+   },
+   {
+    "id": "cimetiere surfacique 2",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "bati_surf",
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "CIMETIERE_SURF",
+     "CIMETIERE_MILI_SURF",
+     "NECROPOLE_NATIONALE"
+    ],
+    "paint": {
+     "fill-pattern": "Cimetiere"
+    }
+   },
+   {
+    "id": "bati hydro surfacique - Autre",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "bati_surf",
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "ECLUSE_SURF",
+     "RESERVOIR_EAU_SURF"
+    ],
+    "paint": {
+     "fill-color": "#ADCCD9",
+     "fill-outline-color": "#336699"
+    }
+   },
+   {
+    "id": "bati hydro surfacique - Pecherie",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "bati_surf",
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "PECHERIE_SURF"
+    ],
+    "paint": {
+     "fill-color": "#BFE2F0",
+     "fill-outline-color": "#509FEF"
+    }
+   },
+   {
+    "id": "bati hydro surfacique - Barrage",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "bati_surf",
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "BARRAGE_SURF"
+    ],
+    "paint": {
+     "fill-color": "#FFFFFF",
+     "fill-outline-color": "#464646"
+    }
+   },
+   {
+    "id": "bati hydro surfacique - Chateau d'eau",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "bati_surf",
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "CHATEAU_EAU_SURF"
+    ],
+    "paint": {
+     "fill-color": "#1466B2"
+    }
+   },
+   {
+    "id": "bati infra surfacique - Silo",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "bati_surf",
+    "minzoom": 15,
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "SILO_SURF"
+    ],
+    "paint": {
+     "fill-color": "#C7A9AA",
+     "fill-outline-color": "#696969"
+    }
+   },
+   {
+    "id": "bati infra surfacique - Reservoir indus",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "bati_surf",
+    "minzoom": 14,
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "RESERVOIR_INDUS_SURF"
+    ],
+    "paint": {
+     "fill-color": "#8D9DAA",
+     "fill-outline-color": "#464646"
+    }
+   },
+   {
+    "id": "bati infra surfacique - Serre",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "bati_surf",
+    "minzoom": 13,
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "SERRE_SURF"
+    ],
+    "paint": {
+     "fill-color": "#CAD6D9",
+     "fill-outline-color": "#8C8C8C"
+    }
+   },
+   {
+    "id": "bati infra surfacique - poste electrique",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "bati_surf",
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "POSTE_ELEC_SURF"
+    ],
+    "paint": {
+     "fill-color": "#7993B6",
+     "fill-opacity": 0.3
+    }
+   },
+   {
+    "id": "bati infra surfacique - poste electrique bord",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "bati_surf",
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "POSTE_ELEC_SURF"
+    ],
+    "paint": {
+     "line-color": "#000000",
+     "line-width": {
+      "stops": [
+       [
+        12,
+        0.3
+       ],
+       [
+        17,
+        1.2
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "bati religieux surfacique - Zoom 14",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "bati_surf",
+    "maxzoom": 14,
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "CHAPELLE_SURF",
+     "EGLISE_SURF",
+     "CHRETIEN_SURF",
+     "SYNAGOGUE_SURF",
+     "MOSQUEE_SURF",
+     "AUTRE_CULTE_SURF"
+    ],
+    "paint": {
+     "fill-color": "#F7CBCB"
+    }
+   },
+   {
+    "id": "bati religieux surfacique - Zoom 15,16,17,18",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "bati_surf",
+    "minzoom": 14,
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "CHAPELLE_SURF",
+     "EGLISE_SURF",
+     "CHRETIEN_SURF",
+     "SYNAGOGUE_SURF",
+     "MOSQUEE_SURF",
+     "AUTRE_CULTE_SURF"
+    ],
+    "paint": {
+     "fill-color": {
+      "stops": [
+       [
+        14,
+        "#F7CBCB"
+       ],
+       [
+        15,
+        "#F7E1E1"
+       ]
+      ]
+     },
+     "fill-outline-color": {
+      "stops": [
+       [
+        14,
+        "#F7A8A8"
+       ],
+       [
+        15,
+        "#F7B7B7"
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "bati remarquable surfacique",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "bati_surf",
+    "minzoom": 13,
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "FORTIF_SURF",
+     "CHATEAU_SURF",
+     "TOUR_MOULIN_SURF",
+     "ARENE_THEATRE",
+     "ARC_TRIOMPHE_SURF",
+     "MONUMENT_SURF"
+    ],
+    "paint": {
+     "fill-color": "#9B9B9B",
+     "fill-outline-color": "#6E6E6E"
+    }
+   },
+   {
+    "id": "bati sportif surfacique fond",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "bati_surf",
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "TENNIS_SURF",
+     "SPORT_INDIF_SURF",
+     "FOOT_SURF",
+     "MULTI_SPORT_SURF",
+     "PISTE_SPORT_SURF",
+     "NATATION_SURF"
+    ],
+    "paint": {
+     "fill-color": "#FFFFFF",
+     "fill-outline-color": "#FFFFFF"
+    }
+   },
+   {
+    "id": "bati sportif surfacique",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "bati_surf",
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "TENNIS_SURF",
+     "SPORT_INDIF_SURF",
+     "FOOT_SURF",
+     "MULTI_SPORT_SURF",
+     "PISTE_SPORT_SURF",
+     "NATATION_SURF"
+    ],
+    "paint": {
+     "line-color": "#BCD9AB",
+     "line-width": 2
+    }
+   },
+   {
+    "id": "bati transport surfacique - piste",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "bati_surf",
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "PISTE_DUR",
+     "PISTE_HERBE"
+    ],
+    "paint": {
+     "fill-color": "#DBDBDB",
+     "fill-outline-color": "#808080"
+    }
+   },
+   {
+    "id": "bati ZAI - Autres",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "bati_zai",
+    "minzoom": 15,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "in",
+     "nature",
+     "Lycée",
+     "Université",
+     "Capitainerie",
+     "Gendarmerie",
+     "Siège d'EPCI",
+     "Musée",
+     "Collège",
+     "Maison de retraite",
+     "Etablissement thermal",
+     "Autre service déconcentré de l'Etat",
+     "Etablissement pénitentiaire",
+     "Divers public ou administratif",
+     "Autre établissement d'enseignement",
+     "Maison du parc",
+     "Palais de justice",
+     "Enseignement primaire",
+     "Office de tourisme",
+     "Hôpital",
+     "Police",
+     "Piscine",
+     "Enseignement supérieur",
+     "Poste",
+     "Caserne",
+     "Etablissement hospitalier",
+     "Etablissement extraterritorial",
+     "Science",
+     "Structure d'accueil pour personnes handicapées",
+     "Administration centrale de l'Etat",
+     "Caserne de pompiers"
+    ],
+    "paint": {
+     "fill-color": "#E3BFE2",
+     "fill-opacity": 0.5,
+     "fill-outline-color": "#E39FE1"
+    }
+   },
+   {
+    "id": "bati ZAI - Commandement",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "bati_zai",
+    "minzoom": 15,
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "in",
+     "nature",
+     "Hôtel de département",
+     "Hôtel de région",
+     "Préfecture de région",
+     "Préfecture",
+     "Sous-préfecture"
+    ],
+    "paint": {
+     "fill-color": "#FF0000",
+     "fill-opacity": 0.3,
+     "fill-outline-color": "#B40000"
+    }
+   },
+   {
+    "id": "construction linéaire - mur",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "bati_lin",
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "MUR"
+    ],
+    "paint": {
+     "line-color": "#8C8C8C",
+     "line-width": 0.3
+    }
+   },
+   {
+    "id": "construction linéaire - autre",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "bati_lin",
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "RUINE_LIN",
+     "MUR_SOUTENEMENT",
+     "FORTIF_LIN"
+    ],
+    "paint": {
+     "line-color": "#646464",
+     "line-width": 0.5
+    }
+   },
+   {
+    "id": "construction hydrographique linéaire - Barrage",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "bati_lin",
+    "minzoom": 13,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "BARRAGE_LIN"
+    ],
+    "paint": {
+     "line-color": "#646464",
+     "line-width": {
+      "stops": [
+       [
+        13,
+        1.5
+       ],
+       [
+        17,
+        5
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "construction hydrographique linéaire - Quai",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "bati_lin",
+    "minzoom": 12,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "QUAI",
+     "DIGUE"
+    ],
+    "paint": {
+     "line-color": "#828282",
+     "line-width": {
+      "stops": [
+       [
+        14,
+        1
+       ],
+       [
+        17,
+        2.5
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "construction hydrographique linéaire - Pecherie",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "bati_lin",
+    "minzoom": 12,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "PECHERIE_LIN"
+    ],
+    "paint": {
+     "line-color": "#0066CC",
+     "line-width": {
+      "stops": [
+       [
+        14,
+        1
+       ],
+       [
+        17,
+        2.5
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Chemin a niveau - piste cyclable",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_chemin",
+    "minzoom": 13,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "PISTE_CYCLABLE"
+    ],
+    "paint": {
+     "line-color": {
+      "stops": [
+       [
+        17,
+        "#9B5CCC"
+       ],
+       [
+        18,
+        "#FFFFFF"
+       ]
+      ]
+     },
+     "line-width": {
+      "stops": [
+       [
+        14,
+        1.1
+       ],
+       [
+        15,
+        1.7
+       ],
+       [
+        16,
+        2
+       ],
+       [
+        17,
+        3.5
+       ],
+       [
+        18,
+        6
+       ]
+      ]
+     },
+     "line-dasharray": [
+      6,
+      2
+     ]
+    }
+   },
+   {
+    "id": "Chemin a niveau - filet exterieur - escalier",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_chemin",
+    "minzoom": 14,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "ESCALIER"
+    ],
+    "paint": {
+     "line-color": {
+      "stops": [
+       [
+        17,
+        "#8C7274"
+       ],
+       [
+        18,
+        "#C8C8C8"
+       ]
+      ]
+     },
+     "line-width": {
+      "stops": [
+       [
+        14,
+        1.75
+       ],
+       [
+        15,
+        3
+       ],
+       [
+        16,
+        4.2
+       ],
+       [
+        17,
+        9.5
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Chemin a niveau - filet interieur - escalier",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_chemin",
+    "minzoom": 14,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "ESCALIER"
+    ],
+    "paint": {
+     "line-color": "#FFFFFF",
+     "line-width": {
+      "stops": [
+       [
+        14,
+        1
+       ],
+       [
+        15,
+        1.9
+       ],
+       [
+        16,
+        2.7
+       ],
+       [
+        17,
+        5.8
+       ]
+      ]
+     },
+     "line-dasharray": [
+      1,
+      0.2
+     ]
+    }
+   },
+   {
+    "id": "Chemin a niveau - Rue pietonne",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_chemin",
+    "minzoom": 14,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "RUE_PIETONNE"
+    ],
+    "paint": {
+     "line-color": {
+      "stops": [
+       [
+        17,
+        "#8C7274"
+       ],
+       [
+        18,
+        "#F8E5D5"
+       ]
+      ]
+     },
+     "line-width": {
+      "stops": [
+       [
+        14,
+        1
+       ],
+       [
+        15,
+        1.2
+       ],
+       [
+        16,
+        1.4
+       ],
+       [
+        17,
+        2
+       ],
+       [
+        18,
+        5
+       ]
+      ]
+     },
+     "line-dasharray": [
+      1,
+      3
+     ]
+    }
+   },
+   {
+    "id": "Chemin a niveau - sentier",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_chemin",
+    "minzoom": 13,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "SENTIER"
+    ],
+    "paint": {
+     "line-color": {
+      "stops": [
+       [
+        17,
+        "#8C7274"
+       ],
+       [
+        18,
+        "#FFFFFF"
+       ]
+      ]
+     },
+     "line-width": {
+      "stops": [
+       [
+        14,
+        1
+       ],
+       [
+        15,
+        1.2
+       ],
+       [
+        16,
+        1.4
+       ],
+       [
+        17,
+        2
+       ],
+       [
+        18,
+        6
+       ]
+      ]
+     },
+     "line-dasharray": [
+      4,
+      3
+     ]
+    }
+   },
+   {
+    "id": "Chemin a niveau - chemin",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_chemin",
+    "minzoom": 12,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "CHEMIN"
+    ],
+    "paint": {
+     "line-color": {
+      "stops": [
+       [
+        17,
+        "#8C7274"
+       ],
+       [
+        18,
+        "#FFFFFF"
+       ]
+      ]
+     },
+     "line-width": {
+      "stops": [
+       [
+        14,
+        1
+       ],
+       [
+        15,
+        1.2
+       ],
+       [
+        16,
+        1.4
+       ],
+       [
+        17,
+        2
+       ],
+       [
+        18,
+        7
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier a niveau - filet extérieur - route non revetu carrosable",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route",
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "NON_REVETUE_CARRO"
+    ],
+    "paint": {
+     "line-color": {
+      "stops": [
+       [
+        12,
+        "#646464"
+       ],
+       [
+        17,
+        "#8C8C8C"
+       ]
+      ]
+     },
+     "line-width": {
+      "stops": [
+       [
+        14,
+        3.2
+       ],
+       [
+        15,
+        5.4
+       ],
+       [
+        16,
+        7.7
+       ],
+       [
+        17,
+        16.8
+       ]
+      ]
+     },
+     "line-dasharray": [
+      2,
+      2
+     ]
+    }
+   },
+   {
+    "id": "Routier a niveau - filet interieur - route non revetu carrosable",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route",
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "NON_REVETUE_CARRO"
+    ],
+    "paint": {
+     "line-color": "#FFFFFF",
+     "line-width": {
+      "stops": [
+       [
+        14,
+        2.3
+       ],
+       [
+        15,
+        4.1
+       ],
+       [
+        16,
+        6.3
+       ],
+       [
+        17,
+        13.5
+       ],
+       [
+        18,
+        16.8
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier a niveau - filet extérieur - bretelle autoroute",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route",
+    "minzoom": 12,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "BRET_AUTO_PEAGE_3",
+     "BRET_AUTO_PEAGE_2",
+     "BRET_AUTO_PEAGE_1",
+     "BRET_AUTO_LIBRE_3",
+     "BRET_AUTO_LIBRE_2",
+     "BRET_AUTO_LIBRE_1"
+    ],
+    "paint": {
+     "line-color": {
+      "stops": [
+       [
+        9,
+        "#DE460E"
+       ],
+       [
+        17,
+        "#F18800"
+       ],
+       [
+        18,
+        "#FFFFFF"
+       ]
+      ]
+     },
+     "line-width": {
+      "stops": [
+       [
+        12,
+        2.5
+       ],
+       [
+        14,
+        3.7
+       ],
+       [
+        15,
+        6.8
+       ],
+       [
+        16,
+        8.4
+       ],
+       [
+        17,
+        14
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier a niveau - filet extérieur - route non classee restreint",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route",
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "NON_CLASSEE_RESTREINT"
+    ],
+    "paint": {
+     "line-color": {
+      "stops": [
+       [
+        17,
+        "#969696"
+       ],
+       [
+        18,
+        "#FFFFFF"
+       ]
+      ]
+     },
+     "line-width": {
+      "stops": [
+       [
+        14,
+        3.2
+       ],
+       [
+        15,
+        5.4
+       ],
+       [
+        16,
+        7.7
+       ],
+       [
+        17,
+        16.8
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier a niveau - filet extérieur - route non classee",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route",
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "NON_CLASSEE_4",
+     "NON_CLASSEE"
+    ],
+    "paint": {
+     "line-color": {
+      "stops": [
+       [
+        17,
+        "#969696"
+       ],
+       [
+        18,
+        "#FFFFFF"
+       ]
+      ]
+     },
+     "line-width": {
+      "stops": [
+       [
+        14,
+        3.2
+       ],
+       [
+        15,
+        5.4
+       ],
+       [
+        16,
+        7.7
+       ],
+       [
+        17,
+        16.8
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier a niveau - filet extérieur - route locale",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route",
+    "minzoom": 7,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "BRET_LOCALE",
+     "LOCALE_4",
+     "LOCALE_3",
+     "LOCALE_2",
+     "LOCALE_1"
+    ],
+    "paint": {
+     "line-color": {
+      "stops": [
+       [
+        12,
+        "#8C8C8C"
+       ],
+       [
+        13,
+        "#B4B4B4"
+       ],
+       [
+        17,
+        "#B4B4B4"
+       ],
+       [
+        18,
+        "#FFFFFF"
+       ]
+      ]
+     },
+     "line-width": {
+      "stops": [
+       [
+        9,
+        2
+       ],
+       [
+        14,
+        3.5
+       ],
+       [
+        15,
+        6
+       ],
+       [
+        16,
+        8.4
+       ],
+       [
+        17,
+        18.3
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier a niveau - filet extérieur - route locale en construction",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route",
+    "minzoom": 11,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "LOCALE_CONSTR"
+    ],
+    "paint": {
+     "line-color": "#C8C8C8",
+     "line-width": {
+      "stops": [
+       [
+        9,
+        2
+       ],
+       [
+        14,
+        3.5
+       ],
+       [
+        15,
+        6
+       ],
+       [
+        16,
+        8.4
+       ],
+       [
+        17,
+        18.3
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier a niveau - filet extérieur - route regionale",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route",
+    "minzoom": 8,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "BRET_REGIONALE",
+     "REGIONALE_4",
+     "REGIONALE_3",
+     "REGIONALE_2",
+     "REGIONALE_1"
+    ],
+    "paint": {
+     "line-color": {
+      "stops": [
+       [
+        9,
+        "#828282"
+       ],
+       [
+        10,
+        "#B4B4B4"
+       ],
+       [
+        17,
+        "#B4B4B4"
+       ],
+       [
+        18,
+        "#FFFFFF"
+       ]
+      ]
+     },
+     "line-width": {
+      "stops": [
+       [
+        6,
+        1.5
+       ],
+       [
+        9,
+        2.3
+       ],
+       [
+        14,
+        5
+       ],
+       [
+        15,
+        8.1
+       ],
+       [
+        16,
+        11.2
+       ],
+       [
+        17,
+        22
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier a niveau - filet extérieur - route regionale en construction",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route",
+    "minzoom": 10,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "REGIONALE_CONSTR"
+    ],
+    "paint": {
+     "line-color": "#C8C8C8",
+     "line-width": {
+      "stops": [
+       [
+        6,
+        1.5
+       ],
+       [
+        9,
+        2.3
+       ],
+       [
+        14,
+        5
+       ],
+       [
+        15,
+        8.1
+       ],
+       [
+        16,
+        11.2
+       ],
+       [
+        17,
+        22
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier a niveau - filet extérieur - route principale",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route",
+    "minzoom": 8,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "BRET_PRINCIPALE",
+     "PRINCIPALE_4",
+     "PRINCIPALE_3",
+     "PRINCIPALE_2",
+     "PRINCIPALE_1"
+    ],
+    "paint": {
+     "line-color": {
+      "stops": [
+       [
+        17,
+        "#E2A52A"
+       ],
+       [
+        18,
+        "#FFFFFF"
+       ]
+      ]
+     },
+     "line-width": {
+      "stops": [
+       [
+        6,
+        1.8
+       ],
+       [
+        9,
+        2.7
+       ],
+       [
+        14,
+        5.9
+       ],
+       [
+        15,
+        9
+       ],
+       [
+        16,
+        12.2
+       ],
+       [
+        17,
+        22.5
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier a niveau - filet extérieur - route principale en construction",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route",
+    "minzoom": 10,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "PRINCIPALE_CONSTR"
+    ],
+    "paint": {
+     "line-color": "#C8C8C8",
+     "line-width": {
+      "stops": [
+       [
+        6,
+        1.8
+       ],
+       [
+        9,
+        2.7
+       ],
+       [
+        14,
+        5.9
+       ],
+       [
+        15,
+        9
+       ],
+       [
+        16,
+        12.2
+       ],
+       [
+        17,
+        22.5
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier a niveau - filet extérieur - autoroute",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route",
+    "minzoom": 8,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "AUTOROU_PEAGE",
+     "AUTOROU_LIBRE"
+    ],
+    "paint": {
+     "line-color": {
+      "stops": [
+       [
+        9,
+        "#DE460E"
+       ],
+       [
+        17,
+        "#F18800"
+       ],
+       [
+        18,
+        "#FFFFFF"
+       ]
+      ]
+     },
+     "line-width": {
+      "stops": [
+       [
+        6,
+        2.5
+       ],
+       [
+        9,
+        3.5
+       ],
+       [
+        14,
+        7.5
+       ],
+       [
+        15,
+        11
+       ],
+       [
+        16,
+        15
+       ],
+       [
+        17,
+        26
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier a niveau - filet extérieur - autoroute en construction",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route",
+    "minzoom": 8,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "AUTOROU_CONSTR"
+    ],
+    "paint": {
+     "line-color": "#C8C8C8",
+     "line-width": {
+      "stops": [
+       [
+        6,
+        2.5
+       ],
+       [
+        9,
+        3.5
+       ],
+       [
+        14,
+        7.5
+       ],
+       [
+        15,
+        11
+       ],
+       [
+        16,
+        15
+       ],
+       [
+        17,
+        26
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier a niveau - filet interieur - bretelle autoroute",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route",
+    "minzoom": 12,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "BRET_AUTO_PEAGE_3",
+     "BRET_AUTO_PEAGE_2",
+     "BRET_AUTO_PEAGE_1",
+     "BRET_AUTO_LIBRE_3",
+     "BRET_AUTO_LIBRE_2",
+     "BRET_AUTO_LIBRE_1"
+    ],
+    "paint": {
+     "line-color": {
+      "stops": [
+       [
+        9,
+        "#F18800"
+       ],
+       [
+        17,
+        "#F2B230"
+       ]
+      ]
+     },
+     "line-width": {
+      "stops": [
+       [
+        12,
+        1.5
+       ],
+       [
+        14,
+        2.6
+       ],
+       [
+        15,
+        5.2
+       ],
+       [
+        16,
+        6.7
+       ],
+       [
+        17,
+        10.8
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier a niveau - filet interieur - route non classee restreint",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route",
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "NON_CLASSEE_RESTREINT"
+    ],
+    "paint": {
+     "line-color": "#EDF1FF",
+     "line-width": {
+      "stops": [
+       [
+        14,
+        2.3
+       ],
+       [
+        15,
+        4.1
+       ],
+       [
+        16,
+        6.3
+       ],
+       [
+        17,
+        13.5
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier a niveau - filet interieur - route non classee",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route",
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "NON_CLASSEE_4",
+     "NON_CLASSEE"
+    ],
+    "paint": {
+     "line-color": "#FFFFFF",
+     "line-width": {
+      "stops": [
+       [
+        14,
+        2.3
+       ],
+       [
+        15,
+        4.1
+       ],
+       [
+        16,
+        6.3
+       ],
+       [
+        17,
+        13.5
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier a niveau - filet interieur - route locale",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route",
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "BRET_LOCALE",
+     "LOCALE_4",
+     "LOCALE_3",
+     "LOCALE_2",
+     "LOCALE_1"
+    ],
+    "paint": {
+     "line-color": {
+      "stops": [
+       [
+        6,
+        "#F2B361"
+       ],
+       [
+        7,
+        "#FFFFFF"
+       ],
+       [
+        12,
+        "#FFFFFF"
+       ],
+       [
+        13,
+        "#FCF4A8"
+       ],
+       [
+        17,
+        "#FCF7C1"
+       ]
+      ]
+     },
+     "line-width": {
+      "stops": [
+       [
+        9,
+        1.3
+       ],
+       [
+        14,
+        2.3
+       ],
+       [
+        15,
+        4.1
+       ],
+       [
+        16,
+        6.1
+       ],
+       [
+        17,
+        13.1
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier a niveau - filet interieur - route locale en construction",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route",
+    "minzoom": 11,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "LOCALE_CONSTR"
+    ],
+    "paint": {
+     "line-color": {
+      "stops": [
+       [
+        12,
+        "#FFFFFF"
+       ],
+       [
+        13,
+        "#FCF4A8"
+       ],
+       [
+        17,
+        "#FCF7C1"
+       ],
+       [
+        18,
+        "#EDEDED"
+       ]
+      ]
+     },
+     "line-width": {
+      "stops": [
+       [
+        9,
+        2
+       ],
+       [
+        14,
+        3.5
+       ],
+       [
+        15,
+        6
+       ],
+       [
+        16,
+        8.4
+       ],
+       [
+        17,
+        18.3
+       ]
+      ]
+     },
+     "line-dasharray": [
+      2,
+      2
+     ]
+    }
+   },
+   {
+    "id": "Routier a niveau - filet interieur - route regionale",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route",
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "BRET_REGIONALE",
+     "REGIONALE_4",
+     "REGIONALE_3",
+     "REGIONALE_2",
+     "REGIONALE_1"
+    ],
+    "paint": {
+     "line-color": {
+      "stops": [
+       [
+        6,
+        "#F2A949"
+       ],
+       [
+        7,
+        "#FFFFFF"
+       ],
+       [
+        9,
+        "#FFFFFF"
+       ],
+       [
+        10,
+        "#FDF28B"
+       ],
+       [
+        17,
+        "#FCF6BD"
+       ]
+      ]
+     },
+     "line-width": {
+      "stops": [
+       [
+        4,
+        1.1
+       ],
+       [
+        6,
+        1.4
+       ],
+       [
+        9,
+        1.5
+       ],
+       [
+        14,
+        3.2
+       ],
+       [
+        15,
+        5.8
+       ],
+       [
+        16,
+        8.3
+       ],
+       [
+        17,
+        16.2
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier a niveau - filet interieur - route regionale en construction",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route",
+    "minzoom": 10,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "REGIONALE_CONSTR"
+    ],
+    "paint": {
+     "line-color": {
+      "stops": [
+       [
+        9,
+        "#FFFFFF"
+       ],
+       [
+        10,
+        "#FDF28B"
+       ],
+       [
+        17,
+        "#FCF6BD"
+       ],
+       [
+        18,
+        "#EDEDED"
+       ]
+      ]
+     },
+     "line-width": {
+      "stops": [
+       [
+        4,
+        0.4
+       ],
+       [
+        6,
+        1.5
+       ],
+       [
+        9,
+        2.3
+       ],
+       [
+        14,
+        5
+       ],
+       [
+        15,
+        8.1
+       ],
+       [
+        16,
+        11.2
+       ],
+       [
+        17,
+        22
+       ]
+      ]
+     },
+     "line-dasharray": [
+      2,
+      2
+     ]
+    }
+   },
+   {
+    "id": "Routier a niveau - filet interieur - route principale",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route",
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "BRET_PRINCIPALE",
+     "PRINCIPALE_4",
+     "PRINCIPALE_3",
+     "PRINCIPALE_2",
+     "PRINCIPALE_1"
+    ],
+    "paint": {
+     "line-color": {
+      "stops": [
+       [
+        6,
+        "#F29924"
+       ],
+       [
+        7,
+        "#F3C66D"
+       ],
+       [
+        9,
+        "#F3C66D"
+       ],
+       [
+        17,
+        "#F2DDB3"
+       ]
+      ]
+     },
+     "line-width": {
+      "stops": [
+       [
+        4,
+        0.6
+       ],
+       [
+        6,
+        1.8
+       ],
+       [
+        9,
+        2.1
+       ],
+       [
+        14,
+        4.4
+       ],
+       [
+        15,
+        7.3
+       ],
+       [
+        16,
+        10
+       ],
+       [
+        17,
+        18.5
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier a niveau - filet interieur - route principale en construction",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route",
+    "minzoom": 10,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "PRINCIPALE_CONSTR"
+    ],
+    "paint": {
+     "line-color": {
+      "stops": [
+       [
+        9,
+        "#F3C66D"
+       ],
+       [
+        17,
+        "#F2DDB3"
+       ],
+       [
+        18,
+        "#EDEDED"
+       ]
+      ]
+     },
+     "line-width": {
+      "stops": [
+       [
+        4,
+        0.5
+       ],
+       [
+        6,
+        1.8
+       ],
+       [
+        9,
+        2.7
+       ],
+       [
+        14,
+        5.9
+       ],
+       [
+        15,
+        9
+       ],
+       [
+        16,
+        12.2
+       ],
+       [
+        17,
+        22.5
+       ]
+      ]
+     },
+     "line-dasharray": [
+      2,
+      2
+     ]
+    }
+   },
+   {
+    "id": "Routier a niveau - filet interieur - autoroute",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route",
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "AUTOROU_PEAGE",
+     "AUTOROU_LIBRE"
+    ],
+    "paint": {
+     "line-color": {
+      "stops": [
+       [
+        9,
+        "#F18800"
+       ],
+       [
+        17,
+        "#F2B230"
+       ]
+      ]
+     },
+     "line-width": {
+      "stops": [
+       [
+        4,
+        0.7
+       ],
+       [
+        6,
+        2.5
+       ],
+       [
+        9,
+        2.7
+       ],
+       [
+        14,
+        5.8
+       ],
+       [
+        15,
+        9
+       ],
+       [
+        16,
+        12
+       ],
+       [
+        17,
+        20.8
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier a niveau - axe central - autoroute",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route",
+    "minzoom": 13,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "AUTOROU_PEAGE",
+     "AUTOROU_LIBRE"
+    ],
+    "paint": {
+     "line-color": "#FFFFFF",
+     "line-width": {
+      "stops": [
+       [
+        9,
+        0.6
+       ],
+       [
+        14,
+        0.7
+       ],
+       [
+        15,
+        1
+       ],
+       [
+        16,
+        1.2
+       ],
+       [
+        17,
+        2.1
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier a niveau - filet interieur - autoroute en construction",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route",
+    "minzoom": 8,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "AUTOROU_CONSTR"
+    ],
+    "paint": {
+     "line-color": {
+      "stops": [
+       [
+        9,
+        "#F18800"
+       ],
+       [
+        17,
+        "#F2B230"
+       ],
+       [
+        18,
+        "#EDEDED"
+       ]
+      ]
+     },
+     "line-width": {
+      "stops": [
+       [
+        4,
+        0.7
+       ],
+       [
+        6,
+        2.5
+       ],
+       [
+        9,
+        3.5
+       ],
+       [
+        14,
+        7.5
+       ],
+       [
+        15,
+        11
+       ],
+       [
+        16,
+        15
+       ],
+       [
+        17,
+        26
+       ]
+      ]
+     },
+     "line-dasharray": [
+      2,
+      2
+     ]
+    }
+   },
+   {
+    "id": "Routier a niveau - axe centrale - autoroute en construction",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route",
+    "minzoom": 13,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "AUTOROU_CONSTR"
+    ],
+    "paint": {
+     "line-color": "#808080",
+     "line-width": {
+      "stops": [
+       [
+        9,
+        0.6
+       ],
+       [
+        14,
+        0.7
+       ],
+       [
+        15,
+        1
+       ],
+       [
+        16,
+        1.2
+       ],
+       [
+        17,
+        2.1
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Ferre a niveau - voie normale",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "ferre",
+    "minzoom": 10,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "VF_1",
+     "VF_2",
+     "VF_3",
+     "VF_4",
+     "VF_ELEC_1",
+     "VF_ELEC_2",
+     "VF_ELEC_3",
+     "VF_ELEC_4"
+    ],
+    "paint": {
+     "line-color": "#787878",
+     "line-width": {
+      "stops": [
+       [
+        10,
+        0.8
+       ],
+       [
+        17,
+        2.5
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Ferre a niveau - voie normale trait perpendic",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "ferre",
+    "minzoom": 10,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "VF_1",
+     "VF_2",
+     "VF_3",
+     "VF_4",
+     "VF_ELEC_1",
+     "VF_ELEC_2",
+     "VF_ELEC_3",
+     "VF_ELEC_4"
+    ],
+    "paint": {
+     "line-color": "#787878",
+     "line-width": {
+      "stops": [
+       [
+        10,
+        3.5
+       ],
+       [
+        17,
+        14.7
+       ]
+      ]
+     },
+     "line-dasharray": [
+      0.1,
+      10
+     ]
+    }
+   },
+   {
+    "id": "Ferre a niveau - voie etroite",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "ferre",
+    "minzoom": 10,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "VF_ETROITE_1",
+     "VF_ETROITE_2",
+     "VF_ETROITE"
+    ],
+    "paint": {
+     "line-color": "#787878",
+     "line-width": {
+      "stops": [
+       [
+        10,
+        0.3
+       ],
+       [
+        17,
+        1.8
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Ferre a niveau - voie etroite trait perpendic",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "ferre",
+    "minzoom": 10,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "VF_ETROITE_1",
+     "VF_ETROITE_2",
+     "VF_ETROITE"
+    ],
+    "paint": {
+     "line-color": "#787878",
+     "line-width": {
+      "stops": [
+       [
+        10,
+        3.5
+       ],
+       [
+        17,
+        14.7
+       ]
+      ]
+     },
+     "line-dasharray": [
+      0.1,
+      10
+     ]
+    }
+   },
+   {
+    "id": "Ferre a niveau - voie service",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "ferre",
+    "minzoom": 14,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "VF_SERVICE",
+     "VF_NON_EXPLOITEE"
+    ],
+    "paint": {
+     "line-color": "#787878",
+     "line-width": {
+      "stops": [
+       [
+        10,
+        0.3
+       ],
+       [
+        17,
+        1.8
+       ]
+      ]
+     },
+     "line-dasharray": [
+      5,
+      2,
+      1,
+      2
+     ]
+    }
+   },
+   {
+    "id": "Ferre a niveau - voie en construction",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "ferre",
+    "minzoom": 10,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "VF_EN_CONSTR"
+    ],
+    "paint": {
+     "line-color": "#787878",
+     "line-width": {
+      "stops": [
+       [
+        10,
+        0.3
+       ],
+       [
+        17,
+        1.8
+       ]
+      ]
+     },
+     "line-dasharray": [
+      2,
+      2
+     ]
+    }
+   },
+   {
+    "id": "Ferre a niveau - voie en construction trait perpendic",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "ferre",
+    "minzoom": 10,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "VF_EN_CONSTR"
+    ],
+    "paint": {
+     "line-color": "#787878",
+     "line-width": {
+      "stops": [
+       [
+        10,
+        3.5
+       ],
+       [
+        17,
+        14.7
+       ]
+      ]
+     },
+     "line-dasharray": [
+      0.1,
+      10
+     ]
+    }
+   },
+   {
+    "id": "Ferre a niveau - funic/urbain",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "ferre",
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "FUNI_CREMAILLERE",
+     "TRANSPORT_URBAIN"
+    ],
+    "paint": {
+     "line-color": "#787878",
+     "line-width": {
+      "stops": [
+       [
+        10,
+        0.3
+       ],
+       [
+        17,
+        1.8
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Ferre a niveau - 2 trait perpendic - funic/urbain",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "ferre",
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "FUNI_CREMAILLERE",
+     "TRANSPORT_URBAIN"
+    ],
+    "paint": {
+     "line-color": "#787878",
+     "line-width": {
+      "stops": [
+       [
+        10,
+        3.5
+       ],
+       [
+        17,
+        17
+       ]
+      ]
+     },
+     "line-dasharray": [
+      0.1,
+      0.2,
+      0.1,
+      10
+     ]
+    }
+   },
+   {
+    "id": "liaison routiere - Bac Liaison Maritime",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_liaison",
+    "minzoom": 8,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "BAC_AUTO",
+     "LIAISON_MARITIME",
+     "BAC_LIAISON_MARITIME"
+    ],
+    "paint": {
+     "line-color": "#5792C2",
+     "line-width": {
+      "stops": [
+       [
+        8,
+        1
+       ],
+       [
+        13,
+        2.5
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "liaison routiere - Gue route",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_liaison",
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "GUE_ROUTE"
+    ],
+    "paint": {
+     "line-color": {
+      "stops": [
+       [
+        13,
+        "#BEBEBE"
+       ],
+       [
+        17,
+        "#646464"
+       ],
+       [
+        18,
+        "#FFFFFF"
+       ]
+      ]
+     },
+     "line-width": {
+      "stops": [
+       [
+        14,
+        2.3
+       ],
+       [
+        15,
+        4.1
+       ],
+       [
+        16,
+        6.3
+       ],
+       [
+        17,
+        13.5
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "liaison routiere - Gue chemin",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_liaison",
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "GUE_CHEMIN"
+    ],
+    "paint": {
+     "line-color": {
+      "stops": [
+       [
+        13,
+        "#BEBEBE"
+       ],
+       [
+        17,
+        "#646464"
+       ]
+      ]
+     },
+     "line-width": {
+      "stops": [
+       [
+        14,
+        1.6
+       ],
+       [
+        15,
+        2.9
+       ],
+       [
+        16,
+        4.4
+       ],
+       [
+        17,
+        6.5
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "liaison routiere - filet extérieur - Pont passerelle",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_liaison",
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "PONT_PASSERELLE",
+     "PONT_LIN",
+     "PONT_MOBILE_LIN"
+    ],
+    "paint": {
+     "line-color": {
+      "stops": [
+       [
+        17,
+        "#C8C8C8"
+       ],
+       [
+        18,
+        "#FFFFFF"
+       ]
+      ]
+     },
+     "line-width": {
+      "stops": [
+       [
+        14,
+        2.2
+       ],
+       [
+        15,
+        3.8
+       ],
+       [
+        16,
+        5.4
+       ],
+       [
+        17,
+        11.8
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "liaison routiere - filet intérieur - Pont passerelle",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_liaison",
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "PONT_PASSERELLE",
+     "PONT_LIN",
+     "PONT_MOBILE_LIN"
+    ],
+    "paint": {
+     "line-color": "#FFFFFF",
+     "line-width": {
+      "stops": [
+       [
+        14,
+        0.7
+       ],
+       [
+        15,
+        1.1
+       ],
+       [
+        16,
+        1.7
+       ],
+       [
+        17,
+        3.8
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier surfacique",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "routier_surf",
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "SURF_ROUT_PRINC",
+     "SURF_ROUT_REG",
+     "SURF_ROUT_LOC",
+     "SURF_ROUT_NON_CLA"
+    ],
+    "paint": {
+     "fill-color": "#FFFFFF",
+     "fill-outline-color": "#000000"
+    }
+   },
+   {
+    "id": "Routier surfacique - Dalle de protection",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "routier_surf",
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "DALLE_DE_PROTECTION"
+    ],
+    "paint": {
+     "fill-opacity": 0.5,
+     "fill-color": "#FFFFFF",
+     "fill-outline-color": "#000000"
+    }
+   },
+   {
+    "id": "Routier surfacique - Escalier surfacique",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "routier_surf",
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "ESCALIER_SURF"
+    ],
+    "paint": {
+     "fill-opacity": 0.8,
+     "fill-color": "#FFFFFF",
+     "fill-outline-color": "#918091"
+    }
+   },
+   {
+    "id": "Routier surfacique - Péage surfacique",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "routier_surf",
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "SURF_PEAGE"
+    ],
+    "paint": {
+     "fill-color": "#F2DAAA",
+     "fill-outline-color": "#E2A52A"
+    }
+   },
+   {
+    "id": "bati transport surfacique - bati peage",
+    "type": "fill",
+    "source": "plan_ign",
+    "source-layer": "bati_surf",
+    "minzoom": 13,
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "BATI_PEAGE"
+    ],
+    "paint": {
+     "fill-color": "#DCDCDC",
+     "fill-outline-color": "#808080"
+    }
+   },
+   {
+    "id": "réseau hydro  - cours d'eau superieur",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "hydro_reseau_sup",
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "COURS_D_EAU_SUP",
+     "COURS_D_EAU_MOY_SUP"
+    ],
+    "paint": {
+     "line-color": "#AAD5E9",
+     "line-width": {
+      "stops": [
+       [
+        12,
+        1.5
+       ],
+       [
+        17,
+        6.5
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "réseau hydro - canal superieur",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "hydro_reseau_sup",
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "CANAL_SUP"
+    ],
+    "paint": {
+     "line-color": "#AAD5E9",
+     "line-width": {
+      "stops": [
+       [
+        12,
+        1.4
+       ],
+       [
+        17,
+        5.9
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "réseau hydro - filet interieur - aqueduc superieur",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "hydro_reseau_sup",
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "AQUEDUC_SUP"
+    ],
+    "paint": {
+     "line-color": "#AAD5E9",
+     "line-width": {
+      "stops": [
+       [
+        12,
+        1.4
+       ],
+       [
+        16,
+        3.5
+       ],
+       [
+        17,
+        5.9
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "réseau hydro - carre - aqueduc superieur",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "hydro_reseau_sup",
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "AQUEDUC_SUP"
+    ],
+    "paint": {
+     "line-color": "#AAD5E9",
+     "line-width": {
+      "stops": [
+       [
+        12,
+        3.5
+       ],
+       [
+        16,
+        8.7
+       ],
+       [
+        17,
+        14.7
+       ]
+      ]
+     },
+     "line-dasharray": [
+      1,
+      5
+     ]
+    }
+   },
+   {
+    "id": "Chemin superieur - piste cyclable",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_chemin_sup",
+    "minzoom": 13,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "PISTE_CYCLABLE_SUP"
+    ],
+    "paint": {
+     "line-color": {
+      "stops": [
+       [
+        17,
+        "#9B5CCC"
+       ],
+       [
+        18,
+        "#FFFFFF"
+       ]
+      ]
+     },
+     "line-width": {
+      "stops": [
+       [
+        14,
+        1.1
+       ],
+       [
+        15,
+        1.7
+       ],
+       [
+        16,
+        2
+       ],
+       [
+        17,
+        3.5
+       ],
+       [
+        18,
+        6
+       ]
+      ]
+     },
+     "line-dasharray": [
+      6,
+      2
+     ]
+    }
+   },
+   {
+    "id": "Chemin superieur - filet exterieur - escalier",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_chemin_sup",
+    "minzoom": 14,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "ESCALIER_SUP"
+    ],
+    "paint": {
+     "line-color": {
+      "stops": [
+       [
+        17,
+        "#8C7274"
+       ],
+       [
+        18,
+        "#C8C8C8"
+       ]
+      ]
+     },
+     "line-width": {
+      "stops": [
+       [
+        14,
+        1.75
+       ],
+       [
+        15,
+        3
+       ],
+       [
+        16,
+        4.2
+       ],
+       [
+        17,
+        9.5
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Chemin superieur - filet interieur - escalier",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_chemin_sup",
+    "minzoom": 14,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "ESCALIER_SUP"
+    ],
+    "paint": {
+     "line-color": "#FFFFFF",
+     "line-width": {
+      "stops": [
+       [
+        14,
+        1
+       ],
+       [
+        15,
+        1.9
+       ],
+       [
+        16,
+        2.7
+       ],
+       [
+        17,
+        5.8
+       ]
+      ]
+     },
+     "line-dasharray": [
+      1,
+      0.2
+     ]
+    }
+   },
+   {
+    "id": "Chemin superieur - Rue pietonne",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_chemin_sup",
+    "minzoom": 14,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "RUE_PIETONNE_SUP"
+    ],
+    "paint": {
+     "line-color": {
+      "stops": [
+       [
+        17,
+        "#8C7274"
+       ],
+       [
+        18,
+        "#EBEBEB"
+       ]
+      ]
+     },
+     "line-width": {
+      "stops": [
+       [
+        14,
+        1
+       ],
+       [
+        15,
+        1.2
+       ],
+       [
+        16,
+        1.4
+       ],
+       [
+        17,
+        2
+       ],
+       [
+        18,
+        5
+       ]
+      ]
+     },
+     "line-dasharray": [
+      1,
+      3
+     ]
+    }
+   },
+   {
+    "id": "Chemin superieur - sentier",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_chemin_sup",
+    "minzoom": 13,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "SENTIER_SUP"
+    ],
+    "paint": {
+     "line-color": {
+      "stops": [
+       [
+        17,
+        "#8C7274"
+       ],
+       [
+        18,
+        "#FFFFFF"
+       ]
+      ]
+     },
+     "line-width": {
+      "stops": [
+       [
+        14,
+        1
+       ],
+       [
+        15,
+        1.2
+       ],
+       [
+        16,
+        1.4
+       ],
+       [
+        17,
+        2
+       ],
+       [
+        18,
+        6
+       ]
+      ]
+     },
+     "line-dasharray": [
+      4,
+      3
+     ]
+    }
+   },
+   {
+    "id": "Chemin superieur - chemin",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_chemin_sup",
+    "minzoom": 12,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "CHEMIN_SUP"
+    ],
+    "paint": {
+     "line-color": {
+      "stops": [
+       [
+        17,
+        "#8C7274"
+       ],
+       [
+        18,
+        "#FFFFFF"
+       ]
+      ]
+     },
+     "line-width": {
+      "stops": [
+       [
+        14,
+        1
+       ],
+       [
+        15,
+        1.2
+       ],
+       [
+        16,
+        1.4
+       ],
+       [
+        17,
+        2
+       ],
+       [
+        18,
+        7
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier superieur - filet extérieur - route non revetu carrosable",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route_sup",
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "NON_REVETUE_CARRO_SUP"
+    ],
+    "paint": {
+     "line-color": {
+      "stops": [
+       [
+        12,
+        "#646464"
+       ],
+       [
+        17,
+        "#8C8C8C"
+       ]
+      ]
+     },
+     "line-width": {
+      "stops": [
+       [
+        14,
+        3.2
+       ],
+       [
+        15,
+        5.4
+       ],
+       [
+        16,
+        7.7
+       ],
+       [
+        17,
+        16.8
+       ]
+      ]
+     },
+     "line-dasharray": [
+      2,
+      2
+     ]
+    }
+   },
+   {
+    "id": "Routier superieur - filet extérieur - bretelle autoroute",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route_sup",
+    "minzoom": 12,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "BRET_AUTO_PEAGE_3_SUP",
+     "BRET_AUTO_PEAGE_2_SUP",
+     "BRET_AUTO_PEAGE_1_SUP",
+     "BRET_AUTO_LIBRE_3_SUP",
+     "BRET_AUTO_LIBRE_2_SUP",
+     "BRET_AUTO_LIBRE_1_SUP"
+    ],
+    "paint": {
+     "line-color": {
+      "stops": [
+       [
+        9,
+        "#DE460E"
+       ],
+       [
+        17,
+        "#F18800"
+       ],
+       [
+        18,
+        "#FFFFFF"
+       ]
+      ]
+     },
+     "line-width": {
+      "stops": [
+       [
+        12,
+        2.5
+       ],
+       [
+        14,
+        3.7
+       ],
+       [
+        15,
+        6.8
+       ],
+       [
+        16,
+        8.4
+       ],
+       [
+        17,
+        14
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier superieur - filet extérieur - route non classee restreint",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route_sup",
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "NON_CLASSEE_RESTREINT_SUP"
+    ],
+    "paint": {
+     "line-color": {
+      "stops": [
+       [
+        17,
+        "#969696"
+       ],
+       [
+        18,
+        "#FFFFFF"
+       ]
+      ]
+     },
+     "line-width": {
+      "stops": [
+       [
+        14,
+        3.2
+       ],
+       [
+        15,
+        5.4
+       ],
+       [
+        16,
+        7.7
+       ],
+       [
+        17,
+        16.8
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier superieur - filet extérieur - route non classee",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route_sup",
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "NON_CLASSEE_4_SUP",
+     "NON_CLASSEE_SUP"
+    ],
+    "paint": {
+     "line-color": {
+      "stops": [
+       [
+        17,
+        "#969696"
+       ],
+       [
+        18,
+        "#FFFFFF"
+       ]
+      ]
+     },
+     "line-width": {
+      "stops": [
+       [
+        14,
+        3.2
+       ],
+       [
+        15,
+        5.4
+       ],
+       [
+        16,
+        7.7
+       ],
+       [
+        17,
+        16.8
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier superieur - filet extérieur - route locale",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route_sup",
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "BRET_LOCALE_SUP",
+     "LOCALE_4_SUP",
+     "LOCALE_3_SUP",
+     "LOCALE_2_SUP",
+     "LOCALE_1_SUP"
+    ],
+    "paint": {
+     "line-color": {
+      "stops": [
+       [
+        12,
+        "#8C8C8C"
+       ],
+       [
+        13,
+        "#B4B4B4"
+       ],
+       [
+        17,
+        "#B4B4B4"
+       ],
+       [
+        18,
+        "#FFFFFF"
+       ]
+      ]
+     },
+     "line-width": {
+      "stops": [
+       [
+        9,
+        2
+       ],
+       [
+        14,
+        3.5
+       ],
+       [
+        15,
+        6
+       ],
+       [
+        16,
+        8.4
+       ],
+       [
+        17,
+        18.3
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier superieur - filet extérieur - route locale en construction",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route_sup",
+    "minzoom": 11,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "LOCALE_CONSTR_SUP"
+    ],
+    "paint": {
+     "line-color": "#C8C8C8",
+     "line-width": {
+      "stops": [
+       [
+        9,
+        2
+       ],
+       [
+        14,
+        3.5
+       ],
+       [
+        15,
+        6
+       ],
+       [
+        16,
+        8.4
+       ],
+       [
+        17,
+        18.3
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier superieur - filet extérieur - route regionale",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route_sup",
+    "minzoom": 8,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "BRET_REGIONALE_SUP",
+     "REGIONALE_4_SUP",
+     "REGIONALE_3_SUP",
+     "REGIONALE_2_SUP",
+     "REGIONALE_1_SUP"
+    ],
+    "paint": {
+     "line-color": {
+      "stops": [
+       [
+        9,
+        "#828282"
+       ],
+       [
+        10,
+        "#B4B4B4"
+       ],
+       [
+        17,
+        "#B4B4B4"
+       ],
+       [
+        18,
+        "#FFFFFF"
+       ]
+      ]
+     },
+     "line-width": {
+      "stops": [
+       [
+        6,
+        1.5
+       ],
+       [
+        9,
+        2.3
+       ],
+       [
+        14,
+        5
+       ],
+       [
+        15,
+        8.1
+       ],
+       [
+        16,
+        11.2
+       ],
+       [
+        17,
+        22
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier superieur - filet extérieur - route regionale en construction",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route_sup",
+    "minzoom": 10,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "REGIONALE_CONSTR_SUP"
+    ],
+    "paint": {
+     "line-color": "#C8C8C8",
+     "line-width": {
+      "stops": [
+       [
+        6,
+        1.5
+       ],
+       [
+        9,
+        2.3
+       ],
+       [
+        14,
+        5
+       ],
+       [
+        15,
+        8.1
+       ],
+       [
+        16,
+        11.2
+       ],
+       [
+        17,
+        22
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier superieur - filet extérieur - route principale",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route_sup",
+    "minzoom": 8,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "BRET_PRINCIPALE_SUP",
+     "PRINCIPALE_4_SUP",
+     "PRINCIPALE_3_SUP",
+     "PRINCIPALE_2_SUP",
+     "PRINCIPALE_1_SUP"
+    ],
+    "paint": {
+     "line-color": {
+      "stops": [
+       [
+        17,
+        "#E2A52A"
+       ],
+       [
+        18,
+        "#FFFFFF"
+       ]
+      ]
+     },
+     "line-width": {
+      "stops": [
+       [
+        6,
+        1.8
+       ],
+       [
+        9,
+        2.7
+       ],
+       [
+        14,
+        5.9
+       ],
+       [
+        15,
+        9
+       ],
+       [
+        16,
+        12.2
+       ],
+       [
+        17,
+        22.5
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier superieur - filet extérieur - route principale en construction",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route_sup",
+    "minzoom": 10,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "PRINCIPALE_CONSTR_SUP"
+    ],
+    "paint": {
+     "line-color": "#C8C8C8",
+     "line-width": {
+      "stops": [
+       [
+        6,
+        1.8
+       ],
+       [
+        9,
+        2.7
+       ],
+       [
+        14,
+        5.9
+       ],
+       [
+        15,
+        9
+       ],
+       [
+        16,
+        12.2
+       ],
+       [
+        17,
+        22.5
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier superieur - filet extérieur - autoroute",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route_sup",
+    "minzoom": 8,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "AUTOROU_PEAGE_SUP",
+     "AUTOROU_LIBRE_SUP"
+    ],
+    "paint": {
+     "line-color": {
+      "stops": [
+       [
+        9,
+        "#DE460E"
+       ],
+       [
+        17,
+        "#F18800"
+       ],
+       [
+        18,
+        "#FFFFFF"
+       ]
+      ]
+     },
+     "line-width": {
+      "stops": [
+       [
+        6,
+        2.5
+       ],
+       [
+        9,
+        3.5
+       ],
+       [
+        14,
+        7.5
+       ],
+       [
+        15,
+        11
+       ],
+       [
+        16,
+        15
+       ],
+       [
+        17,
+        26
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier superieur - filet extérieur - autoroute en construction",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route_sup",
+    "minzoom": 10,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "AUTOROU_CONSTR_SUP"
+    ],
+    "paint": {
+     "line-color": "#C8C8C8",
+     "line-width": {
+      "stops": [
+       [
+        6,
+        2.5
+       ],
+       [
+        9,
+        3.5
+       ],
+       [
+        14,
+        7.5
+       ],
+       [
+        15,
+        11
+       ],
+       [
+        16,
+        15
+       ],
+       [
+        17,
+        26
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier superieur - filet interieur - route non revetu carrosable",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route_sup",
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "NON_REVETUE_CARRO_SUP"
+    ],
+    "paint": {
+     "line-color": "#FFFFFF",
+     "line-width": {
+      "stops": [
+       [
+        14,
+        2.3
+       ],
+       [
+        15,
+        4.1
+       ],
+       [
+        16,
+        6.3
+       ],
+       [
+        17,
+        13.5
+       ],
+       [
+        18,
+        16.8
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier superieur - filet interieur - bretelle autoroute",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route_sup",
+    "minzoom": 12,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "BRET_AUTO_PEAGE_3_SUP",
+     "BRET_AUTO_PEAGE_2_SUP",
+     "BRET_AUTO_PEAGE_1_SUP",
+     "BRET_AUTO_LIBRE_3_SUP",
+     "BRET_AUTO_LIBRE_2_SUP",
+     "BRET_AUTO_LIBRE_1_SUP"
+    ],
+    "paint": {
+     "line-color": {
+      "stops": [
+       [
+        9,
+        "#F18800"
+       ],
+       [
+        17,
+        "#F2B230"
+       ]
+      ]
+     },
+     "line-width": {
+      "stops": [
+       [
+        12,
+        1.5
+       ],
+       [
+        14,
+        2.6
+       ],
+       [
+        15,
+        5.2
+       ],
+       [
+        16,
+        6.7
+       ],
+       [
+        17,
+        10.8
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier superieur - filet interieur - route non classee restreint",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route_sup",
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "NON_CLASSEE_RESTREINT_SUP"
+    ],
+    "paint": {
+     "line-color": "#EDF1FF",
+     "line-width": {
+      "stops": [
+       [
+        14,
+        2.3
+       ],
+       [
+        15,
+        4.1
+       ],
+       [
+        16,
+        6.3
+       ],
+       [
+        17,
+        13.5
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier superieur - filet interieur - route non classee",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route_sup",
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "NON_CLASSEE_4_SUP",
+     "NON_CLASSEE_SUP"
+    ],
+    "paint": {
+     "line-color": "#FFFFFF",
+     "line-width": {
+      "stops": [
+       [
+        14,
+        2.3
+       ],
+       [
+        15,
+        4.1
+       ],
+       [
+        16,
+        6.3
+       ],
+       [
+        17,
+        13.5
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier superieur - filet interieur - route locale",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route_sup",
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "BRET_LOCALE_SUP",
+     "LOCALE_4_SUP",
+     "LOCALE_3_SUP",
+     "LOCALE_2_SUP",
+     "LOCALE_1_SUP"
+    ],
+    "paint": {
+     "line-color": {
+      "stops": [
+       [
+        12,
+        "#FFFFFF"
+       ],
+       [
+        13,
+        "#FCF4A8"
+       ],
+       [
+        17,
+        "#FCF7C1"
+       ]
+      ]
+     },
+     "line-width": {
+      "stops": [
+       [
+        9,
+        1.3
+       ],
+       [
+        14,
+        2.3
+       ],
+       [
+        15,
+        4.1
+       ],
+       [
+        16,
+        6.1
+       ],
+       [
+        17,
+        13.1
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier superieur - filet interieur - route locale en construction",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route_sup",
+    "minzoom": 11,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "LOCALE_CONSTR_SUP"
+    ],
+    "paint": {
+     "line-color": {
+      "stops": [
+       [
+        12,
+        "#FFFFFF"
+       ],
+       [
+        13,
+        "#FCF4A8"
+       ],
+       [
+        17,
+        "#FCF7C1"
+       ]
+      ]
+     },
+     "line-width": {
+      "stops": [
+       [
+        9,
+        2
+       ],
+       [
+        14,
+        3.5
+       ],
+       [
+        15,
+        6
+       ],
+       [
+        16,
+        8.4
+       ],
+       [
+        17,
+        18.3
+       ]
+      ]
+     },
+     "line-dasharray": [
+      2,
+      2
+     ]
+    }
+   },
+   {
+    "id": "Routier superieur - filet interieur - route regionale",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route_sup",
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "BRET_REGIONALE_SUP",
+     "REGIONALE_4_SUP",
+     "REGIONALE_3_SUP",
+     "REGIONALE_2_SUP",
+     "REGIONALE_1_SUP"
+    ],
+    "paint": {
+     "line-color": {
+      "stops": [
+       [
+        9,
+        "#FFFFFF"
+       ],
+       [
+        10,
+        "#FDF28B"
+       ],
+       [
+        17,
+        "#FCF6BD"
+       ]
+      ]
+     },
+     "line-width": {
+      "stops": [
+       [
+        6,
+        1.4
+       ],
+       [
+        9,
+        1.5
+       ],
+       [
+        14,
+        3.2
+       ],
+       [
+        15,
+        5.8
+       ],
+       [
+        16,
+        8.3
+       ],
+       [
+        17,
+        16.2
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier superieur - filet interieur - route regionale en construction",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route_sup",
+    "minzoom": 10,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "REGIONALE_CONSTR_SUP"
+    ],
+    "paint": {
+     "line-color": {
+      "stops": [
+       [
+        9,
+        "#FFFFFF"
+       ],
+       [
+        10,
+        "#FDF28B"
+       ],
+       [
+        17,
+        "#FCF6BD"
+       ]
+      ]
+     },
+     "line-width": {
+      "stops": [
+       [
+        6,
+        1.5
+       ],
+       [
+        9,
+        2.3
+       ],
+       [
+        14,
+        5
+       ],
+       [
+        15,
+        8.1
+       ],
+       [
+        16,
+        11.2
+       ],
+       [
+        17,
+        22
+       ]
+      ]
+     },
+     "line-dasharray": [
+      2,
+      2
+     ]
+    }
+   },
+   {
+    "id": "Routier superieur - filet interieur - route principale",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route_sup",
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "BRET_PRINCIPALE_SUP",
+     "PRINCIPALE_4_SUP",
+     "PRINCIPALE_3_SUP",
+     "PRINCIPALE_2_SUP",
+     "PRINCIPALE_1_SUP"
+    ],
+    "paint": {
+     "line-color": {
+      "stops": [
+       [
+        9,
+        "#F3C66D"
+       ],
+       [
+        17,
+        "#F2DDB3"
+       ]
+      ]
+     },
+     "line-width": {
+      "stops": [
+       [
+        4,
+        0.5
+       ],
+       [
+        6,
+        1.8
+       ],
+       [
+        9,
+        2.1
+       ],
+       [
+        14,
+        4.4
+       ],
+       [
+        15,
+        7.3
+       ],
+       [
+        16,
+        10
+       ],
+       [
+        17,
+        18.5
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier superieur - filet interieur - route principale en construction",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route_sup",
+    "minzoom": 10,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "PRINCIPALE_CONSTR_SUP"
+    ],
+    "paint": {
+     "line-color": {
+      "stops": [
+       [
+        9,
+        "#F3C66D"
+       ],
+       [
+        17,
+        "#F2DDB3"
+       ]
+      ]
+     },
+     "line-width": {
+      "stops": [
+       [
+        6,
+        1.8
+       ],
+       [
+        9,
+        2.7
+       ],
+       [
+        14,
+        5.9
+       ],
+       [
+        15,
+        9
+       ],
+       [
+        16,
+        12.2
+       ],
+       [
+        17,
+        22.5
+       ]
+      ]
+     },
+     "line-dasharray": [
+      2,
+      2
+     ]
+    }
+   },
+   {
+    "id": "Routier superieur - filet interieur - autoroute",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route_sup",
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "AUTOROU_PEAGE_SUP",
+     "AUTOROU_LIBRE_SUP"
+    ],
+    "paint": {
+     "line-color": {
+      "stops": [
+       [
+        9,
+        "#F18800"
+       ],
+       [
+        17,
+        "#F2B230"
+       ]
+      ]
+     },
+     "line-width": {
+      "stops": [
+       [
+        4,
+        0.7
+       ],
+       [
+        6,
+        2.5
+       ],
+       [
+        9,
+        2.7
+       ],
+       [
+        14,
+        5.8
+       ],
+       [
+        15,
+        9
+       ],
+       [
+        16,
+        12
+       ],
+       [
+        17,
+        20.8
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier superieur - axe central - autoroute",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route_sup",
+    "minzoom": 13,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "AUTOROU_PEAGE_SUP",
+     "AUTOROU_LIBRE_SUP"
+    ],
+    "paint": {
+     "line-color": "#FFFFFF",
+     "line-width": {
+      "stops": [
+       [
+        9,
+        0.6
+       ],
+       [
+        14,
+        0.7
+       ],
+       [
+        15,
+        1
+       ],
+       [
+        16,
+        1.2
+       ],
+       [
+        17,
+        2.1
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Routier superieur - filet interieur - autoroute en construction",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route_sup",
+    "minzoom": 10,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "AUTOROU_CONSTR_SUP"
+    ],
+    "paint": {
+     "line-color": {
+      "stops": [
+       [
+        9,
+        "#F18800"
+       ],
+       [
+        17,
+        "#F2B230"
+       ]
+      ]
+     },
+     "line-width": {
+      "stops": [
+       [
+        4,
+        0.7
+       ],
+       [
+        6,
+        2.5
+       ],
+       [
+        9,
+        3.5
+       ],
+       [
+        14,
+        7.5
+       ],
+       [
+        15,
+        11
+       ],
+       [
+        16,
+        15
+       ],
+       [
+        17,
+        26
+       ]
+      ]
+     },
+     "line-dasharray": [
+      2,
+      2
+     ]
+    }
+   },
+   {
+    "id": "Routier superieur - axe centrale - autoroute en construction",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "routier_route_sup",
+    "minzoom": 13,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "AUTOROU_CONSTR_SUP"
+    ],
+    "paint": {
+     "line-color": "#808080",
+     "line-width": {
+      "stops": [
+       [
+        9,
+        0.6
+       ],
+       [
+        14,
+        0.7
+       ],
+       [
+        15,
+        1
+       ],
+       [
+        16,
+        1.2
+       ],
+       [
+        17,
+        2.1
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Ferre superieur - voie normale",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "ferre_sup",
+    "minzoom": 10,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "VF_1_SUP",
+     "VF_2_SUP",
+     "VF_ELEC_1_SUP"
+    ],
+    "paint": {
+     "line-color": "#787878",
+     "line-width": {
+      "stops": [
+       [
+        10,
+        0.8
+       ],
+       [
+        17,
+        2.5
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Ferre superieur - voie normale trait perpendic",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "ferre_sup",
+    "minzoom": 10,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "VF_1_SUP",
+     "VF_2_SUP",
+     "VF_ELEC_1_SUP"
+    ],
+    "paint": {
+     "line-color": "#787878",
+     "line-width": {
+      "stops": [
+       [
+        10,
+        3.5
+       ],
+       [
+        17,
+        14.7
+       ]
+      ]
+     },
+     "line-dasharray": [
+      0.1,
+      10
+     ]
+    }
+   },
+   {
+    "id": "Ferre superieur - voie etroite",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "ferre_sup",
+    "minzoom": 10,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "VF_ETROITE_1_SUP",
+     "VF_ETROITE_SUP"
+    ],
+    "paint": {
+     "line-color": "#787878",
+     "line-width": {
+      "stops": [
+       [
+        10,
+        0.3
+       ],
+       [
+        17,
+        1.8
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Ferre superieur - voie etroite trait perpendic",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "ferre_sup",
+    "minzoom": 10,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "VF_ETROITE_1_SUP",
+     "VF_ETROITE_SUP"
+    ],
+    "paint": {
+     "line-color": "#787878",
+     "line-width": {
+      "stops": [
+       [
+        10,
+        3.5
+       ],
+       [
+        17,
+        14.7
+       ]
+      ]
+     },
+     "line-dasharray": [
+      0.1,
+      10
+     ]
+    }
+   },
+   {
+    "id": "Ferre superieur - voie service",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "ferre_sup",
+    "minzoom": 14,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "VF_SERVICE_SUP",
+     "VF_NON_EXPLOITEE_SUP"
+    ],
+    "paint": {
+     "line-color": "#787878",
+     "line-width": {
+      "stops": [
+       [
+        10,
+        0.3
+       ],
+       [
+        17,
+        1.8
+       ]
+      ]
+     },
+     "line-dasharray": [
+      5,
+      2,
+      1,
+      2
+     ]
+    }
+   },
+   {
+    "id": "Ferre superieur - voie en construction",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "ferre_sup",
+    "minzoom": 10,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "VF_EN_CONSTR_SUP"
+    ],
+    "paint": {
+     "line-color": "#787878",
+     "line-width": {
+      "stops": [
+       [
+        10,
+        0.3
+       ],
+       [
+        17,
+        1.8
+       ]
+      ]
+     },
+     "line-dasharray": [
+      2,
+      2
+     ]
+    }
+   },
+   {
+    "id": "Ferre superieur - voie en construction trait perpendic",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "ferre_sup",
+    "minzoom": 10,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "VF_EN_CONSTR_SUP"
+    ],
+    "paint": {
+     "line-color": "#787878",
+     "line-width": {
+      "stops": [
+       [
+        10,
+        3.5
+       ],
+       [
+        17,
+        14.7
+       ]
+      ]
+     },
+     "line-dasharray": [
+      0.1,
+      10
+     ]
+    }
+   },
+   {
+    "id": "Ferre superieur - funic/urbain",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "ferre_sup",
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "FUNI_CREMAILLERE_SUP",
+     "TRANSPORT_URBAIN_SUP"
+    ],
+    "paint": {
+     "line-color": "#787878",
+     "line-width": {
+      "stops": [
+       [
+        10,
+        0.3
+       ],
+       [
+        17,
+        1.8
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "Ferre superieur - 2 trait perpendic - funic/urbain",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "ferre_sup",
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "FUNI_CREMAILLERE_SUP",
+     "TRANSPORT_URBAIN_SUP"
+    ],
+    "paint": {
+     "line-color": "#787878",
+     "line-width": {
+      "stops": [
+       [
+        10,
+        3.5
+       ],
+       [
+        17,
+        17
+       ]
+      ]
+     },
+     "line-dasharray": [
+      0.1,
+      0.2,
+      0.1,
+      10
+     ]
+    }
+   },
+   {
+    "id": "Limite - cloture",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "limite_lin",
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "CLOTURE"
+    ],
+    "paint": {
+     "line-color": "#000000",
+     "line-width": {
+      "stops": [
+       [
+        13,
+        0.6
+       ],
+       [
+        17,
+        1
+       ]
+      ]
+     },
+     "line-dasharray": [
+      1.5,
+      4
+     ]
+    }
+   },
+   {
+    "id": "Limite - layon",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "limite_lin",
+    "minzoom": 14,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "LAYON"
+    ],
+    "paint": {
+     "line-color": "#B3989A",
+     "line-width": {
+      "stops": [
+       [
+        14,
+        1
+       ],
+       [
+        15,
+        1.2
+       ],
+       [
+        16,
+        1.4
+       ],
+       [
+        17,
+        2
+       ]
+      ]
+     },
+     "line-dasharray": [
+      4,
+      7
+     ]
+    }
+   },
+   {
+    "id": "Zone Règlementee - Enceinte militaire",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "limite_lin",
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "LIM_ZONE_REGLEMENTEE",
+     "LIM_ENCEINTE_MILITAIRE",
+     "LIM_ENCEINTE_MILI",
+     "LIM_CHAMP_TIR"
+    ],
+    "paint": {
+     "line-color": "rgba(226, 130, 92, 0.8)",
+     "line-width": {
+      "stops": [
+       [
+        13,
+        1.7
+       ],
+       [
+        17,
+        3.1
+       ]
+      ]
+     },
+     "line-dasharray": [
+      4,
+      1,
+      2,
+      5
+     ]
+    }
+   },
+   {
+    "id": "limite zone naturelle",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "limite_lin",
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "LIM_ZONE_NATURELLE",
+     "LIM_ZONE_NATURELLE_ILE",
+     "LIM_RESERVE_NATURELLE"
+    ],
+    "paint": {
+     "line-color": "#FFC2CB",
+     "line-width": {
+      "stops": [
+       [
+        13,
+        2
+       ],
+       [
+        17,
+        4
+       ]
+      ]
+     },
+     "line-dasharray": [
+      2,
+      1
+     ]
+    }
+   },
+   {
+    "id": "limite zone naturelle - Parc naturel 10",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "limite_lin",
+    "maxzoom": 10,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "LIM_PARC_NATUREL",
+     "LIM_PARC_NATUREL_ILE"
+    ],
+    "paint": {
+     "line-color": "#42A266",
+     "line-width": {
+      "stops": [
+       [
+        13,
+        2
+       ],
+       [
+        17,
+        4
+       ]
+      ]
+     },
+     "line-dasharray": [
+      2,
+      1
+     ]
+    }
+   },
+   {
+    "id": "limite zone naturelle - Parc naturel 11",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "limite_lin",
+    "minzoom": 10,
+    "maxzoom": 11,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "LIM_PARC_NATUREL",
+     "LIM_PARC_NATUREL_ILE"
+    ],
+    "paint": {
+     "line-color": "#42A266",
+     "line-width": {
+      "stops": [
+       [
+        13,
+        2
+       ],
+       [
+        17,
+        4
+       ]
+      ]
+     },
+     "line-dasharray": [
+      2,
+      2
+     ]
+    }
+   },
+   {
+    "id": "limite zone naturelle - Parc naturel 12",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "limite_lin",
+    "minzoom": 11,
+    "maxzoom": 12,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "LIM_PARC_NATUREL",
+     "LIM_PARC_NATUREL_ILE"
+    ],
+    "paint": {
+     "line-color": "#42A266",
+     "line-width": {
+      "stops": [
+       [
+        13,
+        2
+       ],
+       [
+        17,
+        4
+       ]
+      ]
+     },
+     "line-dasharray": [
+      2,
+      3
+     ]
+    }
+   },
+   {
+    "id": "limite zone naturelle - Parc naturel 13",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "limite_lin",
+    "minzoom": 12,
+    "maxzoom": 13,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "LIM_PARC_NATUREL",
+     "LIM_PARC_NATUREL_ILE"
+    ],
+    "paint": {
+     "line-color": "#42A266",
+     "line-width": {
+      "stops": [
+       [
+        13,
+        2
+       ],
+       [
+        17,
+        4
+       ]
+      ]
+     },
+     "line-dasharray": [
+      2,
+      4
+     ]
+    }
+   },
+   {
+    "id": "limite zone naturelle - Parc naturel 14",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "limite_lin",
+    "minzoom": 13,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "LIM_PARC_NATUREL",
+     "LIM_PARC_NATUREL_ILE"
+    ],
+    "paint": {
+     "line-color": "rgba(66, 162, 102, 0.7)",
+     "line-width": {
+      "stops": [
+       [
+        13,
+        2
+       ],
+       [
+        17,
+        4
+       ]
+      ]
+     },
+     "line-dasharray": [
+      2,
+      5
+     ]
+    }
+   },
+   {
+    "id": "limite zone naturelle - Parc marin",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "limite_lin",
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "LIM_PARC_NATUREL_MARIN"
+    ],
+    "paint": {
+     "line-color": "#2A81A2",
+     "line-width": {
+      "stops": [
+       [
+        13,
+        2
+       ],
+       [
+        17,
+        4
+       ]
+      ]
+     },
+     "line-dasharray": [
+      2,
+      1
+     ]
+    }
+   },
+   {
+    "id": "parcellaire - parcelle bordure",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "parcellaire_parcelle",
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "PARCELLE"
+    ],
+    "paint": {
+     "line-color": "#9933FF",
+     "line-width": 1
+    }
+   },
+   {
+    "id": "parcellaire - section",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "parcellaire_section",
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "SECTION"
+    ],
+    "paint": {
+     "line-color": "#287B00",
+     "line-width": 1.9,
+     "line-dasharray": [
+      2,
+      4,
+      2
+     ]
+    }
+   },
+   {
+    "id": "toponyme - parcellaire - section",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_parcellaire_section",
+    "filter": [
+     "==",
+     "txt_typo",
+     "SECTION"
+    ],
+    "layout": {
+     "symbol-placement": "line",
+     "text-offset": [
+      0,
+      0
+     ],
+     "text-field": "{texte}",
+     "text-size": 15,
+     "text-anchor": "center",
+     "text-keep-upright": true,
+     "text-max-angle": 45,
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#287B00"
+    }
+   },
+   {
+    "id": "toponyme - parcellaire - parcelle",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_parcellaire_parcelle",
+    "filter": [
+     "==",
+     "txt_typo",
+     "PARCELLE"
+    ],
+    "layout": {
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-size": 11,
+     "text-anchor": "center",
+     "text-keep-upright": true,
+     "text-max-angle": 45,
+     "text-font": [
+      "Source Sans Pro Bold"
+     ]
+    },
+    "paint": {
+     "text-color": "#9933FF",
+     "text-halo-width": 1,
+     "text-halo-color": "#FFFFFF"
+    }
+   },
+   {
+    "id": "toponyme - parcellaire - adresse",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_parcellaire_adresse_ponc",
+    "filter": [
+     "==",
+     "txt_typo",
+     "ADRESSE"
+    ],
+    "layout": {
+     "symbol-placement": "point",
+     "text-field": [
+      "concat",
+      "{numero}",
+      "{indice_de_repetition}"
+     ],
+     "text-size": 11,
+     "text-anchor": "center",
+     "text-keep-upright": true,
+     "text-max-angle": 45,
+     "text-font": [
+      "Source Sans Pro Bold"
+     ]
+    },
+    "paint": {
+     "text-color": "#695744",
+     "text-halo-width": 1,
+     "text-halo-color": "#FFFFFF"
+    }
+   },
+   {
+    "id": "limite admin - limite de commune",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "limite_lin",
+    "minzoom": 13,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "LIM_COMMUNE",
+     "LIM_CANTON",
+     "LIM_ARRONDISSEMENT"
+    ],
+    "paint": {
+     "line-color": "rgba(126, 119, 184, 0.5)",
+     "line-width": {
+      "stops": [
+       [
+        13,
+        3
+       ],
+       [
+        17,
+        5.5
+       ]
+      ]
+     },
+     "line-dasharray": [
+      4,
+      2,
+      1,
+      1,
+      1,
+      1,
+      1,
+      2
+     ]
+    }
+   },
+   {
+    "id": "limite admin - limite de département bandeau",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "limite_lin",
+    "minzoom": 8,
+    "maxzoom": 13,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "LIM_DEPARTEMENT"
+    ],
+    "paint": {
+     "line-color": "rgba(178, 175, 219, 0.4)",
+     "line-width": {
+      "stops": [
+       [
+        9,
+        4.1
+       ],
+       [
+        12,
+        6
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "limite admin - limite de département tiret",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "limite_lin",
+    "minzoom": 13,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "LIM_DEPARTEMENT"
+    ],
+    "paint": {
+     "line-color": "rgba(126, 119, 184, 0.5)",
+     "line-width": {
+      "stops": [
+       [
+        13,
+        3
+       ],
+       [
+        17,
+        5.5
+       ]
+      ]
+     },
+     "line-dasharray": [
+      4,
+      2,
+      1,
+      1,
+      1,
+      2
+     ]
+    }
+   },
+   {
+    "id": "limite admin - limite de région bandeau",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "limite_lin",
+    "minzoom": 7,
+    "maxzoom": 13,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "LIM_REGION"
+    ],
+    "paint": {
+     "line-color": "rgba(178, 175, 219, 0.5)",
+     "line-width": {
+      "stops": [
+       [
+        9,
+        4.5
+       ],
+       [
+        12,
+        6.7
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "limite admin - limite de région tiret",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "limite_lin",
+    "minzoom": 13,
+    "maxzoom": 18,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "LIM_REGION"
+    ],
+    "paint": {
+     "line-color": "rgba(126, 119, 184, 0.5)",
+     "line-width": {
+      "stops": [
+       [
+        13,
+        3
+       ],
+       [
+        17,
+        5.5
+       ]
+      ]
+     },
+     "line-dasharray": [
+      4,
+      2,
+      1,
+      2
+     ]
+    }
+   },
+   {
+    "id": "limite etat 1",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "limite_lin",
+    "minzoom": 2,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "LIM_ETAT",
+     "LIM_ETAT_ETRANGER"
+    ],
+    "paint": {
+     "line-color": "rgba(178, 175, 219, 0.6)",
+     "line-width": {
+      "stops": [
+       [
+        2,
+        2
+       ],
+       [
+        3,
+        3.5
+       ],
+       [
+        9,
+        5
+       ],
+       [
+        14,
+        13
+       ],
+       [
+        15,
+        20
+       ],
+       [
+        16,
+        24
+       ],
+       [
+        17,
+        42
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "limite etat 2",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "limite_lin",
+    "minzoom": 7,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "LIM_ETAT",
+     "LIM_ETAT_ETRANGER"
+    ],
+    "paint": {
+     "line-color": "#9F9CB8",
+     "line-width": {
+      "stops": [
+       [
+        9,
+        1.5
+       ],
+       [
+        14,
+        3.5
+       ],
+       [
+        15,
+        5.5
+       ],
+       [
+        16,
+        6.5
+       ],
+       [
+        17,
+        11
+       ]
+      ]
+     },
+     "line-dasharray": [
+      4,
+      2
+     ]
+    }
+   },
+   {
+    "id": "limite cote",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "limite_lin",
+    "minzoom": 7,
+    "maxzoom": 10,
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "LIM_COTE"
+    ],
+    "paint": {
+     "line-color": "#82A3B2",
+     "line-width": 1
+    }
+   },
+   {
+    "id": "ligne electrique",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "bati_lin",
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "LIGNE_ELECTRIQUE"
+    ],
+    "paint": {
+     "line-color": "#808080",
+     "line-width": {
+      "stops": [
+       [
+        13,
+        1
+       ],
+       [
+        17,
+        2
+       ]
+      ]
+     }
+    }
+   },
+   {
+    "id": "autre construction linéaire",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "bati_lin",
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "round",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "CABLE",
+     "REMONTEE_MEC",
+     "HYDROCARBURES",
+     "CONDUITE_MATIERES_P",
+     "SPORT_MONTAGNE_LIN",
+     "PISTE_BOBSLEIGH",
+     "PISTE_LUGE",
+     "PISTE_AERO_LIN"
+    ],
+    "paint": {
+     "line-color": "#808080",
+     "line-width": 1
+    }
+   },
+   {
+    "id": "autre construction linéaire - trait perpend cable",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "bati_lin",
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "CABLE"
+    ],
+    "paint": {
+     "line-color": "#808080",
+     "line-width": 5,
+     "line-dasharray": [
+      0.5,
+      10
+     ]
+    }
+   },
+   {
+    "id": "autre construction linéaire - trait perpend 1 remont",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "bati_lin",
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "REMONTEE_MEC"
+    ],
+    "paint": {
+     "line-color": "#808080",
+     "line-width": 6,
+     "line-dasharray": [
+      1,
+      10
+     ]
+    }
+   },
+   {
+    "id": "autre construction linéaire - trait perpend 2 remont",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "bati_lin",
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "REMONTEE_MEC"
+    ],
+    "paint": {
+     "line-color": "#BEBEBE",
+     "line-width": 6,
+     "line-dasharray": [
+      0.3,
+      0.4,
+      0.3,
+      10
+     ]
+    }
+   },
+   {
+    "id": "autre construction linéaire - trait perpend carbur",
+    "type": "line",
+    "source": "plan_ign",
+    "source-layer": "bati_lin",
+    "layout": {
+     "visibility": "visible",
+     "line-cap": "butt",
+     "line-join": "round"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "HYDROCARBURES",
+     "CONDUITE_MATIERES_P"
+    ],
+    "paint": {
+     "line-color": "#808080",
+     "line-width": 5,
+     "line-dasharray": [
+      1,
+      10
+     ]
+    }
+   },
+   {
+    "id": "routier ponctuel - peage ponctuel",
+    "type": "circle",
+    "source": "plan_ign",
+    "source-layer": "routier_ponc",
+    "minzoom": 8,
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "PEAGE_PONC"
+    ],
+    "paint": {
+     "circle-radius": {
+      "stops": [
+       [
+        9,
+        3.5
+       ],
+       [
+        12,
+        6.5
+       ]
+      ]
+     },
+     "circle-color": "#E2A52A",
+     "circle-stroke-width": 1,
+     "circle-stroke-color": "#808080"
+    }
+   },
+   {
+    "id": "routier ponctuel - barriere",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "routier_ponc",
+    "minzoom": 12,
+    "layout": {
+     "visibility": "visible",
+     "icon-image": "Barriere",
+     "icon-size": {
+      "stops": [
+       [
+        13,
+        0.25
+       ],
+       [
+        16,
+        0.45
+       ],
+       [
+        17,
+        0.7
+       ]
+      ]
+     },
+     "icon-allow-overlap": true,
+     "icon-rotate": [
+      "get",
+      "rotation"
+     ]
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "BARRIERE"
+    ],
+    "paint": {
+     "icon-color": "#969696"
+    }
+   },
+   {
+    "id": "hydro ponctuel",
+    "type": "circle",
+    "source": "plan_ign",
+    "source-layer": "hydro_ponc",
+    "minzoom": 13,
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "FONTAINE",
+     "POINT_D_EAU",
+     "SOURCE",
+     "SOURCE_CAPTEE",
+     "PERTE",
+     "RESURGENCE",
+     "CASCADE",
+     "AUTRE_HYDRO_PONC"
+    ],
+    "paint": {
+     "circle-radius": {
+      "stops": [
+       [
+        14,
+        3
+       ],
+       [
+        17,
+        7
+       ]
+      ]
+     },
+     "circle-color": "#FFFFFF",
+     "circle-opacity": 1,
+     "circle-stroke-width": {
+      "stops": [
+       [
+        14,
+        2
+       ],
+       [
+        17,
+        5
+       ]
+      ]
+     },
+     "circle-stroke-color": "#1466B2"
+    }
+   },
+   {
+    "id": "point coté",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "oro_ponc",
+    "minzoom": 11,
+    "maxzoom": 16,
+    "filter": [
+     "in",
+     "symbo",
+     "POINT_COTE",
+     "POINT_COTE_TOPO",
+     "POINT_COTE_RESEAU",
+     "POINT_RBF"
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "icon-image": "Localite",
+     "icon-size": 0.1,
+     "text-field": "{texte}",
+     "text-size": 10,
+     "text-allow-overlap": false,
+     "text-anchor": "bottom-left",
+     "text-offset": [
+      0.2,
+      0.4
+     ],
+     "text-padding": 2,
+     "text-font": [
+      "Source Sans Pro Italic"
+     ]
+    },
+    "paint": {
+     "text-color": "#505050"
+    }
+   },
+   {
+    "id": "bati ponctuel : Hopital",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "bati_ponc",
+    "layout": {
+     "visibility": "visible",
+     "icon-image": "Hopital",
+     "icon-size": 0.33
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "HOPITAL_PONC"
+    ],
+    "paint": {
+     "icon-color": "#646464"
+    }
+   },
+   {
+    "id": "bati ponctuel hydrographique",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "bati_ponc",
+    "minzoom": 14,
+    "layout": {
+     "visibility": "visible",
+     "icon-image": "Pompage",
+     "icon-size": {
+      "stops": [
+       [
+        13,
+        0.2
+       ],
+       [
+        17,
+        0.6
+       ]
+      ]
+     },
+     "icon-allow-overlap": true
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "CITERNE",
+     "LAVOIR",
+     "STATION_EPURATION",
+     "STATION_DE_POMPAGE",
+     "USINE_PRODUCTION_EAU",
+     "USINE_ELEVATRICE"
+    ],
+    "paint": {
+     "icon-color": "#1C62A6"
+    }
+   },
+   {
+    "id": "bati ponctuel hydrographique - Puits-Abreuvoir",
+    "type": "circle",
+    "source": "plan_ign",
+    "source-layer": "bati_ponc",
+    "minzoom": 13,
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "PUITS",
+     "ABREUVOIR"
+    ],
+    "paint": {
+     "circle-radius": {
+      "stops": [
+       [
+        14,
+        3
+       ],
+       [
+        17,
+        7
+       ]
+      ]
+     },
+     "circle-color": "#FFFFFF",
+     "circle-opacity": 1,
+     "circle-stroke-width": {
+      "stops": [
+       [
+        14,
+        2
+       ],
+       [
+        17,
+        5
+       ]
+      ]
+     },
+     "circle-stroke-color": "#1466B2"
+    }
+   },
+   {
+    "id": "bati ponctuel hydrographique - Phare",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "bati_ponc",
+    "minzoom": 13,
+    "layout": {
+     "visibility": "visible",
+     "icon-image": "Phare",
+     "icon-size": {
+      "stops": [
+       [
+        13,
+        0.7
+       ],
+       [
+        17,
+        1.3
+       ]
+      ]
+     }
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "PHARE"
+    ],
+    "paint": {
+     "icon-color": "#646464"
+    }
+   },
+   {
+    "id": "bati ponctuel hydrographique - Amer-Feu",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "bati_ponc",
+    "minzoom": 13,
+    "layout": {
+     "visibility": "visible",
+     "icon-image": "Feu",
+     "icon-size": {
+      "stops": [
+       [
+        13,
+        0.7
+       ],
+       [
+        17,
+        1.3
+       ]
+      ]
+     }
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "AMER",
+     "FEU",
+     "FEU_PONC",
+     "TOURELLE_LUMINEUSE"
+    ],
+    "paint": {
+     "icon-color": "#646464"
+    }
+   },
+   {
+    "id": "bati ponctuel hydrographique - Balise",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "bati_ponc",
+    "minzoom": 13,
+    "layout": {
+     "visibility": "visible",
+     "icon-image": "Balise",
+     "icon-size": {
+      "stops": [
+       [
+        13,
+        0.7
+       ],
+       [
+        17,
+        1.3
+       ]
+      ]
+     }
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "BALISE",
+     "TOURELLE"
+    ],
+    "paint": {
+     "icon-color": "#646464"
+    }
+   },
+   {
+    "id": "bati ponctuel hydrographique - Ecluse",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "bati_ponc",
+    "minzoom": 12,
+    "maxzoom": 15,
+    "layout": {
+     "visibility": "visible",
+     "icon-image": "Ecluse",
+     "icon-size": 0.2
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "ECLUSE_PONC"
+    ],
+    "paint": {
+     "icon-color": "#1C62A6"
+    }
+   },
+   {
+    "id": "bati ponctuel hydrographique - Barrage",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "bati_ponc",
+    "minzoom": 12,
+    "maxzoom": 14,
+    "layout": {
+     "visibility": "visible",
+     "icon-image": "Barrage",
+     "icon-size": 0.25
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "BARRAGE_PONC"
+    ],
+    "paint": {
+     "icon-color": "#1C62A6"
+    }
+   },
+   {
+    "id": "bati ponctuel hydrographique - Chateau d'eau",
+    "type": "circle",
+    "source": "plan_ign",
+    "source-layer": "bati_ponc",
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "CHATEAU_EAU_PONC"
+    ],
+    "paint": {
+     "circle-radius": {
+      "stops": [
+       [
+        14,
+        3
+       ],
+       [
+        17,
+        8
+       ]
+      ]
+     },
+     "circle-color": "#1466B2"
+    }
+   },
+   {
+    "id": "bati ponctuel hydrographique - Réservoir d'eau",
+    "type": "circle",
+    "source": "plan_ign",
+    "source-layer": "bati_ponc",
+    "maxzoom": 15,
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "RESERVOIR_EAU_PONC"
+    ],
+    "paint": {
+     "circle-radius": {
+      "stops": [
+       [
+        14,
+        3
+       ],
+       [
+        17,
+        8
+       ]
+      ]
+     },
+     "circle-color": "#AAD5E9",
+     "circle-opacity": 1,
+     "circle-stroke-width": {
+      "stops": [
+       [
+        14,
+        1
+       ],
+       [
+        17,
+        2.5
+       ]
+      ]
+     },
+     "circle-stroke-color": "#1466B2"
+    }
+   },
+   {
+    "id": "bati ponctuel infrastructure - Constr spé",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "bati_ponc",
+    "layout": {
+     "visibility": "visible",
+     "icon-image": "ConstrSpeciale",
+     "icon-size": {
+      "stops": [
+       [
+        13,
+        0.22
+       ],
+       [
+        17,
+        0.5
+       ]
+      ]
+     }
+    },
+    "filter": [
+     "in",
+     "symbo",
+     "ANTENNE",
+     "CONSTR_SPE_TECHNIQUE",
+     "CONSTR_INDIF_PONC",
+     "CHEMINEE",
+     "CHEVALEMENT",
+     "PUITS_GAZ",
+     "PUITS_PETROLE",
+     "PYLONE_METEO",
+     "TORCHERE",
+     "TOUR_GUET",
+     "TOUR_HERTZIENNE"
+    ],
+    "paint": {
+     "icon-color": "#646464"
+    }
+   },
+   {
+    "id": "bati ponctuel infrastructure - Silo",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "bati_ponc",
+    "maxzoom": 15,
+    "layout": {
+     "visibility": "visible",
+     "icon-image": "Silo",
+     "icon-size": {
+      "stops": [
+       [
+        13,
+        0.22
+       ],
+       [
+        17,
+        0.5
+       ]
+      ]
+     }
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "SILO_PONC"
+    ],
+    "paint": {
+     "icon-color": "#646464"
+    }
+   },
+   {
+    "id": "bati ponctuel infrastructure - Eolienne",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "bati_ponc",
+    "layout": {
+     "visibility": "visible",
+     "icon-image": "Eolienne",
+     "icon-size": {
+      "stops": [
+       [
+        13,
+        0.4
+       ],
+       [
+        17,
+        1
+       ],
+       [
+        18,
+        0.8
+       ]
+      ]
+     }
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "EOLIENNE"
+    ],
+    "paint": {
+     "icon-color": "#646464"
+    }
+   },
+   {
+    "id": "bati ponctuel infrastructure - Reservoir",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "bati_ponc",
+    "maxzoom": 15,
+    "layout": {
+     "visibility": "visible",
+     "icon-image": "Reservoir",
+     "icon-size": {
+      "stops": [
+       [
+        13,
+        0.26
+       ],
+       [
+        17,
+        0.5
+       ]
+      ]
+     }
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "RESERVOIR_PONC"
+    ],
+    "paint": {
+     "icon-color": "#646464"
+    }
+   },
+   {
+    "id": "bati ponctuel infrastructure - pylone électrique",
+    "type": "circle",
+    "source": "plan_ign",
+    "source-layer": "bati_ponc",
+    "layout": {
+     "visibility": "visible"
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "PYLONE_ELEC"
+    ],
+    "paint": {
+     "circle-radius": {
+      "stops": [
+       [
+        13,
+        1
+       ],
+       [
+        17,
+        2
+       ]
+      ]
+     },
+     "circle-color": "#000000"
+    }
+   },
+   {
+    "id": "bati ponctuel montagne - Abri",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "bati_ponc",
+    "layout": {
+     "visibility": "visible",
+     "icon-image": "Abri",
+     "icon-size": {
+      "stops": [
+       [
+        13,
+        0.4
+       ],
+       [
+        15,
+        0.6
+       ],
+       [
+        17,
+        0.9
+       ]
+      ]
+     }
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "ABRI"
+    ],
+    "paint": {
+     "icon-color": "#246138"
+    }
+   },
+   {
+    "id": "bati ponctuel montagne - Refuge Garde",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "bati_ponc",
+    "layout": {
+     "visibility": "visible",
+     "icon-image": "Refugegard",
+     "icon-size": {
+      "stops": [
+       [
+        13,
+        0.4
+       ],
+       [
+        15,
+        0.6
+       ],
+       [
+        17,
+        0.9
+       ]
+      ]
+     }
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "REFUGE_GARDE"
+    ],
+    "paint": {
+     "icon-color": "#246138"
+    }
+   },
+   {
+    "id": "bati ponctuel montagne - Refuge Non Garde",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "bati_ponc",
+    "layout": {
+     "visibility": "visible",
+     "icon-image": "Refugenongard",
+     "icon-size": {
+      "stops": [
+       [
+        13,
+        0.4
+       ],
+       [
+        15,
+        0.6
+       ],
+       [
+        17,
+        0.9
+       ]
+      ]
+     }
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "REFUGE"
+    ],
+    "paint": {
+     "icon-color": "#246138"
+    }
+   },
+   {
+    "id": "bati ponctuel transport aerien - Aeroport FXX",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "bati_ponc",
+    "layout": {
+     "visibility": "visible",
+     "icon-image": "Aeroport",
+     "icon-size": 0.5
+    },
+    "filter": [
+     "all",
+     [
+      "==",
+      "symbo",
+      "AEROPORT_PONC"
+     ],
+     [
+      "==",
+      "territoire",
+      "FXX"
+     ]
+    ],
+    "paint": {
+     "icon-color": "#646464"
+    }
+   },
+   {
+    "id": "bati ponctuel transport aerien - Aerodrome FXX",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "bati_ponc",
+    "layout": {
+     "visibility": "visible",
+     "icon-image": "Aerodrome",
+     "icon-size": 0.4
+    },
+    "filter": [
+     "all",
+     [
+      "==",
+      "symbo",
+      "AERODROME_PONC"
+     ],
+     [
+      "==",
+      "territoire",
+      "FXX"
+     ]
+    ],
+    "paint": {
+     "icon-color": "#646464"
+    }
+   },
+   {
+    "id": "bati ponctuel transport aerien - Aeroport DOM",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "bati_ponc",
+    "minzoom": 8,
+    "layout": {
+     "visibility": "visible",
+     "icon-image": "Aeroport",
+     "icon-size": 0.5
+    },
+    "filter": [
+     "all",
+     [
+      "==",
+      "symbo",
+      "AEROPORT_PONC"
+     ],
+     [
+      "!=",
+      "territoire",
+      "FXX"
+     ]
+    ],
+    "paint": {
+     "icon-color": "#646464"
+    }
+   },
+   {
+    "id": "bati ponctuel transport aerien - Aerodrome DOM",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "bati_ponc",
+    "minzoom": 8,
+    "layout": {
+     "visibility": "visible",
+     "icon-image": "Aerodrome",
+     "icon-size": 0.4
+    },
+    "filter": [
+     "all",
+     [
+      "==",
+      "symbo",
+      "AERODROME_PONC"
+     ],
+     [
+      "!=",
+      "territoire",
+      "FXX"
+     ]
+    ],
+    "paint": {
+     "icon-color": "#646464"
+    }
+   },
+   {
+    "id": "bati ponctuel transport ferroviaire",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "bati_ponc",
+    "layout": {
+     "visibility": "visible",
+     "icon-image": "Gare",
+     "icon-size": 0.33
+    },
+    "filter": [
+     "==",
+     "symbo",
+     "GARE_VOYAGEURS"
+    ],
+    "paint": {
+     "icon-color": "#787878"
+    }
+   },
+   {
+    "id": "toponyme - bornes postales haute - chemins",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_routier_borne",
+    "minzoom": 17,
+    "maxzoom": 18,
+    "filter": [
+     "in",
+     "symbo",
+     "CHEMIN",
+     "CHEMIN_SOU",
+     "CHEMIN_SUP",
+     "PISTE_CYCLABLE",
+     "PISTE_CYCLABLE_SOU",
+     "PISTE_CYCLABLE_SUP",
+     "RUE_PIETONNE",
+     "RUE_PIETONNE_SOU",
+     "RUE_PIETONNE_SUP",
+     "SENTIER",
+     "SENTIER_SOU",
+     "SENTIER_SUP",
+     "ESCALIER",
+     "ESCALIER_SUP"
+    ],
+    "layout": {
+     "symbol-placement": "line",
+     "text-field": "{borne_sur}",
+     "text-size": 11,
+     "text-anchor": "center",
+     "text-allow-overlap": true,
+     "text-offset": [
+      0,
+      -1
+     ],
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#79654F",
+     "text-halo-width": 1,
+     "text-halo-color": "#FFFFFF"
+    }
+   },
+   {
+    "id": "toponyme - bornes postales haute - non revetue, non classee",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_routier_borne",
+    "minzoom": 17,
+    "maxzoom": 18,
+    "filter": [
+     "in",
+     "symbo",
+     "NON_CLASSEE",
+     "NON_CLASSEE_4",
+     "NON_CLASSEE_4_SUP",
+     "NON_CLASSEE_RESTREINT",
+     "NON_CLASSEE_RESTREINT_SUP",
+     "NON_CLASSEE_SOU",
+     "NON_CLASSEE_SUP",
+     "NON_REVETUE_CARRO",
+     "NON_REVETUE_CARRO_SUP"
+    ],
+    "layout": {
+     "symbol-placement": "line",
+     "text-field": "{borne_sur}",
+     "text-size": 11,
+     "text-anchor": "center",
+     "text-allow-overlap": true,
+     "text-offset": [
+      0,
+      -1.3
+     ],
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#79654F",
+     "text-halo-width": 1,
+     "text-halo-color": "#FFFFFF"
+    }
+   },
+   {
+    "id": "toponyme - bornes postales haute - locales",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_routier_borne",
+    "minzoom": 17,
+    "maxzoom": 18,
+    "filter": [
+     "in",
+     "symbo",
+     "LOCALE_1",
+     "LOCALE_1_SOU",
+     "LOCALE_1_SUP",
+     "LOCALE_2",
+     "LOCALE_2_SOU",
+     "LOCALE_2_SUP",
+     "LOCALE_3",
+     "LOCALE_3_SOU",
+     "LOCALE_3_SUP",
+     "LOCALE_4",
+     "LOCALE_4_SOU",
+     "LOCALE_4_SUP",
+     "LOCALE_CONSTR",
+     "LOCALE_CONSTR_SUP"
+    ],
+    "layout": {
+     "symbol-placement": "line",
+     "text-field": "{borne_sur}",
+     "text-size": 11,
+     "text-anchor": "center",
+     "text-allow-overlap": true,
+     "text-offset": [
+      0,
+      -1.4
+     ],
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#79654F",
+     "text-halo-width": 1,
+     "text-halo-color": "#FFFFFF"
+    }
+   },
+   {
+    "id": "toponyme - bornes postales haute - regionales",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_routier_borne",
+    "minzoom": 17,
+    "maxzoom": 18,
+    "filter": [
+     "in",
+     "symbo",
+     "REGIONALE_1",
+     "REGIONALE_1_SOU",
+     "REGIONALE_1_SUP",
+     "REGIONALE_2",
+     "REGIONALE_2_SOU",
+     "REGIONALE_2_SUP",
+     "REGIONALE_3",
+     "REGIONALE_3_SOU",
+     "REGIONALE_3_SUP",
+     "REGIONALE_4",
+     "REGIONALE_4_SUP",
+     "REGIONALE_CONSTR"
+    ],
+    "layout": {
+     "symbol-placement": "line",
+     "text-field": "{borne_sur}",
+     "text-size": 11,
+     "text-anchor": "center",
+     "text-allow-overlap": true,
+     "text-offset": [
+      0,
+      -1.5
+     ],
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#79654F",
+     "text-halo-width": 1,
+     "text-halo-color": "#FFFFFF"
+    }
+   },
+   {
+    "id": "toponyme - bornes postales haute - principales",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_routier_borne",
+    "minzoom": 17,
+    "maxzoom": 18,
+    "filter": [
+     "in",
+     "symbo",
+     "PRINCIPALE_1",
+     "PRINCIPALE_1_SOU",
+     "PRINCIPALE_1_SUP",
+     "PRINCIPALE_2",
+     "PRINCIPALE_2_SOU",
+     "PRINCIPALE_2_SUP",
+     "PRINCIPALE_3",
+     "PRINCIPALE_3_SOU",
+     "PRINCIPALE_3_SUP",
+     "PRINCIPALE_4",
+     "PRINCIPALE_4_SOU",
+     "PRINCIPALE_4_SUP",
+     "PRINCIPALE_CONSTR"
+    ],
+    "layout": {
+     "symbol-placement": "line",
+     "text-field": "{borne_sur}",
+     "text-size": 11,
+     "text-anchor": "center",
+     "text-allow-overlap": true,
+     "text-offset": [
+      0,
+      -1.6
+     ],
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#79654F",
+     "text-halo-width": 1,
+     "text-halo-color": "#FFFFFF"
+    }
+   },
+   {
+    "id": "toponyme - bornes postales bas - chemins",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_routier_borne",
+    "minzoom": 17,
+    "maxzoom": 18,
+    "filter": [
+     "in",
+     "symbo",
+     "CHEMIN",
+     "CHEMIN_SOU",
+     "CHEMIN_SUP",
+     "PISTE_CYCLABLE",
+     "PISTE_CYCLABLE_SOU",
+     "PISTE_CYCLABLE_SUP",
+     "RUE_PIETONNE",
+     "RUE_PIETONNE_SOU",
+     "RUE_PIETONNE_SUP",
+     "SENTIER",
+     "SENTIER_SOU",
+     "SENTIER_SUP",
+     "ESCALIER",
+     "ESCALIER_SUP"
+    ],
+    "layout": {
+     "symbol-placement": "line",
+     "text-field": "{borne_sous}",
+     "text-size": 11,
+     "text-anchor": "center",
+     "text-allow-overlap": true,
+     "text-offset": [
+      0,
+      1
+     ],
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#79654F",
+     "text-halo-width": 1,
+     "text-halo-color": "#FFFFFF"
+    }
+   },
+   {
+    "id": "toponyme - bornes postales bas - non revetue, non classee",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_routier_borne",
+    "minzoom": 17,
+    "maxzoom": 18,
+    "filter": [
+     "in",
+     "symbo",
+     "NON_CLASSEE",
+     "NON_CLASSEE_4",
+     "NON_CLASSEE_4_SUP",
+     "NON_CLASSEE_RESTREINT",
+     "NON_CLASSEE_RESTREINT_SUP",
+     "NON_CLASSEE_SOU",
+     "NON_CLASSEE_SUP",
+     "NON_REVETUE_CARRO",
+     "NON_REVETUE_CARRO_SUP"
+    ],
+    "layout": {
+     "symbol-placement": "line",
+     "text-field": "{borne_sous}",
+     "text-size": 11,
+     "text-anchor": "center",
+     "text-allow-overlap": true,
+     "text-offset": [
+      0,
+      1.3
+     ],
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#79654F",
+     "text-halo-width": 1,
+     "text-halo-color": "#FFFFFF"
+    }
+   },
+   {
+    "id": "toponyme - bornes postales bas - locales",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_routier_borne",
+    "minzoom": 17,
+    "maxzoom": 18,
+    "filter": [
+     "in",
+     "symbo",
+     "LOCALE_1",
+     "LOCALE_1_SOU",
+     "LOCALE_1_SUP",
+     "LOCALE_2",
+     "LOCALE_2_SOU",
+     "LOCALE_2_SUP",
+     "LOCALE_3",
+     "LOCALE_3_SOU",
+     "LOCALE_3_SUP",
+     "LOCALE_4",
+     "LOCALE_4_SOU",
+     "LOCALE_4_SUP",
+     "LOCALE_CONSTR",
+     "LOCALE_CONSTR_SUP"
+    ],
+    "layout": {
+     "symbol-placement": "line",
+     "text-field": "{borne_sous}",
+     "text-size": 11,
+     "text-anchor": "center",
+     "text-allow-overlap": true,
+     "text-offset": [
+      0,
+      1.4
+     ],
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#79654F",
+     "text-halo-width": 1,
+     "text-halo-color": "#FFFFFF"
+    }
+   },
+   {
+    "id": "toponyme - bornes postales bas - regionales",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_routier_borne",
+    "minzoom": 17,
+    "maxzoom": 18,
+    "filter": [
+     "in",
+     "symbo",
+     "REGIONALE_1",
+     "REGIONALE_1_SOU",
+     "REGIONALE_1_SUP",
+     "REGIONALE_2",
+     "REGIONALE_2_SOU",
+     "REGIONALE_2_SUP",
+     "REGIONALE_3",
+     "REGIONALE_3_SOU",
+     "REGIONALE_3_SUP",
+     "REGIONALE_4",
+     "REGIONALE_4_SUP",
+     "REGIONALE_CONSTR"
+    ],
+    "layout": {
+     "symbol-placement": "line",
+     "text-field": "{borne_sous}",
+     "text-size": 11,
+     "text-anchor": "center",
+     "text-allow-overlap": true,
+     "text-offset": [
+      0,
+      1.5
+     ],
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#79654F",
+     "text-halo-width": 1,
+     "text-halo-color": "#FFFFFF"
+    }
+   },
+   {
+    "id": "toponyme - bornes postales bas - principales",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_routier_borne",
+    "minzoom": 17,
+    "maxzoom": 18,
+    "filter": [
+     "in",
+     "symbo",
+     "PRINCIPALE_1",
+     "PRINCIPALE_1_SOU",
+     "PRINCIPALE_1_SUP",
+     "PRINCIPALE_2",
+     "PRINCIPALE_2_SOU",
+     "PRINCIPALE_2_SUP",
+     "PRINCIPALE_3",
+     "PRINCIPALE_3_SOU",
+     "PRINCIPALE_3_SUP",
+     "PRINCIPALE_4",
+     "PRINCIPALE_4_SOU",
+     "PRINCIPALE_4_SUP",
+     "PRINCIPALE_CONSTR"
+    ],
+    "layout": {
+     "symbol-placement": "line",
+     "text-field": "{borne_sous}",
+     "text-size": 11,
+     "text-anchor": "center",
+     "text-allow-overlap": true,
+     "text-offset": [
+      0,
+      1.6
+     ],
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#79654F",
+     "text-halo-width": 1,
+     "text-halo-color": "#FFFFFF"
+    }
+   },
+   {
+    "id": "toponyme - courbe rocher maitresse",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_oro_ponc",
+    "filter": [
+     "==",
+     "txt_typo",
+     "ORO_COURBE_ROCHER"
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-size": 10,
+     "text-allow-overlap": false,
+     "text-padding": 30,
+     "text-rotate": {
+      "type": "identity",
+      "property": "rotation"
+     },
+     "text-font": [
+      "Source Sans Pro Italic"
+     ]
+    },
+    "paint": {
+     "text-color": "#333333",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 1
+    }
+   },
+   {
+    "id": "toponyme - courbe glacier maitresse",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_oro_ponc",
+    "filter": [
+     "==",
+     "txt_typo",
+     "ORO_COURBE_GLACIER"
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-size": 10,
+     "text-allow-overlap": false,
+     "text-padding": 30,
+     "text-rotate": {
+      "type": "identity",
+      "property": "rotation"
+     },
+     "text-font": [
+      "Source Sans Pro Italic"
+     ]
+    },
+    "paint": {
+     "text-color": "#629FD9",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 1
+    }
+   },
+   {
+    "id": "toponyme - courbe maitresse",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_oro_ponc",
+    "filter": [
+     "==",
+     "txt_typo",
+     "ORO_COURBE"
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-size": 10,
+     "text-allow-overlap": false,
+     "text-padding": 30,
+     "text-rotate": {
+      "type": "identity",
+      "property": "rotation"
+     },
+     "text-font": [
+      "Source Sans Pro Italic"
+     ]
+    },
+    "paint": {
+     "text-color": "#604A2F",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 1
+    }
+   },
+   {
+    "id": "toponyme - liaison maritime",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_routier_liaison_lin",
+    "minzoom": 8,
+    "maxzoom": 18,
+    "filter": [
+     "==",
+     "txt_typo",
+     "LIAISON_MARITIME"
+    ],
+    "layout": {
+     "symbol-placement": "line",
+     "text-field": "{texte}",
+     "text-size": 15,
+     "text-anchor": "center",
+     "text-keep-upright": true,
+     "text-max-angle": 45,
+     "text-padding": 10,
+     "text-font": [
+      "Source Sans Pro Italic"
+     ]
+    },
+    "paint": {
+     "text-color": "#5792C2",
+     "text-halo-width": 5,
+     "text-halo-color": "#AAD5E9"
+    }
+   },
+   {
+    "id": "toponyme bati station de métro + bati ponctuel metro",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_bati_ponc",
+    "minzoom": 14,
+    "filter": [
+     "all",
+     [
+      "==",
+      "txt_typo",
+      "TYPO_E_1"
+     ],
+     [
+      "==",
+      "symbo",
+      "STATION_METRO"
+     ]
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-size": 11,
+     "text-allow-overlap": false,
+     "text-offset": [
+      0.3,
+      -0.25
+     ],
+     "text-padding": 3,
+     "text-anchor": "bottom-left",
+     "text-font": [
+      "Source Sans Pro"
+     ],
+     "icon-image": "Metro",
+     "icon-size": {
+      "stops": [
+       [
+        15,
+        0.33
+       ],
+       [
+        17,
+        0.6
+       ]
+      ]
+     }
+    },
+    "paint": {
+     "text-color": "#3C3C3C",
+     "icon-color": "#646464"
+    }
+   },
+   {
+    "id": "toponyme ferre lineaire",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_ferre_lin",
+    "minzoom": 12,
+    "filter": [
+     "in",
+     "txt_typo",
+     "FER_NOM",
+     "FER_OUVRAGE"
+    ],
+    "layout": {
+     "symbol-placement": "line",
+     "text-field": "{texte}",
+     "text-size": 10,
+     "text-anchor": "center",
+     "text-offset": [
+      0,
+      -1
+     ],
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#000000",
+     "text-halo-width": 1,
+     "text-halo-color": "rgba(255, 255, 255, 1)"
+    }
+   },
+   {
+    "id": "toponyme station epuration, de pompage, usine de production eau",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_bati_ponc",
+    "minzoom": 14,
+    "filter": [
+     "==",
+     "txt_typo",
+     "station"
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{designation}",
+     "text-anchor": "left",
+     "text-offset": [
+      0.8,
+      0
+     ],
+     "text-size": 11,
+     "text-allow-overlap": false,
+     "text-padding": 1,
+     "text-font": [
+      "Source Sans Pro Italic"
+     ]
+    },
+    "paint": {
+     "text-color": "#447FB3"
+    }
+   },
+   {
+    "id": "toponyme bati ponc gare",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_bati_ponc",
+    "minzoom": 15,
+    "filter": [
+     "==",
+     "txt_typo",
+     "gore"
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{designation}",
+     "text-size": 11,
+     "text-allow-overlap": false,
+     "text-padding": 1,
+     "text-font": [
+      "Source Sans Pro Italic"
+     ]
+    },
+    "paint": {
+     "text-color": "#000000"
+    }
+   },
+   {
+    "id": "toponyme bati ponc barrage",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_bati_ponc",
+    "minzoom": 12,
+    "filter": [
+     "==",
+     "txt_typo",
+     "BARRAGE_PONC"
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-anchor": "left",
+     "text-offset": [
+      0.8,
+      0
+     ],
+     "text-size": 11,
+     "text-allow-overlap": false,
+     "text-padding": 1,
+     "text-font": [
+      "Source Sans Pro"
+     ]
+    },
+    "paint": {
+     "text-color": "#447FB3"
+    }
+   },
+   {
+    "id": "toponyme bati ponc phare - niveau 13",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_bati_ponc",
+    "maxzoom": 13,
+    "filter": [
+     "==",
+     "txt_typo",
+     "PHARE"
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-anchor": "right",
+     "text-size": 11,
+     "text-allow-overlap": false,
+     "text-padding": 1,
+     "text-font": [
+      "Source Sans Pro"
+     ]
+    },
+    "paint": {
+     "text-color": "#532A2A"
+    }
+   },
+   {
+    "id": "toponyme bati ponc phare - niveau 14à19",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_bati_ponc",
+    "minzoom": 13,
+    "filter": [
+     "all",
+     [
+      "==",
+      "symbo",
+      "PHARE"
+     ],
+     [
+      "in",
+      "txt_typo",
+      "TYPO_C_6",
+      "TYPO_C_7",
+      "TYPO_C_8",
+      "TYPO_E_GE"
+     ]
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-anchor": "right",
+     "text-size": {
+      "stops": [
+       [
+        13,
+        12
+       ],
+       [
+        18,
+        18
+       ]
+      ]
+     },
+     "text-allow-overlap": false,
+     "text-offset": [
+      -2,
+      0
+     ],
+     "text-padding": 3,
+     "text-font": [
+      "Source Sans Pro"
+     ]
+    },
+    "paint": {
+     "text-color": "#532A2A"
+    }
+   },
+   {
+    "id": "toponyme bati ponc autre",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_bati_ponc",
+    "minzoom": 12,
+    "filter": [
+     "in",
+     "txt_typo",
+     "BAT_ACTIVITE",
+     "BAT_FORTIF",
+     "BAT_VILLAGE_DETRUIT"
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-anchor": "center",
+     "text-size": 11,
+     "text-allow-overlap": false,
+     "text-padding": 1,
+     "text-font": [
+      "Source Sans Pro"
+     ]
+    },
+    "paint": {
+     "text-color": "#532A2A"
+    }
+   },
+   {
+    "id": "toponyme bati ponc aerogare",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_bati_ponc",
+    "minzoom": 14,
+    "maxzoom": 17,
+    "filter": [
+     "all",
+     [
+      "==",
+      "txt_typo",
+      "TYPO_E_GE"
+     ],
+     [
+      "==",
+      "symbo",
+      "AEROGARE"
+     ]
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-anchor": "center",
+     "text-size": {
+      "stops": [
+       [
+        12,
+        9
+       ],
+       [
+        16,
+        11
+       ]
+      ]
+     },
+     "text-allow-overlap": false,
+     "text-padding": 1,
+     "text-font": [
+      "Source Sans Pro Italic"
+     ]
+    },
+    "paint": {
+     "text-color": "#120049",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 1
+    }
+   },
+   {
+    "id": "toponyme bati ponc aeroport 12",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_bati_ponc",
+    "minzoom": 11,
+    "maxzoom": 12,
+    "filter": [
+     "==",
+     "txt_typo",
+     "AEROPORT_PONC"
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-anchor": "bottom",
+     "text-offset": [
+      0,
+      -1.3
+     ],
+     "text-size": 10.5,
+     "text-allow-overlap": false,
+     "text-padding": 1,
+     "text-font": [
+      "Source Sans Pro"
+     ]
+    },
+    "paint": {
+     "text-color": "#120049",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 2
+    }
+   },
+   {
+    "id": "toponyme bati ponc aeroport 13",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_bati_ponc",
+    "minzoom": 12,
+    "maxzoom": 13,
+    "filter": [
+     "==",
+     "txt_typo",
+     "AEROPORT_PONC"
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-anchor": "bottom",
+     "text-offset": [
+      0,
+      -2
+     ],
+     "text-size": 11,
+     "text-allow-overlap": false,
+     "text-padding": 1,
+     "text-font": [
+      "Source Sans Pro"
+     ]
+    },
+    "paint": {
+     "text-color": "#120049",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 2
+    }
+   },
+   {
+    "id": "toponyme bati ponc aeroport",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_bati_ponc",
+    "minzoom": 13,
+    "maxzoom": 17,
+    "filter": [
+     "all",
+     [
+      "==",
+      "txt_typo",
+      "TYPO_A_5"
+     ],
+     [
+      "==",
+      "symbo",
+      "AEROPORT"
+     ]
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-anchor": "center",
+     "text-size": {
+      "stops": [
+       [
+        12,
+        11
+       ],
+       [
+        16,
+        13
+       ]
+      ]
+     },
+     "text-allow-overlap": false,
+     "text-padding": 1,
+     "text-font": [
+      "Source Sans Pro"
+     ]
+    },
+    "paint": {
+     "text-color": "#120049",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 2
+    }
+   },
+   {
+    "id": "toponyme bati ponc aerodrome 12",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_bati_ponc",
+    "minzoom": 11,
+    "maxzoom": 12,
+    "filter": [
+     "==",
+     "txt_typo",
+     "AERODROME_PONC"
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-anchor": "bottom",
+     "text-offset": [
+      0,
+      -1.3
+     ],
+     "text-size": 9.5,
+     "text-allow-overlap": false,
+     "text-padding": 1,
+     "text-font": [
+      "Source Sans Pro"
+     ]
+    },
+    "paint": {
+     "text-color": "#120049",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 2
+    }
+   },
+   {
+    "id": "toponyme bati ponc aerodrome 13",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_bati_ponc",
+    "minzoom": 12,
+    "maxzoom": 13,
+    "filter": [
+     "==",
+     "txt_typo",
+     "AERODROME_PONC"
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-anchor": "bottom",
+     "text-offset": [
+      0,
+      -2
+     ],
+     "text-size": 10,
+     "text-allow-overlap": false,
+     "text-padding": 1,
+     "text-font": [
+      "Source Sans Pro"
+     ]
+    },
+    "paint": {
+     "text-color": "#120049",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 2
+    }
+   },
+   {
+    "id": "toponyme bati ponc aerodrome",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_bati_ponc",
+    "minzoom": 13,
+    "maxzoom": 17,
+    "filter": [
+     "all",
+     [
+      "==",
+      "txt_typo",
+      "TYPO_A_7"
+     ],
+     [
+      "==",
+      "symbo",
+      "AERODROME"
+     ]
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-anchor": "center",
+     "text-size": {
+      "stops": [
+       [
+        12,
+        10
+       ],
+       [
+        16,
+        12
+       ]
+      ]
+     },
+     "text-allow-overlap": false,
+     "text-padding": 1,
+     "text-font": [
+      "Source Sans Pro"
+     ]
+    },
+    "paint": {
+     "text-color": "#120049",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 2
+    }
+   },
+   {
+    "id": "toponyme - hydro ponc 5",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_hydro_ponc",
+    "filter": [
+     "in",
+     "txt_typo",
+     "TYPO_D_9",
+     "TYPO_D_10",
+     "TYPO_E_1_cyan"
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-size": {
+      "stops": [
+       [
+        15,
+        11
+       ],
+       [
+        17,
+        14
+       ]
+      ]
+     },
+     "text-allow-overlap": true,
+     "text-padding": 5,
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#447FB3",
+     "text-halo-color": "#FFFFFF",
+     "text-halo-width": 1
+    }
+   },
+   {
+    "id": "toponyme - hydro ponc glacier",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_hydro_ponc",
+    "filter": [
+     "==",
+     "txt_typo",
+     "ORO_GLACIER_2"
+    ],
+    "layout": {
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-size": 14,
+     "text-anchor": "center",
+     "text-allow-overlap": true,
+     "text-padding": 1,
+     "text-font": [
+      "Source Sans Pro Italic"
+     ]
+    },
+    "paint": {
+     "text-color": "#447FB3",
+     "text-halo-width": 2,
+     "text-halo-color": "rgba(255, 255, 255, 0.5)"
+    }
+   },
+   {
+    "id": "toponyme - limite militaire ponc 3 et 4",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_limite_ponc",
+    "filter": [
+     "in",
+     "txt_typo",
+     "LIM_MILI_3",
+     "LIM_MILI_4"
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-size": 12,
+     "text-allow-overlap": false,
+     "text-padding": 2,
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#0D2000",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 1
+    }
+   },
+   {
+    "id": "toponyme - limite parc ponc 3 et 4",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_limite_ponc",
+    "filter": [
+     "in",
+     "txt_typo",
+     "LIM_PARC_3",
+     "LIM_PARC_4",
+     "RESERVE_NATURELLE_PONC"
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-size": 13,
+     "text-allow-overlap": false,
+     "text-padding": 2,
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#287B00",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 1
+    }
+   },
+   {
+    "id": "toponyme numéro de route - départementale",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_routier_numero_lin",
+    "minzoom": 11,
+    "maxzoom": 16,
+    "filter": [
+     "==",
+     "txt_typo",
+     "Départementale"
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "line",
+     "text-field": "{texte}",
+     "text-size": 10.5,
+     "text-allow-overlap": false,
+     "text-padding": 2,
+     "text-anchor": "center",
+     "text-font": [
+      "Source Sans Pro Semibold"
+     ],
+     "text-rotation-alignment": "viewport"
+    },
+    "paint": {
+     "text-color": "#4D4D4D",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 4
+    }
+   },
+   {
+    "id": "toponyme numéro de route - nationale",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_routier_numero_lin",
+    "minzoom": 7,
+    "maxzoom": 16,
+    "filter": [
+     "==",
+     "txt_typo",
+     "Nationale"
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "line",
+     "text-field": "{texte}",
+     "text-size": 12,
+     "text-allow-overlap": false,
+     "text-padding": 0,
+     "text-anchor": "center",
+     "text-font": [
+      "Source Sans Pro Regular"
+     ],
+     "icon-image": "Ecluse",
+     "icon-rotation-alignment": "viewport",
+     "text-rotation-alignment": "viewport",
+     "icon-text-fit": "both",
+     "icon-size": 0
+    },
+    "paint": {
+     "text-color": "#F0F0F0",
+     "icon-color": "#646464",
+     "text-halo-color": "rgba(80, 80, 80, 0.5)",
+     "text-halo-width": 4
+    }
+   },
+   {
+    "id": "toponyme numéro de route - autoroute",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_routier_numero_lin",
+    "minzoom": 7,
+    "maxzoom": 16,
+    "filter": [
+     "==",
+     "txt_typo",
+     "Autoroute"
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "line",
+     "text-field": "{texte}",
+     "text-size": 15,
+     "text-allow-overlap": false,
+     "text-padding": 0,
+     "text-anchor": "center",
+     "text-font": [
+      "Source Sans Pro Regular"
+     ],
+     "icon-image": "Ecluse",
+     "icon-rotation-alignment": "viewport",
+     "text-rotation-alignment": "viewport",
+     "icon-text-fit": "both",
+     "icon-size": 0
+    },
+    "paint": {
+     "text-color": "#F0F0F0",
+     "icon-color": "#646464",
+     "text-halo-color": "rgba(80, 80, 80, 0.5)",
+     "text-halo-width": 5
+    }
+   },
+   {
+    "id": "toponyme - odonyme abrégé",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_routier_odonyme_lin",
+    "minzoom": 15,
+    "maxzoom": 17,
+    "layout": {
+     "symbol-placement": "line",
+     "text-field": "{nom_gauche}",
+     "text-size": 10,
+     "text-anchor": "center",
+     "text-max-angle": 30,
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#000000",
+     "text-halo-width": 2,
+     "text-halo-color": "rgba(255, 255, 255, 1)"
+    }
+   },
+   {
+    "id": "toponyme - odonyme desabrégé",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_routier_odonyme_lin",
+    "minzoom": 17,
+    "layout": {
+     "symbol-placement": "line",
+     "text-field": "{nom_desabrege}",
+     "text-size": 11,
+     "text-anchor": "center",
+     "text-max-angle": 30,
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#000000",
+     "text-halo-width": 2,
+     "text-halo-color": "rgba(255, 255, 255, 1)"
+    }
+   },
+   {
+    "id": "toponyme - lieu dit non habité 3",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_ocs_ponc",
+    "filter": [
+     "all",
+     [
+      "==",
+      "symbo",
+      "LIEU-DIT_NON_HABITE"
+     ],
+     [
+      "in",
+      "txt_typo",
+      "TYPO_B_10",
+      "TYPO_B_11"
+     ]
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-size": 11,
+     "text-allow-overlap": false,
+     "text-padding": 1,
+     "text-font": [
+      "Source Sans Pro Italic"
+     ]
+    },
+    "paint": {
+     "text-color": "#000000",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 1
+    }
+   },
+   {
+    "id": "toponyme - bois",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_ocs_ponc",
+    "filter": [
+     "all",
+     [
+      "==",
+      "symbo",
+      "BOIS"
+     ],
+     [
+      "in",
+      "txt_typo",
+      "TYPO_F_10",
+      "TYPO_F_11"
+     ]
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-size": 13,
+     "text-allow-overlap": false,
+     "text-padding": 1,
+     "text-font": [
+      "Source Sans Pro Italic"
+     ]
+    },
+    "paint": {
+     "text-color": "#287B00",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 1
+    }
+   },
+   {
+    "id": "toponyme - oro lineaire 4",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_oro_lin",
+    "filter": [
+     "in",
+     "txt_typo",
+     "ORO_SOMMET_3",
+     "ORO_GORGE_2"
+    ],
+    "layout": {
+     "symbol-placement": "line",
+     "text-field": "{texte}",
+     "text-size": 11,
+     "text-anchor": "center",
+     "text-keep-upright": true,
+     "text-max-angle": 45,
+     "text-padding": 1,
+     "text-font": [
+      "Source Sans Pro Italic"
+     ]
+    },
+    "paint": {
+     "text-color": "#863831",
+     "text-halo-width": 1.5,
+     "text-halo-color": "rgba(255, 255, 255, 0.5)"
+    }
+   },
+   {
+    "id": "toponyme - oro ponc 4",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_oro_ponc",
+    "filter": [
+     "in",
+     "txt_typo",
+     "ORO_SOMMET_3",
+     "ORO_GORGE_2",
+     "GROTTE",
+     "GORGE",
+     "TYPO_G_9",
+     "TYPO_G_10"
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-size": {
+      "stops": [
+       [
+        13,
+        11
+       ],
+       [
+        16,
+        16
+       ]
+      ]
+     },
+     "text-allow-overlap": true,
+     "text-padding": 1,
+     "text-font": [
+      "Source Sans Pro Italic"
+     ]
+    },
+    "paint": {
+     "text-color": "#863831",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 1.5
+    }
+   },
+   {
+    "id": "toponyme - hydro ponc 4",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_hydro_ponc",
+    "filter": [
+     "in",
+     "txt_typo",
+     "lac - étang - bassin",
+     "HYD_SURF_4",
+     "HYD_SURF_4_T",
+     "HYD_SURF_5",
+     "HYD_SURF_5_T",
+     "TYPO_D_8",
+     "SOURCE"
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-size": {
+      "stops": [
+       [
+        14,
+        13
+       ],
+       [
+        17,
+        16
+       ]
+      ]
+     },
+     "text-allow-overlap": true,
+     "text-padding": 5,
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#447FB3",
+     "text-halo-color": "#FFFFFF",
+     "text-halo-width": 1
+    }
+   },
+   {
+    "id": "toponyme quartier ",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_localite_ponc",
+    "filter": [
+     "in",
+     "txt_typo",
+     "BAT_QUARTIER",
+     "BAT_QUARTIER_T"
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-size": 11,
+     "text-allow-overlap": false,
+     "text-padding": 1,
+     "text-font": [
+      "Source Sans Pro Italic"
+     ]
+    },
+    "paint": {
+     "text-color": "#000000",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 2
+    }
+   },
+   {
+    "id": "toponyme localite n0 typoA10",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_localite_ponc",
+    "maxzoom": 18,
+    "filter": [
+     "==",
+     "txt_typo",
+     "TYPO_A_10"
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-size": {
+      "stops": [
+       [
+        15,
+        11
+       ],
+       [
+        17,
+        13.5
+       ]
+      ]
+     },
+     "text-allow-overlap": true,
+     "text-anchor": "center",
+     "text-padding": 1,
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#000000",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 2
+    }
+   },
+   {
+    "id": "toponyme - lieu dit non habité",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_ocs_ponc",
+    "filter": [
+     "all",
+     [
+      "==",
+      "symbo",
+      "LIEU-DIT_NON_HABITE"
+     ],
+     [
+      "in",
+      "txt_typo",
+      "TYPO_B_7",
+      "TYPO_B_8",
+      "TYPO_B_9"
+     ]
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-size": 12,
+     "text-allow-overlap": false,
+     "text-padding": 1,
+     "text-font": [
+      "Source Sans Pro Italic"
+     ]
+    },
+    "paint": {
+     "text-color": "#000000",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 1
+    }
+   },
+   {
+    "id": "toponyme - bois 2",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_ocs_ponc",
+    "filter": [
+     "all",
+     [
+      "==",
+      "symbo",
+      "BOIS"
+     ],
+     [
+      "in",
+      "txt_typo",
+      "TYPO_F_7",
+      "TYPO_F_8",
+      "TYPO_F_9"
+     ]
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-size": 16,
+     "text-allow-overlap": false,
+     "text-padding": 1,
+     "text-font": [
+      "Source Sans Pro Italic"
+     ]
+    },
+    "paint": {
+     "text-color": "#287B00",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 2
+    }
+   },
+   {
+    "id": "toponyme localite hameau ",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_localite_ponc",
+    "minzoom": 11,
+    "maxzoom": 13,
+    "filter": [
+     "in",
+     "txt_typo",
+     "BAT_HAMEAU",
+     "BAT_HAMEAU_T"
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "icon-image": "Localite",
+     "icon-size": 0.17,
+     "text-field": "{texte}",
+     "text-size": 11,
+     "text-allow-overlap": false,
+     "text-anchor": "bottom-left",
+     "text-offset": [
+      0.3,
+      0.1
+     ],
+     "text-padding": 1,
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#000000",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 2
+    }
+   },
+   {
+    "id": "toponyme localite importance 5",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_localite_ponc",
+    "minzoom": 9,
+    "filter": [
+     "in",
+     "txt_typo",
+     "commune 5",
+     "BAT_COMMUNE_5",
+     "BAT_COMMUNE_5_T",
+     "BAT_CHEF_LIEU_COM",
+     "BAT_CHEF_LIEU_COM_T",
+     "BAT_CHEF_LIEU_COM-T",
+     "BAT_ANCIENNE_COM",
+     "BAT_ANCIENNE_COM_T",
+     "BAT_COMMUNE_ASSOCIEE",
+     "BAT_COMMUNE_ASSOCIEE_T",
+     "Commune très petite"
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "icon-image": "Localite",
+     "icon-size": 0.21,
+     "text-field": "{texte}",
+     "text-size": 11.5,
+     "text-allow-overlap": false,
+     "text-anchor": "bottom-left",
+     "text-offset": [
+      0.3,
+      0.1
+     ],
+     "text-padding": 1,
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#000000",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 2
+    }
+   },
+   {
+    "id": "toponyme - ocs lineaire 3",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_ocs_lin",
+    "filter": [
+     "==",
+     "txt_typo",
+     "OCS_FORET_3"
+    ],
+    "layout": {
+     "symbol-placement": "line",
+     "text-field": "{texte}",
+     "text-size": {
+      "stops": [
+       [
+        10,
+        12
+       ],
+       [
+        12,
+        15
+       ]
+      ]
+     },
+     "text-anchor": "center",
+     "text-keep-upright": true,
+     "text-max-angle": 45,
+     "text-padding": 1,
+     "text-font": [
+      "Source Sans Pro Italic"
+     ]
+    },
+    "paint": {
+     "text-color": "#287B00",
+     "text-halo-width": 1,
+     "text-halo-color": "rgba(255, 255, 255, 0.5)"
+    }
+   },
+   {
+    "id": "toponyme - lieu dit non habité 1",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_ocs_ponc",
+    "filter": [
+     "all",
+     [
+      "==",
+      "symbo",
+      "LIEU-DIT_NON_HABITE"
+     ],
+     [
+      "in",
+      "txt_typo",
+      "TYPO_B_5",
+      "TYPO_B_4"
+     ]
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-size": 15,
+     "text-allow-overlap": false,
+     "text-padding": 1,
+     "text-font": [
+      "Source Sans Pro Italic"
+     ]
+    },
+    "paint": {
+     "text-color": "#000000",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 1
+    }
+   },
+   {
+    "id": "toponyme - bois 1",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_ocs_ponc",
+    "filter": [
+     "all",
+     [
+      "==",
+      "symbo",
+      "BOIS"
+     ],
+     [
+      "in",
+      "txt_typo",
+      "TYPO_F_5",
+      "TYPO_F_4"
+     ]
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-size": 19,
+     "text-allow-overlap": false,
+     "text-padding": 1,
+     "text-font": [
+      "Source Sans Pro Italic"
+     ]
+    },
+    "paint": {
+     "text-color": "#287B00",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 2
+    }
+   },
+   {
+    "id": "toponyme - bois 0",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_ocs_ponc",
+    "filter": [
+     "all",
+     [
+      "==",
+      "symbo",
+      "BOIS"
+     ],
+     [
+      "in",
+      "txt_typo",
+      "TYPO_F_3",
+      "TYPO_F_2"
+     ]
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-size": 22,
+     "text-allow-overlap": false,
+     "text-padding": 1,
+     "text-font": [
+      "Source Sans Pro Italic"
+     ]
+    },
+    "paint": {
+     "text-color": "#287B00",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 2
+    }
+   },
+   {
+    "id": "toponyme - ocs ponc 3",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_ocs_ponc",
+    "filter": [
+     "==",
+     "txt_typo",
+     "OCS_FORET_3"
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-size": {
+      "stops": [
+       [
+        10,
+        12
+       ],
+       [
+        12,
+        15
+       ]
+      ]
+     },
+     "text-allow-overlap": false,
+     "text-padding": 1,
+     "text-anchor": "center",
+     "text-font": [
+      "Source Sans Pro Italic"
+     ]
+    },
+    "paint": {
+     "text-color": "#287B00",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 1
+    }
+   },
+   {
+    "id": "toponyme - oro lineaire 3",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_oro_lin",
+    "filter": [
+     "in",
+     "txt_typo",
+     "ORO_ILE_3",
+     "ORO_RELIEF_3",
+     "ORO_RELIEF_3_T",
+     "ORO_RELIEF_4",
+     "ORO_RELIEF_4_T",
+     "ORO_CAP_2",
+     "ORO_CAP_3",
+     "ORO_SOMMET_2",
+     "ORO_COL_2",
+     "ORO_GORGE_1",
+     "ORO_GORGE-1"
+    ],
+    "layout": {
+     "symbol-placement": "line",
+     "text-field": "{texte}",
+     "text-size": 12,
+     "text-anchor": "center",
+     "text-keep-upright": true,
+     "text-max-angle": 45,
+     "text-padding": 10,
+     "text-font": [
+      "Source Sans Pro Italic"
+     ]
+    },
+    "paint": {
+     "text-color": "#863831",
+     "text-halo-width": 1.5,
+     "text-halo-color": "rgba(255, 255, 255, 0.5)"
+    }
+   },
+   {
+    "id": "toponyme - oro ponc 3",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_oro_ponc",
+    "filter": [
+     "in",
+     "txt_typo",
+     "ORO_ILE_3",
+     "ORO_RELIEF_3",
+     "ORO_RELIEF_3_T",
+     "ORO_RELIEF_4",
+     "ORO_RELIEF_4_T",
+     "ORO_CAP_2",
+     "ORO_CAP_3",
+     "ORO_SOMMET_2",
+     "ORO_COL_2",
+     "ORO_GORGE_1",
+     "ORO_GORGE-1",
+     "TYPO_G_7",
+     "TYPO_G_8"
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-size": {
+      "stops": [
+       [
+        13,
+        12
+       ],
+       [
+        16,
+        17
+       ]
+      ]
+     },
+     "text-allow-overlap": true,
+     "text-padding": 1,
+     "text-font": [
+      "Source Sans Pro Italic"
+     ]
+    },
+    "paint": {
+     "text-color": "#863831",
+     "text-halo-color": "#FFFFFF",
+     "text-halo-width": 1.5
+    }
+   },
+   {
+    "id": "toponyme - hydro lineaire 3",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_hydro_lin",
+    "filter": [
+     "in",
+     "txt_typo",
+     "HYD_LIN_3",
+     "HYD_LIN_4",
+     "HYD_LIN_5",
+     "petite rivière",
+     "canal",
+     "HYD_SURF_3",
+     "HYD_SURF_3_T",
+     "HYD_SURF_4",
+     "HYD_SURF_4_T",
+     "HYD_SURF_5",
+     "HYD_SURF_5_T",
+     "TYPO_D_5"
+    ],
+    "layout": {
+     "symbol-placement": "line",
+     "text-field": "{texte}",
+     "text-size": {
+      "stops": [
+       [
+        14,
+        12
+       ],
+       [
+        18,
+        19
+       ]
+      ]
+     },
+     "text-anchor": "center",
+     "text-keep-upright": true,
+     "text-max-angle": 45,
+     "text-padding": 10,
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#447FB3",
+     "text-halo-width": 1.5,
+     "text-halo-color": "rgba(255, 255, 255, 0.7)"
+    }
+   },
+   {
+    "id": "toponyme - hydro lineaire 4",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_hydro_lin",
+    "minzoom": 14,
+    "filter": [
+     "in",
+     "txt_typo",
+     "TYPO_D_6",
+     "TYPO_D_8",
+     "TYPO_D_9",
+     "TYPO_D_10"
+    ],
+    "layout": {
+     "symbol-placement": "line",
+     "text-field": "{texte}",
+     "text-size": {
+      "stops": [
+       [
+        14,
+        10
+       ],
+       [
+        18,
+        16
+       ]
+      ]
+     },
+     "text-anchor": "center",
+     "text-keep-upright": true,
+     "text-max-angle": 45,
+     "text-padding": 10,
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#447FB3",
+     "text-halo-width": 1.5,
+     "text-halo-color": "rgba(255, 255, 255, 0.7)"
+    }
+   },
+   {
+    "id": "toponyme - hydro ponc 3",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_hydro_ponc",
+    "filter": [
+     "in",
+     "txt_typo",
+     "petit golfe",
+     "grande baie",
+     "baie",
+     "HYD_SURF_3",
+     "TYPO_D_5",
+     "TYPO_D_6",
+     "TYPO_D_7"
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-size": {
+      "stops": [
+       [
+        15,
+        15
+       ],
+       [
+        17,
+        18
+       ]
+      ]
+     },
+     "text-allow-overlap": true,
+     "text-padding": 10,
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#447FB3",
+     "text-halo-color": "#FFFFFF",
+     "text-halo-width": 2
+    }
+   },
+   {
+    "id": "toponyme bati ponc zai zoom 16",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_bati_ponc",
+    "minzoom": 15,
+    "maxzoom": 16,
+    "filter": [
+     "==",
+     "txt_typo",
+     "zai"
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{designation}",
+     "text-size": 11,
+     "text-allow-overlap": false,
+     "text-padding": 1,
+     "text-font": [
+      "Source Sans Pro Italic"
+     ]
+    },
+    "paint": {
+     "text-color": "#000000"
+    }
+   },
+   {
+    "id": "toponyme bati ponc zai zoom 17 et 18",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_bati_ponc",
+    "minzoom": 16,
+    "filter": [
+     "==",
+     "txt_typo",
+     "zai"
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-size": 11,
+     "text-allow-overlap": false,
+     "text-padding": 1,
+     "text-font": [
+      "Source Sans Pro Italic"
+     ]
+    },
+    "paint": {
+     "text-color": "#000000"
+    }
+   },
+   {
+    "id": "toponyme localite importance 4",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_localite_ponc",
+    "minzoom": 7,
+    "filter": [
+     "in",
+     "txt_typo",
+     "commune 4",
+     "BAT_COMMUNE_4",
+     "BAT_COMMUNE_4_T"
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "icon-image": "Localite",
+     "icon-size": 0.21,
+     "text-field": "{texte}",
+     "text-size": 13,
+     "text-allow-overlap": false,
+     "text-anchor": "bottom-left",
+     "text-offset": [
+      0.3,
+      0.1
+     ],
+     "text-padding": 1,
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#000000",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 2
+    }
+   },
+   {
+    "id": "toponyme localite n0 typoA9",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_localite_ponc",
+    "maxzoom": 18,
+    "filter": [
+     "==",
+     "txt_typo",
+     "TYPO_A_9"
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-size": {
+      "stops": [
+       [
+        15,
+        11.5
+       ],
+       [
+        17,
+        14
+       ]
+      ]
+     },
+     "text-allow-overlap": true,
+     "text-anchor": "center",
+     "text-padding": 1,
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#000000",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 2
+    }
+   },
+   {
+    "id": "toponyme localite n0 typoA8",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_localite_ponc",
+    "maxzoom": 18,
+    "filter": [
+     "==",
+     "txt_typo",
+     "TYPO_A_8"
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-size": {
+      "stops": [
+       [
+        15,
+        12
+       ],
+       [
+        17,
+        15
+       ]
+      ]
+     },
+     "text-allow-overlap": true,
+     "text-anchor": "center",
+     "text-padding": 1,
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#000000",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 2
+    }
+   },
+   {
+    "id": "toponyme - limite militaire ponc 1 et 2",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_limite_ponc",
+    "filter": [
+     "in",
+     "txt_typo",
+     "LIM_MILI_1",
+     "LIM_MILI_2"
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-size": 15,
+     "text-allow-overlap": false,
+     "text-padding": 5,
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#0D2000",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 2
+    }
+   },
+   {
+    "id": "toponyme - limite parc marin",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_limite_ponc",
+    "minzoom": 8,
+    "filter": [
+     "==",
+     "txt_typo",
+     "LIM_PARC_NATUREL_MARIN"
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-size": 15,
+     "text-allow-overlap": false,
+     "text-padding": 10,
+     "text-transform": "uppercase",
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#2A81A2",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 2
+    }
+   },
+   {
+    "id": "toponyme - limite parc ponc 1 et 2",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_limite_ponc",
+    "minzoom": 8,
+    "filter": [
+     "in",
+     "txt_typo",
+     "LIM_PARC_1",
+     "LIM_PARC_2",
+     "LIM_PARC_NATUREL"
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-size": 15,
+     "text-allow-overlap": false,
+     "text-padding": 10,
+     "text-transform": "uppercase",
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#287B00",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 2
+    }
+   },
+   {
+    "id": "toponyme - ocs lineaire 2",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_ocs_lin",
+    "filter": [
+     "==",
+     "txt_typo",
+     "OCS_FORET_2"
+    ],
+    "layout": {
+     "symbol-placement": "line",
+     "text-field": "{texte}",
+     "text-size": {
+      "stops": [
+       [
+        10,
+        15
+       ],
+       [
+        12,
+        18
+       ]
+      ]
+     },
+     "text-anchor": "center",
+     "text-keep-upright": true,
+     "text-max-angle": 45,
+     "text-padding": 1,
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#287B00",
+     "text-halo-width": 2,
+     "text-halo-color": "rgba(255, 255, 255, 0.5)"
+    }
+   },
+   {
+    "id": "toponyme - ocs ponc 2",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_ocs_ponc",
+    "filter": [
+     "==",
+     "txt_typo",
+     "OCS_FORET_2"
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-size": {
+      "stops": [
+       [
+        10,
+        15
+       ],
+       [
+        12,
+        18
+       ]
+      ]
+     },
+     "text-allow-overlap": false,
+     "text-padding": 1,
+     "text-anchor": "center",
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#287B00",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 2
+    }
+   },
+   {
+    "id": "toponyme - oro lineaire 2",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_oro_lin",
+    "filter": [
+     "in",
+     "txt_typo",
+     "ORO_ILE_2",
+     "ORO_RELIEF_2",
+     "ORO_RELIEF_2_T",
+     "ORO_CAP_1",
+     "ORO_SOMMET_1"
+    ],
+    "layout": {
+     "symbol-placement": "line",
+     "text-field": "{texte}",
+     "text-size": 15,
+     "text-anchor": "center",
+     "text-keep-upright": true,
+     "text-padding": 10,
+     "text-max-angle": 45,
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#863831",
+     "text-halo-width": 2,
+     "text-halo-color": "rgba(255, 255, 255, 0.5)"
+    }
+   },
+   {
+    "id": "toponyme - oro ponc 2",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_oro_ponc",
+    "minzoom": 9,
+    "filter": [
+     "in",
+     "txt_typo",
+     "ORO_ILE_2",
+     "ORO_RELIEF_2",
+     "ORO_RELIEF_2_T",
+     "ORO_CAP_1",
+     "ORO_COL_1",
+     "sommet ou col",
+     "ORO_SOMMET_1",
+     "TYPO_G_4",
+     "TYPO_G_6"
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-size": {
+      "stops": [
+       [
+        9,
+        13
+       ],
+       [
+        10,
+        15
+       ],
+       [
+        13,
+        15
+       ],
+       [
+        16,
+        19
+       ]
+      ]
+     },
+     "text-allow-overlap": false,
+     "text-padding": 1,
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#863831",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 2
+    }
+   },
+   {
+    "id": "toponyme - oro ponc 2B",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_oro_ponc",
+    "minzoom": 8,
+    "filter": [
+     "in",
+     "txt_typo",
+     "île",
+     "cap ou pointe"
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-size": 15,
+     "text-allow-overlap": false,
+     "text-padding": 1,
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#863831",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 2
+    }
+   },
+   {
+    "id": "toponyme - hydro lineaire 2",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_hydro_lin",
+    "filter": [
+     "in",
+     "txt_typo",
+     "HYD_LIN_2",
+     "rivière moyenne",
+     "HYD_SURF_2",
+     "HYD_SURF_2_T",
+     "TYPO_D_3"
+    ],
+    "layout": {
+     "symbol-placement": "line",
+     "text-field": "{texte}",
+     "text-size": {
+      "stops": [
+       [
+        14,
+        15
+       ],
+       [
+        18,
+        21
+       ]
+      ]
+     },
+     "text-anchor": "center",
+     "text-keep-upright": true,
+     "text-max-angle": 45,
+     "text-padding": 10,
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#447FB3",
+     "text-halo-width": 2,
+     "text-halo-color": "rgba(255, 255, 255, 0.5)"
+    }
+   },
+   {
+    "id": "toponyme - hydro ponc 2",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_hydro_ponc",
+    "minzoom": 5,
+    "filter": [
+     "in",
+     "txt_typo",
+     "moyen",
+     "golfe moyen",
+     "HYD_SURF_2",
+     "TYPO_D_2",
+     "TYPO_D_3",
+     "TYPO_D_4"
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-size": {
+      "stops": [
+       [
+        5,
+        12
+       ],
+       [
+        6,
+        18
+       ],
+       [
+        10,
+        17
+       ],
+       [
+        18,
+        21
+       ]
+      ]
+     },
+     "text-allow-overlap": false,
+     "text-padding": 10,
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#447FB3",
+     "text-halo-color": "#FFFFFF",
+     "text-halo-width": 2
+    }
+   },
+   {
+    "id": "toponyme localite importance 3",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_localite_ponc",
+    "minzoom": 5,
+    "filter": [
+     "in",
+     "txt_typo",
+     "commune 3",
+     "BAT_COMMUNE_3",
+     "BAT_COMMUNE_3_T"
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "icon-image": "Localite",
+     "icon-size": 0.21,
+     "text-field": "{texte}",
+     "text-size": {
+      "stops": [
+       [
+        5,
+        10
+       ],
+       [
+        6,
+        15
+       ]
+      ]
+     },
+     "text-allow-overlap": false,
+     "text-anchor": "bottom-left",
+     "text-offset": [
+      0.3,
+      0.1
+     ],
+     "text-padding": 1,
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#000000",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 2
+    }
+   },
+   {
+    "id": "toponyme localite n0 typoA7 non commune",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_localite_ponc",
+    "maxzoom": 18,
+    "filter": [
+     "all",
+     [
+      "!=",
+      "symbo",
+      "COMMUNE_FUSIONNEE"
+     ],
+     [
+      "!=",
+      "symbo",
+      "COMMUNE_CHEF_LIEU"
+     ],
+     [
+      "==",
+      "txt_typo",
+      "TYPO_A_7"
+     ]
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-size": {
+      "stops": [
+       [
+        15,
+        13
+       ],
+       [
+        17,
+        16
+       ]
+      ]
+     },
+     "text-allow-overlap": true,
+     "text-anchor": "center",
+     "text-padding": 1,
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#000000",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 2
+    }
+   },
+   {
+    "id": "toponyme localite n0 typoA6 non commune",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_localite_ponc",
+    "maxzoom": 18,
+    "filter": [
+     "all",
+     [
+      "!=",
+      "symbo",
+      "COMMUNE_FUSIONNEE"
+     ],
+     [
+      "!=",
+      "symbo",
+      "COMMUNE_CHEF_LIEU"
+     ],
+     [
+      "==",
+      "txt_typo",
+      "TYPO_A_6"
+     ]
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-size": {
+      "stops": [
+       [
+        15,
+        15
+       ],
+       [
+        17,
+        18
+       ]
+      ]
+     },
+     "text-allow-overlap": true,
+     "text-anchor": "center",
+     "text-padding": 1,
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#000000",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 2
+    }
+   },
+   {
+    "id": "toponyme - oro lineaire 1",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_oro_lin",
+    "filter": [
+     "in",
+     "txt_typo",
+     "ORO_ILE_1",
+     "ORO_RELIEF_1",
+     "ORO_RELIEF_1_T"
+    ],
+    "layout": {
+     "symbol-placement": "line",
+     "text-field": "{texte}",
+     "text-size": 20,
+     "text-anchor": "center",
+     "text-keep-upright": true,
+     "text-padding": 5,
+     "text-max-angle": 45,
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#863831",
+     "text-halo-width": 2,
+     "text-halo-color": "rgba(255, 255, 255, 0.5)"
+    }
+   },
+   {
+    "id": "toponyme - oro ponc monde",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_oro_ponc",
+    "minzoom": 5,
+    "filter": [
+     "in",
+     "txt_typo",
+     "Basin",
+     "Depression",
+     "Desert",
+     "Geoarea",
+     "Gorge",
+     "Isthmus",
+     "Lake",
+     "Lowland",
+     "Pen/cape",
+     "Plain",
+     "Plateau",
+     "Range/mtn",
+     "Tundra",
+     "Valley",
+     "Island",
+     "Island group"
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-size": 11,
+     "text-allow-overlap": false,
+     "text-padding": 1,
+     "text-font": [
+      "Source Sans Pro Italic"
+     ]
+    },
+    "paint": {
+     "text-color": "#863831",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 2
+    }
+   },
+   {
+    "id": "toponyme localite n0 typoA4 non commune",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_localite_ponc",
+    "maxzoom": 16,
+    "filter": [
+     "all",
+     [
+      "!=",
+      "symbo",
+      "COMMUNE_FUSIONNEE"
+     ],
+     [
+      "!=",
+      "symbo",
+      "COMMUNE_CHEF_LIEU"
+     ],
+     [
+      "==",
+      "txt_typo",
+      "TYPO_A_4"
+     ]
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-size": 17,
+     "text-allow-overlap": true,
+     "text-anchor": "center",
+     "text-padding": 1,
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#000000",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 3
+    }
+   },
+   {
+    "id": "toponyme - ocs lineaire 1",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_ocs_lin",
+    "filter": [
+     "==",
+     "txt_typo",
+     "OCS_FORET_1"
+    ],
+    "layout": {
+     "symbol-placement": "line",
+     "text-field": "{texte}",
+     "text-size": {
+      "stops": [
+       [
+        10,
+        18
+       ],
+       [
+        12,
+        22
+       ]
+      ]
+     },
+     "text-anchor": "center",
+     "text-keep-upright": true,
+     "text-padding": 1,
+     "text-max-angle": 45,
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#287B00",
+     "text-halo-width": 2,
+     "text-halo-color": "rgba(255, 255, 255, 0.5)"
+    }
+   },
+   {
+    "id": "toponyme - ocs ponc 1",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_ocs_ponc",
+    "filter": [
+     "==",
+     "txt_typo",
+     "OCS_FORET_1"
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-size": {
+      "stops": [
+       [
+        10,
+        18
+       ],
+       [
+        12,
+        22
+       ]
+      ]
+     },
+     "text-allow-overlap": true,
+     "text-padding": 1,
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#287B00",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 2
+    }
+   },
+   {
+    "id": "toponyme - oro ponc 1",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_oro_ponc",
+    "minzoom": 8,
+    "filter": [
+     "in",
+     "txt_typo",
+     "grande île",
+     "ORO_ILE_1",
+     "ORO_RELIEF_1",
+     "ORO_RELIEF_1_T",
+     "TYPO_G_3",
+     "TYPO_G_2",
+     "TYPO_G_1"
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-size": 21,
+     "text-allow-overlap": true,
+     "text-padding": 1,
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#863831",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 2
+    }
+   },
+   {
+    "id": "toponyme - hydro lineaire glacier",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_hydro_lin",
+    "filter": [
+     "in",
+     "txt_typo",
+     "ORO_GLACIER_1",
+     "ORO_GLACIER_2"
+    ],
+    "layout": {
+     "symbol-placement": "line",
+     "text-field": "{texte}",
+     "text-size": 15,
+     "text-anchor": "center",
+     "text-keep-upright": true,
+     "text-max-angle": 45,
+     "text-font": [
+      "Source Sans Pro Italic"
+     ]
+    },
+    "paint": {
+     "text-color": "#447FB3",
+     "text-halo-width": 2,
+     "text-halo-color": "rgba(255, 255, 255, 0.5)"
+    }
+   },
+   {
+    "id": "toponyme - hydro lineaire 1",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_hydro_lin",
+    "filter": [
+     "in",
+     "txt_typo",
+     "HYD_LIN_1",
+     "HYD-LIN-1",
+     "grande rivière",
+     "HYD_SURF_1",
+     "HYD_SURF_1_T",
+     "TYPO_D_1",
+     "TYPO_D_2"
+    ],
+    "layout": {
+     "symbol-placement": "line",
+     "text-field": "{texte}",
+     "text-size": 18,
+     "text-anchor": "center",
+     "text-keep-upright": true,
+     "text-max-angle": 45,
+     "text-padding": 10,
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#447FB3",
+     "text-halo-width": 2,
+     "text-halo-color": "rgba(255, 255, 255, 0.5)"
+    }
+   },
+   {
+    "id": "toponyme - hydro lineaire ocean",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_hydro_lin",
+    "filter": [
+     "==",
+     "txt_typo",
+     "mer et océan"
+    ],
+    "layout": {
+     "symbol-placement": "line",
+     "text-field": "{texte}",
+     "text-size": 30,
+     "text-anchor": "center",
+     "text-keep-upright": true,
+     "text-max-angle": 45,
+     "text-padding": 10,
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#447FB3",
+     "text-halo-width": 4,
+     "text-halo-color": "rgba(255, 255, 255, 0.5)"
+    }
+   },
+   {
+    "id": "toponyme - hydro ponc 1",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_hydro_ponc",
+    "minzoom": 4,
+    "filter": [
+     "in",
+     "txt_typo",
+     "mer",
+     "grand",
+     "grand golfe",
+     "HYD_SURF_1",
+     "TYPO_D_1"
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-size": {
+      "stops": [
+       [
+        4,
+        16
+       ],
+       [
+        6,
+        30
+       ],
+       [
+        10,
+        25
+       ]
+      ]
+     },
+     "text-allow-overlap": true,
+     "text-padding": 10,
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#447FB3",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 4
+    }
+   },
+   {
+    "id": "toponyme localite importance 2",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_localite_ponc",
+    "minzoom": 4,
+    "filter": [
+     "in",
+     "txt_typo",
+     "commune 2",
+     "BAT_COMMUNE_2",
+     "BAT_COMMUNE-2",
+     "BAT_COMMUNE_2_T"
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "icon-image": "Localite",
+     "icon-size": 0.25,
+     "text-field": "{texte}",
+     "text-size": {
+      "stops": [
+       [
+        4,
+        10
+       ],
+       [
+        6,
+        17
+       ]
+      ]
+     },
+     "text-allow-overlap": true,
+     "text-anchor": "bottom-left",
+     "text-offset": [
+      0.3,
+      0.2
+     ],
+     "text-padding": 1,
+     "text-transform": "uppercase",
+     "text-font": {
+      "stops": [
+       [
+        1,
+        [
+         "Source Sans Pro Regular"
+        ]
+       ],
+       [
+        7,
+        [
+         "Source Sans Pro Bold"
+        ]
+       ],
+       [
+        10,
+        [
+         "Source Sans Pro Regular"
+        ]
+       ]
+      ]
+     }
+    },
+    "paint": {
+     "text-color": "#000000",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 3
+    }
+   },
+   {
+    "id": "toponyme localite n0 typoA3 non commune",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_localite_ponc",
+    "maxzoom": 16,
+    "filter": [
+     "all",
+     [
+      "!=",
+      "symbo",
+      "COMMUNE_FUSIONNEE"
+     ],
+     [
+      "!=",
+      "symbo",
+      "COMMUNE_CHEF_LIEU"
+     ],
+     [
+      "==",
+      "txt_typo",
+      "TYPO_A_3"
+     ]
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-size": 19,
+     "text-allow-overlap": true,
+     "text-anchor": "center",
+     "text-padding": 1,
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#000000",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 3
+    }
+   },
+   {
+    "id": "toponyme localite n0 typoA2 non commune",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_localite_ponc",
+    "maxzoom": 16,
+    "filter": [
+     "all",
+     [
+      "!=",
+      "symbo",
+      "COMMUNE_FUSIONNEE"
+     ],
+     [
+      "!=",
+      "symbo",
+      "COMMUNE_CHEF_LIEU"
+     ],
+     [
+      "==",
+      "txt_typo",
+      "TYPO_A_2"
+     ]
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-size": 21,
+     "text-allow-overlap": true,
+     "text-anchor": "center",
+     "text-padding": 1,
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#000000",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 4
+    }
+   },
+   {
+    "id": "toponyme localite n0 typoA7 commune",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_localite_ponc",
+    "maxzoom": 18,
+    "filter": [
+     "all",
+     [
+      "in",
+      "symbo",
+      "COMMUNE_FUSIONNEE",
+      "COMMUNE_CHEF_LIEU"
+     ],
+     [
+      "==",
+      "txt_typo",
+      "TYPO_A_7"
+     ]
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-size": {
+      "stops": [
+       [
+        15,
+        13
+       ],
+       [
+        17,
+        16
+       ]
+      ]
+     },
+     "text-allow-overlap": true,
+     "text-anchor": "center",
+     "text-padding": 1,
+     "text-transform": "uppercase",
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#000000",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 2
+    }
+   },
+   {
+    "id": "toponyme localite n0 typoA6 commune",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_localite_ponc",
+    "maxzoom": 18,
+    "filter": [
+     "all",
+     [
+      "in",
+      "symbo",
+      "COMMUNE_FUSIONNEE",
+      "COMMUNE_CHEF_LIEU"
+     ],
+     [
+      "==",
+      "txt_typo",
+      "TYPO_A_6"
+     ]
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-size": {
+      "stops": [
+       [
+        15,
+        15
+       ],
+       [
+        17,
+        18
+       ]
+      ]
+     },
+     "text-allow-overlap": true,
+     "text-anchor": "center",
+     "text-padding": 1,
+     "text-transform": "uppercase",
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#000000",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 2
+    }
+   },
+   {
+    "id": "toponyme localite n0 typoA1 non commune",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_localite_ponc",
+    "maxzoom": 16,
+    "filter": [
+     "all",
+     [
+      "!=",
+      "symbo",
+      "COMMUNE_FUSIONNEE"
+     ],
+     [
+      "!=",
+      "symbo",
+      "COMMUNE_CHEF_LIEU"
+     ],
+     [
+      "==",
+      "txt_typo",
+      "TYPO_A_1"
+     ]
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-size": 23,
+     "text-allow-overlap": true,
+     "text-anchor": "center",
+     "text-padding": 1,
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#000000",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 4
+    }
+   },
+   {
+    "id": "toponyme localite n0 typoA4 commune",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_localite_ponc",
+    "maxzoom": 16,
+    "filter": [
+     "all",
+     [
+      "in",
+      "symbo",
+      "COMMUNE_FUSIONNEE",
+      "COMMUNE_CHEF_LIEU"
+     ],
+     [
+      "==",
+      "txt_typo",
+      "TYPO_A_4"
+     ]
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-size": 17,
+     "text-allow-overlap": true,
+     "text-anchor": "center",
+     "text-padding": 1,
+     "text-transform": "uppercase",
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#000000",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 3
+    }
+   },
+   {
+    "id": "toponyme localite n0 typoA3 commune",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_localite_ponc",
+    "maxzoom": 16,
+    "filter": [
+     "all",
+     [
+      "in",
+      "symbo",
+      "COMMUNE_FUSIONNEE",
+      "COMMUNE_CHEF_LIEU"
+     ],
+     [
+      "==",
+      "txt_typo",
+      "TYPO_A_3"
+     ]
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-size": 19,
+     "text-allow-overlap": true,
+     "text-anchor": "center",
+     "text-padding": 1,
+     "text-transform": "uppercase",
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#000000",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 3
+    }
+   },
+   {
+    "id": "toponyme localite n0 typoA2 commune",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_localite_ponc",
+    "maxzoom": 16,
+    "filter": [
+     "all",
+     [
+      "in",
+      "symbo",
+      "COMMUNE_FUSIONNEE",
+      "COMMUNE_CHEF_LIEU"
+     ],
+     [
+      "==",
+      "txt_typo",
+      "TYPO_A_2"
+     ]
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-size": 21,
+     "text-allow-overlap": true,
+     "text-anchor": "center",
+     "text-padding": 1,
+     "text-transform": "uppercase",
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#000000",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 4
+    }
+   },
+   {
+    "id": "toponyme localite importance 1",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_localite_ponc",
+    "minzoom": 3,
+    "filter": [
+     "in",
+     "txt_typo",
+     "commune 1",
+     "BAT_COMMUNE_1",
+     "BAT_COMMUNE_1_T"
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "icon-image": "Localite",
+     "icon-size": 0.3,
+     "text-field": "{texte}",
+     "text-size": {
+      "stops": [
+       [
+        3,
+        10
+       ],
+       [
+        6,
+        20
+       ]
+      ]
+     },
+     "text-allow-overlap": false,
+     "text-anchor": "bottom-left",
+     "text-offset": [
+      0.25,
+      -0.1
+     ],
+     "text-padding": 1,
+     "text-transform": "uppercase",
+     "text-font": {
+      "stops": [
+       [
+        1,
+        [
+         "Source Sans Pro Regular"
+        ]
+       ],
+       [
+        7,
+        [
+         "Source Sans Pro Bold"
+        ]
+       ],
+       [
+        10,
+        [
+         "Source Sans Pro Regular"
+        ]
+       ]
+      ]
+     }
+    },
+    "paint": {
+     "text-color": "#000000",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 4
+    }
+   },
+   {
+    "id": "toponyme localite n0 typoA1 commune",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_localite_ponc",
+    "maxzoom": 16,
+    "filter": [
+     "all",
+     [
+      "in",
+      "symbo",
+      "COMMUNE_FUSIONNEE",
+      "COMMUNE_CHEF_LIEU"
+     ],
+     [
+      "==",
+      "txt_typo",
+      "TYPO_A_1"
+     ]
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-size": 23,
+     "text-allow-overlap": true,
+     "text-anchor": "center",
+     "text-padding": 1,
+     "text-transform": "uppercase",
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#000000",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 4
+    }
+   },
+   {
+    "id": "toponyme - hydro ponc ocean",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_hydro_ponc",
+    "minzoom": 1,
+    "filter": [
+     "==",
+     "txt_typo",
+     "ocean"
+    ],
+    "layout": {
+     "visibility": "visible",
+     "symbol-placement": "point",
+     "text-field": "{texte}",
+     "text-size": {
+      "stops": [
+       [
+        1,
+        16
+       ],
+       [
+        6,
+        30
+       ]
+      ]
+     },
+     "text-allow-overlap": true,
+     "text-anchor": "center",
+     "text-padding": 10,
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#447FB3",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 4
+    }
+   },
+   {
+    "id": "toponyme pays 3",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_localite_ponc",
+    "minzoom": 4,
+    "maxzoom": 5,
+    "filter": [
+     "==",
+     "txt_typo",
+     "pays 3"
+    ],
+    "layout": {
+     "visibility": "visible",
+     "text-field": "{texte}",
+     "text-size": 9,
+     "text-allow-overlap": true,
+     "text-anchor": "center",
+     "text-padding": 1,
+     "text-transform": "uppercase",
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#787878",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 4
+    }
+   },
+   {
+    "id": "toponyme pays 2",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_localite_ponc",
+    "minzoom": 2,
+    "maxzoom": 5,
+    "filter": [
+     "==",
+     "txt_typo",
+     "pays 2"
+    ],
+    "layout": {
+     "visibility": "visible",
+     "text-field": "{texte}",
+     "text-size": 13,
+     "text-allow-overlap": true,
+     "text-anchor": "center",
+     "text-padding": 2,
+     "text-transform": "uppercase",
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#787878",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 4
+    }
+   },
+   {
+    "id": "toponyme pays 1",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_localite_ponc",
+    "minzoom": 2,
+    "maxzoom": 5,
+    "filter": [
+     "==",
+     "txt_typo",
+     "pays 1"
+    ],
+    "layout": {
+     "visibility": "visible",
+     "text-field": "{texte}",
+     "text-size": 13,
+     "text-allow-overlap": true,
+     "text-anchor": "center",
+     "text-padding": 2,
+     "text-transform": "uppercase",
+     "text-font": [
+      "Source Sans Pro Regular"
+     ]
+    },
+    "paint": {
+     "text-color": "#787878",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 4
+    }
+   },
+   {
+    "id": "toponyme continent",
+    "type": "symbol",
+    "source": "plan_ign",
+    "source-layer": "toponyme_localite_ponc",
+    "maxzoom": 3,
+    "filter": [
+     "==",
+     "txt_typo",
+     "continent"
+    ],
+    "layout": {
+     "visibility": "visible",
+     "text-field": "{texte}",
+     "text-size": 15,
+     "text-allow-overlap": true,
+     "text-anchor": "center",
+     "text-padding": 1,
+     "text-transform": "uppercase",
+     "text-font": [
+      "Source Sans Pro Bold"
+     ]
+    },
+    "paint": {
+     "text-color": "#787878",
+     "text-halo-color": "rgba(255, 255, 255, 0.5)",
+     "text-halo-width": 4
+    }
+   }
+  ]
+ }

--- a/components/map/styles/vector.json
+++ b/components/map/styles/vector.json
@@ -7,12 +7,15 @@
       "plan_ign": {
         "type": "vector",
         "url": "https://wxs.ign.fr/essentiels/geoportail/tms/1.0.0/PLAN.IGN/metadata.json/"
-      },
-      "cadastre": {
-        "type": "vector",
-        "url": 
-			"https://wxs.ign.fr/parcellaire/geoportail/wmts?layer=&style=normal&tilematrixset=PM&Service=WMTS&Request=GetTile&Version=1.0.0&Format=image/png&TileMatrix={z}&TileCol={x}&TileRow={y}"
-        }
+		},
+		"cadastre": {
+			"type": "vector",
+			"url": "https://openmaptiles.geo.data.gouv.fr/data/cadastre.json"
+		  },
+		  "decoupage-administratif": {
+			"type": "vector",
+			"url": "https://openmaptiles.geo.data.gouv.fr/data/decoupage-administratif.json"
+		  }
     },
 
 	"transition": {

--- a/components/map/styles/vector.json
+++ b/components/map/styles/vector.json
@@ -3336,24 +3336,7 @@
 		  }
 		 }
 		},
-		{
-		 "id": "parcellaire - parcelle surface",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "parcellaire_parcelle",
-		 "layout": {
-		  "visibility": "none"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "PARCELLE"
-		 ],
-		 "paint": {
-		  "fill-color": "#FFFFD1",
-		  "fill-opacity": 0.7
-		 }
-		},
+		
 		{
 		 "id": "bati surfacique mairie - Zoom 14",
 		 "type": "fill",
@@ -9419,109 +9402,6 @@
 		  ]
 		 }
 		},
-		{
-		 "id": "parcellaire - parcelle bordure",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "parcellaire_parcelle",
-		 "layout": {
-		  "visibility": "none",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "PARCELLE"
-		 ],
-		 "paint": {
-		  "line-color": "#9933FF",
-		  "line-width": 1
-		 }
-		},
-		{
-		 "id": "parcellaire - section",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "parcellaire_section",
-		 "layout": {
-		  "visibility": "none",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "SECTION"
-		 ],
-		 "paint": {
-		  "line-color": "#287B00",
-		  "line-width": 1.9,
-		  "line-dasharray": [
-		   2,
-		   4,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "toponyme - parcellaire - section",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_parcellaire_section",
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "SECTION"
-		 ],
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-offset": [
-		   0,
-		   0
-		  ],
-		  "text-field": "{texte}",
-		  "text-size": 15,
-		  "text-anchor": "center",
-		  "text-keep-upright": true,
-		  "text-max-angle": 45,
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ],
-		  "visibility": "none"
-		 },
-		 "paint": {
-		  "text-color": "#287B00"
-		 }
-		},
-		{
-		 "id": "toponyme - parcellaire - parcelle",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_parcellaire_parcelle",
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "PARCELLE"
-		 ],
-		 "layout": {
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 11,
-		  "text-anchor": "center",
-		  "text-keep-upright": true,
-		  "text-max-angle": 45,
-		  "text-font": [
-		   "Source Sans Pro Bold"
-		  ],
-		  "visibility": "none"
-		 },
-		 "paint": {
-		  "text-color": "#9933FF",
-		  "text-halo-width": 1,
-		  "text-halo-color": "#FFFFFF"
-		 }
-		},
 		
 		{
 		 "id": "limite admin - limite de commune",
@@ -12462,74 +12342,6 @@
 		 }
 		},
 		{
-		 "id": "toponyme quartier ",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_localite_ponc",
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "BAT_QUARTIER",
-		  "BAT_QUARTIER_T"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 11,
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Source Sans Pro Italic"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#000000",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme localite n0 typoA10",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_localite_ponc",
-		 "maxzoom": 21,
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "TYPO_A_10"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 15,
-			 11
-			],
-			[
-			 17,
-			 13.5
-			]
-		   ]
-		  },
-		  "text-allow-overlap": true,
-		  "text-anchor": "center",
-		  "text-padding": 1,
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#000000",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
 		 "id": "toponyme - lieu dit non habité",
 		 "type": "symbol",
 		 "source": "plan_ign",
@@ -12599,43 +12411,6 @@
 		 },
 		 "paint": {
 		  "text-color": "#287B00",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme localite hameau ",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_localite_ponc",
-		 "minzoom": 11,
-		 "maxzoom": 21,
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "BAT_HAMEAU",
-		  "BAT_HAMEAU_T"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "icon-image": "Localite",
-		  "icon-size": 0.17,
-		  "text-field": "{texte}",
-		  "text-size": 11,
-		  "text-allow-overlap": false,
-		  "text-anchor": "bottom-left",
-		  "text-offset": [
-		   0.3,
-		   0.1
-		  ],
-		  "text-padding": 1,
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#000000",
 		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
 		  "text-halo-width": 2
 		 }
@@ -13179,86 +12954,6 @@
 		   0.3,
 		   0.1
 		  ],
-		  "text-padding": 1,
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#000000",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme localite n0 typoA9",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_localite_ponc",
-		 "maxzoom": 21,
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "TYPO_A_9"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 15,
-			 11.5
-			],
-			[
-			 17,
-			 14
-			]
-		   ]
-		  },
-		  "text-allow-overlap": true,
-		  "text-anchor": "center",
-		  "text-padding": 1,
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#000000",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme localite n0 typoA8",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_localite_ponc",
-		 "maxzoom": 21,
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "TYPO_A_8"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 15,
-			 12
-			],
-			[
-			 17,
-			 15
-			]
-		   ]
-		  },
-		  "text-allow-overlap": true,
-		  "text-anchor": "center",
 		  "text-padding": 1,
 		  "text-font": [
 		   "Source Sans Pro Regular"

--- a/components/map/styles/vector.json
+++ b/components/map/styles/vector.json
@@ -37,7 +37,7 @@
 		 },
 		 "paint": {
 		  "fill-color": "#FFFFFF",
-		  "fill-opacity": 1
+		  "fill-opacity": 0.1
 		 }
 		},
 		{
@@ -1620,7 +1620,7 @@
 		  "ESCALIER_SOU"
 		 ],
 		 "paint": {
-		  "line-color": "#FFFFFF",
+		  "line-color": "#EDF1FF",
 		  "line-width": {
 		   "stops": [
 			[
@@ -2589,7 +2589,7 @@
 		   "stops": [
 			[
 			 12,
-			 "#FFFFFF"
+			 "#EDF1FF"
 			],
 			[
 			 13,
@@ -2705,7 +2705,7 @@
 		   "stops": [
 			[
 			 9,
-			 "#FFFFFF"
+			 "#EDF1FF"
 			],
 			[
 			 10,
@@ -2951,7 +2951,7 @@
 		  "AUTOROU_LIBRE_SOU"
 		 ],
 		 "paint": {
-		  "line-color": "#FFFFFF",
+		  "line-color": "#EDF1FF",
 		  "line-width": {
 		   "stops": [
 			[
@@ -4272,7 +4272,7 @@
 			],
 			[
 			 18,
-			 "#FFFFFF"
+			 "#EDF1FF"
 			]
 		   ]
 		  },
@@ -4374,7 +4374,7 @@
 		  "ESCALIER"
 		 ],
 		 "paint": {
-		  "line-color": "#FFFFFF",
+		  "line-color": "#EDF1FF",
 		  "line-width": {
 		   "stops": [
 			[
@@ -4485,7 +4485,7 @@
 			],
 			[
 			 18,
-			 "#FFFFFF"
+			 "#EDF1FF"
 			]
 		   ]
 		  },
@@ -4544,7 +4544,7 @@
 			],
 			[
 			 18,
-			 "#FFFFFF"
+			 "#EDF1FF"
 			]
 		   ]
 		  },
@@ -4645,7 +4645,7 @@
 		  "NON_REVETUE_CARRO"
 		 ],
 		 "paint": {
-		  "line-color": "#FFFFFF",
+		  "line-color": "#EDF1FF",
 		  "line-width": {
 		   "stops": [
 			[
@@ -4706,7 +4706,7 @@
 			],
 			[
 			 18,
-			 "#FFFFFF"
+			 "#EDF1FF"
 			]
 		   ]
 		  },
@@ -4760,7 +4760,7 @@
 			],
 			[
 			 18,
-			 "#FFFFFF"
+			 "#EDF1FF"
 			]
 		   ]
 		  },
@@ -4811,7 +4811,7 @@
 			],
 			[
 			 18,
-			 "#FFFFFF"
+			 "#EDF1FF"
 			]
 		   ]
 		  },
@@ -4874,7 +4874,7 @@
 			],
 			[
 			 18,
-			 "#FFFFFF"
+			 "#EDF1FF"
 			]
 		   ]
 		  },
@@ -4986,7 +4986,7 @@
 			],
 			[
 			 18,
-			 "#FFFFFF"
+			 "#EDF1FF"
 			]
 		   ]
 		  },
@@ -5098,7 +5098,7 @@
 			],
 			[
 			 18,
-			 "#FFFFFF"
+			 "#EDF1FF"
 			]
 		   ]
 		  },
@@ -5211,7 +5211,7 @@
 			],
 			[
 			 18,
-			 "#FFFFFF"
+			 "#EDF1FF"
 			]
 		   ]
 		  },
@@ -5413,7 +5413,7 @@
 		  "NON_CLASSEE"
 		 ],
 		 "paint": {
-		  "line-color": "#FFFFFF",
+		  "line-color": "#EDF1FF",
 		  "line-width": {
 		   "stops": [
 			[
@@ -5465,11 +5465,11 @@
 			],
 			[
 			 7,
-			 "#FFFFFF"
+			 "#EDF1FF"
 			],
 			[
 			 12,
-			 "#FFFFFF"
+			 "#EDF1FF"
 			],
 			[
 			 13,
@@ -5528,7 +5528,7 @@
 		   "stops": [
 			[
 			 12,
-			 "#FFFFFF"
+			 "#EDF1FF"
 			],
 			[
 			 13,
@@ -5603,11 +5603,11 @@
 			],
 			[
 			 7,
-			 "#FFFFFF"
+			 "#EDF1FF"
 			],
 			[
 			 9,
-			 "#FFFFFF"
+			 "#EDF1FF"
 			],
 			[
 			 10,
@@ -5674,7 +5674,7 @@
 		   "stops": [
 			[
 			 9,
-			 "#FFFFFF"
+			 "#EDF1FF"
 			],
 			[
 			 10,
@@ -5957,7 +5957,7 @@
 		  "AUTOROU_LIBRE"
 		 ],
 		 "paint": {
-		  "line-color": "#FFFFFF",
+		  "line-color": "#EDF1FF",
 		  "line-width": {
 		   "stops": [
 			[
@@ -6500,7 +6500,7 @@
 			],
 			[
 			 18,
-			 "#FFFFFF"
+			 "#EDF1FF"
 			]
 		   ]
 		  },
@@ -6603,7 +6603,7 @@
 			],
 			[
 			 18,
-			 "#FFFFFF"
+			 "#EDF1FF"
 			]
 		   ]
 		  },
@@ -6648,7 +6648,7 @@
 		  "PONT_MOBILE_LIN"
 		 ],
 		 "paint": {
-		  "line-color": "#FFFFFF",
+		  "line-color": "#EDF1FF",
 		  "line-width": {
 		   "stops": [
 			[
@@ -6688,7 +6688,7 @@
 		  "SURF_ROUT_NON_CLA"
 		 ],
 		 "paint": {
-		  "fill-color": "#FFFFFF",
+		  "fill-color": "#EDF1FF",
 		  "fill-outline-color": "#000000"
 		 }
 		},
@@ -6932,7 +6932,7 @@
 			],
 			[
 			 18,
-			 "#FFFFFF"
+			 "#EDF1FF"
 			]
 		   ]
 		  },
@@ -7204,7 +7204,7 @@
 			],
 			[
 			 18,
-			 "#FFFFFF"
+			 "#EDF1FF"
 			]
 		   ]
 		  },
@@ -7323,7 +7323,7 @@
 			],
 			[
 			 18,
-			 "#FFFFFF"
+			 "#EDF1FF"
 			]
 		   ]
 		  },
@@ -7377,7 +7377,7 @@
 			],
 			[
 			 18,
-			 "#FFFFFF"
+			 "#EDF1FF"
 			]
 		   ]
 		  },
@@ -7428,7 +7428,7 @@
 			],
 			[
 			 18,
-			 "#FFFFFF"
+			 "#EDF1FF"
 			]
 		   ]
 		  },
@@ -7490,7 +7490,7 @@
 			],
 			[
 			 18,
-			 "#FFFFFF"
+			 "#EDF1FF"
 			]
 		   ]
 		  },
@@ -7602,7 +7602,7 @@
 			],
 			[
 			 18,
-			 "#FFFFFF"
+			 "#EDF1FF"
 			]
 		   ]
 		  },
@@ -7714,7 +7714,7 @@
 			],
 			[
 			 18,
-			 "#FFFFFF"
+			 "#EDF1FF"
 			]
 		   ]
 		  },
@@ -7827,7 +7827,7 @@
 			],
 			[
 			 18,
-			 "#FFFFFF"
+			 "#EDF1FF"
 			]
 		   ]
 		  },
@@ -7926,7 +7926,7 @@
 		  "NON_REVETUE_CARRO_SUP"
 		 ],
 		 "paint": {
-		  "line-color": "#FFFFFF",
+		  "line-color": "#EDF1FF",
 		  "line-width": {
 		   "stops": [
 			[
@@ -8072,7 +8072,7 @@
 		  "NON_CLASSEE_SUP"
 		 ],
 		 "paint": {
-		  "line-color": "#FFFFFF",
+		  "line-color": "#EDF1FF",
 		  "line-width": {
 		   "stops": [
 			[
@@ -8120,7 +8120,7 @@
 		   "stops": [
 			[
 			 12,
-			 "#FFFFFF"
+			 "#EDF1FF"
 			],
 			[
 			 13,
@@ -8180,7 +8180,7 @@
 		   "stops": [
 			[
 			 12,
-			 "#FFFFFF"
+			 "#EDF1FF"
 			],
 			[
 			 13,
@@ -8247,7 +8247,7 @@
 		   "stops": [
 			[
 			 9,
-			 "#FFFFFF"
+			 "#EDF1FF"
 			],
 			[
 			 10,
@@ -8311,7 +8311,7 @@
 		   "stops": [
 			[
 			 9,
-			 "#FFFFFF"
+			 "#EDF1FF"
 			],
 			[
 			 10,
@@ -8571,7 +8571,7 @@
 		  "AUTOROU_LIBRE_SUP"
 		 ],
 		 "paint": {
-		  "line-color": "#FFFFFF",
+		  "line-color": "#EDF1FF",
 		  "line-width": {
 		   "stops": [
 			[
@@ -9522,38 +9522,7 @@
 		  "text-halo-color": "#FFFFFF"
 		 }
 		},
-		{
-		 "id": "toponyme - parcellaire - adresse",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_parcellaire_adresse_ponc",
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "ADRESSE"
-		 ],
-		 "layout": {
-		  "symbol-placement": "point",
-		  "text-field": [
-		   "concat",
-		   "{numero}",
-		   "{indice_de_repetition}"
-		  ],
-		  "text-size": 11,
-		  "text-anchor": "center",
-		  "text-keep-upright": true,
-		  "text-max-angle": 45,
-		  "text-font": [
-		   "Source Sans Pro Bold"
-		  ],
-		  "visibility": "none"
-		 },
-		 "paint": {
-		  "text-color": "#695744",
-		  "text-halo-width": 1,
-		  "text-halo-color": "#FFFFFF"
-		 }
-		},
+		
 		{
 		 "id": "limite admin - limite de commune",
 		 "type": "line",
@@ -12359,7 +12328,7 @@
 		  ]
 		 ],
 		 "layout": {
-		  "visibility": "visible",
+		  "visibility": "none",
 		  "symbol-placement": "point",
 		  "text-field": "{texte}",
 		  "text-size": 13,
@@ -12618,7 +12587,7 @@
 		  ]
 		 ],
 		 "layout": {
-		  "visibility": "visible",
+		  "visibility": "none",
 		  "symbol-placement": "point",
 		  "text-field": "{texte}",
 		  "text-size": 16,
@@ -12812,7 +12781,7 @@
 		  ]
 		 ],
 		 "layout": {
-		  "visibility": "visible",
+		  "visibility": "none",
 		  "symbol-placement": "point",
 		  "text-field": "{texte}",
 		  "text-size": 19,
@@ -12848,7 +12817,7 @@
 		  ]
 		 ],
 		 "layout": {
-		  "visibility": "visible",
+		  "visibility": "none",
 		  "symbol-placement": "point",
 		  "text-field": "{texte}",
 		  "text-size": 22,

--- a/components/map/styles/vector.json
+++ b/components/map/styles/vector.json
@@ -1,16 +1,43 @@
 {
 	"version": 8,
-	"name": "PLAN IGN",
-    "glyphs":"https://wxs.ign.fr/static/vectorTiles/fonts/{fontstack}/{range}.pbf",
-	"sprite": "https://wxs.ign.fr/static/vectorTiles/styles/PLAN.IGN/sprite/PlanIgn",
-    "sources": {
-	  "plan_ign": {
-        "type": "vector",
-		"tiles": [
-		  "https://wxs.ign.fr/essentiels/geoportail/tms/1.0.0/PLAN.IGN/{z}/{x}/{y}.pbf"
-		],
-		"scheme": "xyz",
-		"attribution": "<a target='_blank' href='https://geoservices.ign.fr/'>© IGN</a>"
+	"name": "OSM Bright",
+	"metadata": {
+	  "mapbox:type": "template",
+	  "mapbox:groups": {
+		"1444849364238.8171": {
+		  "collapsed": false,
+		  "name": "Buildings"
+		},
+		"1444849354174.1904": {
+		  "collapsed": true,
+		  "name": "Tunnels"
+		},
+		"1444849388993.3071": {
+		  "collapsed": false,
+		  "name": "Land"
+		},
+		"1444849382550.77": {
+		  "collapsed": false,
+		  "name": "Water"
+		},
+		"1444849345966.4436": {
+		  "collapsed": false,
+		  "name": "Roads"
+		},
+		"1444849334699.1902": {
+		  "collapsed": true,
+		  "name": "Bridges"
+		}
+	  },
+	  "mapbox:autocomposite": false,
+	  "openmaptiles:version": "3.x",
+	  "openmaptiles:mapbox:owner": "openmaptiles",
+	  "openmaptiles:mapbox:source:url": "mapbox://openmaptiles.4qljc88t"
+	},
+	"sources": {
+	  "openmaptiles": {
+		"type": "vector",
+		"url": "https://openmaptiles.geo.data.gouv.fr/data/france-vector.json"
 	  },
 	  "cadastre": {
 		"type": "vector",
@@ -20,14530 +47,4174 @@
 		"type": "vector",
 		"url": "https://openmaptiles.geo.data.gouv.fr/data/decoupage-administratif.json"
 	  }
-    },
-	"transition": {
-      "duration": 50,
-	  "delay": 0
 	},
+	"sprite": "https://openmaptiles.github.io/osm-bright-gl-style/sprite",
+	"glyphs": "https://openmaptiles.geo.data.gouv.fr/fonts/{fontstack}/{range}.pbf",
 	"layers": [
-		{
-		 "id": "bckgrd",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "fond_opaque",
-		 "minzoom": 0,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "paint": {
-		  "fill-color": "#FFFFFF",
-		  "fill-opacity": 0.1
-		 }
-		},
-		{
-		 "id": "orographie : relief - 0m",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "oro_relief",
-		 "minzoom": 0,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "HYPSO_0"
-		 ],
-		 "paint": {
-		  "fill-color": "#D6E5BA",
-		  "fill-opacity": 1
-		 }
-		},
-		{
-		 "id": "orographie : relief - 100m",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "oro_relief",
-		 "minzoom": 0,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "HYPSO_100"
-		 ],
-		 "paint": {
-		  "fill-color": "#F7F2DA",
-		  "fill-opacity": 1
-		 }
-		},
-		{
-		 "id": "orographie : relief - 200m",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "oro_relief",
-		 "minzoom": 0,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "HYPSO_200"
-		 ],
-		 "paint": {
-		  "fill-color": "#EBDEBF",
-		  "fill-opacity": 1
-		 }
-		},
-		{
-		 "id": "orographie : relief - 1000m",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "oro_relief",
-		 "minzoom": 0,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "HYPSO_1000"
-		 ],
-		 "paint": {
-		  "fill-color": "#DABE97",
-		  "fill-opacity": 1
-		 }
-		},
-		{
-		 "id": "orographie : relief - 3000m",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "oro_relief",
-		 "minzoom": 0,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "HYPSO_3000"
-		 ],
-		 "paint": {
-		  "fill-color": "#B28773",
-		  "fill-opacity": 1
-		 }
-		},
-		{
-		 "id": "orographie : relief - 4000m",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "oro_relief",
-		 "minzoom": 0,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "HYPSO_4000"
-		 ],
-		 "paint": {
-		  "fill-color": "#9E6A54",
-		  "fill-opacity": 1
-		 }
-		},
-		{
-		 "id": "orographie : relief - 5000m",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "oro_relief",
-		 "minzoom": 0,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "HYPSO_5000"
-		 ],
-		 "paint": {
-		  "fill-color": "#773A2B",
-		  "fill-opacity": 1
-		 }
-		},
-		{
-		 "id": "orographie : relief - glacier",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "oro_relief",
-		 "minzoom": 0,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "GLACIER"
-		 ],
-		 "paint": {
-		  "fill-color": "#FFFFFF",
-		  "fill-opacity": 0.7
-		 }
-		},
-		{
-		 "id": "ocs - vegetation - zone boiséee, foret fermee, peupleraie",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "ocs_vegetation_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "ZONE_BOISEE",
-		  "ZONE_FORET_FERMEE_FEUIL",
-		  "ZONE_FORET_FERMEE_CONI",
-		  "ZONE_FORET_FERMEE_MIXTE",
-		  "ZONE_PEUPLERAIE"
-		 ],
-		 "paint": {
-		  "fill-color": "#DFE8D5",
-		  "fill-outline-color": "#DFE8D5"
-		 }
-		},
-		{
-		 "id": "ocs - vegetation - forêt ouverte",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "ocs_vegetation_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "ZONE_FORET_OUVERTE"
-		 ],
-		 "paint": {
-		  "fill-color": "#EDF2D9",
-		  "fill-outline-color": "#EDF2D9"
-		 }
-		},
-		{
-		 "id": "ocs - vegetation - lande ligneuse",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "ocs_vegetation_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "ZONE_LANDE_LIGNEUSE"
-		 ],
-		 "paint": {
-		  "fill-color": "#F2EECD"
-		 }
-		},
-		{
-		 "id": "ocs - vegetation - vigne",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "ocs_vegetation_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "ZONE_VIGNE"
-		 ],
-		 "paint": {
-		  "fill-color": "#FFEDD9"
-		 }
-		},
-		{
-		 "id": "ocs - vegetation - verger",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "ocs_vegetation_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "ZONE_VERGER"
-		 ],
-		 "paint": {
-		  "fill-color": "#FAE2C5"
-		 }
-		},
-		{
-		 "id": "ocs - vegetation - canne à sucre, bananeraie",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "ocs_vegetation_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "ZONE_CANNE_BANANE"
-		 ],
-		 "paint": {
-		  "fill-color": "#FAEDFA"
-		 }
-		},
-		{
-		 "id": "hydro surfacique - Estran",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "hydro_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "ZONE_D_ESTRAN"
-		 ],
-		 "paint": {
-		  "fill-color": "#C3DDE9",
-		  "fill-outline-color": "#C3DDE9"
-		 }
-		},
-		{
-		 "id": "ocs - vegetation - mangrovre",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "ocs_vegetation_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "ZONE_MANGROVE"
-		 ],
-		 "paint": {
-		  "fill-color": {
-		   "stops": [
-			[
-			 9,
-			 "#85CCCB"
-			],
-			[
-			 10,
-			 "#90CCCB"
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "ocs - vegetation - marais",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "ocs_vegetation_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "ZONE_MARAIS"
-		 ],
-		 "paint": {
-		  "fill-pattern": "Marais"
-		 }
-		},
-		{
-		 "id": "ocs - vegetation - marais salant",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "ocs_vegetation_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "ZONE_MARAIS_SALANT"
-		 ],
-		 "paint": {
-		  "fill-pattern": "MaraisSalant"
-		 }
-		},
-		{
-		 "id": "ocs - Zone",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "ocs_nature_sol_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "ZONE_ROCHEUSE"
-		 ],
-		 "paint": {
-		  "fill-color": "#D0D0D0",
-		  "fill-opacity": 0.3
-		 }
-		},
-		{
-		 "id": "ocs - Zone sable sec",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "ocs_nature_sol_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "ZONE_SABLE_SEC"
-		 ],
-		 "paint": {
-		  "fill-pattern": "Sable"
-		 }
-		},
-		{
-		 "id": "ocs - Zone sable humide",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "ocs_nature_sol_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "ZONE_SABLE_HUMIDE",
-		  "FOND_CUVETTE_HUMIDE"
-		 ],
-		 "paint": {
-		  "fill-pattern": "SableHumide"
-		 }
-		},
-		{
-		 "id": "ocs - Zone graviers galets secs",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "ocs_nature_sol_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "GRAVIERS_GALETS_SEC"
-		 ],
-		 "paint": {
-		  "fill-pattern": "GravierSec"
-		 }
-		},
-		{
-		 "id": "ocs - Zone graviers galets humides",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "ocs_nature_sol_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "GRAVIERS_GALETS_HUM"
-		 ],
-		 "paint": {
-		  "fill-pattern": "Gravier"
-		 }
-		},
-		{
-		 "id": "ocs - Zone rocher hydro",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "ocs_nature_sol_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "ZONE_ROCHER_HYDRO"
-		 ],
-		 "paint": {
-		  "fill-pattern": "RocherHydro"
-		 }
-		},
-		{
-		 "id": "ocs - Zone glacier",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "ocs_nature_sol_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "ZONE_GLACIER"
-		 ],
-		 "paint": {
-		  "fill-pattern": "Glacier",
-		  "fill-opacity": {
-		   "stops": [
-			[
-			 10,
-			 0.5
-			],
-			[
-			 12,
-			 0.3
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "zone batie",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_zone_surf",
-		 "minzoom": 7,
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "ZONE_BATI"
-		 ],
-		 "paint": {
-		  "fill-color": "#E8E2D1",
-		  "fill-opacity": {
-		   "stops": [
-			[
-			 12,
-			 1
-			],
-			[
-			 13,
-			 0.9
-			],
-			[
-			 14,
-			 0.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "zone d'activité",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_zone_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "ZONE_INDUS_ACTI"
-		 ],
-		 "paint": {
-		  "fill-color": "#D9D9D9"
-		 }
-		},
-		{
-		 "id": "oro - courbe et cuvette maitresse",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "oro_courbe",
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "CNV_MAITRESSE",
-		  "CUVETTE_MAITRESSE"
-		 ],
-		 "paint": {
-		  "line-color": "#D9C8A9",
-		  "line-width": {
-		   "stops": [
-			[
-			 13,
-			 1.7
-			],
-			[
-			 15,
-			 2
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "oro - courbe et cuvette normale",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "oro_courbe",
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "CNV_NORMALE",
-		  "CUVETTE_NORMALE"
-		 ],
-		 "paint": {
-		  "line-color": "#D9C8A9",
-		  "line-width": {
-		   "stops": [
-			[
-			 13,
-			 1
-			],
-			[
-			 15,
-			 1.2
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "oro - courbe et cuvette intercalaire",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "oro_courbe",
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "CNV_INTERCALAIRE",
-		  "CUVETTE_INTERCAL",
-		  "CNV_SS_INTERCALAIRE"
-		 ],
-		 "paint": {
-		  "line-color": "#D9C8A9",
-		  "line-width": 0.7,
-		  "line-dasharray": [
-		   20,
-		   7
-		  ]
-		 }
-		},
-		{
-		 "id": "oro - courbe et cuvette glacier maitresse",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "oro_courbe",
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "CNV_GLACIER_MAITRESSE",
-		  "CUV_GLACIER_MAITRESSE"
-		 ],
-		 "paint": {
-		  "line-color": "#A4BFD9",
-		  "line-width": {
-		   "stops": [
-			[
-			 13,
-			 1.7
-			],
-			[
-			 15,
-			 2
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "oro - courbe et cuvette glacier normale",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "oro_courbe",
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "CNV_GLACIER_NORMALE",
-		  "CUV_GLACIER_NORMALE"
-		 ],
-		 "paint": {
-		  "line-color": "#A4BFD9",
-		  "line-width": {
-		   "stops": [
-			[
-			 13,
-			 1
-			],
-			[
-			 15,
-			 1.2
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "oro - courbe et cuvette glacier intercalaire",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "oro_courbe",
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "CNV_GLACIER_INTERCAL",
-		  "CUV_GLACIER_INTERCAL"
-		 ],
-		 "paint": {
-		  "line-color": "#A4BFD9",
-		  "line-width": {
-		   "stops": [
-			[
-			 13,
-			 0.7
-			],
-			[
-			 15,
-			 0.9
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   20,
-		   7
-		  ]
-		 }
-		},
-		{
-		 "id": "oro - courbe et cuvette rocher maitresse",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "oro_courbe",
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "CNV_ROCHER_MAITRESSE",
-		  "CUV_ROCHER_MAITRESSE"
-		 ],
-		 "paint": {
-		  "line-color": "#AAAAAA",
-		  "line-width": 1.7
-		 }
-		},
-		{
-		 "id": "oro - courbe et cuvette rocher normale",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "oro_courbe",
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "CNV_ROCHER_NORMALE",
-		  "CUV_ROCHER_NORMALE"
-		 ],
-		 "paint": {
-		  "line-color": "#AAAAAA",
-		  "line-width": 1
-		 }
-		},
-		{
-		 "id": "oro - courbe et cuvette rocher intercalaire",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "oro_courbe",
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "CNV_ROCHER_INTERCAL",
-		  "CUV_ROCHER_INTERCAL"
-		 ],
-		 "paint": {
-		  "line-color": "#AAAAAA",
-		  "line-width": {
-		   "stops": [
-			[
-			 13,
-			 0.7
-			],
-			[
-			 15,
-			 0.9
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   20,
-		   7
-		  ]
-		 }
-		},
-		{
-		 "id": "oro - courbe et cuvette bathymetrique",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "oro_courbe",
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "CNV_BATHYMETRIQUE",
-		  "CUV_BATHYMETRIQUE"
-		 ],
-		 "paint": {
-		  "line-color": "#0000FF",
-		  "line-width": 1
-		 }
-		},
-		{
-		 "id": "oro lin - talus",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "oro_lin",
-		 "minzoom": 14,
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "TALUS"
-		 ],
-		 "paint": {
-		  "line-color": "#D9C8A9",
-		  "line-width": 1
-		 }
-		},
-		{
-		 "id": "oro lin - talus - trait perpendiculaire",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "oro_lin",
-		 "minzoom": 14,
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "TALUS"
-		 ],
-		 "paint": {
-		  "line-color": "#D9C8A9",
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 7
-			],
-			[
-			 16,
-			 9
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   0.1,
-		   1
-		  ],
-		  "line-translate": [
-		   0,
-		   4
-		  ]
-		 }
-		},
-		{
-		 "id": "toponyme - cote de courbe normale",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "oro_courbe",
-		 "minzoom": 13,
-		 "maxzoom": 21,
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 13,
-			 10
-			],
-			[
-			 15,
-			 13
-			]
-		   ]
-		  },
-		  "text-anchor": "center",
-		  "text-rotation-alignment": "map",
-		  "text-pitch-alignment": "viewport",
-		  "text-keep-upright": false,
-		  "text-max-angle": 20,
-		  "text-max-width": 100,
-		  "text-font": [
-		   "Source Sans Pro Italic"
-		  ],
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "all",
-		  [
-		   "!=",
-		   "texte",
-		   "0"
-		  ],
-		  [
-		   "==",
-		   "hors_zone",
-		   "true"
-		  ],
-		  [
-		   "in",
-		   "symbo",
-		   "CNV_MAITRESSE",
-		   "CUVETTE_MAITRESSE"
-		  ]
-		 ],
-		 "paint": {
-		  "text-color": "#604A2F",
-		  "text-halo-width": 0.5,
-		  "text-halo-color": "#FFFFFF"
-		 }
-		},
-		{
-		 "id": "toponyme - cote de courbe rocher",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "oro_courbe",
-		 "minzoom": 13,
-		 "maxzoom": 21,
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 13,
-			 10
-			],
-			[
-			 15,
-			 13
-			]
-		   ]
-		  },
-		  "text-anchor": "center",
-		  "text-rotation-alignment": "map",
-		  "text-pitch-alignment": "viewport",
-		  "text-keep-upright": false,
-		  "text-max-angle": 20,
-		  "text-max-width": 100,
-		  "text-font": [
-		   "Source Sans Pro Italic"
-		  ],
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "all",
-		  [
-		   "!=",
-		   "texte",
-		   "0"
-		  ],
-		  [
-		   "==",
-		   "hors_zone",
-		   "true"
-		  ],
-		  [
-		   "in",
-		   "symbo",
-		   "CNV_ROCHER_MAITRESSE",
-		   "CUV_ROCHER_MAITRESSE"
-		  ]
-		 ],
-		 "paint": {
-		  "text-color": "#333333",
-		  "text-halo-width": 0.5,
-		  "text-halo-color": "#FFFFFF"
-		 }
-		},
-		{
-		 "id": "toponyme - cote de courbe glacier",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "oro_courbe",
-		 "minzoom": 13,
-		 "maxzoom": 21,
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 13,
-			 10
-			],
-			[
-			 15,
-			 13
-			]
-		   ]
-		  },
-		  "text-anchor": "center",
-		  "text-rotation-alignment": "map",
-		  "text-pitch-alignment": "viewport",
-		  "text-keep-upright": false,
-		  "text-max-angle": 20,
-		  "text-max-width": 100,
-		  "text-font": [
-		   "Source Sans Pro Italic"
-		  ],
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "all",
-		  [
-		   "!=",
-		   "texte",
-		   "0"
-		  ],
-		  [
-		   "==",
-		   "hors_zone",
-		   "true"
-		  ],
-		  [
-		   "in",
-		   "symbo",
-		   "CNV_GLACIER_MAITRESSE",
-		   "CUV_GLACIER_MAITRESSE"
-		  ]
-		 ],
-		 "paint": {
-		  "text-color": "#629FD9",
-		  "text-halo-width": 0.5,
-		  "text-halo-color": "#FFFFFF"
-		 }
-		},
-		{
-		 "id": "hydro surfacique",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "hydro_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "SURFACE_D_EAU",
-		  "BASSIN",
-		  "ZONE_MARINE"
-		 ],
-		 "paint": {
-		  "fill-color": "#AAD5E9",
-		  "fill-outline-color": "#AAD5E9"
-		 }
-		},
-		{
-		 "id": "hydro surfacique temporaire",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "hydro_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "SURFACE_D_EAU_TEMP"
-		 ],
-		 "paint": {
-		  "fill-color": "rgba(168, 203, 220, 0.5)"
-		 }
-		},
-		{
-		 "id": "réseau hydro  - cours d'eau souterrain",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "hydro_reseau_sou",
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "COURS_D_EAU_SOU",
-		  "COURS_D_EAU_MOY_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#AAD5E9",
-		  "line-width": {
-		   "stops": [
-			[
-			 12,
-			 1.5
-			],
-			[
-			 17,
-			 6.5
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   2,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "réseau hydro - filet interieur - aqueduc souterrain",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "hydro_reseau_sou",
-		 "minzoom": 12,
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "AQUEDUC_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#AAD5E9",
-		  "line-width": {
-		   "stops": [
-			[
-			 12,
-			 1.4
-			],
-			[
-			 16,
-			 3.5
-			],
-			[
-			 17,
-			 5.9
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   2,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "réseau hydro - carre - aqueduc souterrain",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "hydro_reseau_sou",
-		 "minzoom": 12,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "AQUEDUC_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#AAD5E9",
-		  "line-width": {
-		   "stops": [
-			[
-			 12,
-			 3.5
-			],
-			[
-			 16,
-			 8.7
-			],
-			[
-			 17,
-			 14.7
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   1,
-		   5
-		  ]
-		 }
-		},
-		{
-		 "id": "Ferre souterrain - voie normale",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "ferre_sou",
-		 "minzoom": 10,
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "VF_1_SOU",
-		  "VF_2_SOU",
-		  "VF_ELEC_1_SOU",
-		  "VF_FERRO_ROUTIER_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#B4B4B4",
-		  "line-width": {
-		   "stops": [
-			[
-			 10,
-			 0.8
-			],
-			[
-			 17,
-			 2.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Ferre souterrain - trait perpendic épais",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "ferre_sou",
-		 "minzoom": 10,
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "VF_1_SOU",
-		  "VF_2_SOU",
-		  "VF_ELEC_1_SOU",
-		  "VF_FERRO_ROUTIER_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#B4B4B4",
-		  "line-width": {
-		   "stops": [
-			[
-			 10,
-			 3.5
-			],
-			[
-			 17,
-			 14.7
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   0.1,
-		   10
-		  ]
-		 }
-		},
-		{
-		 "id": "Ferre souterrain - voie etroite",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "ferre_sou",
-		 "minzoom": 10,
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "VF_ETROITE_1_SOU",
-		  "VF_ETROITE_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#B4B4B4",
-		  "line-width": {
-		   "stops": [
-			[
-			 10,
-			 0.3
-			],
-			[
-			 17,
-			 1.8
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Ferre souterrain - trait perpendic fin",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "ferre_sou",
-		 "minzoom": 10,
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "VF_ETROITE_1_SOU",
-		  "VF_ETROITE_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#B4B4B4",
-		  "line-width": {
-		   "stops": [
-			[
-			 10,
-			 3.5
-			],
-			[
-			 17,
-			 14.7
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   0.1,
-		   10
-		  ]
-		 }
-		},
-		{
-		 "id": "Ferre souterrain - voie service",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "ferre_sou",
-		 "minzoom": 14,
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "VF_SERVICE_SOU",
-		  "VF_NON_EXPLOITEE_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#B4B4B4",
-		  "line-width": {
-		   "stops": [
-			[
-			 10,
-			 0.3
-			],
-			[
-			 17,
-			 1.8
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   5,
-		   2,
-		   1,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "Ferre souterrain - funic/urbain",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "ferre_sou",
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "FUNI_CREMAILLERE_SOU",
-		  "TRANSPORT_URBAIN_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#B4B4B4",
-		  "line-width": {
-		   "stops": [
-			[
-			 10,
-			 0.3
-			],
-			[
-			 17,
-			 1.8
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Ferre souterrain - 2 trait perpendic - funic/urbain",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "ferre_sou",
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "FUNI_CREMAILLERE_SOU",
-		  "TRANSPORT_URBAIN_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#B4B4B4",
-		  "line-width": {
-		   "stops": [
-			[
-			 10,
-			 3.5
-			],
-			[
-			 17,
-			 17
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   0.1,
-		   0.2,
-		   0.1,
-		   10
-		  ]
-		 }
-		},
-		{
-		 "id": "Chemin souterrain - piste cyclable",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_chemin_sou",
-		 "minzoom": 13,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "PISTE_CYCLABLE_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#AB81CC",
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 1.1
-			],
-			[
-			 15,
-			 1.7
-			],
-			[
-			 16,
-			 2
-			],
-			[
-			 17,
-			 3.5
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   6,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "Chemin souterrain - filet exterieur - escalier",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_chemin_sou",
-		 "minzoom": 14,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "ESCALIER_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#B3989A",
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 1.75
-			],
-			[
-			 15,
-			 3
-			],
-			[
-			 16,
-			 4.2
-			],
-			[
-			 17,
-			 9.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Chemin souterrain - filet interieur - escalier",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_chemin_sou",
-		 "minzoom": 14,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "ESCALIER_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#EDF1FF",
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 1
-			],
-			[
-			 15,
-			 1.9
-			],
-			[
-			 16,
-			 2.7
-			],
-			[
-			 17,
-			 5.8
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   1,
-		   0.2
-		  ]
-		 }
-		},
-		{
-		 "id": "Chemin souterrain - Rue pietonne",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_chemin_sou",
-		 "minzoom": 14,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "RUE_PIETONNE_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#B3989A",
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 1
-			],
-			[
-			 15,
-			 1.2
-			],
-			[
-			 16,
-			 1.4
-			],
-			[
-			 17,
-			 2
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   1,
-		   3
-		  ]
-		 }
-		},
-		{
-		 "id": "Chemin souterrain - sentier",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_chemin_sou",
-		 "minzoom": 13,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "SENTIER_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#B3989A",
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 1
-			],
-			[
-			 15,
-			 1.2
-			],
-			[
-			 16,
-			 1.4
-			],
-			[
-			 17,
-			 2
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   4,
-		   3
-		  ]
-		 }
-		},
-		{
-		 "id": "Chemin souterrain - chemin",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_chemin_sou",
-		 "minzoom": 12,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "CHEMIN_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#B3989A",
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 1
-			],
-			[
-			 15,
-			 1.2
-			],
-			[
-			 16,
-			 1.4
-			],
-			[
-			 17,
-			 2
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier souterrain - filet extérieur - route non revetu carrosable",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sou",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "NON_REVETUE_CARRO_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#AFAFAF",
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 3.2
-			],
-			[
-			 15,
-			 5.4
-			],
-			[
-			 16,
-			 7.7
-			],
-			[
-			 17,
-			 16.8
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   2,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "Routier souterrain - filet extérieur - bretelle autoroute",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sou",
-		 "minzoom": 12,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BRET_AUTO_PEAGE_3_SOU",
-		  "BRET_AUTO_PEAGE_2_SOU",
-		  "BRET_AUTO_PEAGE_1_SOU",
-		  "BRET_AUTO_LIBRE_3_SOU",
-		  "BRET_AUTO_LIBRE_2_SOU",
-		  "BRET_AUTO_LIBRE_1_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "rgba(222, 70, 14, 0.5)",
-		  "line-width": {
-		   "stops": [
-			[
-			 12,
-			 2.5
-			],
-			[
-			 14,
-			 3.7
-			],
-			[
-			 15,
-			 6.8
-			],
-			[
-			 16,
-			 8.4
-			],
-			[
-			 17,
-			 14
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier souterrain - filet extérieur - route non classee restreint",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sou",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "NON_CLASSEE_RESTREINT_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#AFAFAF",
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 3.2
-			],
-			[
-			 15,
-			 5.4
-			],
-			[
-			 16,
-			 7.7
-			],
-			[
-			 17,
-			 16.8
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier souterrain - filet extérieur - route non classee",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sou",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "NON_CLASSEE_4_SOU",
-		  "NON_CLASSEE_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#AFAFAF",
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 3.2
-			],
-			[
-			 15,
-			 5.4
-			],
-			[
-			 16,
-			 7.7
-			],
-			[
-			 17,
-			 16.8
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier souterrain - filet extérieur - route locale",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sou",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BRET_LOCALE_SOU",
-		  "LOCALE_4_SOU",
-		  "LOCALE_3_SOU",
-		  "LOCALE_2_SOU",
-		  "LOCALE_1_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "rgba(130, 130, 130, 0.5)",
-		  "line-width": {
-		   "stops": [
-			[
-			 9,
-			 2
-			],
-			[
-			 14,
-			 3.5
-			],
-			[
-			 15,
-			 6
-			],
-			[
-			 16,
-			 8.4
-			],
-			[
-			 17,
-			 18.3
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier souterrain - filet extérieur - route locale en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sou",
-		 "minzoom": 11,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "LOCALE_CONSTR_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#C8C8C8",
-		  "line-width": {
-		   "stops": [
-			[
-			 9,
-			 2
-			],
-			[
-			 14,
-			 3.5
-			],
-			[
-			 15,
-			 6
-			],
-			[
-			 16,
-			 8.4
-			],
-			[
-			 17,
-			 18.3
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier souterrain - filet extérieur - route regionale",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sou",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BRET_REGIONALE_SOU",
-		  "REGIONALE_4_SOU",
-		  "REGIONALE_3_SOU",
-		  "REGIONALE_2_SOU",
-		  "REGIONALE_1_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "rgba(130, 130, 130, 0.5)",
-		  "line-width": {
-		   "stops": [
-			[
-			 6,
-			 1.5
-			],
-			[
-			 9,
-			 2.3
-			],
-			[
-			 14,
-			 5
-			],
-			[
-			 15,
-			 8.1
-			],
-			[
-			 16,
-			 11.2
-			],
-			[
-			 17,
-			 22
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier souterrain - filet extérieur - route regionale en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sou",
-		 "minzoom": 10,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "REGIONALE_CONSTR_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#C8C8C8",
-		  "line-width": {
-		   "stops": [
-			[
-			 6,
-			 1.5
-			],
-			[
-			 9,
-			 2.3
-			],
-			[
-			 14,
-			 5
-			],
-			[
-			 15,
-			 8.1
-			],
-			[
-			 16,
-			 11.2
-			],
-			[
-			 17,
-			 22
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier souterrain - filet extérieur - route principale",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sou",
-		 "minzoom": 7,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BRET_PRINCIPALE_SOU",
-		  "PRINCIPALE_4_SOU",
-		  "PRINCIPALE_3_SOU",
-		  "PRINCIPALE_2_SOU",
-		  "PRINCIPALE_1_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "rgba(222, 70, 14, 0.5)",
-		  "line-width": {
-		   "stops": [
-			[
-			 6,
-			 1.8
-			],
-			[
-			 9,
-			 2.7
-			],
-			[
-			 14,
-			 5.9
-			],
-			[
-			 15,
-			 9
-			],
-			[
-			 16,
-			 12.2
-			],
-			[
-			 17,
-			 22.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier souterrain - filet extérieur - route principale en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sou",
-		 "minzoom": 10,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "PRINCIPALE_CONSTR_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#C8C8C8",
-		  "line-width": {
-		   "stops": [
-			[
-			 6,
-			 1.8
-			],
-			[
-			 9,
-			 2.7
-			],
-			[
-			 14,
-			 5.9
-			],
-			[
-			 15,
-			 9
-			],
-			[
-			 16,
-			 12.2
-			],
-			[
-			 17,
-			 22.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier souterrain - filet extérieur - autoroute",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sou",
-		 "minzoom": 7,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "AUTOROU_PEAGE_SOU",
-		  "AUTOROU_LIBRE_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "rgba(222, 70, 14, 0.5)",
-		  "line-width": {
-		   "stops": [
-			[
-			 6,
-			 2.5
-			],
-			[
-			 9,
-			 3.5
-			],
-			[
-			 14,
-			 7.5
-			],
-			[
-			 15,
-			 11
-			],
-			[
-			 16,
-			 15
-			],
-			[
-			 17,
-			 26
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier souterrain - filet extérieur - autoroute en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sou",
-		 "minzoom": 10,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "AUTOROU_CONSTR_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#C8C8C8",
-		  "line-width": {
-		   "stops": [
-			[
-			 6,
-			 2.5
-			],
-			[
-			 9,
-			 3.5
-			],
-			[
-			 14,
-			 7.5
-			],
-			[
-			 15,
-			 11
-			],
-			[
-			 16,
-			 15
-			],
-			[
-			 17,
-			 26
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier souterrain - filet interieur - route non revetu carrosable",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sou",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "NON_REVETUE_CARRO_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#DCDCDC",
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 2.3
-			],
-			[
-			 15,
-			 4.1
-			],
-			[
-			 16,
-			 6.3
-			],
-			[
-			 17,
-			 13.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier souterrain - filet interieur - bretelle autoroute",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sou",
-		 "minzoom": 12,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BRET_AUTO_PEAGE_3_SOU",
-		  "BRET_AUTO_PEAGE_2_SOU",
-		  "BRET_AUTO_PEAGE_1_SOU",
-		  "BRET_AUTO_LIBRE_3_SOU",
-		  "BRET_AUTO_LIBRE_2_SOU",
-		  "BRET_AUTO_LIBRE_1_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "rgba(255, 255, 255, 0.5)",
-		  "line-width": {
-		   "stops": [
-			[
-			 12,
-			 1.5
-			],
-			[
-			 14,
-			 2.6
-			],
-			[
-			 15,
-			 5.2
-			],
-			[
-			 16,
-			 6.7
-			],
-			[
-			 17,
-			 10.8
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier souterrain - filet interieur - route non classee restreint",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sou",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "NON_CLASSEE_RESTREINT_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#F2F5FF",
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 2.3
-			],
-			[
-			 15,
-			 4.1
-			],
-			[
-			 16,
-			 6.3
-			],
-			[
-			 17,
-			 13.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier souterrain - filet interieur - route non classee",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sou",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "NON_CLASSEE_4_SOU",
-		  "NON_CLASSEE_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#DCDCDC",
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 2.3
-			],
-			[
-			 15,
-			 4.1
-			],
-			[
-			 16,
-			 6.3
-			],
-			[
-			 17,
-			 13.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier souterrain - filet interieur - route locale",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sou",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BRET_LOCALE_SOU",
-		  "LOCALE_4_SOU",
-		  "LOCALE_3_SOU",
-		  "LOCALE_2_SOU",
-		  "LOCALE_1_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "rgba(255, 255, 255, 0.5)",
-		  "line-width": {
-		   "stops": [
-			[
-			 9,
-			 1.3
-			],
-			[
-			 14,
-			 2.3
-			],
-			[
-			 15,
-			 4.1
-			],
-			[
-			 16,
-			 6.1
-			],
-			[
-			 17,
-			 13.1
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier souterrain - filet interieur - route locale en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sou",
-		 "minzoom": 11,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "LOCALE_CONSTR_SOU"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 12,
-			 "#EDF1FF"
-			],
-			[
-			 13,
-			 "#FCF4A8"
-			],
-			[
-			 17,
-			 "#FCF7C1"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 9,
-			 2
-			],
-			[
-			 14,
-			 3.5
-			],
-			[
-			 15,
-			 6
-			],
-			[
-			 16,
-			 8.4
-			],
-			[
-			 17,
-			 18.3
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   2,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "Routier souterrain - filet interieur - route regionale",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sou",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BRET_REGIONALE_SOU",
-		  "REGIONALE_4_SOU",
-		  "REGIONALE_3_SOU",
-		  "REGIONALE_2_SOU",
-		  "REGIONALE_1_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "rgba(255, 255, 255, 0.5)",
-		  "line-width": {
-		   "stops": [
-			[
-			 6,
-			 1.4
-			],
-			[
-			 9,
-			 1.5
-			],
-			[
-			 14,
-			 3.2
-			],
-			[
-			 15,
-			 5.8
-			],
-			[
-			 16,
-			 8.3
-			],
-			[
-			 17,
-			 16.2
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier souterrain - filet interieur - route regionale en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sou",
-		 "minzoom": 10,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "REGIONALE_CONSTR_SOU"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 9,
-			 "#EDF1FF"
-			],
-			[
-			 10,
-			 "#FDF28B"
-			],
-			[
-			 17,
-			 "#FCF6BD"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 4,
-			 0.4
-			],
-			[
-			 6,
-			 1.5
-			],
-			[
-			 9,
-			 2.3
-			],
-			[
-			 14,
-			 5
-			],
-			[
-			 15,
-			 8.1
-			],
-			[
-			 16,
-			 11.2
-			],
-			[
-			 17,
-			 22
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   2,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "Routier souterrain - filet interieur - route principale",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sou",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BRET_PRINCIPALE_SOU",
-		  "PRINCIPALE_4_SOU",
-		  "PRINCIPALE_3_SOU",
-		  "PRINCIPALE_2_SOU",
-		  "PRINCIPALE_1_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "rgba(255, 255, 255, 0.5)",
-		  "line-width": {
-		   "stops": [
-			[
-			 4,
-			 0.5
-			],
-			[
-			 6,
-			 1.8
-			],
-			[
-			 9,
-			 2.1
-			],
-			[
-			 14,
-			 4.4
-			],
-			[
-			 15,
-			 7.3
-			],
-			[
-			 16,
-			 10
-			],
-			[
-			 17,
-			 18.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier souterrain - filet interieur - route principale en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sou",
-		 "minzoom": 10,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "PRINCIPALE_CONSTR_SOU"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 9,
-			 "#F3C66D"
-			],
-			[
-			 17,
-			 "#F2DDB3"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 4,
-			 0.5
-			],
-			[
-			 6,
-			 1.8
-			],
-			[
-			 9,
-			 2.7
-			],
-			[
-			 14,
-			 5.9
-			],
-			[
-			 15,
-			 9
-			],
-			[
-			 16,
-			 12.2
-			],
-			[
-			 17,
-			 22.5
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   2,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "Routier souterrain - filet interieur - autoroute",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sou",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "AUTOROU_PEAGE_SOU",
-		  "AUTOROU_LIBRE_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "rgba(255, 255, 255, 0.5)",
-		  "line-width": {
-		   "stops": [
-			[
-			 4,
-			 0.7
-			],
-			[
-			 6,
-			 2.5
-			],
-			[
-			 9,
-			 2.7
-			],
-			[
-			 14,
-			 5.8
-			],
-			[
-			 15,
-			 9
-			],
-			[
-			 16,
-			 12
-			],
-			[
-			 17,
-			 20.8
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier souterrain - axe central - autoroute",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sou",
-		 "minzoom": 13,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "AUTOROU_PEAGE_SOU",
-		  "AUTOROU_LIBRE_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#EDF1FF",
-		  "line-width": {
-		   "stops": [
-			[
-			 9,
-			 0.6
-			],
-			[
-			 14,
-			 0.7
-			],
-			[
-			 15,
-			 1
-			],
-			[
-			 16,
-			 1.2
-			],
-			[
-			 17,
-			 2.1
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier souterrain - filet interieur - autoroute en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sou",
-		 "minzoom": 10,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "AUTOROU_CONSTR_SOU"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 9,
-			 "#F2BA59"
-			],
-			[
-			 17,
-			 "#F2C261"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 4,
-			 0.7
-			],
-			[
-			 6,
-			 2.5
-			],
-			[
-			 9,
-			 3.5
-			],
-			[
-			 14,
-			 7.5
-			],
-			[
-			 15,
-			 11
-			],
-			[
-			 16,
-			 15
-			],
-			[
-			 17,
-			 26
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   2,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "Routier souterrain - axe central - autoroute en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sou",
-		 "minzoom": 13,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "AUTOROU_CONSTR_SOU"
-		 ],
-		 "paint": {
-		  "line-color": "#808080",
-		  "line-width": {
-		   "stops": [
-			[
-			 9,
-			 0.6
-			],
-			[
-			 14,
-			 0.7
-			],
-			[
-			 15,
-			 1
-			],
-			[
-			 16,
-			 1.2
-			],
-			[
-			 17,
-			 2.1
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "réseau hydro - cours d'eau temporaire",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "hydro_reseau",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "COURS_D_EAU_TEMP",
-		  "COURS_D_EAU_TEMP_MOY"
-		 ],
-		 "paint": {
-		  "line-color": "#AAD5E9",
-		  "line-width": {
-		   "stops": [
-			[
-			 12,
-			 1.5
-			],
-			[
-			 17,
-			 4
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   6,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "réseau hydro - cours d'eau",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "hydro_reseau",
-		 "minzoom": 3,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "COURS_D_EAU"
-		 ],
-		 "paint": {
-		  "line-color": "#AAD5E9",
-		  "line-width": {
-		   "stops": [
-			[
-			 4,
-			 0.3
-			],
-			[
-			 7,
-			 1.5
-			],
-			[
-			 12,
-			 1.5
-			],
-			[
-			 17,
-			 6.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "réseau hydro - canal",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "hydro_reseau",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "CANAL"
-		 ],
-		 "paint": {
-		  "line-color": "#AAD5E9",
-		  "line-width": {
-		   "stops": [
-			[
-			 12,
-			 1.4
-			],
-			[
-			 17,
-			 5.9
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "réseau hydro - filet interieur - aqueduc",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "hydro_reseau",
-		 "minzoom": 12,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "AQUEDUC_AU_SOL"
-		 ],
-		 "paint": {
-		  "line-color": "#AAD5E9",
-		  "line-width": {
-		   "stops": [
-			[
-			 12,
-			 1.4
-			],
-			[
-			 16,
-			 3.5
-			],
-			[
-			 17,
-			 5.9
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "réseau hydro - carre - aqueduc",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "hydro_reseau",
-		 "minzoom": 12,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "AQUEDUC_AU_SOL"
-		 ],
-		 "paint": {
-		  "line-color": "#AAD5E9",
-		  "line-width": {
-		   "stops": [
-			[
-			 12,
-			 3.5
-			],
-			[
-			 16,
-			 8.7
-			],
-			[
-			 17,
-			 14.7
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   1,
-		   5
-		  ]
-		 }
-		},
-		{
-		 "id": "réseau hydro - cours d'eau moyen ",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "hydro_reseau",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "COURS_D_EAU_MOY"
-		 ],
-		 "paint": {
-		  "line-color": "#AAD5E9",
-		  "line-width": {
-		   "stops": [
-			[
-			 7,
-			 2
-			],
-			[
-			 12,
-			 2.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "réseau hydro - cours d'eau large ",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "hydro_reseau",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "COURS_D_EAU_LAR"
-		 ],
-		 "paint": {
-		  "line-color": "#AAD5E9",
-		  "line-width": {
-		   "stops": [
-			[
-			 7,
-			 3
-			],
-			[
-			 11,
-			 5
-			]
-		   ]
-		  }
-		 }
-		},
-		
-		{
-		 "id": "bati surfacique mairie - Zoom 14",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "maxzoom": 14,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "MAIRIE",
-		  "MAIRIE_ANNEXE"
-		 ],
-		 "paint": {
-		  "fill-color": "#FFA6A6"
-		 }
-		},
-		{
-		 "id": "bati surfacique mairie - Zoom 15,16,17,18",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "minzoom": 14,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "MAIRIE",
-		  "MAIRIE_ANNEXE"
-		 ],
-		 "paint": {
-		  "fill-color": {
-		   "stops": [
-			[
-			 14,
-			 "#FFA6A6"
-			],
-			[
-			 15,
-			 "#FFAEAE"
-			]
-		   ]
-		  },
-		  "fill-outline-color": "#FF7C7C"
-		 }
-		},
-		{
-		 "id": "bati surfacique fonctionnel industriel ou commercial - Zoom 14,15",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BATI_COMMERCIAL",
-		  "BATI_INDUSTRIEL",
-		  "HANGAR",
-		  "HANGAR_COMMERCIAL",
-		  "HANGAR_INDUSTRIEL"
-		 ],
-		 "paint": {
-		  "fill-color": "#C8C8C8"
-		 }
-		},
-		{
-		 "id": "bati surfacique fonctionnel industriel ou commercial - Zoom 16,17,18",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "minzoom": 15,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BATI_COMMERCIAL",
-		  "BATI_INDUSTRIEL",
-		  "HANGAR",
-		  "HANGAR_COMMERCIAL",
-		  "HANGAR_INDUSTRIEL"
-		 ],
-		 "paint": {
-		  "fill-color": {
-		   "stops": [
-			[
-			 15,
-			 "#D1D1D1"
-			],
-			[
-			 16,
-			 "#E6E6E6"
-			]
-		   ]
-		  },
-		  "fill-outline-color": "#B8B8B8"
-		 }
-		},
-		{
-		 "id": "bati surfacique fonctionnel public - Zoom 14,15",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BATI_PUBLIC",
-		  "HANGAR_PUBLIC"
-		 ],
-		 "paint": {
-		  "fill-color": "#B9B6D6"
-		 }
-		},
-		{
-		 "id": "bati surfacique fonctionnel public - Zoom 16,17,18",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "minzoom": 21,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BATI_PUBLIC",
-		  "HANGAR_PUBLIC"
-		 ],
-		 "paint": {
-		  "fill-color": {
-		   "stops": [
-			[
-			 15,
-			 "#CFC5DE"
-			],
-			[
-			 16,
-			 "#E4DAF3"
-			]
-		   ]
-		  },
-		  "fill-outline-color": "#A6A1D6"
-		 }
-		},
-		{
-		 "id": "bati surfacique fonctionnel sportif - bordure",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "minzoom": 15,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "BATI_SPORTIF"
-		 ],
-		 "paint": {
-		  "line-color": "#BCD9AB",
-		  "line-width": 4
-		 }
-		},
-		{
-		 "id": "bati surfacique fonctionnel sportif",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "minzoom": 13,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "BATI_SPORTIF"
-		 ],
-		 "paint": {
-		  "fill-color": {
-		   "stops": [
-			[
-			 14,
-			 "#C9E1DD"
-			],
-			[
-			 15,
-			 "#DCE6E4"
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "bati surfacique fonctionnel gare - Zoom 14,15",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "BATI_GARE"
-		 ],
-		 "paint": {
-		  "fill-color": "#B3B5F5"
-		 }
-		},
-		{
-		 "id": "bati surfacique fonctionnel gare - Zoom 16,17,18",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "minzoom": 15,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "BATI_GARE"
-		 ],
-		 "paint": {
-		  "fill-color": {
-		   "stops": [
-			[
-			 15,
-			 "#BFC1F5"
-			],
-			[
-			 16,
-			 "#CBCDF5"
-			]
-		   ]
-		  },
-		  "fill-outline-color": "#9B9EF6"
-		 }
-		},
-		{
-		 "id": "bati surfacique quelconque - Zoom 15",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "minzoom": 14,
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "BATI_QQUE"
-		 ],
-		 "paint": {
-		  "fill-color": "#D6C6B8"
-		 }
-		},
-		{
-		 "id": "bati surfacique quelconque - Zoom 16,17,18",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "minzoom": 15,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "BATI_QQUE"
-		 ],
-		 "paint": {
-		  "fill-color": {
-		   "stops": [
-			[
-			 15,
-			 "#E6E0CF"
-			],
-			[
-			 16,
-			 "#F1EBD9"
-			]
-		   ]
-		  },
-		  "fill-outline-color": "#C3AA8E"
-		 }
-		},
-		{
-		 "id": "cimetiere surfacique 1",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "CIMETIERE_SURF",
-		  "CIMETIERE_MILI_SURF",
-		  "NECROPOLE_NATIONALE"
-		 ],
-		 "paint": {
-		  "fill-color": "#F0F0F0",
-		  "fill-opacity": 0.5,
-		  "fill-outline-color": "#818181"
-		 }
-		},
-		{
-		 "id": "cimetiere surfacique 2",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "CIMETIERE_SURF",
-		  "CIMETIERE_MILI_SURF",
-		  "NECROPOLE_NATIONALE"
-		 ],
-		 "paint": {
-		  "fill-pattern": "Cimetiere"
-		 }
-		},
-		{
-		 "id": "bati hydro surfacique - Autre",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "ECLUSE_SURF",
-		  "RESERVOIR_EAU_SURF"
-		 ],
-		 "paint": {
-		  "fill-color": "#ADCCD9",
-		  "fill-outline-color": "#336699"
-		 }
-		},
-		{
-		 "id": "bati hydro surfacique - Pecherie",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "PECHERIE_SURF"
-		 ],
-		 "paint": {
-		  "fill-color": "#BFE2F0",
-		  "fill-outline-color": "#509FEF"
-		 }
-		},
-		{
-		 "id": "bati hydro surfacique - Barrage",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "BARRAGE_SURF"
-		 ],
-		 "paint": {
-		  "fill-color": "#FFFFFF",
-		  "fill-outline-color": "#464646"
-		 }
-		},
-		{
-		 "id": "bati hydro surfacique - Chateau d'eau",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "CHATEAU_EAU_SURF"
-		 ],
-		 "paint": {
-		  "fill-color": "#1466B2"
-		 }
-		},
-		{
-		 "id": "bati infra surfacique - Silo",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "minzoom": 15,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "SILO_SURF"
-		 ],
-		 "paint": {
-		  "fill-color": "#C7A9AA",
-		  "fill-outline-color": "#696969"
-		 }
-		},
-		{
-		 "id": "bati infra surfacique - Reservoir indus",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "minzoom": 14,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "RESERVOIR_INDUS_SURF"
-		 ],
-		 "paint": {
-		  "fill-color": "#8D9DAA",
-		  "fill-outline-color": "#464646"
-		 }
-		},
-		{
-		 "id": "bati infra surfacique - Serre",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "minzoom": 13,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "SERRE_SURF"
-		 ],
-		 "paint": {
-		  "fill-color": "#CAD6D9",
-		  "fill-outline-color": "#8C8C8C"
-		 }
-		},
-		{
-		 "id": "bati infra surfacique - poste electrique",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "POSTE_ELEC_SURF"
-		 ],
-		 "paint": {
-		  "fill-color": "#7993B6",
-		  "fill-opacity": 0.3
-		 }
-		},
-		{
-		 "id": "bati infra surfacique - poste electrique bord",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "POSTE_ELEC_SURF"
-		 ],
-		 "paint": {
-		  "line-color": "#000000",
-		  "line-width": {
-		   "stops": [
-			[
-			 12,
-			 0.3
-			],
-			[
-			 17,
-			 1.2
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "bati religieux surfacique - Zoom 14",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "maxzoom": 14,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "CHAPELLE_SURF",
-		  "EGLISE_SURF",
-		  "CHRETIEN_SURF",
-		  "SYNAGOGUE_SURF",
-		  "MOSQUEE_SURF",
-		  "AUTRE_CULTE_SURF"
-		 ],
-		 "paint": {
-		  "fill-color": "#F7CBCB"
-		 }
-		},
-		{
-		 "id": "bati religieux surfacique - Zoom 15,16,17,18",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "minzoom": 14,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "CHAPELLE_SURF",
-		  "EGLISE_SURF",
-		  "CHRETIEN_SURF",
-		  "SYNAGOGUE_SURF",
-		  "MOSQUEE_SURF",
-		  "AUTRE_CULTE_SURF"
-		 ],
-		 "paint": {
-		  "fill-color": {
-		   "stops": [
-			[
-			 14,
-			 "#F7CBCB"
-			],
-			[
-			 15,
-			 "#F7E1E1"
-			]
-		   ]
-		  },
-		  "fill-outline-color": {
-		   "stops": [
-			[
-			 14,
-			 "#F7A8A8"
-			],
-			[
-			 15,
-			 "#F7B7B7"
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "bati remarquable surfacique",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "minzoom": 13,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "FORTIF_SURF",
-		  "CHATEAU_SURF",
-		  "TOUR_MOULIN_SURF",
-		  "ARENE_THEATRE",
-		  "ARC_TRIOMPHE_SURF",
-		  "MONUMENT_SURF"
-		 ],
-		 "paint": {
-		  "fill-color": "#9B9B9B",
-		  "fill-outline-color": "#6E6E6E"
-		 }
-		},
-		{
-		 "id": "bati sportif surfacique fond",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "TENNIS_SURF",
-		  "SPORT_INDIF_SURF",
-		  "FOOT_SURF",
-		  "MULTI_SPORT_SURF",
-		  "PISTE_SPORT_SURF",
-		  "NATATION_SURF"
-		 ],
-		 "paint": {
-		  "fill-color": "#FFFFFF",
-		  "fill-outline-color": "#FFFFFF"
-		 }
-		},
-		{
-		 "id": "bati sportif surfacique",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "TENNIS_SURF",
-		  "SPORT_INDIF_SURF",
-		  "FOOT_SURF",
-		  "MULTI_SPORT_SURF",
-		  "PISTE_SPORT_SURF",
-		  "NATATION_SURF"
-		 ],
-		 "paint": {
-		  "line-color": "#BCD9AB",
-		  "line-width": 2
-		 }
-		},
-		{
-		 "id": "bati transport surfacique - piste",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "PISTE_DUR",
-		  "PISTE_HERBE"
-		 ],
-		 "paint": {
-		  "fill-color": "#DBDBDB",
-		  "fill-outline-color": "#808080"
-		 }
-		},
-		{
-		 "id": "bati ZAI - Autres",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_zai",
-		 "minzoom": 15,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "in",
-		  "nature",
-		  "Lycée",
-		  "Université",
-		  "Capitainerie",
-		  "Gendarmerie",
-		  "Siège d'EPCI",
-		  "Musée",
-		  "Collège",
-		  "Maison de retraite",
-		  "Etablissement thermal",
-		  "Autre service déconcentré de l'Etat",
-		  "Etablissement pénitentiaire",
-		  "Divers public ou administratif",
-		  "Autre établissement d'enseignement",
-		  "Maison du parc",
-		  "Palais de justice",
-		  "Enseignement primaire",
-		  "Office de tourisme",
-		  "Hôpital",
-		  "Police",
-		  "Piscine",
-		  "Enseignement supérieur",
-		  "Poste",
-		  "Caserne",
-		  "Etablissement hospitalier",
-		  "Etablissement extraterritorial",
-		  "Science",
-		  "Structure d'accueil pour personnes handicapées",
-		  "Administration centrale de l'Etat",
-		  "Caserne de pompiers"
-		 ],
-		 "paint": {
-		  "fill-color": "#E3BFE2",
-		  "fill-opacity": 0.5,
-		  "fill-outline-color": "#E39FE1"
-		 }
-		},
-		{
-		 "id": "bati ZAI - Commandement",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_zai",
-		 "minzoom": 15,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "in",
-		  "nature",
-		  "Hôtel de département",
-		  "Hôtel de région",
-		  "Préfecture de région",
-		  "Préfecture",
-		  "Sous-préfecture"
-		 ],
-		 "paint": {
-		  "fill-color": "#FF0000",
-		  "fill-opacity": 0.3,
-		  "fill-outline-color": "#B40000"
-		 }
-		},
-		{
-		 "id": "construction linéaire - mur",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "bati_lin",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "MUR"
-		 ],
-		 "paint": {
-		  "line-color": "#8C8C8C",
-		  "line-width": 0.3
-		 }
-		},
-		{
-		 "id": "construction linéaire - autre",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "bati_lin",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "RUINE_LIN",
-		  "MUR_SOUTENEMENT",
-		  "FORTIF_LIN"
-		 ],
-		 "paint": {
-		  "line-color": "#646464",
-		  "line-width": 0.5
-		 }
-		},
-		{
-		 "id": "construction hydrographique linéaire - Barrage",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "bati_lin",
-		 "minzoom": 13,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "BARRAGE_LIN"
-		 ],
-		 "paint": {
-		  "line-color": "#646464",
-		  "line-width": {
-		   "stops": [
-			[
-			 13,
-			 1.5
-			],
-			[
-			 17,
-			 5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "construction hydrographique linéaire - Quai",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "bati_lin",
-		 "minzoom": 12,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "QUAI",
-		  "DIGUE"
-		 ],
-		 "paint": {
-		  "line-color": "#828282",
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 1
-			],
-			[
-			 17,
-			 2.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "construction hydrographique linéaire - Pecherie",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "bati_lin",
-		 "minzoom": 12,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "PECHERIE_LIN"
-		 ],
-		 "paint": {
-		  "line-color": "#0066CC",
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 1
-			],
-			[
-			 17,
-			 2.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Chemin a niveau - piste cyclable",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_chemin",
-		 "minzoom": 13,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "PISTE_CYCLABLE"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 17,
-			 "#9B5CCC"
-			],
-			[
-			 18,
-			 "#EDF1FF"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 1.1
-			],
-			[
-			 15,
-			 1.7
-			],
-			[
-			 16,
-			 2
-			],
-			[
-			 17,
-			 3.5
-			],
-			[
-			 18,
-			 6
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   6,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "Chemin a niveau - filet exterieur - escalier",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_chemin",
-		 "minzoom": 14,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "ESCALIER"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 17,
-			 "#8C7274"
-			],
-			[
-			 18,
-			 "#C8C8C8"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 1.75
-			],
-			[
-			 15,
-			 3
-			],
-			[
-			 16,
-			 4.2
-			],
-			[
-			 17,
-			 9.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Chemin a niveau - filet interieur - escalier",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_chemin",
-		 "minzoom": 14,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "ESCALIER"
-		 ],
-		 "paint": {
-		  "line-color": "#EDF1FF",
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 1
-			],
-			[
-			 15,
-			 1.9
-			],
-			[
-			 16,
-			 2.7
-			],
-			[
-			 17,
-			 5.8
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   1,
-		   0.2
-		  ]
-		 }
-		},
-		{
-		 "id": "Chemin a niveau - Rue pietonne",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_chemin",
-		 "minzoom": 14,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "RUE_PIETONNE"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 17,
-			 "#8C7274"
-			],
-			[
-			 18,
-			 "#F8E5D5"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 1
-			],
-			[
-			 15,
-			 1.2
-			],
-			[
-			 16,
-			 1.4
-			],
-			[
-			 17,
-			 2
-			],
-			[
-			 18,
-			 5
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   1,
-		   3
-		  ]
-		 }
-		},
-		{
-		 "id": "Chemin a niveau - sentier",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_chemin",
-		 "minzoom": 13,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "SENTIER"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 17,
-			 "#8C7274"
-			],
-			[
-			 18,
-			 "#EDF1FF"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 1
-			],
-			[
-			 15,
-			 1.2
-			],
-			[
-			 16,
-			 1.4
-			],
-			[
-			 17,
-			 2
-			],
-			[
-			 18,
-			 6
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   4,
-		   3
-		  ]
-		 }
-		},
-		{
-		 "id": "Chemin a niveau - chemin",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_chemin",
-		 "minzoom": 12,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "CHEMIN"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 17,
-			 "#8C7274"
-			],
-			[
-			 18,
-			 "#EDF1FF"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 1
-			],
-			[
-			 15,
-			 1.2
-			],
-			[
-			 16,
-			 1.4
-			],
-			[
-			 17,
-			 2
-			],
-			[
-			 18,
-			 7
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier a niveau - filet extérieur - route non revetu carrosable",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "NON_REVETUE_CARRO"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 12,
-			 "#646464"
-			],
-			[
-			 17,
-			 "#8C8C8C"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 3.2
-			],
-			[
-			 15,
-			 5.4
-			],
-			[
-			 16,
-			 7.7
-			],
-			[
-			 17,
-			 16.8
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   2,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "Routier a niveau - filet interieur - route non revetu carrosable",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "NON_REVETUE_CARRO"
-		 ],
-		 "paint": {
-		  "line-color": "#EDF1FF",
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 2.3
-			],
-			[
-			 15,
-			 4.1
-			],
-			[
-			 16,
-			 6.3
-			],
-			[
-			 17,
-			 13.5
-			],
-			[
-			 18,
-			 16.8
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier a niveau - filet extérieur - bretelle autoroute",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route",
-		 "minzoom": 12,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BRET_AUTO_PEAGE_3",
-		  "BRET_AUTO_PEAGE_2",
-		  "BRET_AUTO_PEAGE_1",
-		  "BRET_AUTO_LIBRE_3",
-		  "BRET_AUTO_LIBRE_2",
-		  "BRET_AUTO_LIBRE_1"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 9,
-			 "#DE460E"
-			],
-			[
-			 17,
-			 "#F18800"
-			],
-			[
-			 18,
-			 "#EDF1FF"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 12,
-			 2.5
-			],
-			[
-			 14,
-			 3.7
-			],
-			[
-			 15,
-			 6.8
-			],
-			[
-			 16,
-			 8.4
-			],
-			[
-			 17,
-			 14
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier a niveau - filet extérieur - route non classee restreint",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "NON_CLASSEE_RESTREINT"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 17,
-			 "#969696"
-			],
-			[
-			 18,
-			 "#EDF1FF"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 3.2
-			],
-			[
-			 15,
-			 5.4
-			],
-			[
-			 16,
-			 7.7
-			],
-			[
-			 17,
-			 16.8
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier a niveau - filet extérieur - route non classee",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "NON_CLASSEE_4",
-		  "NON_CLASSEE"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 17,
-			 "#969696"
-			],
-			[
-			 18,
-			 "#EDF1FF"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 3.2
-			],
-			[
-			 15,
-			 5.4
-			],
-			[
-			 16,
-			 7.7
-			],
-			[
-			 17,
-			 16.8
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier a niveau - filet extérieur - route locale",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route",
-		 "minzoom": 7,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BRET_LOCALE",
-		  "LOCALE_4",
-		  "LOCALE_3",
-		  "LOCALE_2",
-		  "LOCALE_1"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 12,
-			 "#8C8C8C"
-			],
-			[
-			 13,
-			 "#B4B4B4"
-			],
-			[
-			 17,
-			 "#B4B4B4"
-			],
-			[
-			 18,
-			 "#EDF1FF"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 9,
-			 2
-			],
-			[
-			 14,
-			 3.5
-			],
-			[
-			 15,
-			 6
-			],
-			[
-			 16,
-			 8.4
-			],
-			[
-			 17,
-			 18.3
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier a niveau - filet extérieur - route locale en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route",
-		 "minzoom": 11,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "LOCALE_CONSTR"
-		 ],
-		 "paint": {
-		  "line-color": "#C8C8C8",
-		  "line-width": {
-		   "stops": [
-			[
-			 9,
-			 2
-			],
-			[
-			 14,
-			 3.5
-			],
-			[
-			 15,
-			 6
-			],
-			[
-			 16,
-			 8.4
-			],
-			[
-			 17,
-			 18.3
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier a niveau - filet extérieur - route regionale",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route",
-		 "minzoom": 8,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BRET_REGIONALE",
-		  "REGIONALE_4",
-		  "REGIONALE_3",
-		  "REGIONALE_2",
-		  "REGIONALE_1"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 9,
-			 "#828282"
-			],
-			[
-			 10,
-			 "#B4B4B4"
-			],
-			[
-			 17,
-			 "#B4B4B4"
-			],
-			[
-			 18,
-			 "#EDF1FF"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 6,
-			 1.5
-			],
-			[
-			 9,
-			 2.3
-			],
-			[
-			 14,
-			 5
-			],
-			[
-			 15,
-			 8.1
-			],
-			[
-			 16,
-			 11.2
-			],
-			[
-			 17,
-			 22
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier a niveau - filet extérieur - route regionale en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route",
-		 "minzoom": 10,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "REGIONALE_CONSTR"
-		 ],
-		 "paint": {
-		  "line-color": "#C8C8C8",
-		  "line-width": {
-		   "stops": [
-			[
-			 6,
-			 1.5
-			],
-			[
-			 9,
-			 2.3
-			],
-			[
-			 14,
-			 5
-			],
-			[
-			 15,
-			 8.1
-			],
-			[
-			 16,
-			 11.2
-			],
-			[
-			 17,
-			 22
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier a niveau - filet extérieur - route principale",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route",
-		 "minzoom": 8,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BRET_PRINCIPALE",
-		  "PRINCIPALE_4",
-		  "PRINCIPALE_3",
-		  "PRINCIPALE_2",
-		  "PRINCIPALE_1"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 17,
-			 "#E2A52A"
-			],
-			[
-			 18,
-			 "#EDF1FF"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 6,
-			 1.8
-			],
-			[
-			 9,
-			 2.7
-			],
-			[
-			 14,
-			 5.9
-			],
-			[
-			 15,
-			 9
-			],
-			[
-			 16,
-			 12.2
-			],
-			[
-			 17,
-			 22.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier a niveau - filet extérieur - route principale en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route",
-		 "minzoom": 10,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "PRINCIPALE_CONSTR"
-		 ],
-		 "paint": {
-		  "line-color": "#C8C8C8",
-		  "line-width": {
-		   "stops": [
-			[
-			 6,
-			 1.8
-			],
-			[
-			 9,
-			 2.7
-			],
-			[
-			 14,
-			 5.9
-			],
-			[
-			 15,
-			 9
-			],
-			[
-			 16,
-			 12.2
-			],
-			[
-			 17,
-			 22.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier a niveau - filet extérieur - autoroute",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route",
-		 "minzoom": 8,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "AUTOROU_PEAGE",
-		  "AUTOROU_LIBRE"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 9,
-			 "#DE460E"
-			],
-			[
-			 17,
-			 "#F18800"
-			],
-			[
-			 18,
-			 "#EDF1FF"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 6,
-			 2.5
-			],
-			[
-			 9,
-			 3.5
-			],
-			[
-			 14,
-			 7.5
-			],
-			[
-			 15,
-			 11
-			],
-			[
-			 16,
-			 15
-			],
-			[
-			 17,
-			 26
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier a niveau - filet extérieur - autoroute en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route",
-		 "minzoom": 8,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "AUTOROU_CONSTR"
-		 ],
-		 "paint": {
-		  "line-color": "#C8C8C8",
-		  "line-width": {
-		   "stops": [
-			[
-			 6,
-			 2.5
-			],
-			[
-			 9,
-			 3.5
-			],
-			[
-			 14,
-			 7.5
-			],
-			[
-			 15,
-			 11
-			],
-			[
-			 16,
-			 15
-			],
-			[
-			 17,
-			 26
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier a niveau - filet interieur - bretelle autoroute",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route",
-		 "minzoom": 12,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BRET_AUTO_PEAGE_3",
-		  "BRET_AUTO_PEAGE_2",
-		  "BRET_AUTO_PEAGE_1",
-		  "BRET_AUTO_LIBRE_3",
-		  "BRET_AUTO_LIBRE_2",
-		  "BRET_AUTO_LIBRE_1"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 9,
-			 "#F18800"
-			],
-			[
-			 17,
-			 "#F2B230"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 12,
-			 1.5
-			],
-			[
-			 14,
-			 2.6
-			],
-			[
-			 15,
-			 5.2
-			],
-			[
-			 16,
-			 6.7
-			],
-			[
-			 17,
-			 10.8
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier a niveau - filet interieur - route non classee restreint",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "NON_CLASSEE_RESTREINT"
-		 ],
-		 "paint": {
-		  "line-color": "#EDF1FF",
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 2.3
-			],
-			[
-			 15,
-			 4.1
-			],
-			[
-			 16,
-			 6.3
-			],
-			[
-			 17,
-			 13.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier a niveau - filet interieur - route non classee",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "NON_CLASSEE_4",
-		  "NON_CLASSEE"
-		 ],
-		 "paint": {
-		  "line-color": "#EDF1FF",
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 2.3
-			],
-			[
-			 15,
-			 4.1
-			],
-			[
-			 16,
-			 6.3
-			],
-			[
-			 17,
-			 13.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier a niveau - filet interieur - route locale",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BRET_LOCALE",
-		  "LOCALE_4",
-		  "LOCALE_3",
-		  "LOCALE_2",
-		  "LOCALE_1"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 6,
-			 "#F2B361"
-			],
-			[
-			 7,
-			 "#EDF1FF"
-			],
-			[
-			 12,
-			 "#EDF1FF"
-			],
-			[
-			 13,
-			 "#FCF4A8"
-			],
-			[
-			 17,
-			 "#FCF7C1"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 9,
-			 1.3
-			],
-			[
-			 14,
-			 2.3
-			],
-			[
-			 15,
-			 4.1
-			],
-			[
-			 16,
-			 6.1
-			],
-			[
-			 17,
-			 13.1
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier a niveau - filet interieur - route locale en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route",
-		 "minzoom": 11,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "LOCALE_CONSTR"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 12,
-			 "#EDF1FF"
-			],
-			[
-			 13,
-			 "#FCF4A8"
-			],
-			[
-			 17,
-			 "#FCF7C1"
-			],
-			[
-			 18,
-			 "#EDEDED"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 9,
-			 2
-			],
-			[
-			 14,
-			 3.5
-			],
-			[
-			 15,
-			 6
-			],
-			[
-			 16,
-			 8.4
-			],
-			[
-			 17,
-			 18.3
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   2,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "Routier a niveau - filet interieur - route regionale",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BRET_REGIONALE",
-		  "REGIONALE_4",
-		  "REGIONALE_3",
-		  "REGIONALE_2",
-		  "REGIONALE_1"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 6,
-			 "#F2A949"
-			],
-			[
-			 7,
-			 "#EDF1FF"
-			],
-			[
-			 9,
-			 "#EDF1FF"
-			],
-			[
-			 10,
-			 "#FDF28B"
-			],
-			[
-			 17,
-			 "#FCF6BD"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 4,
-			 1.1
-			],
-			[
-			 6,
-			 1.4
-			],
-			[
-			 9,
-			 1.5
-			],
-			[
-			 14,
-			 3.2
-			],
-			[
-			 15,
-			 5.8
-			],
-			[
-			 16,
-			 8.3
-			],
-			[
-			 17,
-			 16.2
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier a niveau - filet interieur - route regionale en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route",
-		 "minzoom": 10,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "REGIONALE_CONSTR"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 9,
-			 "#EDF1FF"
-			],
-			[
-			 10,
-			 "#FDF28B"
-			],
-			[
-			 17,
-			 "#FCF6BD"
-			],
-			[
-			 18,
-			 "#EDEDED"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 4,
-			 0.4
-			],
-			[
-			 6,
-			 1.5
-			],
-			[
-			 9,
-			 2.3
-			],
-			[
-			 14,
-			 5
-			],
-			[
-			 15,
-			 8.1
-			],
-			[
-			 16,
-			 11.2
-			],
-			[
-			 17,
-			 22
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   2,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "Routier a niveau - filet interieur - route principale",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BRET_PRINCIPALE",
-		  "PRINCIPALE_4",
-		  "PRINCIPALE_3",
-		  "PRINCIPALE_2",
-		  "PRINCIPALE_1"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 6,
-			 "#F29924"
-			],
-			[
-			 7,
-			 "#F3C66D"
-			],
-			[
-			 9,
-			 "#F3C66D"
-			],
-			[
-			 17,
-			 "#F2DDB3"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 4,
-			 0.6
-			],
-			[
-			 6,
-			 1.8
-			],
-			[
-			 9,
-			 2.1
-			],
-			[
-			 14,
-			 4.4
-			],
-			[
-			 15,
-			 7.3
-			],
-			[
-			 16,
-			 10
-			],
-			[
-			 17,
-			 18.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier a niveau - filet interieur - route principale en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route",
-		 "minzoom": 10,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "PRINCIPALE_CONSTR"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 9,
-			 "#F3C66D"
-			],
-			[
-			 17,
-			 "#F2DDB3"
-			],
-			[
-			 18,
-			 "#EDEDED"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 4,
-			 0.5
-			],
-			[
-			 6,
-			 1.8
-			],
-			[
-			 9,
-			 2.7
-			],
-			[
-			 14,
-			 5.9
-			],
-			[
-			 15,
-			 9
-			],
-			[
-			 16,
-			 12.2
-			],
-			[
-			 17,
-			 22.5
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   2,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "Routier a niveau - filet interieur - autoroute",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "AUTOROU_PEAGE",
-		  "AUTOROU_LIBRE"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 9,
-			 "#F18800"
-			],
-			[
-			 17,
-			 "#F2B230"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 4,
-			 0.7
-			],
-			[
-			 6,
-			 2.5
-			],
-			[
-			 9,
-			 2.7
-			],
-			[
-			 14,
-			 5.8
-			],
-			[
-			 15,
-			 9
-			],
-			[
-			 16,
-			 12
-			],
-			[
-			 17,
-			 20.8
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier a niveau - axe central - autoroute",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route",
-		 "minzoom": 13,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "AUTOROU_PEAGE",
-		  "AUTOROU_LIBRE"
-		 ],
-		 "paint": {
-		  "line-color": "#EDF1FF",
-		  "line-width": {
-		   "stops": [
-			[
-			 9,
-			 0.6
-			],
-			[
-			 14,
-			 0.7
-			],
-			[
-			 15,
-			 1
-			],
-			[
-			 16,
-			 1.2
-			],
-			[
-			 17,
-			 2.1
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier a niveau - filet interieur - autoroute en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route",
-		 "minzoom": 8,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "AUTOROU_CONSTR"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 9,
-			 "#F18800"
-			],
-			[
-			 17,
-			 "#F2B230"
-			],
-			[
-			 18,
-			 "#EDEDED"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 4,
-			 0.7
-			],
-			[
-			 6,
-			 2.5
-			],
-			[
-			 9,
-			 3.5
-			],
-			[
-			 14,
-			 7.5
-			],
-			[
-			 15,
-			 11
-			],
-			[
-			 16,
-			 15
-			],
-			[
-			 17,
-			 26
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   2,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "Routier a niveau - axe centrale - autoroute en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route",
-		 "minzoom": 13,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "AUTOROU_CONSTR"
-		 ],
-		 "paint": {
-		  "line-color": "#808080",
-		  "line-width": {
-		   "stops": [
-			[
-			 9,
-			 0.6
-			],
-			[
-			 14,
-			 0.7
-			],
-			[
-			 15,
-			 1
-			],
-			[
-			 16,
-			 1.2
-			],
-			[
-			 17,
-			 2.1
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Ferre a niveau - voie normale",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "ferre",
-		 "minzoom": 10,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "VF_1",
-		  "VF_2",
-		  "VF_3",
-		  "VF_4",
-		  "VF_ELEC_1",
-		  "VF_ELEC_2",
-		  "VF_ELEC_3",
-		  "VF_ELEC_4"
-		 ],
-		 "paint": {
-		  "line-color": "#787878",
-		  "line-width": {
-		   "stops": [
-			[
-			 10,
-			 0.8
-			],
-			[
-			 17,
-			 2.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Ferre a niveau - voie normale trait perpendic",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "ferre",
-		 "minzoom": 10,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "VF_1",
-		  "VF_2",
-		  "VF_3",
-		  "VF_4",
-		  "VF_ELEC_1",
-		  "VF_ELEC_2",
-		  "VF_ELEC_3",
-		  "VF_ELEC_4"
-		 ],
-		 "paint": {
-		  "line-color": "#787878",
-		  "line-width": {
-		   "stops": [
-			[
-			 10,
-			 3.5
-			],
-			[
-			 17,
-			 14.7
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   0.1,
-		   10
-		  ]
-		 }
-		},
-		{
-		 "id": "Ferre a niveau - voie etroite",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "ferre",
-		 "minzoom": 10,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "VF_ETROITE_1",
-		  "VF_ETROITE_2",
-		  "VF_ETROITE"
-		 ],
-		 "paint": {
-		  "line-color": "#787878",
-		  "line-width": {
-		   "stops": [
-			[
-			 10,
-			 0.3
-			],
-			[
-			 17,
-			 1.8
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Ferre a niveau - voie etroite trait perpendic",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "ferre",
-		 "minzoom": 10,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "VF_ETROITE_1",
-		  "VF_ETROITE_2",
-		  "VF_ETROITE"
-		 ],
-		 "paint": {
-		  "line-color": "#787878",
-		  "line-width": {
-		   "stops": [
-			[
-			 10,
-			 3.5
-			],
-			[
-			 17,
-			 14.7
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   0.1,
-		   10
-		  ]
-		 }
-		},
-		{
-		 "id": "Ferre a niveau - voie service",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "ferre",
-		 "minzoom": 14,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "VF_SERVICE",
-		  "VF_NON_EXPLOITEE"
-		 ],
-		 "paint": {
-		  "line-color": "#787878",
-		  "line-width": {
-		   "stops": [
-			[
-			 10,
-			 0.3
-			],
-			[
-			 17,
-			 1.8
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   5,
-		   2,
-		   1,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "Ferre a niveau - voie en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "ferre",
-		 "minzoom": 10,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "VF_EN_CONSTR"
-		 ],
-		 "paint": {
-		  "line-color": "#787878",
-		  "line-width": {
-		   "stops": [
-			[
-			 10,
-			 0.3
-			],
-			[
-			 17,
-			 1.8
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   2,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "Ferre a niveau - voie en construction trait perpendic",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "ferre",
-		 "minzoom": 10,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "VF_EN_CONSTR"
-		 ],
-		 "paint": {
-		  "line-color": "#787878",
-		  "line-width": {
-		   "stops": [
-			[
-			 10,
-			 3.5
-			],
-			[
-			 17,
-			 14.7
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   0.1,
-		   10
-		  ]
-		 }
-		},
-		{
-		 "id": "Ferre a niveau - funic/urbain",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "ferre",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "FUNI_CREMAILLERE",
-		  "TRANSPORT_URBAIN"
-		 ],
-		 "paint": {
-		  "line-color": "#787878",
-		  "line-width": {
-		   "stops": [
-			[
-			 10,
-			 0.3
-			],
-			[
-			 17,
-			 1.8
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Ferre a niveau - 2 trait perpendic - funic/urbain",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "ferre",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "FUNI_CREMAILLERE",
-		  "TRANSPORT_URBAIN"
-		 ],
-		 "paint": {
-		  "line-color": "#787878",
-		  "line-width": {
-		   "stops": [
-			[
-			 10,
-			 3.5
-			],
-			[
-			 17,
-			 17
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   0.1,
-		   0.2,
-		   0.1,
-		   10
-		  ]
-		 }
-		},
-		{
-		 "id": "liaison routiere - Bac Liaison Maritime",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_liaison",
-		 "minzoom": 8,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BAC_AUTO",
-		  "LIAISON_MARITIME",
-		  "BAC_LIAISON_MARITIME"
-		 ],
-		 "paint": {
-		  "line-color": "#5792C2",
-		  "line-width": {
-		   "stops": [
-			[
-			 8,
-			 1
-			],
-			[
-			 13,
-			 2.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "liaison routiere - Gue route",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_liaison",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "GUE_ROUTE"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 13,
-			 "#BEBEBE"
-			],
-			[
-			 17,
-			 "#646464"
-			],
-			[
-			 18,
-			 "#EDF1FF"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 2.3
-			],
-			[
-			 15,
-			 4.1
-			],
-			[
-			 16,
-			 6.3
-			],
-			[
-			 17,
-			 13.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "liaison routiere - Gue chemin",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_liaison",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "GUE_CHEMIN"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 13,
-			 "#BEBEBE"
-			],
-			[
-			 17,
-			 "#646464"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 1.6
-			],
-			[
-			 15,
-			 2.9
-			],
-			[
-			 16,
-			 4.4
-			],
-			[
-			 17,
-			 6.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "liaison routiere - filet extérieur - Pont passerelle",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_liaison",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "PONT_PASSERELLE",
-		  "PONT_LIN",
-		  "PONT_MOBILE_LIN"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 17,
-			 "#C8C8C8"
-			],
-			[
-			 18,
-			 "#EDF1FF"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 2.2
-			],
-			[
-			 15,
-			 3.8
-			],
-			[
-			 16,
-			 5.4
-			],
-			[
-			 17,
-			 11.8
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "liaison routiere - filet intérieur - Pont passerelle",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_liaison",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "PONT_PASSERELLE",
-		  "PONT_LIN",
-		  "PONT_MOBILE_LIN"
-		 ],
-		 "paint": {
-		  "line-color": "#EDF1FF",
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 0.7
-			],
-			[
-			 15,
-			 1.1
-			],
-			[
-			 16,
-			 1.7
-			],
-			[
-			 17,
-			 3.8
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier surfacique",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "routier_surf",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "SURF_ROUT_PRINC",
-		  "SURF_ROUT_REG",
-		  "SURF_ROUT_LOC",
-		  "SURF_ROUT_NON_CLA"
-		 ],
-		 "paint": {
-		  "fill-color": "#EDF1FF",
-		  "fill-outline-color": "#000000"
-		 }
-		},
-		{
-		 "id": "Routier surfacique - Dalle de protection",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "routier_surf",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "DALLE_DE_PROTECTION"
-		 ],
-		 "paint": {
-		  "fill-opacity": 0.5,
-		  "fill-color": "#FFFFFF",
-		  "fill-outline-color": "#000000"
-		 }
-		},
-		{
-		 "id": "Routier surfacique - Escalier surfacique",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "routier_surf",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "ESCALIER_SURF"
-		 ],
-		 "paint": {
-		  "fill-opacity": 0.8,
-		  "fill-color": "#FFFFFF",
-		  "fill-outline-color": "#918091"
-		 }
-		},
-		{
-		 "id": "Routier surfacique - Péage surfacique",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "routier_surf",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "SURF_PEAGE"
-		 ],
-		 "paint": {
-		  "fill-color": "#F2DAAA",
-		  "fill-outline-color": "#E2A52A"
-		 }
-		},
-		{
-		 "id": "bati transport surfacique - bati peage",
-		 "type": "fill",
-		 "source": "plan_ign",
-		 "source-layer": "bati_surf",
-		 "minzoom": 13,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "BATI_PEAGE"
-		 ],
-		 "paint": {
-		  "fill-color": "#DCDCDC",
-		  "fill-outline-color": "#808080"
-		 }
-		},
-		{
-		 "id": "réseau hydro  - cours d'eau superieur",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "hydro_reseau_sup",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "COURS_D_EAU_SUP",
-		  "COURS_D_EAU_MOY_SUP"
-		 ],
-		 "paint": {
-		  "line-color": "#AAD5E9",
-		  "line-width": {
-		   "stops": [
-			[
-			 12,
-			 1.5
-			],
-			[
-			 17,
-			 6.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "réseau hydro - canal superieur",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "hydro_reseau_sup",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "CANAL_SUP"
-		 ],
-		 "paint": {
-		  "line-color": "#AAD5E9",
-		  "line-width": {
-		   "stops": [
-			[
-			 12,
-			 1.4
-			],
-			[
-			 17,
-			 5.9
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "réseau hydro - filet interieur - aqueduc superieur",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "hydro_reseau_sup",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "AQUEDUC_SUP"
-		 ],
-		 "paint": {
-		  "line-color": "#AAD5E9",
-		  "line-width": {
-		   "stops": [
-			[
-			 12,
-			 1.4
-			],
-			[
-			 16,
-			 3.5
-			],
-			[
-			 17,
-			 5.9
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "réseau hydro - carre - aqueduc superieur",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "hydro_reseau_sup",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "AQUEDUC_SUP"
-		 ],
-		 "paint": {
-		  "line-color": "#AAD5E9",
-		  "line-width": {
-		   "stops": [
-			[
-			 12,
-			 3.5
-			],
-			[
-			 16,
-			 8.7
-			],
-			[
-			 17,
-			 14.7
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   1,
-		   5
-		  ]
-		 }
-		},
-		{
-		 "id": "Chemin superieur - piste cyclable",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_chemin_sup",
-		 "minzoom": 13,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "PISTE_CYCLABLE_SUP"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 17,
-			 "#9B5CCC"
-			],
-			[
-			 18,
-			 "#EDF1FF"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 1.1
-			],
-			[
-			 15,
-			 1.7
-			],
-			[
-			 16,
-			 2
-			],
-			[
-			 17,
-			 3.5
-			],
-			[
-			 18,
-			 6
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   6,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "Chemin superieur - filet exterieur - escalier",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_chemin_sup",
-		 "minzoom": 14,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "ESCALIER_SUP"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 17,
-			 "#8C7274"
-			],
-			[
-			 18,
-			 "#C8C8C8"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 1.75
-			],
-			[
-			 15,
-			 3
-			],
-			[
-			 16,
-			 4.2
-			],
-			[
-			 17,
-			 9.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Chemin superieur - filet interieur - escalier",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_chemin_sup",
-		 "minzoom": 14,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "ESCALIER_SUP"
-		 ],
-		 "paint": {
-		  "line-color": "#FFFFFF",
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 1
-			],
-			[
-			 15,
-			 1.9
-			],
-			[
-			 16,
-			 2.7
-			],
-			[
-			 17,
-			 5.8
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   1,
-		   0.2
-		  ]
-		 }
-		},
-		{
-		 "id": "Chemin superieur - Rue pietonne",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_chemin_sup",
-		 "minzoom": 14,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "RUE_PIETONNE_SUP"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 17,
-			 "#8C7274"
-			],
-			[
-			 18,
-			 "#EBEBEB"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 1
-			],
-			[
-			 15,
-			 1.2
-			],
-			[
-			 16,
-			 1.4
-			],
-			[
-			 17,
-			 2
-			],
-			[
-			 18,
-			 5
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   1,
-		   3
-		  ]
-		 }
-		},
-		{
-		 "id": "Chemin superieur - sentier",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_chemin_sup",
-		 "minzoom": 13,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "SENTIER_SUP"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 17,
-			 "#8C7274"
-			],
-			[
-			 18,
-			 "#FFFFFF"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 1
-			],
-			[
-			 15,
-			 1.2
-			],
-			[
-			 16,
-			 1.4
-			],
-			[
-			 17,
-			 2
-			],
-			[
-			 18,
-			 6
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   4,
-		   3
-		  ]
-		 }
-		},
-		{
-		 "id": "Chemin superieur - chemin",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_chemin_sup",
-		 "minzoom": 12,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "CHEMIN_SUP"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 17,
-			 "#8C7274"
-			],
-			[
-			 18,
-			 "#EDF1FF"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 1
-			],
-			[
-			 15,
-			 1.2
-			],
-			[
-			 16,
-			 1.4
-			],
-			[
-			 17,
-			 2
-			],
-			[
-			 18,
-			 7
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier superieur - filet extérieur - route non revetu carrosable",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sup",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "NON_REVETUE_CARRO_SUP"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 12,
-			 "#646464"
-			],
-			[
-			 17,
-			 "#8C8C8C"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 3.2
-			],
-			[
-			 15,
-			 5.4
-			],
-			[
-			 16,
-			 7.7
-			],
-			[
-			 17,
-			 16.8
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   2,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "Routier superieur - filet extérieur - bretelle autoroute",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sup",
-		 "minzoom": 12,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BRET_AUTO_PEAGE_3_SUP",
-		  "BRET_AUTO_PEAGE_2_SUP",
-		  "BRET_AUTO_PEAGE_1_SUP",
-		  "BRET_AUTO_LIBRE_3_SUP",
-		  "BRET_AUTO_LIBRE_2_SUP",
-		  "BRET_AUTO_LIBRE_1_SUP"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 9,
-			 "#DE460E"
-			],
-			[
-			 17,
-			 "#F18800"
-			],
-			[
-			 18,
-			 "#EDF1FF"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 12,
-			 2.5
-			],
-			[
-			 14,
-			 3.7
-			],
-			[
-			 15,
-			 6.8
-			],
-			[
-			 16,
-			 8.4
-			],
-			[
-			 17,
-			 14
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier superieur - filet extérieur - route non classee restreint",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sup",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "NON_CLASSEE_RESTREINT_SUP"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 17,
-			 "#969696"
-			],
-			[
-			 18,
-			 "#EDF1FF"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 3.2
-			],
-			[
-			 15,
-			 5.4
-			],
-			[
-			 16,
-			 7.7
-			],
-			[
-			 17,
-			 16.8
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier superieur - filet extérieur - route non classee",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sup",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "NON_CLASSEE_4_SUP",
-		  "NON_CLASSEE_SUP"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 17,
-			 "#969696"
-			],
-			[
-			 18,
-			 "#EDF1FF"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 3.2
-			],
-			[
-			 15,
-			 5.4
-			],
-			[
-			 16,
-			 7.7
-			],
-			[
-			 17,
-			 16.8
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier superieur - filet extérieur - route locale",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sup",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BRET_LOCALE_SUP",
-		  "LOCALE_4_SUP",
-		  "LOCALE_3_SUP",
-		  "LOCALE_2_SUP",
-		  "LOCALE_1_SUP"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 12,
-			 "#8C8C8C"
-			],
-			[
-			 13,
-			 "#B4B4B4"
-			],
-			[
-			 17,
-			 "#B4B4B4"
-			],
-			[
-			 18,
-			 "#EDF1FF"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 9,
-			 2
-			],
-			[
-			 14,
-			 3.5
-			],
-			[
-			 15,
-			 6
-			],
-			[
-			 16,
-			 8.4
-			],
-			[
-			 17,
-			 18.3
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier superieur - filet extérieur - route locale en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sup",
-		 "minzoom": 11,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "LOCALE_CONSTR_SUP"
-		 ],
-		 "paint": {
-		  "line-color": "#C8C8C8",
-		  "line-width": {
-		   "stops": [
-			[
-			 9,
-			 2
-			],
-			[
-			 14,
-			 3.5
-			],
-			[
-			 15,
-			 6
-			],
-			[
-			 16,
-			 8.4
-			],
-			[
-			 17,
-			 18.3
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier superieur - filet extérieur - route regionale",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sup",
-		 "minzoom": 8,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BRET_REGIONALE_SUP",
-		  "REGIONALE_4_SUP",
-		  "REGIONALE_3_SUP",
-		  "REGIONALE_2_SUP",
-		  "REGIONALE_1_SUP"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 9,
-			 "#828282"
-			],
-			[
-			 10,
-			 "#B4B4B4"
-			],
-			[
-			 17,
-			 "#B4B4B4"
-			],
-			[
-			 18,
-			 "#EDF1FF"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 6,
-			 1.5
-			],
-			[
-			 9,
-			 2.3
-			],
-			[
-			 14,
-			 5
-			],
-			[
-			 15,
-			 8.1
-			],
-			[
-			 16,
-			 11.2
-			],
-			[
-			 17,
-			 22
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier superieur - filet extérieur - route regionale en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sup",
-		 "minzoom": 10,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "REGIONALE_CONSTR_SUP"
-		 ],
-		 "paint": {
-		  "line-color": "#C8C8C8",
-		  "line-width": {
-		   "stops": [
-			[
-			 6,
-			 1.5
-			],
-			[
-			 9,
-			 2.3
-			],
-			[
-			 14,
-			 5
-			],
-			[
-			 15,
-			 8.1
-			],
-			[
-			 16,
-			 11.2
-			],
-			[
-			 17,
-			 22
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier superieur - filet extérieur - route principale",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sup",
-		 "minzoom": 8,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BRET_PRINCIPALE_SUP",
-		  "PRINCIPALE_4_SUP",
-		  "PRINCIPALE_3_SUP",
-		  "PRINCIPALE_2_SUP",
-		  "PRINCIPALE_1_SUP"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 17,
-			 "#E2A52A"
-			],
-			[
-			 18,
-			 "#EDF1FF"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 6,
-			 1.8
-			],
-			[
-			 9,
-			 2.7
-			],
-			[
-			 14,
-			 5.9
-			],
-			[
-			 15,
-			 9
-			],
-			[
-			 16,
-			 12.2
-			],
-			[
-			 17,
-			 22.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier superieur - filet extérieur - route principale en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sup",
-		 "minzoom": 10,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "PRINCIPALE_CONSTR_SUP"
-		 ],
-		 "paint": {
-		  "line-color": "#C8C8C8",
-		  "line-width": {
-		   "stops": [
-			[
-			 6,
-			 1.8
-			],
-			[
-			 9,
-			 2.7
-			],
-			[
-			 14,
-			 5.9
-			],
-			[
-			 15,
-			 9
-			],
-			[
-			 16,
-			 12.2
-			],
-			[
-			 17,
-			 22.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier superieur - filet extérieur - autoroute",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sup",
-		 "minzoom": 8,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "AUTOROU_PEAGE_SUP",
-		  "AUTOROU_LIBRE_SUP"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 9,
-			 "#DE460E"
-			],
-			[
-			 17,
-			 "#F18800"
-			],
-			[
-			 18,
-			 "#EDF1FF"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 6,
-			 2.5
-			],
-			[
-			 9,
-			 3.5
-			],
-			[
-			 14,
-			 7.5
-			],
-			[
-			 15,
-			 11
-			],
-			[
-			 16,
-			 15
-			],
-			[
-			 17,
-			 26
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier superieur - filet extérieur - autoroute en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sup",
-		 "minzoom": 10,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "AUTOROU_CONSTR_SUP"
-		 ],
-		 "paint": {
-		  "line-color": "#C8C8C8",
-		  "line-width": {
-		   "stops": [
-			[
-			 6,
-			 2.5
-			],
-			[
-			 9,
-			 3.5
-			],
-			[
-			 14,
-			 7.5
-			],
-			[
-			 15,
-			 11
-			],
-			[
-			 16,
-			 15
-			],
-			[
-			 17,
-			 26
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier superieur - filet interieur - route non revetu carrosable",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sup",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "NON_REVETUE_CARRO_SUP"
-		 ],
-		 "paint": {
-		  "line-color": "#EDF1FF",
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 2.3
-			],
-			[
-			 15,
-			 4.1
-			],
-			[
-			 16,
-			 6.3
-			],
-			[
-			 17,
-			 13.5
-			],
-			[
-			 18,
-			 16.8
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier superieur - filet interieur - bretelle autoroute",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sup",
-		 "minzoom": 12,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BRET_AUTO_PEAGE_3_SUP",
-		  "BRET_AUTO_PEAGE_2_SUP",
-		  "BRET_AUTO_PEAGE_1_SUP",
-		  "BRET_AUTO_LIBRE_3_SUP",
-		  "BRET_AUTO_LIBRE_2_SUP",
-		  "BRET_AUTO_LIBRE_1_SUP"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 9,
-			 "#F18800"
-			],
-			[
-			 17,
-			 "#F2B230"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 12,
-			 1.5
-			],
-			[
-			 14,
-			 2.6
-			],
-			[
-			 15,
-			 5.2
-			],
-			[
-			 16,
-			 6.7
-			],
-			[
-			 17,
-			 10.8
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier superieur - filet interieur - route non classee restreint",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sup",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "NON_CLASSEE_RESTREINT_SUP"
-		 ],
-		 "paint": {
-		  "line-color": "#EDF1FF",
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 2.3
-			],
-			[
-			 15,
-			 4.1
-			],
-			[
-			 16,
-			 6.3
-			],
-			[
-			 17,
-			 13.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier superieur - filet interieur - route non classee",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sup",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "NON_CLASSEE_4_SUP",
-		  "NON_CLASSEE_SUP"
-		 ],
-		 "paint": {
-		  "line-color": "#EDF1FF",
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 2.3
-			],
-			[
-			 15,
-			 4.1
-			],
-			[
-			 16,
-			 6.3
-			],
-			[
-			 17,
-			 13.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier superieur - filet interieur - route locale",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sup",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BRET_LOCALE_SUP",
-		  "LOCALE_4_SUP",
-		  "LOCALE_3_SUP",
-		  "LOCALE_2_SUP",
-		  "LOCALE_1_SUP"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 12,
-			 "#EDF1FF"
-			],
-			[
-			 13,
-			 "#FCF4A8"
-			],
-			[
-			 17,
-			 "#FCF7C1"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 9,
-			 1.3
-			],
-			[
-			 14,
-			 2.3
-			],
-			[
-			 15,
-			 4.1
-			],
-			[
-			 16,
-			 6.1
-			],
-			[
-			 17,
-			 13.1
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier superieur - filet interieur - route locale en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sup",
-		 "minzoom": 11,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "LOCALE_CONSTR_SUP"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 12,
-			 "#EDF1FF"
-			],
-			[
-			 13,
-			 "#FCF4A8"
-			],
-			[
-			 17,
-			 "#FCF7C1"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 9,
-			 2
-			],
-			[
-			 14,
-			 3.5
-			],
-			[
-			 15,
-			 6
-			],
-			[
-			 16,
-			 8.4
-			],
-			[
-			 17,
-			 18.3
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   2,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "Routier superieur - filet interieur - route regionale",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sup",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BRET_REGIONALE_SUP",
-		  "REGIONALE_4_SUP",
-		  "REGIONALE_3_SUP",
-		  "REGIONALE_2_SUP",
-		  "REGIONALE_1_SUP"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 9,
-			 "#EDF1FF"
-			],
-			[
-			 10,
-			 "#FDF28B"
-			],
-			[
-			 17,
-			 "#FCF6BD"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 6,
-			 1.4
-			],
-			[
-			 9,
-			 1.5
-			],
-			[
-			 14,
-			 3.2
-			],
-			[
-			 15,
-			 5.8
-			],
-			[
-			 16,
-			 8.3
-			],
-			[
-			 17,
-			 16.2
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier superieur - filet interieur - route regionale en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sup",
-		 "minzoom": 10,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "REGIONALE_CONSTR_SUP"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 9,
-			 "#EDF1FF"
-			],
-			[
-			 10,
-			 "#FDF28B"
-			],
-			[
-			 17,
-			 "#FCF6BD"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 6,
-			 1.5
-			],
-			[
-			 9,
-			 2.3
-			],
-			[
-			 14,
-			 5
-			],
-			[
-			 15,
-			 8.1
-			],
-			[
-			 16,
-			 11.2
-			],
-			[
-			 17,
-			 22
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   2,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "Routier superieur - filet interieur - route principale",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sup",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BRET_PRINCIPALE_SUP",
-		  "PRINCIPALE_4_SUP",
-		  "PRINCIPALE_3_SUP",
-		  "PRINCIPALE_2_SUP",
-		  "PRINCIPALE_1_SUP"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 9,
-			 "#F3C66D"
-			],
-			[
-			 17,
-			 "#F2DDB3"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 4,
-			 0.5
-			],
-			[
-			 6,
-			 1.8
-			],
-			[
-			 9,
-			 2.1
-			],
-			[
-			 14,
-			 4.4
-			],
-			[
-			 15,
-			 7.3
-			],
-			[
-			 16,
-			 10
-			],
-			[
-			 17,
-			 18.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier superieur - filet interieur - route principale en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sup",
-		 "minzoom": 10,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "PRINCIPALE_CONSTR_SUP"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 9,
-			 "#F3C66D"
-			],
-			[
-			 17,
-			 "#F2DDB3"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 6,
-			 1.8
-			],
-			[
-			 9,
-			 2.7
-			],
-			[
-			 14,
-			 5.9
-			],
-			[
-			 15,
-			 9
-			],
-			[
-			 16,
-			 12.2
-			],
-			[
-			 17,
-			 22.5
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   2,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "Routier superieur - filet interieur - autoroute",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sup",
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "AUTOROU_PEAGE_SUP",
-		  "AUTOROU_LIBRE_SUP"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 9,
-			 "#F18800"
-			],
-			[
-			 17,
-			 "#F2B230"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 4,
-			 0.7
-			],
-			[
-			 6,
-			 2.5
-			],
-			[
-			 9,
-			 2.7
-			],
-			[
-			 14,
-			 5.8
-			],
-			[
-			 15,
-			 9
-			],
-			[
-			 16,
-			 12
-			],
-			[
-			 17,
-			 20.8
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier superieur - axe central - autoroute",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sup",
-		 "minzoom": 13,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "AUTOROU_PEAGE_SUP",
-		  "AUTOROU_LIBRE_SUP"
-		 ],
-		 "paint": {
-		  "line-color": "#EDF1FF",
-		  "line-width": {
-		   "stops": [
-			[
-			 9,
-			 0.6
-			],
-			[
-			 14,
-			 0.7
-			],
-			[
-			 15,
-			 1
-			],
-			[
-			 16,
-			 1.2
-			],
-			[
-			 17,
-			 2.1
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Routier superieur - filet interieur - autoroute en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sup",
-		 "minzoom": 10,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "AUTOROU_CONSTR_SUP"
-		 ],
-		 "paint": {
-		  "line-color": {
-		   "stops": [
-			[
-			 9,
-			 "#F18800"
-			],
-			[
-			 17,
-			 "#F2B230"
-			]
-		   ]
-		  },
-		  "line-width": {
-		   "stops": [
-			[
-			 4,
-			 0.7
-			],
-			[
-			 6,
-			 2.5
-			],
-			[
-			 9,
-			 3.5
-			],
-			[
-			 14,
-			 7.5
-			],
-			[
-			 15,
-			 11
-			],
-			[
-			 16,
-			 15
-			],
-			[
-			 17,
-			 26
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   2,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "Routier superieur - axe centrale - autoroute en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "routier_route_sup",
-		 "minzoom": 13,
-		 "maxzoom": 22,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "AUTOROU_CONSTR_SUP"
-		 ],
-		 "paint": {
-		  "line-color": "#808080",
-		  "line-width": {
-		   "stops": [
-			[
-			 9,
-			 0.6
-			],
-			[
-			 14,
-			 0.7
-			],
-			[
-			 15,
-			 1
-			],
-			[
-			 16,
-			 1.2
-			],
-			[
-			 17,
-			 2.1
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Ferre superieur - voie normale",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "ferre_sup",
-		 "minzoom": 10,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "VF_1_SUP",
-		  "VF_2_SUP",
-		  "VF_ELEC_1_SUP"
-		 ],
-		 "paint": {
-		  "line-color": "#787878",
-		  "line-width": {
-		   "stops": [
-			[
-			 10,
-			 0.8
-			],
-			[
-			 17,
-			 2.5
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Ferre superieur - voie normale trait perpendic",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "ferre_sup",
-		 "minzoom": 10,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "VF_1_SUP",
-		  "VF_2_SUP",
-		  "VF_ELEC_1_SUP"
-		 ],
-		 "paint": {
-		  "line-color": "#787878",
-		  "line-width": {
-		   "stops": [
-			[
-			 10,
-			 3.5
-			],
-			[
-			 17,
-			 14.7
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   0.1,
-		   10
-		  ]
-		 }
-		},
-		{
-		 "id": "Ferre superieur - voie etroite",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "ferre_sup",
-		 "minzoom": 10,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "VF_ETROITE_1_SUP",
-		  "VF_ETROITE_SUP"
-		 ],
-		 "paint": {
-		  "line-color": "#787878",
-		  "line-width": {
-		   "stops": [
-			[
-			 10,
-			 0.3
-			],
-			[
-			 17,
-			 1.8
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Ferre superieur - voie etroite trait perpendic",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "ferre_sup",
-		 "minzoom": 10,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "VF_ETROITE_1_SUP",
-		  "VF_ETROITE_SUP"
-		 ],
-		 "paint": {
-		  "line-color": "#787878",
-		  "line-width": {
-		   "stops": [
-			[
-			 10,
-			 3.5
-			],
-			[
-			 17,
-			 14.7
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   0.1,
-		   10
-		  ]
-		 }
-		},
-		{
-		 "id": "Ferre superieur - voie service",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "ferre_sup",
-		 "minzoom": 14,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "VF_SERVICE_SUP",
-		  "VF_NON_EXPLOITEE_SUP"
-		 ],
-		 "paint": {
-		  "line-color": "#787878",
-		  "line-width": {
-		   "stops": [
-			[
-			 10,
-			 0.3
-			],
-			[
-			 17,
-			 1.8
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   5,
-		   2,
-		   1,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "Ferre superieur - voie en construction",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "ferre_sup",
-		 "minzoom": 10,
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "VF_EN_CONSTR_SUP"
-		 ],
-		 "paint": {
-		  "line-color": "#787878",
-		  "line-width": {
-		   "stops": [
-			[
-			 10,
-			 0.3
-			],
-			[
-			 17,
-			 1.8
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   2,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "Ferre superieur - voie en construction trait perpendic",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "ferre_sup",
-		 "minzoom": 10,
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "VF_EN_CONSTR_SUP"
-		 ],
-		 "paint": {
-		  "line-color": "#787878",
-		  "line-width": {
-		   "stops": [
-			[
-			 10,
-			 3.5
-			],
-			[
-			 17,
-			 14.7
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   0.1,
-		   10
-		  ]
-		 }
-		},
-		{
-		 "id": "Ferre superieur - funic/urbain",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "ferre_sup",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "FUNI_CREMAILLERE_SUP",
-		  "TRANSPORT_URBAIN_SUP"
-		 ],
-		 "paint": {
-		  "line-color": "#787878",
-		  "line-width": {
-		   "stops": [
-			[
-			 10,
-			 0.3
-			],
-			[
-			 17,
-			 1.8
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "Ferre superieur - 2 trait perpendic - funic/urbain",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "ferre_sup",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "FUNI_CREMAILLERE_SUP",
-		  "TRANSPORT_URBAIN_SUP"
-		 ],
-		 "paint": {
-		  "line-color": "#787878",
-		  "line-width": {
-		   "stops": [
-			[
-			 10,
-			 3.5
-			],
-			[
-			 17,
-			 17
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   0.1,
-		   0.2,
-		   0.1,
-		   10
-		  ]
-		 }
-		},
-		{
-		 "id": "Limite - cloture",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "limite_lin",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "CLOTURE"
-		 ],
-		 "paint": {
-		  "line-color": "#000000",
-		  "line-width": {
-		   "stops": [
-			[
-			 13,
-			 0.6
-			],
-			[
-			 17,
-			 1
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   1.5,
-		   4
-		  ]
-		 }
-		},
-		{
-		 "id": "Limite - layon",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "limite_lin",
-		 "minzoom": 14,
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "LAYON"
-		 ],
-		 "paint": {
-		  "line-color": "#B3989A",
-		  "line-width": {
-		   "stops": [
-			[
-			 14,
-			 1
-			],
-			[
-			 15,
-			 1.2
-			],
-			[
-			 16,
-			 1.4
-			],
-			[
-			 17,
-			 2
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   4,
-		   7
-		  ]
-		 }
-		},
-		{
-		 "id": "Zone Règlementee - Enceinte militaire",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "limite_lin",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "LIM_ZONE_REGLEMENTEE",
-		  "LIM_ENCEINTE_MILITAIRE",
-		  "LIM_ENCEINTE_MILI",
-		  "LIM_CHAMP_TIR"
-		 ],
-		 "paint": {
-		  "line-color": "rgba(226, 130, 92, 0.8)",
-		  "line-width": {
-		   "stops": [
-			[
-			 13,
-			 1.7
-			],
-			[
-			 17,
-			 3.1
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   4,
-		   1,
-		   2,
-		   5
-		  ]
-		 }
-		},
-		{
-		 "id": "limite zone naturelle",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "limite_lin",
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "LIM_ZONE_NATURELLE",
-		  "LIM_ZONE_NATURELLE_ILE",
-		  "LIM_RESERVE_NATURELLE"
-		 ],
-		 "paint": {
-		  "line-color": "#FFC2CB",
-		  "line-width": {
-		   "stops": [
-			[
-			 13,
-			 2
-			],
-			[
-			 17,
-			 4
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   2,
-		   1
-		  ]
-		 }
-		},
-		{
-		 "id": "limite zone naturelle - Parc naturel 10",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "limite_lin",
-		 "maxzoom": 10,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "LIM_PARC_NATUREL",
-		  "LIM_PARC_NATUREL_ILE"
-		 ],
-		 "paint": {
-		  "line-color": "#42A266",
-		  "line-width": {
-		   "stops": [
-			[
-			 13,
-			 2
-			],
-			[
-			 17,
-			 4
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   2,
-		   1
-		  ]
-		 }
-		},
-		{
-		 "id": "limite zone naturelle - Parc naturel 11",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "limite_lin",
-		 "minzoom": 10,
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "LIM_PARC_NATUREL",
-		  "LIM_PARC_NATUREL_ILE"
-		 ],
-		 "paint": {
-		  "line-color": "#42A266",
-		  "line-width": {
-		   "stops": [
-			[
-			 13,
-			 2
-			],
-			[
-			 17,
-			 4
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   2,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "limite zone naturelle - Parc naturel 12",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "limite_lin",
-		 "minzoom": 11,
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "LIM_PARC_NATUREL",
-		  "LIM_PARC_NATUREL_ILE"
-		 ],
-		 "paint": {
-		  "line-color": "#42A266",
-		  "line-width": {
-		   "stops": [
-			[
-			 13,
-			 2
-			],
-			[
-			 17,
-			 4
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   2,
-		   3
-		  ]
-		 }
-		},
-		{
-		 "id": "limite zone naturelle - Parc naturel 13",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "limite_lin",
-		 "minzoom": 12,
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "LIM_PARC_NATUREL",
-		  "LIM_PARC_NATUREL_ILE"
-		 ],
-		 "paint": {
-		  "line-color": "#42A266",
-		  "line-width": {
-		   "stops": [
-			[
-			 13,
-			 2
-			],
-			[
-			 17,
-			 4
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   2,
-		   4
-		  ]
-		 }
-		},
-		{
-		 "id": "limite zone naturelle - Parc naturel 14",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "limite_lin",
-		 "minzoom": 13,
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "LIM_PARC_NATUREL",
-		  "LIM_PARC_NATUREL_ILE"
-		 ],
-		 "paint": {
-		  "line-color": "rgba(66, 162, 102, 0.7)",
-		  "line-width": {
-		   "stops": [
-			[
-			 13,
-			 2
-			],
-			[
-			 17,
-			 4
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   2,
-		   5
-		  ]
-		 }
-		},
-		{
-		 "id": "limite zone naturelle - Parc marin",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "limite_lin",
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "LIM_PARC_NATUREL_MARIN"
-		 ],
-		 "paint": {
-		  "line-color": "#2A81A2",
-		  "line-width": {
-		   "stops": [
-			[
-			 13,
-			 2
-			],
-			[
-			 17,
-			 4
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   2,
-		   1
-		  ]
-		 }
-		},
-		
-		{
-		 "id": "limite admin - limite de commune",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "limite_lin",
-		 "minzoom": 13,
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "LIM_COMMUNE",
-		  "LIM_CANTON",
-		  "LIM_ARRONDISSEMENT"
-		 ],
-		 "paint": {
-		  "line-color": "rgba(126, 119, 184, 0.5)",
-		  "line-width": {
-		   "stops": [
-			[
-			 13,
-			 3
-			],
-			[
-			 17,
-			 5.5
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   4,
-		   2,
-		   1,
-		   1,
-		   1,
-		   1,
-		   1,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "limite admin - limite de département bandeau",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "limite_lin",
-		 "minzoom": 8,
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "LIM_DEPARTEMENT"
-		 ],
-		 "paint": {
-		  "line-color": "rgba(178, 175, 219, 0.4)",
-		  "line-width": {
-		   "stops": [
-			[
-			 9,
-			 4.1
-			],
-			[
-			 12,
-			 6
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "limite admin - limite de département tiret",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "limite_lin",
-		 "minzoom": 13,
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "LIM_DEPARTEMENT"
-		 ],
-		 "paint": {
-		  "line-color": "rgba(126, 119, 184, 0.5)",
-		  "line-width": {
-		   "stops": [
-			[
-			 13,
-			 3
-			],
-			[
-			 17,
-			 5.5
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   4,
-		   2,
-		   1,
-		   1,
-		   1,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "limite admin - limite de région bandeau",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "limite_lin",
-		 "minzoom": 7,
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "LIM_REGION"
-		 ],
-		 "paint": {
-		  "line-color": "rgba(178, 175, 219, 0.5)",
-		  "line-width": {
-		   "stops": [
-			[
-			 9,
-			 4.5
-			],
-			[
-			 12,
-			 6.7
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "limite admin - limite de région tiret",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "limite_lin",
-		 "minzoom": 13,
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "LIM_REGION"
-		 ],
-		 "paint": {
-		  "line-color": "rgba(126, 119, 184, 0.5)",
-		  "line-width": {
-		   "stops": [
-			[
-			 13,
-			 3
-			],
-			[
-			 17,
-			 5.5
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   4,
-		   2,
-		   1,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "limite etat 1",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "limite_lin",
-		 "minzoom": 2,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "LIM_ETAT",
-		  "LIM_ETAT_ETRANGER"
-		 ],
-		 "paint": {
-		  "line-color": "rgba(178, 175, 219, 0.6)",
-		  "line-width": {
-		   "stops": [
-			[
-			 2,
-			 2
-			],
-			[
-			 3,
-			 3.5
-			],
-			[
-			 9,
-			 5
-			],
-			[
-			 14,
-			 13
-			],
-			[
-			 15,
-			 20
-			],
-			[
-			 16,
-			 24
-			],
-			[
-			 17,
-			 42
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "limite etat 2",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "limite_lin",
-		 "minzoom": 7,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "LIM_ETAT",
-		  "LIM_ETAT_ETRANGER"
-		 ],
-		 "paint": {
-		  "line-color": "#9F9CB8",
-		  "line-width": {
-		   "stops": [
-			[
-			 9,
-			 1.5
-			],
-			[
-			 14,
-			 3.5
-			],
-			[
-			 15,
-			 5.5
-			],
-			[
-			 16,
-			 6.5
-			],
-			[
-			 17,
-			 11
-			]
-		   ]
-		  },
-		  "line-dasharray": [
-		   4,
-		   2
-		  ]
-		 }
-		},
-		{
-		 "id": "limite cote",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "limite_lin",
-		 "minzoom": 7,
-		 "maxzoom": 10,
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "LIM_COTE"
-		 ],
-		 "paint": {
-		  "line-color": "#82A3B2",
-		  "line-width": 1
-		 }
-		},
-		{
-		 "id": "ligne electrique",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "bati_lin",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "LIGNE_ELECTRIQUE"
-		 ],
-		 "paint": {
-		  "line-color": "#808080",
-		  "line-width": {
-		   "stops": [
-			[
-			 13,
-			 1
-			],
-			[
-			 17,
-			 2
-			]
-		   ]
-		  }
-		 }
-		},
-		{
-		 "id": "autre construction linéaire",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "bati_lin",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "round",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "CABLE",
-		  "REMONTEE_MEC",
-		  "HYDROCARBURES",
-		  "CONDUITE_MATIERES_P",
-		  "SPORT_MONTAGNE_LIN",
-		  "PISTE_BOBSLEIGH",
-		  "PISTE_LUGE",
-		  "PISTE_AERO_LIN"
-		 ],
-		 "paint": {
-		  "line-color": "#808080",
-		  "line-width": 1
-		 }
-		},
-		{
-		 "id": "autre construction linéaire - trait perpend cable",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "bati_lin",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "CABLE"
-		 ],
-		 "paint": {
-		  "line-color": "#808080",
-		  "line-width": 5,
-		  "line-dasharray": [
-		   0.5,
-		   10
-		  ]
-		 }
-		},
-		{
-		 "id": "autre construction linéaire - trait perpend 1 remont",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "bati_lin",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "REMONTEE_MEC"
-		 ],
-		 "paint": {
-		  "line-color": "#808080",
-		  "line-width": 6,
-		  "line-dasharray": [
-		   1,
-		   10
-		  ]
-		 }
-		},
-		{
-		 "id": "autre construction linéaire - trait perpend 2 remont",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "bati_lin",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "REMONTEE_MEC"
-		 ],
-		 "paint": {
-		  "line-color": "#BEBEBE",
-		  "line-width": 6,
-		  "line-dasharray": [
-		   0.3,
-		   0.4,
-		   0.3,
-		   10
-		  ]
-		 }
-		},
-		{
-		 "id": "autre construction linéaire - trait perpend carbur",
-		 "type": "line",
-		 "source": "plan_ign",
-		 "source-layer": "bati_lin",
-		 "layout": {
-		  "visibility": "visible",
-		  "line-cap": "butt",
-		  "line-join": "round"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "HYDROCARBURES",
-		  "CONDUITE_MATIERES_P"
-		 ],
-		 "paint": {
-		  "line-color": "#808080",
-		  "line-width": 5,
-		  "line-dasharray": [
-		   1,
-		   10
-		  ]
-		 }
-		},
-		{
-		 "id": "routier ponctuel - peage ponctuel",
-		 "type": "circle",
-		 "source": "plan_ign",
-		 "source-layer": "routier_ponc",
-		 "minzoom": 8,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "PEAGE_PONC"
-		 ],
-		 "paint": {
-		  "circle-radius": {
-		   "stops": [
-			[
-			 9,
-			 3.5
-			],
-			[
-			 12,
-			 6.5
-			]
-		   ]
-		  },
-		  "circle-color": "#E2A52A",
-		  "circle-stroke-width": 1,
-		  "circle-stroke-color": "#808080"
-		 }
-		},
-		{
-		 "id": "routier ponctuel - barriere",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "routier_ponc",
-		 "minzoom": 12,
-		 "layout": {
-		  "visibility": "visible",
-		  "icon-image": "Barriere",
-		  "icon-size": {
-		   "stops": [
-			[
-			 13,
-			 0.25
-			],
-			[
-			 16,
-			 0.45
-			],
-			[
-			 17,
-			 0.7
-			]
-		   ]
-		  },
-		  "icon-allow-overlap": true,
-		  "icon-rotate": [
-		   "get",
-		   "rotation"
-		  ]
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "BARRIERE"
-		 ],
-		 "paint": {
-		  "icon-color": "#969696"
-		 }
-		},
-		{
-		 "id": "hydro ponctuel",
-		 "type": "circle",
-		 "source": "plan_ign",
-		 "source-layer": "hydro_ponc",
-		 "minzoom": 13,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "FONTAINE",
-		  "POINT_D_EAU",
-		  "SOURCE",
-		  "SOURCE_CAPTEE",
-		  "PERTE",
-		  "RESURGENCE",
-		  "CASCADE",
-		  "AUTRE_HYDRO_PONC"
-		 ],
-		 "paint": {
-		  "circle-radius": {
-		   "stops": [
-			[
-			 14,
-			 3
-			],
-			[
-			 17,
-			 7
-			]
-		   ]
-		  },
-		  "circle-color": "#FFFFFF",
-		  "circle-opacity": 1,
-		  "circle-stroke-width": {
-		   "stops": [
-			[
-			 14,
-			 2
-			],
-			[
-			 17,
-			 5
-			]
-		   ]
-		  },
-		  "circle-stroke-color": "#1466B2"
-		 }
-		},
-		{
-		 "id": "point coté",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "oro_ponc",
-		 "minzoom": 11,
-		 "maxzoom": 21,
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "POINT_COTE",
-		  "POINT_COTE_TOPO",
-		  "POINT_COTE_RESEAU",
-		  "POINT_RBF"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "icon-image": "Localite",
-		  "icon-size": 0.1,
-		  "text-field": "{texte}",
-		  "text-size": 10,
-		  "text-allow-overlap": false,
-		  "text-anchor": "bottom-left",
-		  "text-offset": [
-		   0.2,
-		   0.4
-		  ],
-		  "text-padding": 2,
-		  "text-font": [
-		   "Source Sans Pro Italic"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#505050"
-		 }
-		},
-		{
-		 "id": "bati ponctuel : Hopital",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "bati_ponc",
-		 "layout": {
-		  "visibility": "visible",
-		  "icon-image": "Hopital",
-		  "icon-size": 0.33
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "HOPITAL_PONC"
-		 ],
-		 "paint": {
-		  "icon-color": "#646464"
-		 }
-		},
-		{
-		 "id": "bati ponctuel hydrographique",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "bati_ponc",
-		 "minzoom": 14,
-		 "layout": {
-		  "visibility": "visible",
-		  "icon-image": "Pompage",
-		  "icon-size": {
-		   "stops": [
-			[
-			 13,
-			 0.2
-			],
-			[
-			 17,
-			 0.6
-			]
-		   ]
-		  },
-		  "icon-allow-overlap": true
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "CITERNE",
-		  "LAVOIR",
-		  "STATION_EPURATION",
-		  "STATION_DE_POMPAGE",
-		  "USINE_PRODUCTION_EAU",
-		  "USINE_ELEVATRICE"
-		 ],
-		 "paint": {
-		  "icon-color": "#1C62A6"
-		 }
-		},
-		{
-		 "id": "bati ponctuel hydrographique - Puits-Abreuvoir",
-		 "type": "circle",
-		 "source": "plan_ign",
-		 "source-layer": "bati_ponc",
-		 "minzoom": 13,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "PUITS",
-		  "ABREUVOIR"
-		 ],
-		 "paint": {
-		  "circle-radius": {
-		   "stops": [
-			[
-			 14,
-			 3
-			],
-			[
-			 17,
-			 7
-			]
-		   ]
-		  },
-		  "circle-color": "#FFFFFF",
-		  "circle-opacity": 1,
-		  "circle-stroke-width": {
-		   "stops": [
-			[
-			 14,
-			 2
-			],
-			[
-			 17,
-			 5
-			]
-		   ]
-		  },
-		  "circle-stroke-color": "#1466B2"
-		 }
-		},
-		{
-		 "id": "bati ponctuel hydrographique - Phare",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "bati_ponc",
-		 "minzoom": 13,
-		 "layout": {
-		  "visibility": "visible",
-		  "icon-image": "Phare",
-		  "icon-size": {
-		   "stops": [
-			[
-			 13,
-			 0.7
-			],
-			[
-			 17,
-			 1.3
-			]
-		   ]
-		  }
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "PHARE"
-		 ],
-		 "paint": {
-		  "icon-color": "#646464"
-		 }
-		},
-		{
-		 "id": "bati ponctuel hydrographique - Amer-Feu",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "bati_ponc",
-		 "minzoom": 13,
-		 "layout": {
-		  "visibility": "visible",
-		  "icon-image": "Feu",
-		  "icon-size": {
-		   "stops": [
-			[
-			 13,
-			 0.7
-			],
-			[
-			 17,
-			 1.3
-			]
-		   ]
-		  }
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "AMER",
-		  "FEU",
-		  "FEU_PONC",
-		  "TOURELLE_LUMINEUSE"
-		 ],
-		 "paint": {
-		  "icon-color": "#646464"
-		 }
-		},
-		{
-		 "id": "bati ponctuel hydrographique - Balise",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "bati_ponc",
-		 "minzoom": 13,
-		 "layout": {
-		  "visibility": "visible",
-		  "icon-image": "Balise",
-		  "icon-size": {
-		   "stops": [
-			[
-			 13,
-			 0.7
-			],
-			[
-			 17,
-			 1.3
-			]
-		   ]
-		  }
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "BALISE",
-		  "TOURELLE"
-		 ],
-		 "paint": {
-		  "icon-color": "#646464"
-		 }
-		},
-		{
-		 "id": "bati ponctuel hydrographique - Ecluse",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "bati_ponc",
-		 "minzoom": 12,
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "icon-image": "Ecluse",
-		  "icon-size": 0.2
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "ECLUSE_PONC"
-		 ],
-		 "paint": {
-		  "icon-color": "#1C62A6"
-		 }
-		},
-		{
-		 "id": "bati ponctuel hydrographique - Barrage",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "bati_ponc",
-		 "minzoom": 12,
-		 "maxzoom": 14,
-		 "layout": {
-		  "visibility": "visible",
-		  "icon-image": "Barrage",
-		  "icon-size": 0.25
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "BARRAGE_PONC"
-		 ],
-		 "paint": {
-		  "icon-color": "#1C62A6"
-		 }
-		},
-		{
-		 "id": "bati ponctuel hydrographique - Chateau d'eau",
-		 "type": "circle",
-		 "source": "plan_ign",
-		 "source-layer": "bati_ponc",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "CHATEAU_EAU_PONC"
-		 ],
-		 "paint": {
-		  "circle-radius": {
-		   "stops": [
-			[
-			 14,
-			 3
-			],
-			[
-			 17,
-			 8
-			]
-		   ]
-		  },
-		  "circle-color": "#1466B2"
-		 }
-		},
-		{
-		 "id": "bati ponctuel hydrographique - Réservoir d'eau",
-		 "type": "circle",
-		 "source": "plan_ign",
-		 "source-layer": "bati_ponc",
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "RESERVOIR_EAU_PONC"
-		 ],
-		 "paint": {
-		  "circle-radius": {
-		   "stops": [
-			[
-			 14,
-			 3
-			],
-			[
-			 17,
-			 8
-			]
-		   ]
-		  },
-		  "circle-color": "#AAD5E9",
-		  "circle-opacity": 1,
-		  "circle-stroke-width": {
-		   "stops": [
-			[
-			 14,
-			 1
-			],
-			[
-			 17,
-			 2.5
-			]
-		   ]
-		  },
-		  "circle-stroke-color": "#1466B2"
-		 }
-		},
-		{
-		 "id": "bati ponctuel infrastructure - Constr spé",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "bati_ponc",
-		 "layout": {
-		  "visibility": "visible",
-		  "icon-image": "ConstrSpeciale",
-		  "icon-size": {
-		   "stops": [
-			[
-			 13,
-			 0.22
-			],
-			[
-			 17,
-			 0.5
-			]
-		   ]
-		  }
-		 },
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "ANTENNE",
-		  "CONSTR_SPE_TECHNIQUE",
-		  "CONSTR_INDIF_PONC",
-		  "CHEMINEE",
-		  "CHEVALEMENT",
-		  "PUITS_GAZ",
-		  "PUITS_PETROLE",
-		  "PYLONE_METEO",
-		  "TORCHERE",
-		  "TOUR_GUET",
-		  "TOUR_HERTZIENNE"
-		 ],
-		 "paint": {
-		  "icon-color": "#646464"
-		 }
-		},
-		{
-		 "id": "bati ponctuel infrastructure - Silo",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "bati_ponc",
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "icon-image": "Silo",
-		  "icon-size": {
-		   "stops": [
-			[
-			 13,
-			 0.22
-			],
-			[
-			 17,
-			 0.5
-			]
-		   ]
-		  }
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "SILO_PONC"
-		 ],
-		 "paint": {
-		  "icon-color": "#646464"
-		 }
-		},
-		{
-		 "id": "bati ponctuel infrastructure - Eolienne",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "bati_ponc",
-		 "layout": {
-		  "visibility": "visible",
-		  "icon-image": "Eolienne",
-		  "icon-size": {
-		   "stops": [
-			[
-			 13,
-			 0.4
-			],
-			[
-			 17,
-			 1
-			],
-			[
-			 18,
-			 0.8
-			]
-		   ]
-		  }
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "EOLIENNE"
-		 ],
-		 "paint": {
-		  "icon-color": "#646464"
-		 }
-		},
-		{
-		 "id": "bati ponctuel infrastructure - Reservoir",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "bati_ponc",
-		 "maxzoom": 21,
-		 "layout": {
-		  "visibility": "visible",
-		  "icon-image": "Reservoir",
-		  "icon-size": {
-		   "stops": [
-			[
-			 13,
-			 0.26
-			],
-			[
-			 17,
-			 0.5
-			]
-		   ]
-		  }
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "RESERVOIR_PONC"
-		 ],
-		 "paint": {
-		  "icon-color": "#646464"
-		 }
-		},
-		{
-		 "id": "bati ponctuel infrastructure - pylone électrique",
-		 "type": "circle",
-		 "source": "plan_ign",
-		 "source-layer": "bati_ponc",
-		 "layout": {
-		  "visibility": "visible"
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "PYLONE_ELEC"
-		 ],
-		 "paint": {
-		  "circle-radius": {
-		   "stops": [
-			[
-			 13,
-			 1
-			],
-			[
-			 17,
-			 2
-			]
-		   ]
-		  },
-		  "circle-color": "#000000"
-		 }
-		},
-		{
-		 "id": "bati ponctuel montagne - Abri",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "bati_ponc",
-		 "layout": {
-		  "visibility": "visible",
-		  "icon-image": "Abri",
-		  "icon-size": {
-		   "stops": [
-			[
-			 13,
-			 0.4
-			],
-			[
-			 15,
-			 0.6
-			],
-			[
-			 17,
-			 0.9
-			]
-		   ]
-		  }
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "ABRI"
-		 ],
-		 "paint": {
-		  "icon-color": "#246138"
-		 }
-		},
-		{
-		 "id": "bati ponctuel montagne - Refuge Garde",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "bati_ponc",
-		 "layout": {
-		  "visibility": "visible",
-		  "icon-image": "Refugegard",
-		  "icon-size": {
-		   "stops": [
-			[
-			 13,
-			 0.4
-			],
-			[
-			 15,
-			 0.6
-			],
-			[
-			 17,
-			 0.9
-			]
-		   ]
-		  }
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "REFUGE_GARDE"
-		 ],
-		 "paint": {
-		  "icon-color": "#246138"
-		 }
-		},
-		{
-		 "id": "bati ponctuel montagne - Refuge Non Garde",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "bati_ponc",
-		 "layout": {
-		  "visibility": "visible",
-		  "icon-image": "Refugenongard",
-		  "icon-size": {
-		   "stops": [
-			[
-			 13,
-			 0.4
-			],
-			[
-			 15,
-			 0.6
-			],
-			[
-			 17,
-			 0.9
-			]
-		   ]
-		  }
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "REFUGE"
-		 ],
-		 "paint": {
-		  "icon-color": "#246138"
-		 }
-		},
-		{
-		 "id": "bati ponctuel transport aerien - Aeroport FXX",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "bati_ponc",
-		 "layout": {
-		  "visibility": "visible",
-		  "icon-image": "Aeroport",
-		  "icon-size": 0.5
-		 },
-		 "filter": [
-		  "all",
-		  [
-		   "==",
-		   "symbo",
-		   "AEROPORT_PONC"
-		  ],
-		  [
-		   "==",
-		   "territoire",
-		   "FXX"
-		  ]
-		 ],
-		 "paint": {
-		  "icon-color": "#646464"
-		 }
-		},
-		{
-		 "id": "bati ponctuel transport aerien - Aerodrome FXX",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "bati_ponc",
-		 "layout": {
-		  "visibility": "visible",
-		  "icon-image": "Aerodrome",
-		  "icon-size": 0.4
-		 },
-		 "filter": [
-		  "all",
-		  [
-		   "==",
-		   "symbo",
-		   "AERODROME_PONC"
-		  ],
-		  [
-		   "==",
-		   "territoire",
-		   "FXX"
-		  ]
-		 ],
-		 "paint": {
-		  "icon-color": "#646464"
-		 }
-		},
-		{
-		 "id": "bati ponctuel transport aerien - Aeroport DOM",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "bati_ponc",
-		 "minzoom": 8,
-		 "layout": {
-		  "visibility": "visible",
-		  "icon-image": "Aeroport",
-		  "icon-size": 0.5
-		 },
-		 "filter": [
-		  "all",
-		  [
-		   "==",
-		   "symbo",
-		   "AEROPORT_PONC"
-		  ],
-		  [
-		   "!=",
-		   "territoire",
-		   "FXX"
-		  ]
-		 ],
-		 "paint": {
-		  "icon-color": "#646464"
-		 }
-		},
-		{
-		 "id": "bati ponctuel transport aerien - Aerodrome DOM",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "bati_ponc",
-		 "minzoom": 8,
-		 "layout": {
-		  "visibility": "visible",
-		  "icon-image": "Aerodrome",
-		  "icon-size": 0.4
-		 },
-		 "filter": [
-		  "all",
-		  [
-		   "==",
-		   "symbo",
-		   "AERODROME_PONC"
-		  ],
-		  [
-		   "!=",
-		   "territoire",
-		   "FXX"
-		  ]
-		 ],
-		 "paint": {
-		  "icon-color": "#646464"
-		 }
-		},
-		{
-		 "id": "bati ponctuel transport ferroviaire",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "bati_ponc",
-		 "layout": {
-		  "visibility": "visible",
-		  "icon-image": "Gare",
-		  "icon-size": 0.33
-		 },
-		 "filter": [
-		  "==",
-		  "symbo",
-		  "GARE_VOYAGEURS"
-		 ],
-		 "paint": {
-		  "icon-color": "#787878"
-		 }
-		},
-		{
-		 "id": "toponyme - bornes postales haute - chemins",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_routier_borne",
-		 "minzoom": 17,
-		 "maxzoom": 22,
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "CHEMIN",
-		  "CHEMIN_SOU",
-		  "CHEMIN_SUP",
-		  "PISTE_CYCLABLE",
-		  "PISTE_CYCLABLE_SOU",
-		  "PISTE_CYCLABLE_SUP",
-		  "RUE_PIETONNE",
-		  "RUE_PIETONNE_SOU",
-		  "RUE_PIETONNE_SUP",
-		  "SENTIER",
-		  "SENTIER_SOU",
-		  "SENTIER_SUP",
-		  "ESCALIER",
-		  "ESCALIER_SUP"
-		 ],
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{borne_sur}",
-		  "text-size": 11,
-		  "text-anchor": "center",
-		  "text-allow-overlap": true,
-		  "text-offset": [
-		   0,
-		   -1
-		  ],
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ],
-		  "visibility": "none"
-		 },
-		 "paint": {
-		  "text-color": "#79654F",
-		  "text-halo-width": 1,
-		  "text-halo-color": "#FFFFFF"
-		 }
-		},
-		{
-		 "id": "toponyme - bornes postales haute - non revetue, non classee",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_routier_borne",
-		 "minzoom": 17,
-		 "maxzoom": 22,
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "NON_CLASSEE",
-		  "NON_CLASSEE_4",
-		  "NON_CLASSEE_4_SUP",
-		  "NON_CLASSEE_RESTREINT",
-		  "NON_CLASSEE_RESTREINT_SUP",
-		  "NON_CLASSEE_SOU",
-		  "NON_CLASSEE_SUP",
-		  "NON_REVETUE_CARRO",
-		  "NON_REVETUE_CARRO_SUP"
-		 ],
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{borne_sur}",
-		  "text-size": 11,
-		  "text-anchor": "center",
-		  "text-allow-overlap": true,
-		  "text-offset": [
-		   0,
-		   -1.3
-		  ],
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ],
-		  "visibility": "none"
-		 },
-		 "paint": {
-		  "text-color": "#79654F",
-		  "text-halo-width": 1,
-		  "text-halo-color": "#FFFFFF"
-		 }
-		},
-		{
-		 "id": "toponyme - bornes postales haute - locales",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_routier_borne",
-		 "minzoom": 17,
-		 "maxzoom": 22,
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "LOCALE_1",
-		  "LOCALE_1_SOU",
-		  "LOCALE_1_SUP",
-		  "LOCALE_2",
-		  "LOCALE_2_SOU",
-		  "LOCALE_2_SUP",
-		  "LOCALE_3",
-		  "LOCALE_3_SOU",
-		  "LOCALE_3_SUP",
-		  "LOCALE_4",
-		  "LOCALE_4_SOU",
-		  "LOCALE_4_SUP",
-		  "LOCALE_CONSTR",
-		  "LOCALE_CONSTR_SUP"
-		 ],
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{borne_sur}",
-		  "text-size": 11,
-		  "text-anchor": "center",
-		  "text-allow-overlap": true,
-		  "text-offset": [
-		   0,
-		   -1.4
-		  ],
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ],
-		  "visibility": "none"
-		 },
-		 "paint": {
-		  "text-color": "#79654F",
-		  "text-halo-width": 1,
-		  "text-halo-color": "#FFFFFF"
-		 }
-		},
-		{
-		 "id": "toponyme - bornes postales haute - regionales",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_routier_borne",
-		 "minzoom": 17,
-		 "maxzoom": 22,
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "REGIONALE_1",
-		  "REGIONALE_1_SOU",
-		  "REGIONALE_1_SUP",
-		  "REGIONALE_2",
-		  "REGIONALE_2_SOU",
-		  "REGIONALE_2_SUP",
-		  "REGIONALE_3",
-		  "REGIONALE_3_SOU",
-		  "REGIONALE_3_SUP",
-		  "REGIONALE_4",
-		  "REGIONALE_4_SUP",
-		  "REGIONALE_CONSTR"
-		 ],
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{borne_sur}",
-		  "text-size": 11,
-		  "text-anchor": "center",
-		  "text-allow-overlap": true,
-		  "text-offset": [
-		   0,
-		   -1.5
-		  ],
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ],
-		  "visibility": "none"
-		 },
-		 "paint": {
-		  "text-color": "#79654F",
-		  "text-halo-width": 1,
-		  "text-halo-color": "#FFFFFF"
-		 }
-		},
-		{
-		 "id": "toponyme - bornes postales haute - principales",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_routier_borne",
-		 "minzoom": 17,
-		 "maxzoom": 22,
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "PRINCIPALE_1",
-		  "PRINCIPALE_1_SOU",
-		  "PRINCIPALE_1_SUP",
-		  "PRINCIPALE_2",
-		  "PRINCIPALE_2_SOU",
-		  "PRINCIPALE_2_SUP",
-		  "PRINCIPALE_3",
-		  "PRINCIPALE_3_SOU",
-		  "PRINCIPALE_3_SUP",
-		  "PRINCIPALE_4",
-		  "PRINCIPALE_4_SOU",
-		  "PRINCIPALE_4_SUP",
-		  "PRINCIPALE_CONSTR"
-		 ],
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{borne_sur}",
-		  "text-size": 11,
-		  "text-anchor": "center",
-		  "text-allow-overlap": true,
-		  "text-offset": [
-		   0,
-		   -1.6
-		  ],
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ],
-		  "visibility": "none"
-		 },
-		 "paint": {
-		  "text-color": "#79654F",
-		  "text-halo-width": 1,
-		  "text-halo-color": "#FFFFFF"
-		 }
-		},
-		{
-		 "id": "toponyme - bornes postales bas - chemins",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_routier_borne",
-		 "minzoom": 17,
-		 "maxzoom": 22,
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "CHEMIN",
-		  "CHEMIN_SOU",
-		  "CHEMIN_SUP",
-		  "PISTE_CYCLABLE",
-		  "PISTE_CYCLABLE_SOU",
-		  "PISTE_CYCLABLE_SUP",
-		  "RUE_PIETONNE",
-		  "RUE_PIETONNE_SOU",
-		  "RUE_PIETONNE_SUP",
-		  "SENTIER",
-		  "SENTIER_SOU",
-		  "SENTIER_SUP",
-		  "ESCALIER",
-		  "ESCALIER_SUP"
-		 ],
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{borne_sous}",
-		  "text-size": 11,
-		  "text-anchor": "center",
-		  "text-allow-overlap": true,
-		  "text-offset": [
-		   0,
-		   1
-		  ],
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ],
-		  "visibility": "none"
-		 },
-		 "paint": {
-		  "text-color": "#79654F",
-		  "text-halo-width": 1,
-		  "text-halo-color": "#FFFFFF"
-		 }
-		},
-		{
-		 "id": "toponyme - bornes postales bas - non revetue, non classee",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_routier_borne",
-		 "minzoom": 17,
-		 "maxzoom": 22,
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "NON_CLASSEE",
-		  "NON_CLASSEE_4",
-		  "NON_CLASSEE_4_SUP",
-		  "NON_CLASSEE_RESTREINT",
-		  "NON_CLASSEE_RESTREINT_SUP",
-		  "NON_CLASSEE_SOU",
-		  "NON_CLASSEE_SUP",
-		  "NON_REVETUE_CARRO",
-		  "NON_REVETUE_CARRO_SUP"
-		 ],
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{borne_sous}",
-		  "text-size": 11,
-		  "text-anchor": "center",
-		  "text-allow-overlap": true,
-		  "text-offset": [
-		   0,
-		   1.3
-		  ],
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ],
-		  "visibility": "none"
-		 },
-		 "paint": {
-		  "text-color": "#79654F",
-		  "text-halo-width": 1,
-		  "text-halo-color": "#FFFFFF"
-		 }
-		},
-		{
-		 "id": "toponyme - bornes postales bas - locales",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_routier_borne",
-		 "minzoom": 17,
-		 "maxzoom": 22,
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "LOCALE_1",
-		  "LOCALE_1_SOU",
-		  "LOCALE_1_SUP",
-		  "LOCALE_2",
-		  "LOCALE_2_SOU",
-		  "LOCALE_2_SUP",
-		  "LOCALE_3",
-		  "LOCALE_3_SOU",
-		  "LOCALE_3_SUP",
-		  "LOCALE_4",
-		  "LOCALE_4_SOU",
-		  "LOCALE_4_SUP",
-		  "LOCALE_CONSTR",
-		  "LOCALE_CONSTR_SUP"
-		 ],
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{borne_sous}",
-		  "text-size": 11,
-		  "text-anchor": "center",
-		  "text-allow-overlap": true,
-		  "text-offset": [
-		   0,
-		   1.4
-		  ],
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ],
-		  "visibility": "none"
-		 },
-		 "paint": {
-		  "text-color": "#79654F",
-		  "text-halo-width": 1,
-		  "text-halo-color": "#FFFFFF"
-		 }
-		},
-		{
-		 "id": "toponyme - bornes postales bas - regionales",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_routier_borne",
-		 "minzoom": 17,
-		 "maxzoom": 22,
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "REGIONALE_1",
-		  "REGIONALE_1_SOU",
-		  "REGIONALE_1_SUP",
-		  "REGIONALE_2",
-		  "REGIONALE_2_SOU",
-		  "REGIONALE_2_SUP",
-		  "REGIONALE_3",
-		  "REGIONALE_3_SOU",
-		  "REGIONALE_3_SUP",
-		  "REGIONALE_4",
-		  "REGIONALE_4_SUP",
-		  "REGIONALE_CONSTR"
-		 ],
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{borne_sous}",
-		  "text-size": 11,
-		  "text-anchor": "center",
-		  "text-allow-overlap": true,
-		  "text-offset": [
-		   0,
-		   1.5
-		  ],
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ],
-		  "visibility": "none"
-		 },
-		 "paint": {
-		  "text-color": "#79654F",
-		  "text-halo-width": 1,
-		  "text-halo-color": "#FFFFFF"
-		 }
-		},
-		{
-		 "id": "toponyme - bornes postales bas - principales",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_routier_borne",
-		 "minzoom": 17,
-		 "maxzoom": 22,
-		 "filter": [
-		  "in",
-		  "symbo",
-		  "PRINCIPALE_1",
-		  "PRINCIPALE_1_SOU",
-		  "PRINCIPALE_1_SUP",
-		  "PRINCIPALE_2",
-		  "PRINCIPALE_2_SOU",
-		  "PRINCIPALE_2_SUP",
-		  "PRINCIPALE_3",
-		  "PRINCIPALE_3_SOU",
-		  "PRINCIPALE_3_SUP",
-		  "PRINCIPALE_4",
-		  "PRINCIPALE_4_SOU",
-		  "PRINCIPALE_4_SUP",
-		  "PRINCIPALE_CONSTR"
-		 ],
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{borne_sous}",
-		  "text-size": 11,
-		  "text-anchor": "center",
-		  "text-allow-overlap": true,
-		  "text-offset": [
-		   0,
-		   1.6
-		  ],
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ],
-		  "visibility": "none"
-		 },
-		 "paint": {
-		  "text-color": "#79654F",
-		  "text-halo-width": 1,
-		  "text-halo-color": "#FFFFFF"
-		 }
-		},
-		{
-		 "id": "toponyme - courbe rocher maitresse",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_oro_ponc",
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "ORO_COURBE_ROCHER"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 10,
-		  "text-allow-overlap": false,
-		  "text-padding": 30,
-		  "text-rotate": {
-		   "type": "identity",
-		   "property": "rotation"
-		  },
-		  "text-font": [
-		   "Source Sans Pro Italic"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#333333",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 1
-		 }
-		},
-		{
-		 "id": "toponyme - courbe glacier maitresse",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_oro_ponc",
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "ORO_COURBE_GLACIER"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 10,
-		  "text-allow-overlap": false,
-		  "text-padding": 30,
-		  "text-rotate": {
-		   "type": "identity",
-		   "property": "rotation"
-		  },
-		  "text-font": [
-		   "Source Sans Pro Italic"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#629FD9",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 1
-		 }
-		},
-		{
-		 "id": "toponyme - courbe maitresse",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_oro_ponc",
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "ORO_COURBE"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 10,
-		  "text-allow-overlap": false,
-		  "text-padding": 30,
-		  "text-rotate": {
-		   "type": "identity",
-		   "property": "rotation"
-		  },
-		  "text-font": [
-		   "Source Sans Pro Italic"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#604A2F",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 1
-		 }
-		},
-		{
-		 "id": "toponyme - liaison maritime",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_routier_liaison_lin",
-		 "minzoom": 8,
-		 "maxzoom": 22,
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "LIAISON_MARITIME"
-		 ],
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{texte}",
-		  "text-size": 15,
-		  "text-anchor": "center",
-		  "text-keep-upright": true,
-		  "text-max-angle": 45,
-		  "text-padding": 10,
-		  "text-font": [
-		   "Source Sans Pro Italic"
-		  ],
-		  "visibility": "visible"
-		 },
-		 "paint": {
-		  "text-color": "#5792C2",
-		  "text-halo-width": 5,
-		  "text-halo-color": "#AAD5E9"
-		 }
-		},
-		{
-		 "id": "toponyme bati station de métro + bati ponctuel metro",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_bati_ponc",
-		 "minzoom": 14,
-		 "filter": [
-		  "all",
-		  [
-		   "==",
-		   "txt_typo",
-		   "TYPO_E_1"
-		  ],
-		  [
-		   "==",
-		   "symbo",
-		   "STATION_METRO"
-		  ]
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 11,
-		  "text-allow-overlap": false,
-		  "text-offset": [
-		   0.3,
-		   -0.25
-		  ],
-		  "text-padding": 3,
-		  "text-anchor": "bottom-left",
-		  "text-font": [
-		   "Source Sans Pro"
-		  ],
-		  "icon-image": "Metro",
-		  "icon-size": {
-		   "stops": [
-			[
-			 15,
-			 0.33
-			],
-			[
-			 17,
-			 0.6
-			]
-		   ]
-		  }
-		 },
-		 "paint": {
-		  "text-color": "#3C3C3C",
-		  "icon-color": "#646464"
-		 }
-		},
-		{
-		 "id": "toponyme ferre lineaire",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_ferre_lin",
-		 "minzoom": 12,
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "FER_NOM",
-		  "FER_OUVRAGE"
-		 ],
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{texte}",
-		  "text-size": 10,
-		  "text-anchor": "center",
-		  "text-offset": [
-		   0,
-		   -1
-		  ],
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ],
-		  "visibility": "visible"
-		 },
-		 "paint": {
-		  "text-color": "#000000",
-		  "text-halo-width": 1,
-		  "text-halo-color": "rgba(255, 255, 255, 1)"
-		 }
-		},
-		{
-		 "id": "toponyme station epuration, de pompage, usine de production eau",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_bati_ponc",
-		 "minzoom": 14,
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "station"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{designation}",
-		  "text-anchor": "left",
-		  "text-offset": [
-		   0.8,
-		   0
-		  ],
-		  "text-size": 11,
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Source Sans Pro Italic"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#447FB3"
-		 }
-		},
-		{
-		 "id": "toponyme bati ponc gare",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_bati_ponc",
-		 "minzoom": 15,
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "gore"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{designation}",
-		  "text-size": 11,
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Source Sans Pro Italic"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#000000"
-		 }
-		},
-		{
-		 "id": "toponyme bati ponc barrage",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_bati_ponc",
-		 "minzoom": 12,
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "BARRAGE_PONC"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-anchor": "left",
-		  "text-offset": [
-		   0.8,
-		   0
-		  ],
-		  "text-size": 11,
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Source Sans Pro"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#447FB3"
-		 }
-		},
-		{
-		 "id": "toponyme bati ponc phare - niveau 13",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_bati_ponc",
-		 "maxzoom": 21,
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "PHARE"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-anchor": "right",
-		  "text-size": 11,
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Source Sans Pro"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#532A2A"
-		 }
-		},
-		{
-		 "id": "toponyme bati ponc phare - niveau 14à19",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_bati_ponc",
-		 "minzoom": 13,
-		 "filter": [
-		  "all",
-		  [
-		   "==",
-		   "symbo",
-		   "PHARE"
-		  ],
-		  [
-		   "in",
-		   "txt_typo",
-		   "TYPO_C_6",
-		   "TYPO_C_7",
-		   "TYPO_C_8",
-		   "TYPO_E_GE"
-		  ]
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-anchor": "right",
-		  "text-size": {
-		   "stops": [
-			[
-			 13,
-			 12
-			],
-			[
-			 18,
-			 18
-			]
-		   ]
-		  },
-		  "text-allow-overlap": false,
-		  "text-offset": [
-		   -2,
-		   0
-		  ],
-		  "text-padding": 3,
-		  "text-font": [
-		   "Source Sans Pro"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#532A2A"
-		 }
-		},
-		{
-		 "id": "toponyme bati ponc autre",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_bati_ponc",
-		 "minzoom": 12,
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "BAT_ACTIVITE",
-		  "BAT_FORTIF",
-		  "BAT_VILLAGE_DETRUIT"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-anchor": "center",
-		  "text-size": 11,
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Source Sans Pro"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#532A2A"
-		 }
-		},
-		{
-		 "id": "toponyme bati ponc aerogare",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_bati_ponc",
-		 "minzoom": 14,
-		 "maxzoom": 21,
-		 "filter": [
-		  "all",
-		  [
-		   "==",
-		   "txt_typo",
-		   "TYPO_E_GE"
-		  ],
-		  [
-		   "==",
-		   "symbo",
-		   "AEROGARE"
-		  ]
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-anchor": "center",
-		  "text-size": {
-		   "stops": [
-			[
-			 12,
-			 9
-			],
-			[
-			 16,
-			 11
-			]
-		   ]
-		  },
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Source Sans Pro Italic"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#120049",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 1
-		 }
-		},
-		{
-		 "id": "toponyme bati ponc aeroport 12",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_bati_ponc",
-		 "minzoom": 11,
-		 "maxzoom": 21,
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "AEROPORT_PONC"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-anchor": "bottom",
-		  "text-offset": [
-		   0,
-		   -1.3
-		  ],
-		  "text-size": 10.5,
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Source Sans Pro"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#120049",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme bati ponc aeroport 13",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_bati_ponc",
-		 "minzoom": 12,
-		 "maxzoom": 21,
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "AEROPORT_PONC"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-anchor": "bottom",
-		  "text-offset": [
-		   0,
-		   -2
-		  ],
-		  "text-size": 11,
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Source Sans Pro"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#120049",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme bati ponc aeroport",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_bati_ponc",
-		 "minzoom": 13,
-		 "maxzoom": 21,
-		 "filter": [
-		  "all",
-		  [
-		   "==",
-		   "txt_typo",
-		   "TYPO_A_5"
-		  ],
-		  [
-		   "==",
-		   "symbo",
-		   "AEROPORT"
-		  ]
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-anchor": "center",
-		  "text-size": {
-		   "stops": [
-			[
-			 12,
-			 11
-			],
-			[
-			 16,
-			 13
-			]
-		   ]
-		  },
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Source Sans Pro"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#120049",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme bati ponc aerodrome 12",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_bati_ponc",
-		 "minzoom": 11,
-		 "maxzoom": 21,
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "AERODROME_PONC"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-anchor": "bottom",
-		  "text-offset": [
-		   0,
-		   -1.3
-		  ],
-		  "text-size": 9.5,
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Source Sans Pro"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#120049",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme bati ponc aerodrome 13",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_bati_ponc",
-		 "minzoom": 12,
-		 "maxzoom": 21,
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "AERODROME_PONC"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-anchor": "bottom",
-		  "text-offset": [
-		   0,
-		   -2
-		  ],
-		  "text-size": 10,
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#120049",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme bati ponc aerodrome",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_bati_ponc",
-		 "minzoom": 13,
-		 "maxzoom": 21,
-		 "filter": [
-		  "all",
-		  [
-		   "==",
-		   "txt_typo",
-		   "TYPO_A_7"
-		  ],
-		  [
-		   "==",
-		   "symbo",
-		   "AERODROME"
-		  ]
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-anchor": "center",
-		  "text-size": {
-		   "stops": [
-			[
-			 12,
-			 10
-			],
-			[
-			 16,
-			 12
-			]
-		   ]
-		  },
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Source Sans Pro"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#120049",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme - hydro ponc 5",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_hydro_ponc",
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "TYPO_D_9",
-		  "TYPO_D_10",
-		  "TYPO_E_1_cyan"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 15,
-			 11
-			],
-			[
-			 17,
-			 14
-			]
-		   ]
-		  },
-		  "text-allow-overlap": true,
-		  "text-padding": 5,
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#447FB3",
-		  "text-halo-color": "#FFFFFF",
-		  "text-halo-width": 1
-		 }
-		},
-		{
-		 "id": "toponyme - hydro ponc glacier",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_hydro_ponc",
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "ORO_GLACIER_2"
-		 ],
-		 "layout": {
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 14,
-		  "text-anchor": "center",
-		  "text-allow-overlap": true,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Source Sans Pro Italic"
-		  ],
-		  "visibility": "visible"
-		 },
-		 "paint": {
-		  "text-color": "#447FB3",
-		  "text-halo-width": 2,
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)"
-		 }
-		},
-		{
-		 "id": "toponyme - limite militaire ponc 3 et 4",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_limite_ponc",
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "LIM_MILI_3",
-		  "LIM_MILI_4"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 12,
-		  "text-allow-overlap": false,
-		  "text-padding": 2,
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#0D2000",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 1
-		 }
-		},
-		{
-		 "id": "toponyme - limite parc ponc 3 et 4",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_limite_ponc",
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "LIM_PARC_3",
-		  "LIM_PARC_4",
-		  "RESERVE_NATURELLE_PONC"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 13,
-		  "text-allow-overlap": false,
-		  "text-padding": 2,
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#287B00",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 1
-		 }
-		},
-		{
-		 "id": "toponyme numéro de route - départementale",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_routier_numero_lin",
-		 "minzoom": 11,
-		 "maxzoom": 22,
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "Départementale"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "line",
-		  "text-field": "{texte}",
-		  "text-size": 10.5,
-		  "text-allow-overlap": false,
-		  "text-padding": 2,
-		  "text-anchor": "center",
-		  "text-font": [
-		   "Source Sans Pro Semibold"
-		  ],
-		  "text-rotation-alignment": "viewport"
-		 },
-		 "paint": {
-		  "text-color": "#4D4D4D",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 4
-		 }
-		},
-		{
-		 "id": "toponyme numéro de route - nationale",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_routier_numero_lin",
-		 "minzoom": 7,
-		 "maxzoom": 22,
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "Nationale"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "line",
-		  "text-field": "{texte}",
-		  "text-size": 12,
-		  "text-allow-overlap": false,
-		  "text-padding": 0,
-		  "text-anchor": "center",
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ],
-		  "icon-image": "Ecluse",
-		  "icon-rotation-alignment": "viewport",
-		  "text-rotation-alignment": "viewport",
-		  "icon-text-fit": "both",
-		  "icon-size": 0
-		 },
-		 "paint": {
-		  "text-color": "#F0F0F0",
-		  "icon-color": "#646464",
-		  "text-halo-color": "rgba(80, 80, 80, 0.5)",
-		  "text-halo-width": 4
-		 }
-		},
-		{
-		 "id": "toponyme numéro de route - autoroute",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_routier_numero_lin",
-		 "minzoom": 7,
-		 "maxzoom": 22,
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "Autoroute"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "line",
-		  "text-field": "{texte}",
-		  "text-size": 15,
-		  "text-allow-overlap": false,
-		  "text-padding": 0,
-		  "text-anchor": "center",
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ],
-		  "icon-image": "Ecluse",
-		  "icon-rotation-alignment": "viewport",
-		  "text-rotation-alignment": "viewport",
-		  "icon-text-fit": "both",
-		  "icon-size": 0
-		 },
-		 "paint": {
-		  "text-color": "#F0F0F0",
-		  "icon-color": "#646464",
-		  "text-halo-color": "rgba(80, 80, 80, 0.5)",
-		  "text-halo-width": 5
-		 }
-		},
-		{
-		 "id": "toponyme - odonyme abrégé",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_routier_odonyme_lin",
-		 "minzoom": 15,
-		 "maxzoom": 22,
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{nom_gauche}",
-		  "text-size": 10,
-		  "text-anchor": "center",
-		  "text-max-angle": 30,
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ],
-		  "visibility": "none"
-		 },
-		 "paint": {
-		  "text-color": "#000000",
-		  "text-halo-width": 2,
-		  "text-halo-color": "rgba(255, 255, 255, 1)"
-		 }
-		},
-		{
-		 "id": "toponyme - odonyme desabrégé",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_routier_odonyme_lin",
-		 "minzoom": 17,
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{nom_desabrege}",
-		  "text-size": 11,
-		  "text-anchor": "center",
-		  "text-max-angle": 30,
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ],
-		  "visibility": "none"
-		 },
-		 "paint": {
-		  "text-color": "#000000",
-		  "text-halo-width": 2,
-		  "text-halo-color": "rgba(255, 255, 255, 1)"
-		 }
-		},
-		{
-		 "id": "toponyme - lieu dit non habité 3",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_ocs_ponc",
-		 "filter": [
-		  "all",
-		  [
-		   "==",
-		   "symbo",
-		   "LIEU-DIT_NON_HABITE"
-		  ],
-		  [
-		   "in",
-		   "txt_typo",
-		   "TYPO_B_10",
-		   "TYPO_B_11"
-		  ]
-		 ],
-		 "layout": {
-		  "visibility": "none",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 11,
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Source Sans Pro Italic"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#000000",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 1
-		 }
-		},
-		{
-		 "id": "toponyme - bois",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_ocs_ponc",
-		 "filter": [
-		  "all",
-		  [
-		   "==",
-		   "symbo",
-		   "BOIS"
-		  ],
-		  [
-		   "in",
-		   "txt_typo",
-		   "TYPO_F_10",
-		   "TYPO_F_11"
-		  ]
-		 ],
-		 "layout": {
-		  "visibility": "none",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 13,
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Source Sans Pro Italic"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#287B00",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 1
-		 }
-		},
-		{
-		 "id": "toponyme - oro lineaire 4",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_oro_lin",
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "ORO_SOMMET_3",
-		  "ORO_GORGE_2"
-		 ],
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{texte}",
-		  "text-size": 11,
-		  "text-anchor": "center",
-		  "text-keep-upright": true,
-		  "text-max-angle": 45,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Source Sans Pro Italic"
-		  ],
-		  "visibility": "visible"
-		 },
-		 "paint": {
-		  "text-color": "#863831",
-		  "text-halo-width": 1.5,
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)"
-		 }
-		},
-		{
-		 "id": "toponyme - oro ponc 4",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_oro_ponc",
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "ORO_SOMMET_3",
-		  "ORO_GORGE_2",
-		  "GROTTE",
-		  "GORGE",
-		  "TYPO_G_9",
-		  "TYPO_G_10"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 13,
-			 11
-			],
-			[
-			 16,
-			 16
-			]
-		   ]
-		  },
-		  "text-allow-overlap": true,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Source Sans Pro Italic"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#863831",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 1.5
-		 }
-		},
-		{
-		 "id": "toponyme - hydro ponc 4",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_hydro_ponc",
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "lac - étang - bassin",
-		  "HYD_SURF_4",
-		  "HYD_SURF_4_T",
-		  "HYD_SURF_5",
-		  "HYD_SURF_5_T",
-		  "TYPO_D_8",
-		  "SOURCE"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 14,
-			 13
-			],
-			[
-			 17,
-			 16
-			]
-		   ]
-		  },
-		  "text-allow-overlap": true,
-		  "text-padding": 5,
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#447FB3",
-		  "text-halo-color": "#FFFFFF",
-		  "text-halo-width": 1
-		 }
-		},
-		{
-		 "id": "toponyme - lieu dit non habité",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_ocs_ponc",
-		 "filter": [
-		  "all",
-		  [
-		   "==",
-		   "symbo",
-		   "LIEU-DIT_NON_HABITE"
-		  ],
-		  [
-		   "in",
-		   "txt_typo",
-		   "TYPO_B_7",
-		   "TYPO_B_8",
-		   "TYPO_B_9"
-		  ]
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 12,
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Source Sans Pro Italic"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#000000",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 1
-		 }
-		},
-		{
-		 "id": "toponyme - bois 2",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_ocs_ponc",
-		 "filter": [
-		  "all",
-		  [
-		   "==",
-		   "symbo",
-		   "BOIS"
-		  ],
-		  [
-		   "in",
-		   "txt_typo",
-		   "TYPO_F_7",
-		   "TYPO_F_8",
-		   "TYPO_F_9"
-		  ]
-		 ],
-		 "layout": {
-		  "visibility": "none",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 16,
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Source Sans Pro Italic"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#287B00",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme localite importance 5",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_localite_ponc",
-		 "minzoom": 9,
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "commune 5",
-		  "BAT_COMMUNE_5",
-		  "BAT_COMMUNE_5_T",
-		  "BAT_CHEF_LIEU_COM",
-		  "BAT_CHEF_LIEU_COM_T",
-		  "BAT_CHEF_LIEU_COM-T",
-		  "BAT_ANCIENNE_COM",
-		  "BAT_ANCIENNE_COM_T",
-		  "BAT_COMMUNE_ASSOCIEE",
-		  "BAT_COMMUNE_ASSOCIEE_T",
-		  "Commune très petite"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "icon-image": "Localite",
-		  "icon-size": 0.21,
-		  "text-field": "{texte}",
-		  "text-size": 11.5,
-		  "text-allow-overlap": false,
-		  "text-anchor": "bottom-left",
-		  "text-offset": [
-		   0.3,
-		   0.1
-		  ],
-		  "text-padding": 1,
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#000000",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme - ocs lineaire 3",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_ocs_lin",
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "OCS_FORET_3"
-		 ],
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 10,
-			 12
-			],
-			[
-			 12,
-			 15
-			]
-		   ]
-		  },
-		  "text-anchor": "center",
-		  "text-keep-upright": true,
-		  "text-max-angle": 45,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Source Sans Pro Italic"
-		  ],
-		  "visibility": "visible"
-		 },
-		 "paint": {
-		  "text-color": "#287B00",
-		  "text-halo-width": 1,
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)"
-		 }
-		},
-		{
-		 "id": "toponyme - lieu dit non habité 1",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_ocs_ponc",
-		 "filter": [
-		  "all",
-		  [
-		   "==",
-		   "symbo",
-		   "LIEU-DIT_NON_HABITE"
-		  ],
-		  [
-		   "in",
-		   "txt_typo",
-		   "TYPO_B_5",
-		   "TYPO_B_4"
-		  ]
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 15,
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Source Sans Pro Italic"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#000000",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 1
-		 }
-		},
-		{
-		 "id": "toponyme - bois 1",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_ocs_ponc",
-		 "filter": [
-		  "all",
-		  [
-		   "==",
-		   "symbo",
-		   "BOIS"
-		  ],
-		  [
-		   "in",
-		   "txt_typo",
-		   "TYPO_F_5",
-		   "TYPO_F_4"
-		  ]
-		 ],
-		 "layout": {
-		  "visibility": "none",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 19,
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Source Sans Pro Italic"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#287B00",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme - bois 0",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_ocs_ponc",
-		 "filter": [
-		  "all",
-		  [
-		   "==",
-		   "symbo",
-		   "BOIS"
-		  ],
-		  [
-		   "in",
-		   "txt_typo",
-		   "TYPO_F_3",
-		   "TYPO_F_2"
-		  ]
-		 ],
-		 "layout": {
-		  "visibility": "none",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 22,
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Source Sans Pro Italic"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#287B00",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme - ocs ponc 3",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_ocs_ponc",
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "OCS_FORET_3"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 10,
-			 12
-			],
-			[
-			 12,
-			 15
-			]
-		   ]
-		  },
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-anchor": "center",
-		  "text-font": [
-		   "Source Sans Pro Italic"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#287B00",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 1
-		 }
-		},
-		{
-		 "id": "toponyme - oro lineaire 3",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_oro_lin",
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "ORO_ILE_3",
-		  "ORO_RELIEF_3",
-		  "ORO_RELIEF_3_T",
-		  "ORO_RELIEF_4",
-		  "ORO_RELIEF_4_T",
-		  "ORO_CAP_2",
-		  "ORO_CAP_3",
-		  "ORO_SOMMET_2",
-		  "ORO_COL_2",
-		  "ORO_GORGE_1",
-		  "ORO_GORGE-1"
-		 ],
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{texte}",
-		  "text-size": 12,
-		  "text-anchor": "center",
-		  "text-keep-upright": true,
-		  "text-max-angle": 45,
-		  "text-padding": 10,
-		  "text-font": [
-		   "Source Sans Pro Italic"
-		  ],
-		  "visibility": "visible"
-		 },
-		 "paint": {
-		  "text-color": "#863831",
-		  "text-halo-width": 1.5,
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)"
-		 }
-		},
-		{
-		 "id": "toponyme - oro ponc 3",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_oro_ponc",
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "ORO_ILE_3",
-		  "ORO_RELIEF_3",
-		  "ORO_RELIEF_3_T",
-		  "ORO_RELIEF_4",
-		  "ORO_RELIEF_4_T",
-		  "ORO_CAP_2",
-		  "ORO_CAP_3",
-		  "ORO_SOMMET_2",
-		  "ORO_COL_2",
-		  "ORO_GORGE_1",
-		  "ORO_GORGE-1",
-		  "TYPO_G_7",
-		  "TYPO_G_8"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 13,
-			 12
-			],
-			[
-			 16,
-			 17
-			]
-		   ]
-		  },
-		  "text-allow-overlap": true,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Source Sans Pro Italic"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#863831",
-		  "text-halo-color": "#FFFFFF",
-		  "text-halo-width": 1.5
-		 }
-		},
-		{
-		 "id": "toponyme - hydro lineaire 3",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_hydro_lin",
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "HYD_LIN_3",
-		  "HYD_LIN_4",
-		  "HYD_LIN_5",
-		  "petite rivière",
-		  "canal",
-		  "HYD_SURF_3",
-		  "HYD_SURF_3_T",
-		  "HYD_SURF_4",
-		  "HYD_SURF_4_T",
-		  "HYD_SURF_5",
-		  "HYD_SURF_5_T",
-		  "TYPO_D_5"
-		 ],
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 14,
-			 12
-			],
-			[
-			 18,
-			 19
-			]
-		   ]
-		  },
-		  "text-anchor": "center",
-		  "text-keep-upright": true,
-		  "text-max-angle": 45,
-		  "text-padding": 10,
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ],
-		  "visibility": "visible"
-		 },
-		 "paint": {
-		  "text-color": "#447FB3",
-		  "text-halo-width": 1.5,
-		  "text-halo-color": "rgba(255, 255, 255, 0.7)"
-		 }
-		},
-		{
-		 "id": "toponyme - hydro lineaire 4",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_hydro_lin",
-		 "minzoom": 14,
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "TYPO_D_6",
-		  "TYPO_D_8",
-		  "TYPO_D_9",
-		  "TYPO_D_10"
-		 ],
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 14,
-			 10
-			],
-			[
-			 18,
-			 16
-			]
-		   ]
-		  },
-		  "text-anchor": "center",
-		  "text-keep-upright": true,
-		  "text-max-angle": 45,
-		  "text-padding": 10,
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ],
-		  "visibility": "visible"
-		 },
-		 "paint": {
-		  "text-color": "#447FB3",
-		  "text-halo-width": 1.5,
-		  "text-halo-color": "rgba(255, 255, 255, 0.7)"
-		 }
-		},
-		{
-		 "id": "toponyme - hydro ponc 3",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_hydro_ponc",
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "petit golfe",
-		  "grande baie",
-		  "baie",
-		  "HYD_SURF_3",
-		  "TYPO_D_5",
-		  "TYPO_D_6",
-		  "TYPO_D_7"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 15,
-			 15
-			],
-			[
-			 17,
-			 18
-			]
-		   ]
-		  },
-		  "text-allow-overlap": true,
-		  "text-padding": 10,
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#447FB3",
-		  "text-halo-color": "#FFFFFF",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme bati ponc zai zoom 16",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_bati_ponc",
-		 "minzoom": 15,
-		 "maxzoom": 21,
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "zai"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{designation}",
-		  "text-size": 11,
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Source Sans Pro Italic"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#000000"
-		 }
-		},
-		{
-		 "id": "toponyme bati ponc zai zoom 17 et 18",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_bati_ponc",
-		 "minzoom": 16,
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "zai"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 11,
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Source Sans Pro Italic"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#000000"
-		 }
-		},
-		{
-		 "id": "toponyme localite importance 4",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_localite_ponc",
-		 "minzoom": 7,
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "commune 4",
-		  "BAT_COMMUNE_4",
-		  "BAT_COMMUNE_4_T"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "icon-image": "Localite",
-		  "icon-size": 0.21,
-		  "text-field": "{texte}",
-		  "text-size": 13,
-		  "text-allow-overlap": false,
-		  "text-anchor": "bottom-left",
-		  "text-offset": [
-		   0.3,
-		   0.1
-		  ],
-		  "text-padding": 1,
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#000000",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme - limite militaire ponc 1 et 2",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_limite_ponc",
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "LIM_MILI_1",
-		  "LIM_MILI_2"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 15,
-		  "text-allow-overlap": false,
-		  "text-padding": 5,
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#0D2000",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme - limite parc marin",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_limite_ponc",
-		 "minzoom": 8,
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "LIM_PARC_NATUREL_MARIN"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 15,
-		  "text-allow-overlap": false,
-		  "text-padding": 10,
-		  "text-transform": "uppercase",
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#2A81A2",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme - limite parc ponc 1 et 2",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_limite_ponc",
-		 "minzoom": 8,
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "LIM_PARC_1",
-		  "LIM_PARC_2",
-		  "LIM_PARC_NATUREL"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 15,
-		  "text-allow-overlap": false,
-		  "text-padding": 10,
-		  "text-transform": "uppercase",
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#287B00",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme - ocs lineaire 2",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_ocs_lin",
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "OCS_FORET_2"
-		 ],
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 10,
-			 15
-			],
-			[
-			 12,
-			 18
-			]
-		   ]
-		  },
-		  "text-anchor": "center",
-		  "text-keep-upright": true,
-		  "text-max-angle": 45,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ],
-		  "visibility": "visible"
-		 },
-		 "paint": {
-		  "text-color": "#287B00",
-		  "text-halo-width": 2,
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)"
-		 }
-		},
-		{
-		 "id": "toponyme - ocs ponc 2",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_ocs_ponc",
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "OCS_FORET_2"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 10,
-			 15
-			],
-			[
-			 12,
-			 18
-			]
-		   ]
-		  },
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-anchor": "center",
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#287B00",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme - oro lineaire 2",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_oro_lin",
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "ORO_ILE_2",
-		  "ORO_RELIEF_2",
-		  "ORO_RELIEF_2_T",
-		  "ORO_CAP_1",
-		  "ORO_SOMMET_1"
-		 ],
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{texte}",
-		  "text-size": 15,
-		  "text-anchor": "center",
-		  "text-keep-upright": true,
-		  "text-padding": 10,
-		  "text-max-angle": 45,
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ],
-		  "visibility": "visible"
-		 },
-		 "paint": {
-		  "text-color": "#863831",
-		  "text-halo-width": 2,
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)"
-		 }
-		},
-		{
-		 "id": "toponyme - oro ponc 2",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_oro_ponc",
-		 "minzoom": 9,
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "ORO_ILE_2",
-		  "ORO_RELIEF_2",
-		  "ORO_RELIEF_2_T",
-		  "ORO_CAP_1",
-		  "ORO_COL_1",
-		  "sommet ou col",
-		  "ORO_SOMMET_1",
-		  "TYPO_G_4",
-		  "TYPO_G_6"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 9,
-			 13
-			],
-			[
-			 10,
-			 15
-			],
-			[
-			 13,
-			 15
-			],
-			[
-			 16,
-			 19
-			]
-		   ]
-		  },
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#863831",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme - oro ponc 2B",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_oro_ponc",
-		 "minzoom": 8,
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "île",
-		  "cap ou pointe"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 15,
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#863831",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme - hydro lineaire 2",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_hydro_lin",
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "HYD_LIN_2",
-		  "rivière moyenne",
-		  "HYD_SURF_2",
-		  "HYD_SURF_2_T",
-		  "TYPO_D_3"
-		 ],
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 14,
-			 15
-			],
-			[
-			 18,
-			 21
-			]
-		   ]
-		  },
-		  "text-anchor": "center",
-		  "text-keep-upright": true,
-		  "text-max-angle": 45,
-		  "text-padding": 10,
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ],
-		  "visibility": "visible"
-		 },
-		 "paint": {
-		  "text-color": "#447FB3",
-		  "text-halo-width": 2,
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)"
-		 }
-		},
-		{
-		 "id": "toponyme - hydro ponc 2",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_hydro_ponc",
-		 "minzoom": 5,
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "moyen",
-		  "golfe moyen",
-		  "HYD_SURF_2",
-		  "TYPO_D_2",
-		  "TYPO_D_3",
-		  "TYPO_D_4"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 5,
-			 12
-			],
-			[
-			 6,
-			 18
-			],
-			[
-			 10,
-			 17
-			],
-			[
-			 18,
-			 21
-			]
-		   ]
-		  },
-		  "text-allow-overlap": false,
-		  "text-padding": 10,
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#447FB3",
-		  "text-halo-color": "#FFFFFF",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme localite importance 3",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_localite_ponc",
-		 "minzoom": 5,
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "commune 3",
-		  "BAT_COMMUNE_3",
-		  "BAT_COMMUNE_3_T"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "icon-image": "Localite",
-		  "icon-size": 0.21,
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 5,
-			 10
-			],
-			[
-			 6,
-			 15
-			]
-		   ]
-		  },
-		  "text-allow-overlap": false,
-		  "text-anchor": "bottom-left",
-		  "text-offset": [
-		   0.3,
-		   0.1
-		  ],
-		  "text-padding": 1,
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#000000",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme localite n0 typoA7 non commune",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_localite_ponc",
-		 "maxzoom": 21,
-		 "filter": [
-		  "all",
-		  [
-		   "!=",
-		   "symbo",
-		   "COMMUNE_FUSIONNEE"
-		  ],
-		  [
-		   "!=",
-		   "symbo",
-		   "COMMUNE_CHEF_LIEU"
-		  ],
-		  [
-		   "==",
-		   "txt_typo",
-		   "TYPO_A_7"
-		  ]
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 15,
-			 13
-			],
-			[
-			 17,
-			 16
-			]
-		   ]
-		  },
-		  "text-allow-overlap": true,
-		  "text-anchor": "center",
-		  "text-padding": 1,
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#000000",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme localite n0 typoA6 non commune",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_localite_ponc",
-		 "maxzoom": 21,
-		 "filter": [
-		  "all",
-		  [
-		   "!=",
-		   "symbo",
-		   "COMMUNE_FUSIONNEE"
-		  ],
-		  [
-		   "!=",
-		   "symbo",
-		   "COMMUNE_CHEF_LIEU"
-		  ],
-		  [
-		   "==",
-		   "txt_typo",
-		   "TYPO_A_6"
-		  ]
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 15,
-			 15
-			],
-			[
-			 17,
-			 18
-			]
-		   ]
-		  },
-		  "text-allow-overlap": true,
-		  "text-anchor": "center",
-		  "text-padding": 1,
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#000000",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme - oro lineaire 1",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_oro_lin",
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "ORO_ILE_1",
-		  "ORO_RELIEF_1",
-		  "ORO_RELIEF_1_T"
-		 ],
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{texte}",
-		  "text-size": 20,
-		  "text-anchor": "center",
-		  "text-keep-upright": true,
-		  "text-padding": 5,
-		  "text-max-angle": 45,
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ],
-		  "visibility": "visible"
-		 },
-		 "paint": {
-		  "text-color": "#863831",
-		  "text-halo-width": 2,
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)"
-		 }
-		},
-		{
-		 "id": "toponyme - oro ponc monde",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_oro_ponc",
-		 "minzoom": 5,
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "Basin",
-		  "Depression",
-		  "Desert",
-		  "Geoarea",
-		  "Gorge",
-		  "Isthmus",
-		  "Lake",
-		  "Lowland",
-		  "Pen/cape",
-		  "Plain",
-		  "Plateau",
-		  "Range/mtn",
-		  "Tundra",
-		  "Valley",
-		  "Island",
-		  "Island group"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 11,
-		  "text-allow-overlap": false,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Source Sans Pro Italic"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#863831",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme localite n0 typoA4 non commune",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_localite_ponc",
-		 "maxzoom": 21,
-		 "filter": [
-		  "all",
-		  [
-		   "!=",
-		   "symbo",
-		   "COMMUNE_FUSIONNEE"
-		  ],
-		  [
-		   "!=",
-		   "symbo",
-		   "COMMUNE_CHEF_LIEU"
-		  ],
-		  [
-		   "==",
-		   "txt_typo",
-		   "TYPO_A_4"
-		  ]
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 17,
-		  "text-allow-overlap": true,
-		  "text-anchor": "center",
-		  "text-padding": 1,
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#000000",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 3
-		 }
-		},
-		{
-		 "id": "toponyme - ocs lineaire 1",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_ocs_lin",
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "OCS_FORET_1"
-		 ],
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 10,
-			 18
-			],
-			[
-			 12,
-			 22
-			]
-		   ]
-		  },
-		  "text-anchor": "center",
-		  "text-keep-upright": true,
-		  "text-padding": 1,
-		  "text-max-angle": 45,
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ],
-		  "visibility": "visible"
-		 },
-		 "paint": {
-		  "text-color": "#287B00",
-		  "text-halo-width": 2,
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)"
-		 }
-		},
-		{
-		 "id": "toponyme - ocs ponc 1",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_ocs_ponc",
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "OCS_FORET_1"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 10,
-			 18
-			],
-			[
-			 12,
-			 22
-			]
-		   ]
-		  },
-		  "text-allow-overlap": true,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#287B00",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme - oro ponc 1",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_oro_ponc",
-		 "minzoom": 8,
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "grande île",
-		  "ORO_ILE_1",
-		  "ORO_RELIEF_1",
-		  "ORO_RELIEF_1_T",
-		  "TYPO_G_3",
-		  "TYPO_G_2",
-		  "TYPO_G_1"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 21,
-		  "text-allow-overlap": true,
-		  "text-padding": 1,
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#863831",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme - hydro lineaire glacier",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_hydro_lin",
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "ORO_GLACIER_1",
-		  "ORO_GLACIER_2"
-		 ],
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{texte}",
-		  "text-size": 15,
-		  "text-anchor": "center",
-		  "text-keep-upright": true,
-		  "text-max-angle": 45,
-		  "text-font": [
-		   "Source Sans Pro Italic"
-		  ],
-		  "visibility": "visible"
-		 },
-		 "paint": {
-		  "text-color": "#447FB3",
-		  "text-halo-width": 2,
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)"
-		 }
-		},
-		{
-		 "id": "toponyme - hydro lineaire 1",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_hydro_lin",
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "HYD_LIN_1",
-		  "HYD-LIN-1",
-		  "grande rivière",
-		  "HYD_SURF_1",
-		  "HYD_SURF_1_T",
-		  "TYPO_D_1",
-		  "TYPO_D_2"
-		 ],
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{texte}",
-		  "text-size": 18,
-		  "text-anchor": "center",
-		  "text-keep-upright": true,
-		  "text-max-angle": 45,
-		  "text-padding": 10,
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ],
-		  "visibility": "visible"
-		 },
-		 "paint": {
-		  "text-color": "#447FB3",
-		  "text-halo-width": 2,
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)"
-		 }
-		},
-		{
-		 "id": "toponyme - hydro lineaire ocean",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_hydro_lin",
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "mer et océan"
-		 ],
-		 "layout": {
-		  "symbol-placement": "line",
-		  "text-field": "{texte}",
-		  "text-size": 30,
-		  "text-anchor": "center",
-		  "text-keep-upright": true,
-		  "text-max-angle": 45,
-		  "text-padding": 10,
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ],
-		  "visibility": "visible"
-		 },
-		 "paint": {
-		  "text-color": "#447FB3",
-		  "text-halo-width": 4,
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)"
-		 }
-		},
-		{
-		 "id": "toponyme - hydro ponc 1",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_hydro_ponc",
-		 "minzoom": 4,
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "mer",
-		  "grand",
-		  "grand golfe",
-		  "HYD_SURF_1",
-		  "TYPO_D_1"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 4,
-			 16
-			],
-			[
-			 6,
-			 30
-			],
-			[
-			 10,
-			 25
-			]
-		   ]
-		  },
-		  "text-allow-overlap": true,
-		  "text-padding": 10,
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#447FB3",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 4
-		 }
-		},
-		{
-		 "id": "toponyme localite importance 2",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_localite_ponc",
-		 "minzoom": 4,
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "commune 2",
-		  "BAT_COMMUNE_2",
-		  "BAT_COMMUNE-2",
-		  "BAT_COMMUNE_2_T"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "icon-image": "Localite",
-		  "icon-size": 0.25,
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 4,
-			 10
-			],
-			[
-			 6,
-			 17
-			]
-		   ]
-		  },
-		  "text-allow-overlap": true,
-		  "text-anchor": "bottom-left",
-		  "text-offset": [
-		   0.3,
-		   0.2
-		  ],
-		  "text-padding": 1,
-		  "text-transform": "uppercase",
-		  "text-font": {
-		   "stops": [
-			[
-			 1,
-			 [
-			  "Source Sans Pro Regular"
-			 ]
-			],
-			[
-			 7,
-			 [
-			  "Source Sans Pro Bold"
-			 ]
-			],
-			[
-			 10,
-			 [
-			  "Source Sans Pro Regular"
-			 ]
-			]
-		   ]
-		  }
-		 },
-		 "paint": {
-		  "text-color": "#000000",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 3
-		 }
-		},
-		{
-		 "id": "toponyme localite n0 typoA3 non commune",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_localite_ponc",
-		 "maxzoom": 21,
-		 "filter": [
-		  "all",
-		  [
-		   "!=",
-		   "symbo",
-		   "COMMUNE_FUSIONNEE"
-		  ],
-		  [
-		   "!=",
-		   "symbo",
-		   "COMMUNE_CHEF_LIEU"
-		  ],
-		  [
-		   "==",
-		   "txt_typo",
-		   "TYPO_A_3"
-		  ]
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 19,
-		  "text-allow-overlap": true,
-		  "text-anchor": "center",
-		  "text-padding": 1,
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#000000",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 3
-		 }
-		},
-		{
-		 "id": "toponyme localite n0 typoA2 non commune",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_localite_ponc",
-		 "maxzoom": 21,
-		 "filter": [
-		  "all",
-		  [
-		   "!=",
-		   "symbo",
-		   "COMMUNE_FUSIONNEE"
-		  ],
-		  [
-		   "!=",
-		   "symbo",
-		   "COMMUNE_CHEF_LIEU"
-		  ],
-		  [
-		   "==",
-		   "txt_typo",
-		   "TYPO_A_2"
-		  ]
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 21,
-		  "text-allow-overlap": true,
-		  "text-anchor": "center",
-		  "text-padding": 1,
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#000000",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 4
-		 }
-		},
-		{
-		 "id": "toponyme localite n0 typoA7 commune",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_localite_ponc",
-		 "maxzoom": 21,
-		 "filter": [
-		  "all",
-		  [
-		   "in",
-		   "symbo",
-		   "COMMUNE_FUSIONNEE",
-		   "COMMUNE_CHEF_LIEU"
-		  ],
-		  [
-		   "==",
-		   "txt_typo",
-		   "TYPO_A_7"
-		  ]
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 15,
-			 13
-			],
-			[
-			 17,
-			 16
-			]
-		   ]
-		  },
-		  "text-allow-overlap": true,
-		  "text-anchor": "center",
-		  "text-padding": 1,
-		  "text-transform": "uppercase",
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#000000",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme localite n0 typoA6 commune",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_localite_ponc",
-		 "maxzoom": 21,
-		 "filter": [
-		  "all",
-		  [
-		   "in",
-		   "symbo",
-		   "COMMUNE_FUSIONNEE",
-		   "COMMUNE_CHEF_LIEU"
-		  ],
-		  [
-		   "==",
-		   "txt_typo",
-		   "TYPO_A_6"
-		  ]
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 15,
-			 15
-			],
-			[
-			 17,
-			 18
-			]
-		   ]
-		  },
-		  "text-allow-overlap": true,
-		  "text-anchor": "center",
-		  "text-padding": 1,
-		  "text-transform": "uppercase",
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#000000",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 2
-		 }
-		},
-		{
-		 "id": "toponyme localite n0 typoA1 non commune",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_localite_ponc",
-		 "maxzoom": 21,
-		 "filter": [
-		  "all",
-		  [
-		   "!=",
-		   "symbo",
-		   "COMMUNE_FUSIONNEE"
-		  ],
-		  [
-		   "!=",
-		   "symbo",
-		   "COMMUNE_CHEF_LIEU"
-		  ],
-		  [
-		   "==",
-		   "txt_typo",
-		   "TYPO_A_1"
-		  ]
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 23,
-		  "text-allow-overlap": true,
-		  "text-anchor": "center",
-		  "text-padding": 1,
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#000000",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 4
-		 }
-		},
-		{
-		 "id": "toponyme localite n0 typoA4 commune",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_localite_ponc",
-		 "maxzoom": 21,
-		 "filter": [
-		  "all",
-		  [
-		   "in",
-		   "symbo",
-		   "COMMUNE_FUSIONNEE",
-		   "COMMUNE_CHEF_LIEU"
-		  ],
-		  [
-		   "==",
-		   "txt_typo",
-		   "TYPO_A_4"
-		  ]
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 17,
-		  "text-allow-overlap": true,
-		  "text-anchor": "center",
-		  "text-padding": 1,
-		  "text-transform": "uppercase",
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#000000",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 3
-		 }
-		},
-		{
-		 "id": "toponyme localite n0 typoA3 commune",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_localite_ponc",
-		 "maxzoom": 21,
-		 "filter": [
-		  "all",
-		  [
-		   "in",
-		   "symbo",
-		   "COMMUNE_FUSIONNEE",
-		   "COMMUNE_CHEF_LIEU"
-		  ],
-		  [
-		   "==",
-		   "txt_typo",
-		   "TYPO_A_3"
-		  ]
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 19,
-		  "text-allow-overlap": true,
-		  "text-anchor": "center",
-		  "text-padding": 1,
-		  "text-transform": "uppercase",
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#000000",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 3
-		 }
-		},
-		{
-		 "id": "toponyme localite n0 typoA2 commune",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_localite_ponc",
-		 "maxzoom": 21,
-		 "filter": [
-		  "all",
-		  [
-		   "in",
-		   "symbo",
-		   "COMMUNE_FUSIONNEE",
-		   "COMMUNE_CHEF_LIEU"
-		  ],
-		  [
-		   "==",
-		   "txt_typo",
-		   "TYPO_A_2"
-		  ]
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 21,
-		  "text-allow-overlap": true,
-		  "text-anchor": "center",
-		  "text-padding": 1,
-		  "text-transform": "uppercase",
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#000000",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 4
-		 }
-		},
-		{
-		 "id": "toponyme localite importance 1",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_localite_ponc",
-		 "minzoom": 3,
-		 "filter": [
-		  "in",
-		  "txt_typo",
-		  "commune 1",
-		  "BAT_COMMUNE_1",
-		  "BAT_COMMUNE_1_T"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "icon-image": "Localite",
-		  "icon-size": 0.3,
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 3,
-			 10
-			],
-			[
-			 6,
-			 20
-			]
-		   ]
-		  },
-		  "text-allow-overlap": false,
-		  "text-anchor": "bottom-left",
-		  "text-offset": [
-		   0.25,
-		   -0.1
-		  ],
-		  "text-padding": 1,
-		  "text-transform": "uppercase",
-		  "text-font": {
-		   "stops": [
-			[
-			 1,
-			 [
-			  "Source Sans Pro Regular"
-			 ]
-			],
-			[
-			 7,
-			 [
-			  "Source Sans Pro Bold"
-			 ]
-			],
-			[
-			 10,
-			 [
-			  "Source Sans Pro Regular"
-			 ]
-			]
-		   ]
-		  }
-		 },
-		 "paint": {
-		  "text-color": "#000000",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 4
-		 }
-		},
-		{
-		 "id": "toponyme localite n0 typoA1 commune",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_localite_ponc",
-		 "maxzoom": 21,
-		 "filter": [
-		  "all",
-		  [
-		   "in",
-		   "symbo",
-		   "COMMUNE_FUSIONNEE",
-		   "COMMUNE_CHEF_LIEU"
-		  ],
-		  [
-		   "==",
-		   "txt_typo",
-		   "TYPO_A_1"
-		  ]
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": 23,
-		  "text-allow-overlap": true,
-		  "text-anchor": "center",
-		  "text-padding": 1,
-		  "text-transform": "uppercase",
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#000000",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 4
-		 }
-		},
-		{
-		 "id": "toponyme - hydro ponc ocean",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_hydro_ponc",
-		 "minzoom": 1,
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "ocean"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "symbol-placement": "point",
-		  "text-field": "{texte}",
-		  "text-size": {
-		   "stops": [
-			[
-			 1,
-			 16
-			],
-			[
-			 6,
-			 30
-			]
-		   ]
-		  },
-		  "text-allow-overlap": true,
-		  "text-anchor": "center",
-		  "text-padding": 10,
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#447FB3",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 4
-		 }
-		},
-		{
-		 "id": "toponyme pays 3",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_localite_ponc",
-		 "minzoom": 4,
-		 "maxzoom": 5,
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "pays 3"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "text-field": "{texte}",
-		  "text-size": 9,
-		  "text-allow-overlap": true,
-		  "text-anchor": "center",
-		  "text-padding": 1,
-		  "text-transform": "uppercase",
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#787878",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 4
-		 }
-		},
-		{
-		 "id": "toponyme pays 2",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_localite_ponc",
-		 "minzoom": 2,
-		 "maxzoom": 5,
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "pays 2"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "text-field": "{texte}",
-		  "text-size": 13,
-		  "text-allow-overlap": true,
-		  "text-anchor": "center",
-		  "text-padding": 2,
-		  "text-transform": "uppercase",
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#787878",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 4
-		 }
-		},
-		{
-		 "id": "toponyme pays 1",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_localite_ponc",
-		 "minzoom": 2,
-		 "maxzoom": 5,
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "pays 1"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "text-field": "{texte}",
-		  "text-size": 13,
-		  "text-allow-overlap": true,
-		  "text-anchor": "center",
-		  "text-padding": 2,
-		  "text-transform": "uppercase",
-		  "text-font": [
-		   "Source Sans Pro Regular"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#787878",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 4
-		 }
-		},
-		{
-		 "id": "toponyme continent",
-		 "type": "symbol",
-		 "source": "plan_ign",
-		 "source-layer": "toponyme_localite_ponc",
-		 "maxzoom": 3,
-		 "filter": [
-		  "==",
-		  "txt_typo",
-		  "continent"
-		 ],
-		 "layout": {
-		  "visibility": "visible",
-		  "text-field": "{texte}",
-		  "text-size": 15,
-		  "text-allow-overlap": true,
-		  "text-anchor": "center",
-		  "text-padding": 1,
-		  "text-transform": "uppercase",
-		  "text-font": [
-		   "Source Sans Pro Bold"
-		  ]
-		 },
-		 "paint": {
-		  "text-color": "#787878",
-		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
-		  "text-halo-width": 4
-		 }
+	  {
+		"id": "background",
+		"type": "background",
+		"paint": {
+		  "background-color": "#f8f4f0"
 		}
-	   ]
+	  },
+	  {
+		"filter": [
+		  "==",
+		  "subclass",
+		  "glacier"
+		],
+		"id": "landcover-glacier",
+		"layout": {
+		  "visibility": "visible"
+		},
+		"metadata": {
+		  "mapbox:group": "1444849388993.3071"
+		},
+		"paint": {
+		  "fill-color": "#fff",
+		  "fill-opacity": {
+			"base": 1,
+			"stops": [
+			  [
+				0,
+				0.9
+			  ],
+			  [
+				10,
+				0.3
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "landcover",
+		"type": "fill"
+	  },
+	  {
+		"filter": [
+		  "==",
+		  "class",
+		  "residential"
+		],
+		"id": "landuse-residential",
+		"metadata": {
+		  "mapbox:group": "1444849388993.3071"
+		},
+		"paint": {
+		  "fill-color": {
+			"base": 1,
+			"stops": [
+			  [
+				12,
+				"hsla(30, 19%, 90%, 0.4)"
+			  ],
+			  [
+				16,
+				"hsla(30, 19%, 90%, 0.2)"
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "landuse",
+		"type": "fill"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"$type",
+			"Polygon"
+		  ],
+		  [
+			"==",
+			"class",
+			"commercial"
+		  ]
+		],
+		"id": "landuse-commercial",
+		"metadata": {
+		  "mapbox:group": "1444849388993.3071"
+		},
+		"paint": {
+		  "fill-color": "hsla(0, 60%, 87%, 0.23)"
+		},
+		"source": "openmaptiles",
+		"source-layer": "landuse",
+		"type": "fill"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"$type",
+			"Polygon"
+		  ],
+		  [
+			"==",
+			"class",
+			"industrial"
+		  ]
+		],
+		"id": "landuse-industrial",
+		"metadata": {
+		  "mapbox:group": "1444849388993.3071"
+		},
+		"paint": {
+		  "fill-color": "hsla(49, 100%, 88%, 0.34)"
+		},
+		"source": "openmaptiles",
+		"source-layer": "landuse",
+		"type": "fill"
+	  },
+	  {
+		"filter": [
+		  "==",
+		  "class",
+		  "cemetery"
+		],
+		"id": "landuse-cemetery",
+		"metadata": {
+		  "mapbox:group": "1444849388993.3071"
+		},
+		"paint": {
+		  "fill-color": "#e0e4dd"
+		},
+		"source": "openmaptiles",
+		"source-layer": "landuse",
+		"type": "fill"
+	  },
+	  {
+		"filter": [
+		  "==",
+		  "class",
+		  "hospital"
+		],
+		"id": "landuse-hospital",
+		"metadata": {
+		  "mapbox:group": "1444849388993.3071"
+		},
+		"paint": {
+		  "fill-color": "#fde"
+		},
+		"source": "openmaptiles",
+		"source-layer": "landuse",
+		"type": "fill"
+	  },
+	  {
+		"filter": [
+		  "==",
+		  "class",
+		  "school"
+		],
+		"id": "landuse-school",
+		"metadata": {
+		  "mapbox:group": "1444849388993.3071"
+		},
+		"paint": {
+		  "fill-color": "#f0e8f8"
+		},
+		"source": "openmaptiles",
+		"source-layer": "landuse",
+		"type": "fill"
+	  },
+	  {
+		"filter": [
+		  "==",
+		  "class",
+		  "railway"
+		],
+		"id": "landuse-railway",
+		"metadata": {
+		  "mapbox:group": "1444849388993.3071"
+		},
+		"paint": {
+		  "fill-color": "hsla(30, 19%, 90%, 0.4)"
+		},
+		"source": "openmaptiles",
+		"source-layer": "landuse",
+		"type": "fill"
+	  },
+	  {
+		"filter": [
+		  "==",
+		  "class",
+		  "wood"
+		],
+		"id": "landcover-wood",
+		"metadata": {
+		  "mapbox:group": "1444849388993.3071"
+		},
+		"paint": {
+		  "fill-antialias": {
+			"base": 1,
+			"stops": [
+			  [
+				0,
+				false
+			  ],
+			  [
+				9,
+				true
+			  ]
+			]
+		  },
+		  "fill-color": "#6a4",
+		  "fill-opacity": 0.1,
+		  "fill-outline-color": "hsla(0, 0%, 0%, 0.03)"
+		},
+		"source": "openmaptiles",
+		"source-layer": "landcover",
+		"type": "fill"
+	  },
+	  {
+		"filter": [
+		  "==",
+		  "class",
+		  "grass"
+		],
+		"id": "landcover-grass",
+		"metadata": {
+		  "mapbox:group": "1444849388993.3071"
+		},
+		"paint": {
+		  "fill-color": "#d8e8c8",
+		  "fill-opacity": 1
+		},
+		"source": "openmaptiles",
+		"source-layer": "landcover",
+		"type": "fill"
+	  },
+	  {
+		"filter": [
+		  "==",
+		  "class",
+		  "public_park"
+		],
+		"id": "landcover-grass-park",
+		"metadata": {
+		  "mapbox:group": "1444849388993.3071"
+		},
+		"paint": {
+		  "fill-color": "#d8e8c8",
+		  "fill-opacity": 0.8
+		},
+		"source": "openmaptiles",
+		"source-layer": "park",
+		"type": "fill"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"in",
+			"class",
+			"river",
+			"stream",
+			"canal"
+		  ],
+		  [
+			"==",
+			"brunnel",
+			"tunnel"
+		  ]
+		],
+		"id": "waterway_tunnel",
+		"layout": {
+		  "line-cap": "round"
+		},
+		"minzoom": 14,
+		"paint": {
+		  "line-color": "#a0c8f0",
+		  "line-dasharray": [
+			2,
+			4
+		  ],
+		  "line-width": {
+			"base": 1.3,
+			"stops": [
+			  [
+				13,
+				0.5
+			  ],
+			  [
+				20,
+				6
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "waterway",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "!in",
+		  "class",
+		  "canal",
+		  "river",
+		  "stream"
+		],
+		"id": "waterway-other",
+		"layout": {
+		  "line-cap": "round"
+		},
+		"metadata": {
+		  "mapbox:group": "1444849382550.77"
+		},
+		"paint": {
+		  "line-color": "#a0c8f0",
+		  "line-width": {
+			"base": 1.3,
+			"stops": [
+			  [
+				13,
+				0.5
+			  ],
+			  [
+				20,
+				2
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "waterway",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"in",
+			"class",
+			"canal",
+			"stream"
+		  ],
+		  [
+			"!=",
+			"brunnel",
+			"tunnel"
+		  ]
+		],
+		"id": "waterway-stream-canal",
+		"layout": {
+		  "line-cap": "round"
+		},
+		"metadata": {
+		  "mapbox:group": "1444849382550.77"
+		},
+		"paint": {
+		  "line-color": "#a0c8f0",
+		  "line-width": {
+			"base": 1.3,
+			"stops": [
+			  [
+				13,
+				0.5
+			  ],
+			  [
+				20,
+				6
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "waterway",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"class",
+			"river"
+		  ],
+		  [
+			"!=",
+			"brunnel",
+			"tunnel"
+		  ]
+		],
+		"id": "waterway-river",
+		"layout": {
+		  "line-cap": "round"
+		},
+		"metadata": {
+		  "mapbox:group": "1444849382550.77"
+		},
+		"paint": {
+		  "line-color": "#a0c8f0",
+		  "line-width": {
+			"base": 1.2,
+			"stops": [
+			  [
+				10,
+				0.8
+			  ],
+			  [
+				20,
+				6
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "waterway",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "==",
+		  "$type",
+		  "Polygon"
+		],
+		"id": "water-offset",
+		"layout": {
+		  "visibility": "visible"
+		},
+		"maxzoom": 8,
+		"metadata": {
+		  "mapbox:group": "1444849382550.77"
+		},
+		"paint": {
+		  "fill-color": "#a0c8f0",
+		  "fill-opacity": 1,
+		  "fill-translate": {
+			"base": 1,
+			"stops": [
+			  [
+				6,
+				[
+				  2,
+				  0
+				]
+			  ],
+			  [
+				8,
+				[
+				  0,
+				  0
+				]
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "water",
+		"type": "fill"
+	  },
+	  {
+		"id": "water",
+		"layout": {
+		  "visibility": "visible"
+		},
+		"metadata": {
+		  "mapbox:group": "1444849382550.77"
+		},
+		"paint": {
+		  "fill-color": "hsl(210, 67%, 85%)"
+		},
+		"source": "openmaptiles",
+		"source-layer": "water",
+		"type": "fill"
+	  },
+	  {
+		"filter": [
+		  "==",
+		  "subclass",
+		  "ice_shelf"
+		],
+		"id": "landcover-ice-shelf",
+		"layout": {
+		  "visibility": "visible"
+		},
+		"metadata": {
+		  "mapbox:group": "1444849382550.77"
+		},
+		"paint": {
+		  "fill-color": "#fff",
+		  "fill-opacity": {
+			"base": 1,
+			"stops": [
+			  [
+				0,
+				0.9
+			  ],
+			  [
+				10,
+				0.3
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "landcover",
+		"type": "fill"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"class",
+			"sand"
+		  ]
+		],
+		"id": "landcover-sand",
+		"layout": {
+		  "visibility": "visible"
+		},
+		"metadata": {
+		  "mapbox:group": "1444849382550.77"
+		},
+		"paint": {
+		  "fill-color": "rgba(245, 238, 188, 1)",
+		  "fill-opacity": 1
+		},
+		"source": "openmaptiles",
+		"source-layer": "landcover",
+		"type": "fill"
+	  },
+	  {
+		"id": "building",
+		"metadata": {
+		  "mapbox:group": "1444849364238.8171"
+		},
+		"paint": {
+		  "fill-antialias": true,
+		  "fill-color": {
+			"base": 1,
+			"stops": [
+			  [
+				15.5,
+				"#f2eae2"
+			  ],
+			  [
+				16,
+				"#dfdbd7"
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "building",
+		"type": "fill"
+	  },
+	  {
+		"id": "building-top",
+		"layout": {
+		  "visibility": "visible"
+		},
+		"metadata": {
+		  "mapbox:group": "1444849364238.8171"
+		},
+		"paint": {
+		  "fill-color": "#f2eae2",
+		  "fill-opacity": {
+			"base": 1,
+			"stops": [
+			  [
+				13,
+				0
+			  ],
+			  [
+				16,
+				1
+			  ]
+			]
+		  },
+		  "fill-outline-color": "#dfdbd7",
+		  "fill-translate": {
+			"base": 1,
+			"stops": [
+			  [
+				14,
+				[
+				  0,
+				  0
+				]
+			  ],
+			  [
+				16,
+				[
+				  -2,
+				  -2
+				]
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "building",
+		"type": "fill"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"brunnel",
+			"tunnel"
+		  ],
+		  [
+			"in",
+			"class",
+			"service",
+			"track"
+		  ]
+		],
+		"id": "tunnel-service-track-casing",
+		"layout": {
+		  "line-join": "round"
+		},
+		"metadata": {
+		  "mapbox:group": "1444849354174.1904"
+		},
+		"paint": {
+		  "line-color": "#cfcdca",
+		  "line-dasharray": [
+			0.5,
+			0.25
+		  ],
+		  "line-width": {
+			"base": 1.2,
+			"stops": [
+			  [
+				15,
+				1
+			  ],
+			  [
+				16,
+				4
+			  ],
+			  [
+				20,
+				11
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"brunnel",
+			"tunnel"
+		  ],
+		  [
+			"==",
+			"class",
+			"minor"
+		  ]
+		],
+		"id": "tunnel-minor-casing",
+		"layout": {
+		  "line-join": "round"
+		},
+		"metadata": {
+		  "mapbox:group": "1444849354174.1904"
+		},
+		"paint": {
+		  "line-color": "#cfcdca",
+		  "line-opacity": {
+			"stops": [
+			  [
+				12,
+				0
+			  ],
+			  [
+				12.5,
+				1
+			  ]
+			]
+		  },
+		  "line-width": {
+			"base": 1.2,
+			"stops": [
+			  [
+				12,
+				0.5
+			  ],
+			  [
+				13,
+				1
+			  ],
+			  [
+				14,
+				4
+			  ],
+			  [
+				20,
+				15
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"brunnel",
+			"tunnel"
+		  ],
+		  [
+			"in",
+			"class",
+			"secondary",
+			"tertiary"
+		  ]
+		],
+		"id": "tunnel-secondary-tertiary-casing",
+		"layout": {
+		  "line-join": "round"
+		},
+		"metadata": {
+		  "mapbox:group": "1444849354174.1904"
+		},
+		"paint": {
+		  "line-color": "#e9ac77",
+		  "line-opacity": 1,
+		  "line-width": {
+			"base": 1.2,
+			"stops": [
+			  [
+				8,
+				1.5
+			  ],
+			  [
+				20,
+				17
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"brunnel",
+			"tunnel"
+		  ],
+		  [
+			"in",
+			"class",
+			"primary",
+			"trunk"
+		  ]
+		],
+		"id": "tunnel-trunk-primary-casing",
+		"layout": {
+		  "line-join": "round"
+		},
+		"metadata": {
+		  "mapbox:group": "1444849354174.1904"
+		},
+		"paint": {
+		  "line-color": "#e9ac77",
+		  "line-width": {
+			"base": 1.2,
+			"stops": [
+			  [
+				5,
+				0.4
+			  ],
+			  [
+				6,
+				0.6
+			  ],
+			  [
+				7,
+				1.5
+			  ],
+			  [
+				20,
+				22
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"brunnel",
+			"tunnel"
+		  ],
+		  [
+			"==",
+			"class",
+			"motorway"
+		  ]
+		],
+		"id": "tunnel-motorway-casing",
+		"layout": {
+		  "line-join": "round",
+		  "visibility": "visible"
+		},
+		"metadata": {
+		  "mapbox:group": "1444849354174.1904"
+		},
+		"paint": {
+		  "line-color": "#e9ac77",
+		  "line-dasharray": [
+			0.5,
+			0.25
+		  ],
+		  "line-width": {
+			"base": 1.2,
+			"stops": [
+			  [
+				5,
+				0.4
+			  ],
+			  [
+				6,
+				0.6
+			  ],
+			  [
+				7,
+				1.5
+			  ],
+			  [
+				20,
+				22
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"$type",
+			"LineString"
+		  ],
+		  [
+			"all",
+			[
+			  "==",
+			  "brunnel",
+			  "tunnel"
+			],
+			[
+			  "==",
+			  "class",
+			  "path"
+			]
+		  ]
+		],
+		"id": "tunnel-path",
+		"metadata": {
+		  "mapbox:group": "1444849354174.1904"
+		},
+		"paint": {
+		  "line-color": "#cba",
+		  "line-dasharray": [
+			1.5,
+			0.75
+		  ],
+		  "line-width": {
+			"base": 1.2,
+			"stops": [
+			  [
+				15,
+				1.2
+			  ],
+			  [
+				20,
+				4
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"brunnel",
+			"tunnel"
+		  ],
+		  [
+			"in",
+			"class",
+			"service",
+			"track"
+		  ]
+		],
+		"id": "tunnel-service-track",
+		"layout": {
+		  "line-join": "round"
+		},
+		"metadata": {
+		  "mapbox:group": "1444849354174.1904"
+		},
+		"paint": {
+		  "line-color": "#fff",
+		  "line-width": {
+			"base": 1.2,
+			"stops": [
+			  [
+				15.5,
+				0
+			  ],
+			  [
+				16,
+				2
+			  ],
+			  [
+				20,
+				7.5
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"brunnel",
+			"tunnel"
+		  ],
+		  [
+			"==",
+			"class",
+			"minor_road"
+		  ]
+		],
+		"id": "tunnel-minor",
+		"layout": {
+		  "line-join": "round"
+		},
+		"metadata": {
+		  "mapbox:group": "1444849354174.1904"
+		},
+		"paint": {
+		  "line-color": "#fff",
+		  "line-opacity": 1,
+		  "line-width": {
+			"base": 1.2,
+			"stops": [
+			  [
+				13.5,
+				0
+			  ],
+			  [
+				14,
+				2.5
+			  ],
+			  [
+				20,
+				11.5
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"brunnel",
+			"tunnel"
+		  ],
+		  [
+			"in",
+			"class",
+			"secondary",
+			"tertiary"
+		  ]
+		],
+		"id": "tunnel-secondary-tertiary",
+		"layout": {
+		  "line-join": "round"
+		},
+		"metadata": {
+		  "mapbox:group": "1444849354174.1904"
+		},
+		"paint": {
+		  "line-color": "#fff4c6",
+		  "line-width": {
+			"base": 1.2,
+			"stops": [
+			  [
+				6.5,
+				0
+			  ],
+			  [
+				7,
+				0.5
+			  ],
+			  [
+				20,
+				10
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"brunnel",
+			"tunnel"
+		  ],
+		  [
+			"in",
+			"class",
+			"primary",
+			"trunk"
+		  ]
+		],
+		"id": "tunnel-trunk-primary",
+		"layout": {
+		  "line-join": "round"
+		},
+		"metadata": {
+		  "mapbox:group": "1444849354174.1904"
+		},
+		"paint": {
+		  "line-color": "#fff4c6",
+		  "line-width": {
+			"base": 1.2,
+			"stops": [
+			  [
+				6.5,
+				0
+			  ],
+			  [
+				7,
+				0.5
+			  ],
+			  [
+				20,
+				18
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"brunnel",
+			"tunnel"
+		  ],
+		  [
+			"==",
+			"class",
+			"motorway"
+		  ]
+		],
+		"id": "tunnel-motorway",
+		"layout": {
+		  "line-join": "round",
+		  "visibility": "visible"
+		},
+		"metadata": {
+		  "mapbox:group": "1444849354174.1904"
+		},
+		"paint": {
+		  "line-color": "#ffdaa6",
+		  "line-width": {
+			"base": 1.2,
+			"stops": [
+			  [
+				6.5,
+				0
+			  ],
+			  [
+				7,
+				0.5
+			  ],
+			  [
+				20,
+				18
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"brunnel",
+			"tunnel"
+		  ],
+		  [
+			"==",
+			"class",
+			"rail"
+		  ]
+		],
+		"id": "tunnel-railway",
+		"metadata": {
+		  "mapbox:group": "1444849354174.1904"
+		},
+		"paint": {
+		  "line-color": "#bbb",
+		  "line-dasharray": [
+			2,
+			2
+		  ],
+		  "line-width": {
+			"base": 1.4,
+			"stops": [
+			  [
+				14,
+				0.4
+			  ],
+			  [
+				15,
+				0.75
+			  ],
+			  [
+				20,
+				2
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"in",
+			"class",
+			"ferry"
+		  ]
+		],
+		"id": "ferry",
+		"layout": {
+		  "line-join": "round",
+		  "visibility": "visible"
+		},
+		"paint": {
+		  "line-color": "rgba(108, 159, 182, 1)",
+		  "line-dasharray": [
+			2,
+			2
+		  ],
+		  "line-width": 1.1
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"in",
+			"class",
+			"taxiway"
+		  ]
+		],
+		"id": "aeroway-taxiway-casing",
+		"layout": {
+		  "line-cap": "round",
+		  "line-join": "round",
+		  "visibility": "visible"
+		},
+		"metadata": {
+		  "mapbox:group": "1444849345966.4436"
+		},
+		"minzoom": 12,
+		"paint": {
+		  "line-color": "rgba(153, 153, 153, 1)",
+		  "line-opacity": 1,
+		  "line-width": {
+			"base": 1.5,
+			"stops": [
+			  [
+				11,
+				2
+			  ],
+			  [
+				17,
+				12
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "aeroway",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"in",
+			"class",
+			"runway"
+		  ]
+		],
+		"id": "aeroway-runway-casing",
+		"layout": {
+		  "line-cap": "round",
+		  "line-join": "round",
+		  "visibility": "visible"
+		},
+		"metadata": {
+		  "mapbox:group": "1444849345966.4436"
+		},
+		"minzoom": 12,
+		"paint": {
+		  "line-color": "rgba(153, 153, 153, 1)",
+		  "line-opacity": 1,
+		  "line-width": {
+			"base": 1.5,
+			"stops": [
+			  [
+				11,
+				5
+			  ],
+			  [
+				17,
+				55
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "aeroway",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"$type",
+			"Polygon"
+		  ],
+		  [
+			"in",
+			"class",
+			"runway",
+			"taxiway"
+		  ]
+		],
+		"id": "aeroway-area",
+		"layout": {
+		  "visibility": "visible"
+		},
+		"metadata": {
+		  "mapbox:group": "1444849345966.4436"
+		},
+		"minzoom": 4,
+		"paint": {
+		  "fill-color": "rgba(255, 255, 255, 1)",
+		  "fill-opacity": {
+			"base": 1,
+			"stops": [
+			  [
+				13,
+				0
+			  ],
+			  [
+				14,
+				1
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "aeroway",
+		"type": "fill"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"in",
+			"class",
+			"taxiway"
+		  ],
+		  [
+			"==",
+			"$type",
+			"LineString"
+		  ]
+		],
+		"id": "aeroway-taxiway",
+		"layout": {
+		  "line-cap": "round",
+		  "line-join": "round",
+		  "visibility": "visible"
+		},
+		"metadata": {
+		  "mapbox:group": "1444849345966.4436"
+		},
+		"minzoom": 4,
+		"paint": {
+		  "line-color": "rgba(255, 255, 255, 1)",
+		  "line-opacity": {
+			"base": 1,
+			"stops": [
+			  [
+				11,
+				0
+			  ],
+			  [
+				12,
+				1
+			  ]
+			]
+		  },
+		  "line-width": {
+			"base": 1.5,
+			"stops": [
+			  [
+				11,
+				1
+			  ],
+			  [
+				17,
+				10
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "aeroway",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"in",
+			"class",
+			"runway"
+		  ],
+		  [
+			"==",
+			"$type",
+			"LineString"
+		  ]
+		],
+		"id": "aeroway-runway",
+		"layout": {
+		  "line-cap": "round",
+		  "line-join": "round",
+		  "visibility": "visible"
+		},
+		"metadata": {
+		  "mapbox:group": "1444849345966.4436"
+		},
+		"minzoom": 4,
+		"paint": {
+		  "line-color": "rgba(255, 255, 255, 1)",
+		  "line-opacity": {
+			"base": 1,
+			"stops": [
+			  [
+				11,
+				0
+			  ],
+			  [
+				12,
+				1
+			  ]
+			]
+		  },
+		  "line-width": {
+			"base": 1.5,
+			"stops": [
+			  [
+				11,
+				4
+			  ],
+			  [
+				17,
+				50
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "aeroway",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"$type",
+			"Polygon"
+		  ],
+		  [
+			"==",
+			"class",
+			"pier"
+		  ]
+		],
+		"id": "road_area_pier",
+		"layout": {
+		  "visibility": "visible"
+		},
+		"metadata": {},
+		"paint": {
+		  "fill-antialias": true,
+		  "fill-color": "#f8f4f0"
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "fill"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"$type",
+			"LineString"
+		  ],
+		  [
+			"in",
+			"class",
+			"pier"
+		  ]
+		],
+		"id": "road_pier",
+		"layout": {
+		  "line-cap": "round",
+		  "line-join": "round"
+		},
+		"metadata": {},
+		"paint": {
+		  "line-color": "#f8f4f0",
+		  "line-width": {
+			"base": 1.2,
+			"stops": [
+			  [
+				15,
+				1
+			  ],
+			  [
+				17,
+				4
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"$type",
+			"Polygon"
+		  ],
+		  [
+			"!in",
+			"class",
+			"pier"
+		  ]
+		],
+		"id": "highway-area",
+		"layout": {
+		  "visibility": "visible"
+		},
+		"metadata": {
+		  "mapbox:group": "1444849345966.4436"
+		},
+		"paint": {
+		  "fill-antialias": false,
+		  "fill-color": "hsla(0, 0%, 89%, 0.56)",
+		  "fill-opacity": 0.9,
+		  "fill-outline-color": "#cfcdca"
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "fill"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"!in",
+			"brunnel",
+			"bridge",
+			"tunnel"
+		  ],
+		  [
+			"==",
+			"class",
+			"motorway_link"
+		  ]
+		],
+		"id": "highway-motorway-link-casing",
+		"layout": {
+		  "line-cap": "round",
+		  "line-join": "round"
+		},
+		"metadata": {
+		  "mapbox:group": "1444849345966.4436"
+		},
+		"minzoom": 12,
+		"paint": {
+		  "line-color": "#e9ac77",
+		  "line-opacity": 1,
+		  "line-width": {
+			"base": 1.2,
+			"stops": [
+			  [
+				12,
+				1
+			  ],
+			  [
+				13,
+				3
+			  ],
+			  [
+				14,
+				4
+			  ],
+			  [
+				20,
+				15
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"!in",
+			"brunnel",
+			"bridge",
+			"tunnel"
+		  ],
+		  [
+			"in",
+			"class",
+			"primary_link",
+			"secondary_link",
+			"tertiary_link",
+			"trunk_link"
+		  ]
+		],
+		"id": "highway-link-casing",
+		"layout": {
+		  "line-cap": "round",
+		  "line-join": "round",
+		  "visibility": "visible"
+		},
+		"metadata": {
+		  "mapbox:group": "1444849345966.4436"
+		},
+		"minzoom": 13,
+		"paint": {
+		  "line-color": "#e9ac77",
+		  "line-opacity": 1,
+		  "line-width": {
+			"base": 1.2,
+			"stops": [
+			  [
+				12,
+				1
+			  ],
+			  [
+				13,
+				3
+			  ],
+			  [
+				14,
+				4
+			  ],
+			  [
+				20,
+				15
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"$type",
+			"LineString"
+		  ],
+		  [
+			"all",
+			[
+			  "!=",
+			  "brunnel",
+			  "tunnel"
+			],
+			[
+			  "in",
+			  "class",
+			  "minor",
+			  "service",
+			  "track"
+			]
+		  ]
+		],
+		"id": "highway-minor-casing",
+		"layout": {
+		  "line-cap": "round",
+		  "line-join": "round"
+		},
+		"metadata": {
+		  "mapbox:group": "1444849345966.4436"
+		},
+		"paint": {
+		  "line-color": "#cfcdca",
+		  "line-opacity": {
+			"stops": [
+			  [
+				12,
+				0
+			  ],
+			  [
+				12.5,
+				1
+			  ]
+			]
+		  },
+		  "line-width": {
+			"base": 1.2,
+			"stops": [
+			  [
+				12,
+				0.5
+			  ],
+			  [
+				13,
+				1
+			  ],
+			  [
+				14,
+				4
+			  ],
+			  [
+				20,
+				15
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"!in",
+			"brunnel",
+			"bridge",
+			"tunnel"
+		  ],
+		  [
+			"in",
+			"class",
+			"secondary",
+			"tertiary"
+		  ]
+		],
+		"id": "highway-secondary-tertiary-casing",
+		"layout": {
+		  "line-cap": "butt",
+		  "line-join": "round",
+		  "visibility": "visible"
+		},
+		"metadata": {
+		  "mapbox:group": "1444849345966.4436"
+		},
+		"paint": {
+		  "line-color": "#e9ac77",
+		  "line-opacity": 1,
+		  "line-width": {
+			"base": 1.2,
+			"stops": [
+			  [
+				8,
+				1.5
+			  ],
+			  [
+				20,
+				17
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"!in",
+			"brunnel",
+			"bridge",
+			"tunnel"
+		  ],
+		  [
+			"in",
+			"class",
+			"primary"
+		  ]
+		],
+		"id": "highway-primary-casing",
+		"layout": {
+		  "line-cap": "butt",
+		  "line-join": "round",
+		  "visibility": "visible"
+		},
+		"metadata": {
+		  "mapbox:group": "1444849345966.4436"
+		},
+		"minzoom": 5,
+		"paint": {
+		  "line-color": "#e9ac77",
+		  "line-opacity": {
+			"stops": [
+			  [
+				7,
+				0
+			  ],
+			  [
+				8,
+				1
+			  ]
+			]
+		  },
+		  "line-width": {
+			"base": 1.2,
+			"stops": [
+			  [
+				7,
+				0
+			  ],
+			  [
+				8,
+				0.6
+			  ],
+			  [
+				9,
+				1.5
+			  ],
+			  [
+				20,
+				22
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"!in",
+			"brunnel",
+			"bridge",
+			"tunnel"
+		  ],
+		  [
+			"in",
+			"class",
+			"trunk"
+		  ]
+		],
+		"id": "highway-trunk-casing",
+		"layout": {
+		  "line-cap": "butt",
+		  "line-join": "round",
+		  "visibility": "visible"
+		},
+		"metadata": {
+		  "mapbox:group": "1444849345966.4436"
+		},
+		"minzoom": 5,
+		"paint": {
+		  "line-color": "#e9ac77",
+		  "line-opacity": {
+			"stops": [
+			  [
+				5,
+				0
+			  ],
+			  [
+				6,
+				1
+			  ]
+			]
+		  },
+		  "line-width": {
+			"base": 1.2,
+			"stops": [
+			  [
+				5,
+				0
+			  ],
+			  [
+				6,
+				0.6
+			  ],
+			  [
+				7,
+				1.5
+			  ],
+			  [
+				20,
+				22
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"!in",
+			"brunnel",
+			"bridge",
+			"tunnel"
+		  ],
+		  [
+			"==",
+			"class",
+			"motorway"
+		  ]
+		],
+		"id": "highway-motorway-casing",
+		"layout": {
+		  "line-cap": "butt",
+		  "line-join": "round",
+		  "visibility": "visible"
+		},
+		"metadata": {
+		  "mapbox:group": "1444849345966.4436"
+		},
+		"minzoom": 4,
+		"paint": {
+		  "line-color": "#e9ac77",
+		  "line-opacity": {
+			"stops": [
+			  [
+				4,
+				0
+			  ],
+			  [
+				5,
+				1
+			  ]
+			]
+		  },
+		  "line-width": {
+			"base": 1.2,
+			"stops": [
+			  [
+				4,
+				0
+			  ],
+			  [
+				5,
+				0.4
+			  ],
+			  [
+				6,
+				0.6
+			  ],
+			  [
+				7,
+				1.5
+			  ],
+			  [
+				20,
+				22
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"$type",
+			"LineString"
+		  ],
+		  [
+			"all",
+			[
+			  "!in",
+			  "brunnel",
+			  "bridge",
+			  "tunnel"
+			],
+			[
+			  "==",
+			  "class",
+			  "path"
+			]
+		  ]
+		],
+		"id": "highway-path",
+		"metadata": {
+		  "mapbox:group": "1444849345966.4436"
+		},
+		"paint": {
+		  "line-color": "#cba",
+		  "line-dasharray": [
+			1.5,
+			0.75
+		  ],
+		  "line-width": {
+			"base": 1.2,
+			"stops": [
+			  [
+				15,
+				1.2
+			  ],
+			  [
+				20,
+				4
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"!in",
+			"brunnel",
+			"bridge",
+			"tunnel"
+		  ],
+		  [
+			"==",
+			"class",
+			"motorway_link"
+		  ]
+		],
+		"id": "highway-motorway-link",
+		"layout": {
+		  "line-cap": "round",
+		  "line-join": "round"
+		},
+		"metadata": {
+		  "mapbox:group": "1444849345966.4436"
+		},
+		"minzoom": 12,
+		"paint": {
+		  "line-color": "#fc8",
+		  "line-width": {
+			"base": 1.2,
+			"stops": [
+			  [
+				12.5,
+				0
+			  ],
+			  [
+				13,
+				1.5
+			  ],
+			  [
+				14,
+				2.5
+			  ],
+			  [
+				20,
+				11.5
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"!in",
+			"brunnel",
+			"bridge",
+			"tunnel"
+		  ],
+		  [
+			"in",
+			"class",
+			"primary_link",
+			"secondary_link",
+			"tertiary_link",
+			"trunk_link"
+		  ]
+		],
+		"id": "highway-link",
+		"layout": {
+		  "line-cap": "round",
+		  "line-join": "round",
+		  "visibility": "visible"
+		},
+		"metadata": {
+		  "mapbox:group": "1444849345966.4436"
+		},
+		"minzoom": 13,
+		"paint": {
+		  "line-color": "#fea",
+		  "line-width": {
+			"base": 1.2,
+			"stops": [
+			  [
+				12.5,
+				0
+			  ],
+			  [
+				13,
+				1.5
+			  ],
+			  [
+				14,
+				2.5
+			  ],
+			  [
+				20,
+				11.5
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"$type",
+			"LineString"
+		  ],
+		  [
+			"all",
+			[
+			  "!=",
+			  "brunnel",
+			  "tunnel"
+			],
+			[
+			  "in",
+			  "class",
+			  "minor",
+			  "service",
+			  "track"
+			]
+		  ]
+		],
+		"id": "highway-minor",
+		"layout": {
+		  "line-cap": "round",
+		  "line-join": "round"
+		},
+		"metadata": {
+		  "mapbox:group": "1444849345966.4436"
+		},
+		"paint": {
+		  "line-color": "#fff",
+		  "line-opacity": 1,
+		  "line-width": {
+			"base": 1.2,
+			"stops": [
+			  [
+				13.5,
+				0
+			  ],
+			  [
+				14,
+				2.5
+			  ],
+			  [
+				20,
+				11.5
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"!in",
+			"brunnel",
+			"bridge",
+			"tunnel"
+		  ],
+		  [
+			"in",
+			"class",
+			"secondary",
+			"tertiary"
+		  ]
+		],
+		"id": "highway-secondary-tertiary",
+		"layout": {
+		  "line-cap": "round",
+		  "line-join": "round",
+		  "visibility": "visible"
+		},
+		"metadata": {
+		  "mapbox:group": "1444849345966.4436"
+		},
+		"paint": {
+		  "line-color": "#fea",
+		  "line-width": {
+			"base": 1.2,
+			"stops": [
+			  [
+				6.5,
+				0
+			  ],
+			  [
+				8,
+				0.5
+			  ],
+			  [
+				20,
+				13
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"$type",
+			"LineString"
+		  ],
+		  [
+			"all",
+			[
+			  "!in",
+			  "brunnel",
+			  "bridge",
+			  "tunnel"
+			],
+			[
+			  "in",
+			  "class",
+			  "primary"
+			]
+		  ]
+		],
+		"id": "highway-primary",
+		"layout": {
+		  "line-cap": "round",
+		  "line-join": "round",
+		  "visibility": "visible"
+		},
+		"metadata": {
+		  "mapbox:group": "1444849345966.4436"
+		},
+		"paint": {
+		  "line-color": "#fea",
+		  "line-width": {
+			"base": 1.2,
+			"stops": [
+			  [
+				8.5,
+				0
+			  ],
+			  [
+				9,
+				0.5
+			  ],
+			  [
+				20,
+				18
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"$type",
+			"LineString"
+		  ],
+		  [
+			"all",
+			[
+			  "!in",
+			  "brunnel",
+			  "bridge",
+			  "tunnel"
+			],
+			[
+			  "in",
+			  "class",
+			  "trunk"
+			]
+		  ]
+		],
+		"id": "highway-trunk",
+		"layout": {
+		  "line-cap": "round",
+		  "line-join": "round",
+		  "visibility": "visible"
+		},
+		"metadata": {
+		  "mapbox:group": "1444849345966.4436"
+		},
+		"paint": {
+		  "line-color": "#fea",
+		  "line-width": {
+			"base": 1.2,
+			"stops": [
+			  [
+				6.5,
+				0
+			  ],
+			  [
+				7,
+				0.5
+			  ],
+			  [
+				20,
+				18
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"$type",
+			"LineString"
+		  ],
+		  [
+			"all",
+			[
+			  "!in",
+			  "brunnel",
+			  "bridge",
+			  "tunnel"
+			],
+			[
+			  "==",
+			  "class",
+			  "motorway"
+			]
+		  ]
+		],
+		"id": "highway-motorway",
+		"layout": {
+		  "line-cap": "round",
+		  "line-join": "round",
+		  "visibility": "visible"
+		},
+		"metadata": {
+		  "mapbox:group": "1444849345966.4436"
+		},
+		"minzoom": 5,
+		"paint": {
+		  "line-color": "#fc8",
+		  "line-width": {
+			"base": 1.2,
+			"stops": [
+			  [
+				6.5,
+				0
+			  ],
+			  [
+				7,
+				0.5
+			  ],
+			  [
+				20,
+				18
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"$type",
+			"LineString"
+		  ],
+		  [
+			"all",
+			[
+			  "==",
+			  "class",
+			  "transit"
+			],
+			[
+			  "!in",
+			  "brunnel",
+			  "tunnel"
+			]
+		  ]
+		],
+		"id": "railway-transit",
+		"layout": {
+		  "visibility": "visible"
+		},
+		"metadata": {
+		  "mapbox:group": "1444849345966.4436"
+		},
+		"paint": {
+		  "line-color": "hsla(0, 0%, 73%, 0.77)",
+		  "line-width": {
+			"base": 1.4,
+			"stops": [
+			  [
+				14,
+				0.4
+			  ],
+			  [
+				20,
+				1
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"$type",
+			"LineString"
+		  ],
+		  [
+			"all",
+			[
+			  "==",
+			  "class",
+			  "transit"
+			],
+			[
+			  "!in",
+			  "brunnel",
+			  "tunnel"
+			]
+		  ]
+		],
+		"id": "railway-transit-hatching",
+		"layout": {
+		  "visibility": "visible"
+		},
+		"metadata": {
+		  "mapbox:group": "1444849345966.4436"
+		},
+		"paint": {
+		  "line-color": "hsla(0, 0%, 73%, 0.68)",
+		  "line-dasharray": [
+			0.2,
+			8
+		  ],
+		  "line-width": {
+			"base": 1.4,
+			"stops": [
+			  [
+				14.5,
+				0
+			  ],
+			  [
+				15,
+				2
+			  ],
+			  [
+				20,
+				6
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"$type",
+			"LineString"
+		  ],
+		  [
+			"all",
+			[
+			  "==",
+			  "class",
+			  "rail"
+			],
+			[
+			  "has",
+			  "service"
+			]
+		  ]
+		],
+		"id": "railway-service",
+		"metadata": {
+		  "mapbox:group": "1444849345966.4436"
+		},
+		"paint": {
+		  "line-color": "hsla(0, 0%, 73%, 0.77)",
+		  "line-width": {
+			"base": 1.4,
+			"stops": [
+			  [
+				14,
+				0.4
+			  ],
+			  [
+				20,
+				1
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"$type",
+			"LineString"
+		  ],
+		  [
+			"all",
+			[
+			  "==",
+			  "class",
+			  "rail"
+			],
+			[
+			  "has",
+			  "service"
+			]
+		  ]
+		],
+		"id": "railway-service-hatching",
+		"layout": {
+		  "visibility": "visible"
+		},
+		"metadata": {
+		  "mapbox:group": "1444849345966.4436"
+		},
+		"paint": {
+		  "line-color": "hsla(0, 0%, 73%, 0.68)",
+		  "line-dasharray": [
+			0.2,
+			8
+		  ],
+		  "line-width": {
+			"base": 1.4,
+			"stops": [
+			  [
+				14.5,
+				0
+			  ],
+			  [
+				15,
+				2
+			  ],
+			  [
+				20,
+				6
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"$type",
+			"LineString"
+		  ],
+		  [
+			"all",
+			[
+			  "!has",
+			  "service"
+			],
+			[
+			  "!in",
+			  "brunnel",
+			  "bridge",
+			  "tunnel"
+			],
+			[
+			  "==",
+			  "class",
+			  "rail"
+			]
+		  ]
+		],
+		"id": "railway",
+		"metadata": {
+		  "mapbox:group": "1444849345966.4436"
+		},
+		"paint": {
+		  "line-color": "#bbb",
+		  "line-width": {
+			"base": 1.4,
+			"stops": [
+			  [
+				14,
+				0.4
+			  ],
+			  [
+				15,
+				0.75
+			  ],
+			  [
+				20,
+				2
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"$type",
+			"LineString"
+		  ],
+		  [
+			"all",
+			[
+			  "!has",
+			  "service"
+			],
+			[
+			  "!in",
+			  "brunnel",
+			  "bridge",
+			  "tunnel"
+			],
+			[
+			  "==",
+			  "class",
+			  "rail"
+			]
+		  ]
+		],
+		"id": "railway-hatching",
+		"metadata": {
+		  "mapbox:group": "1444849345966.4436"
+		},
+		"paint": {
+		  "line-color": "#bbb",
+		  "line-dasharray": [
+			0.2,
+			8
+		  ],
+		  "line-width": {
+			"base": 1.4,
+			"stops": [
+			  [
+				14.5,
+				0
+			  ],
+			  [
+				15,
+				3
+			  ],
+			  [
+				20,
+				8
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"brunnel",
+			"bridge"
+		  ],
+		  [
+			"==",
+			"class",
+			"motorway_link"
+		  ]
+		],
+		"id": "bridge-motorway-link-casing",
+		"layout": {
+		  "line-join": "round"
+		},
+		"metadata": {
+		  "mapbox:group": "1444849334699.1902"
+		},
+		"paint": {
+		  "line-color": "#e9ac77",
+		  "line-opacity": 1,
+		  "line-width": {
+			"base": 1.2,
+			"stops": [
+			  [
+				12,
+				1
+			  ],
+			  [
+				13,
+				3
+			  ],
+			  [
+				14,
+				4
+			  ],
+			  [
+				20,
+				15
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"brunnel",
+			"bridge"
+		  ],
+		  [
+			"in",
+			"class",
+			"primary_link",
+			"secondary_link",
+			"tertiary_link",
+			"trunk_link"
+		  ]
+		],
+		"id": "bridge-link-casing",
+		"layout": {
+		  "line-join": "round"
+		},
+		"metadata": {
+		  "mapbox:group": "1444849334699.1902"
+		},
+		"paint": {
+		  "line-color": "#e9ac77",
+		  "line-opacity": 1,
+		  "line-width": {
+			"base": 1.2,
+			"stops": [
+			  [
+				12,
+				1
+			  ],
+			  [
+				13,
+				3
+			  ],
+			  [
+				14,
+				4
+			  ],
+			  [
+				20,
+				15
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"brunnel",
+			"bridge"
+		  ],
+		  [
+			"in",
+			"class",
+			"secondary",
+			"tertiary"
+		  ]
+		],
+		"id": "bridge-secondary-tertiary-casing",
+		"layout": {
+		  "line-join": "round"
+		},
+		"metadata": {
+		  "mapbox:group": "1444849334699.1902"
+		},
+		"paint": {
+		  "line-color": "#e9ac77",
+		  "line-opacity": 1,
+		  "line-width": {
+			"base": 1.2,
+			"stops": [
+			  [
+				8,
+				1.5
+			  ],
+			  [
+				20,
+				28
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"brunnel",
+			"bridge"
+		  ],
+		  [
+			"in",
+			"class",
+			"primary",
+			"trunk"
+		  ]
+		],
+		"id": "bridge-trunk-primary-casing",
+		"layout": {
+		  "line-join": "round"
+		},
+		"metadata": {
+		  "mapbox:group": "1444849334699.1902"
+		},
+		"paint": {
+		  "line-color": "hsl(28, 76%, 67%)",
+		  "line-width": {
+			"base": 1.2,
+			"stops": [
+			  [
+				5,
+				0.4
+			  ],
+			  [
+				6,
+				0.6
+			  ],
+			  [
+				7,
+				1.5
+			  ],
+			  [
+				20,
+				26
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"brunnel",
+			"bridge"
+		  ],
+		  [
+			"==",
+			"class",
+			"motorway"
+		  ]
+		],
+		"id": "bridge-motorway-casing",
+		"layout": {
+		  "line-join": "round"
+		},
+		"metadata": {
+		  "mapbox:group": "1444849334699.1902"
+		},
+		"paint": {
+		  "line-color": "#e9ac77",
+		  "line-width": {
+			"base": 1.2,
+			"stops": [
+			  [
+				5,
+				0.4
+			  ],
+			  [
+				6,
+				0.6
+			  ],
+			  [
+				7,
+				1.5
+			  ],
+			  [
+				20,
+				22
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"$type",
+			"LineString"
+		  ],
+		  [
+			"all",
+			[
+			  "==",
+			  "brunnel",
+			  "bridge"
+			],
+			[
+			  "==",
+			  "class",
+			  "path"
+			]
+		  ]
+		],
+		"id": "bridge-path-casing",
+		"metadata": {
+		  "mapbox:group": "1444849334699.1902"
+		},
+		"paint": {
+		  "line-color": "#f8f4f0",
+		  "line-width": {
+			"base": 1.2,
+			"stops": [
+			  [
+				15,
+				1.2
+			  ],
+			  [
+				20,
+				18
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"$type",
+			"LineString"
+		  ],
+		  [
+			"all",
+			[
+			  "==",
+			  "brunnel",
+			  "bridge"
+			],
+			[
+			  "==",
+			  "class",
+			  "path"
+			]
+		  ]
+		],
+		"id": "bridge-path",
+		"metadata": {
+		  "mapbox:group": "1444849334699.1902"
+		},
+		"paint": {
+		  "line-color": "#cba",
+		  "line-dasharray": [
+			1.5,
+			0.75
+		  ],
+		  "line-width": {
+			"base": 1.2,
+			"stops": [
+			  [
+				15,
+				1.2
+			  ],
+			  [
+				20,
+				4
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"brunnel",
+			"bridge"
+		  ],
+		  [
+			"==",
+			"class",
+			"motorway_link"
+		  ]
+		],
+		"id": "bridge-motorway-link",
+		"layout": {
+		  "line-join": "round"
+		},
+		"metadata": {
+		  "mapbox:group": "1444849334699.1902"
+		},
+		"paint": {
+		  "line-color": "#fc8",
+		  "line-width": {
+			"base": 1.2,
+			"stops": [
+			  [
+				12.5,
+				0
+			  ],
+			  [
+				13,
+				1.5
+			  ],
+			  [
+				14,
+				2.5
+			  ],
+			  [
+				20,
+				11.5
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"brunnel",
+			"bridge"
+		  ],
+		  [
+			"in",
+			"class",
+			"primary_link",
+			"secondary_link",
+			"tertiary_link",
+			"trunk_link"
+		  ]
+		],
+		"id": "bridge-link",
+		"layout": {
+		  "line-join": "round"
+		},
+		"metadata": {
+		  "mapbox:group": "1444849334699.1902"
+		},
+		"paint": {
+		  "line-color": "#fea",
+		  "line-width": {
+			"base": 1.2,
+			"stops": [
+			  [
+				12.5,
+				0
+			  ],
+			  [
+				13,
+				1.5
+			  ],
+			  [
+				14,
+				2.5
+			  ],
+			  [
+				20,
+				11.5
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"brunnel",
+			"bridge"
+		  ],
+		  [
+			"in",
+			"class",
+			"secondary",
+			"tertiary"
+		  ]
+		],
+		"id": "bridge-secondary-tertiary",
+		"layout": {
+		  "line-join": "round"
+		},
+		"metadata": {
+		  "mapbox:group": "1444849334699.1902"
+		},
+		"paint": {
+		  "line-color": "#fea",
+		  "line-width": {
+			"base": 1.2,
+			"stops": [
+			  [
+				6.5,
+				0
+			  ],
+			  [
+				7,
+				0.5
+			  ],
+			  [
+				20,
+				20
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"brunnel",
+			"bridge"
+		  ],
+		  [
+			"in",
+			"class",
+			"primary",
+			"trunk"
+		  ]
+		],
+		"id": "bridge-trunk-primary",
+		"layout": {
+		  "line-join": "round"
+		},
+		"metadata": {
+		  "mapbox:group": "1444849334699.1902"
+		},
+		"paint": {
+		  "line-color": "#fea",
+		  "line-width": {
+			"base": 1.2,
+			"stops": [
+			  [
+				6.5,
+				0
+			  ],
+			  [
+				7,
+				0.5
+			  ],
+			  [
+				20,
+				18
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"brunnel",
+			"bridge"
+		  ],
+		  [
+			"==",
+			"class",
+			"motorway"
+		  ]
+		],
+		"id": "bridge-motorway",
+		"layout": {
+		  "line-join": "round"
+		},
+		"metadata": {
+		  "mapbox:group": "1444849334699.1902"
+		},
+		"paint": {
+		  "line-color": "#fc8",
+		  "line-width": {
+			"base": 1.2,
+			"stops": [
+			  [
+				6.5,
+				0
+			  ],
+			  [
+				7,
+				0.5
+			  ],
+			  [
+				20,
+				18
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"brunnel",
+			"bridge"
+		  ],
+		  [
+			"==",
+			"class",
+			"rail"
+		  ]
+		],
+		"id": "bridge-railway",
+		"metadata": {
+		  "mapbox:group": "1444849334699.1902"
+		},
+		"paint": {
+		  "line-color": "#bbb",
+		  "line-width": {
+			"base": 1.4,
+			"stops": [
+			  [
+				14,
+				0.4
+			  ],
+			  [
+				15,
+				0.75
+			  ],
+			  [
+				20,
+				2
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"brunnel",
+			"bridge"
+		  ],
+		  [
+			"==",
+			"class",
+			"rail"
+		  ]
+		],
+		"id": "bridge-railway-hatching",
+		"metadata": {
+		  "mapbox:group": "1444849334699.1902"
+		},
+		"paint": {
+		  "line-color": "#bbb",
+		  "line-dasharray": [
+			0.2,
+			8
+		  ],
+		  "line-width": {
+			"base": 1.4,
+			"stops": [
+			  [
+				14.5,
+				0
+			  ],
+			  [
+				15,
+				3
+			  ],
+			  [
+				20,
+				8
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "==",
+		  "class",
+		  "cable_car"
+		],
+		"id": "cablecar",
+		"layout": {
+		  "line-cap": "round",
+		  "visibility": "visible"
+		},
+		"minzoom": 13,
+		"paint": {
+		  "line-color": "hsl(0, 0%, 70%)",
+		  "line-width": {
+			"base": 1,
+			"stops": [
+			  [
+				11,
+				1
+			  ],
+			  [
+				19,
+				2.5
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "==",
+		  "class",
+		  "cable_car"
+		],
+		"id": "cablecar-dash",
+		"layout": {
+		  "line-cap": "round",
+		  "visibility": "visible"
+		},
+		"minzoom": 13,
+		"paint": {
+		  "line-color": "hsl(0, 0%, 70%)",
+		  "line-dasharray": [
+			2,
+			3
+		  ],
+		  "line-width": {
+			"base": 1,
+			"stops": [
+			  [
+				11,
+				3
+			  ],
+			  [
+				19,
+				5.5
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			">=",
+			"admin_level",
+			4
+		  ],
+		  [
+			"<=",
+			"admin_level",
+			8
+		  ],
+		  [
+			"!=",
+			"maritime",
+			1
+		  ]
+		],
+		"id": "boundary-land-level-4",
+		"layout": {
+		  "line-join": "round"
+		},
+		"paint": {
+		  "line-color": "#9e9cab",
+		  "line-dasharray": [
+			3,
+			1,
+			1,
+			1
+		  ],
+		  "line-width": {
+			"base": 1.4,
+			"stops": [
+			  [
+				4,
+				0.4
+			  ],
+			  [
+				5,
+				1
+			  ],
+			  [
+				12,
+				3
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "boundary",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"admin_level",
+			2
+		  ],
+		  [
+			"!=",
+			"maritime",
+			1
+		  ],
+		  [
+			"!=",
+			"disputed",
+			1
+		  ]
+		],
+		"id": "boundary-land-level-2",
+		"layout": {
+		  "line-cap": "round",
+		  "line-join": "round"
+		},
+		"paint": {
+		  "line-color": "hsl(248, 7%, 66%)",
+		  "line-width": {
+			"base": 1,
+			"stops": [
+			  [
+				0,
+				0.6
+			  ],
+			  [
+				4,
+				1.4
+			  ],
+			  [
+				5,
+				2
+			  ],
+			  [
+				12,
+				8
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "boundary",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"!=",
+			"maritime",
+			1
+		  ],
+		  [
+			"==",
+			"disputed",
+			1
+		  ]
+		],
+		"id": "boundary-land-disputed",
+		"layout": {
+		  "line-cap": "round",
+		  "line-join": "round"
+		},
+		"paint": {
+		  "line-color": "hsl(248, 7%, 70%)",
+		  "line-dasharray": [
+			1,
+			3
+		  ],
+		  "line-width": {
+			"base": 1,
+			"stops": [
+			  [
+				0,
+				0.6
+			  ],
+			  [
+				4,
+				1.4
+			  ],
+			  [
+				5,
+				2
+			  ],
+			  [
+				12,
+				8
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "boundary",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"in",
+			"admin_level",
+			2,
+			4
+		  ],
+		  [
+			"==",
+			"maritime",
+			1
+		  ]
+		],
+		"id": "boundary-water",
+		"layout": {
+		  "line-cap": "round",
+		  "line-join": "round"
+		},
+		"paint": {
+		  "line-color": "rgba(154, 189, 214, 1)",
+		  "line-opacity": {
+			"stops": [
+			  [
+				6,
+				0.6
+			  ],
+			  [
+				10,
+				1
+			  ]
+			]
+		  },
+		  "line-width": {
+			"base": 1,
+			"stops": [
+			  [
+				0,
+				0.6
+			  ],
+			  [
+				4,
+				1.4
+			  ],
+			  [
+				5,
+				2
+			  ],
+			  [
+				12,
+				8
+			  ]
+			]
+		  }
+		},
+		"source": "openmaptiles",
+		"source-layer": "boundary",
+		"type": "line"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"$type",
+			"LineString"
+		  ],
+		  [
+			"has",
+			"name"
+		  ]
+		],
+		"id": "waterway-name",
+		"layout": {
+		  "symbol-placement": "line",
+		  "symbol-spacing": 350,
+		  "text-field": "{name:latin} {name:nonlatin}",
+		  "text-letter-spacing": 0.2,
+		  "text-max-width": 5,
+		  "text-rotation-alignment": "map",
+		  "text-size": 14
+		},
+		"minzoom": 13,
+		"paint": {
+		  "text-color": "#74aee9",
+		  "text-halo-color": "rgba(255,255,255,0.7)",
+		  "text-halo-width": 1.5
+		},
+		"source": "openmaptiles",
+		"source-layer": "waterway",
+		"type": "symbol"
+	  },
+	  {
+		"filter": [
+		  "==",
+		  "$type",
+		  "LineString"
+		],
+		"id": "water-name-lakeline",
+		"layout": {
+		  "symbol-placement": "line",
+		  "symbol-spacing": 350,
+		  "text-field": "{name:latin}\n{name:nonlatin}",
+		  "text-letter-spacing": 0.2,
+		  "text-max-width": 5,
+		  "text-rotation-alignment": "map",
+		  "text-size": 14
+		},
+		"paint": {
+		  "text-color": "#74aee9",
+		  "text-halo-color": "rgba(255,255,255,0.7)",
+		  "text-halo-width": 1.5
+		},
+		"source": "openmaptiles",
+		"source-layer": "water_name",
+		"type": "symbol"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"$type",
+			"Point"
+		  ],
+		  [
+			"==",
+			"class",
+			"ocean"
+		  ]
+		],
+		"id": "water-name-ocean",
+		"layout": {
+		  "symbol-placement": "point",
+		  "symbol-spacing": 350,
+		  "text-field": "{name:latin}",
+		  "text-letter-spacing": 0.2,
+		  "text-max-width": 5,
+		  "text-rotation-alignment": "map",
+		  "text-size": 14
+		},
+		"paint": {
+		  "text-color": "#74aee9",
+		  "text-halo-color": "rgba(255,255,255,0.7)",
+		  "text-halo-width": 1.5
+		},
+		"source": "openmaptiles",
+		"source-layer": "water_name",
+		"type": "symbol"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"$type",
+			"Point"
+		  ],
+		  [
+			"!in",
+			"class",
+			"ocean"
+		  ]
+		],
+		"id": "water-name-other",
+		"layout": {
+		  "symbol-placement": "point",
+		  "symbol-spacing": 350,
+		  "text-field": "{name:latin}\n{name:nonlatin}",
+		  "text-letter-spacing": 0.2,
+		  "text-max-width": 5,
+		  "text-rotation-alignment": "map",
+		  "text-size": {
+			"stops": [
+			  [
+				0,
+				10
+			  ],
+			  [
+				6,
+				14
+			  ]
+			]
+		  },
+		  "visibility": "visible"
+		},
+		"paint": {
+		  "text-color": "#74aee9",
+		  "text-halo-color": "rgba(255,255,255,0.7)",
+		  "text-halo-width": 1.5
+		},
+		"source": "openmaptiles",
+		"source-layer": "water_name",
+		"type": "symbol"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"$type",
+			"Point"
+		  ],
+		  [
+			">=",
+			"rank",
+			25
+		  ],
+		  [
+			"any",
+			[
+			  "!has",
+			  "level"
+			],
+			[
+			  "==",
+			  "level",
+			  0
+			]
+		  ]
+		],
+		"id": "poi-level-3",
+		"layout": {
+		  "icon-image": "{class}_11",
+		  "text-anchor": "top",
+		  "text-field": "{name:latin}\n{name:nonlatin}",
+		  "text-max-width": 9,
+		  "text-offset": [
+			0,
+			0.6
+		  ],
+		  "text-padding": 2,
+		  "text-size": 12
+		},
+		"minzoom": 16,
+		"paint": {
+		  "text-color": "#666",
+		  "text-halo-blur": 0.5,
+		  "text-halo-color": "#ffffff",
+		  "text-halo-width": 1
+		},
+		"source": "openmaptiles",
+		"source-layer": "poi",
+		"type": "symbol"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"$type",
+			"Point"
+		  ],
+		  [
+			"<=",
+			"rank",
+			24
+		  ],
+		  [
+			">=",
+			"rank",
+			15
+		  ],
+		  [
+			"any",
+			[
+			  "!has",
+			  "level"
+			],
+			[
+			  "==",
+			  "level",
+			  0
+			]
+		  ]
+		],
+		"id": "poi-level-2",
+		"layout": {
+		  "icon-image": "{class}_11",
+		  "text-anchor": "top",
+		  "text-field": "{name:latin}\n{name:nonlatin}",
+		  "text-max-width": 9,
+		  "text-offset": [
+			0,
+			0.6
+		  ],
+		  "text-padding": 2,
+		  "text-size": 12
+		},
+		"minzoom": 15,
+		"paint": {
+		  "text-color": "#666",
+		  "text-halo-blur": 0.5,
+		  "text-halo-color": "#ffffff",
+		  "text-halo-width": 1
+		},
+		"source": "openmaptiles",
+		"source-layer": "poi",
+		"type": "symbol"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"$type",
+			"Point"
+		  ],
+		  [
+			"<=",
+			"rank",
+			14
+		  ],
+		  [
+			"has",
+			"name"
+		  ],
+		  [
+			"any",
+			[
+			  "!has",
+			  "level"
+			],
+			[
+			  "==",
+			  "level",
+			  0
+			]
+		  ]
+		],
+		"id": "poi-level-1",
+		"layout": {
+		  "icon-image": "{class}_11",
+		  "text-anchor": "top",
+		  "text-field": "{name:latin}\n{name:nonlatin}",
+		  "text-max-width": 9,
+		  "text-offset": [
+			0,
+			0.6
+		  ],
+		  "text-padding": 2,
+		  "text-size": 12
+		},
+		"minzoom": 14,
+		"paint": {
+		  "text-color": "#666",
+		  "text-halo-blur": 0.5,
+		  "text-halo-color": "#ffffff",
+		  "text-halo-width": 1
+		},
+		"source": "openmaptiles",
+		"source-layer": "poi",
+		"type": "symbol"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"$type",
+			"Point"
+		  ],
+		  [
+			"has",
+			"name"
+		  ],
+		  [
+			"==",
+			"class",
+			"railway"
+		  ],
+		  [
+			"==",
+			"subclass",
+			"station"
+		  ]
+		],
+		"id": "poi-railway",
+		"layout": {
+		  "icon-allow-overlap": false,
+		  "icon-ignore-placement": false,
+		  "icon-image": "{class}_11",
+		  "icon-optional": false,
+		  "text-allow-overlap": false,
+		  "text-anchor": "top",
+		  "text-field": "{name:latin}\n{name:nonlatin}",
+		  "text-ignore-placement": false,
+		  "text-max-width": 9,
+		  "text-offset": [
+			0,
+			0.6
+		  ],
+		  "text-optional": true,
+		  "text-padding": 2,
+		  "text-size": 12
+		},
+		"minzoom": 13,
+		"paint": {
+		  "text-color": "#666",
+		  "text-halo-blur": 0.5,
+		  "text-halo-color": "#ffffff",
+		  "text-halo-width": 1
+		},
+		"source": "openmaptiles",
+		"source-layer": "poi",
+		"type": "symbol"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"oneway",
+			1
+		  ],
+		  [
+			"in",
+			"class",
+			"motorway",
+			"trunk",
+			"primary",
+			"secondary",
+			"tertiary",
+			"minor",
+			"service"
+		  ]
+		],
+		"id": "road_oneway",
+		"layout": {
+		  "icon-image": "oneway",
+		  "icon-padding": 2,
+		  "icon-rotate": 90,
+		  "icon-rotation-alignment": "map",
+		  "icon-size": {
+			"stops": [
+			  [
+				15,
+				0.5
+			  ],
+			  [
+				19,
+				1
+			  ]
+			]
+		  },
+		  "symbol-placement": "line",
+		  "symbol-spacing": 75
+		},
+		"minzoom": 15,
+		"paint": {
+		  "icon-opacity": 0.5
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "symbol"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"==",
+			"oneway",
+			-1
+		  ],
+		  [
+			"in",
+			"class",
+			"motorway",
+			"trunk",
+			"primary",
+			"secondary",
+			"tertiary",
+			"minor",
+			"service"
+		  ]
+		],
+		"id": "road_oneway_opposite",
+		"layout": {
+		  "icon-image": "oneway",
+		  "icon-padding": 2,
+		  "icon-rotate": -90,
+		  "icon-rotation-alignment": "map",
+		  "icon-size": {
+			"stops": [
+			  [
+				15,
+				0.5
+			  ],
+			  [
+				19,
+				1
+			  ]
+			]
+		  },
+		  "symbol-placement": "line",
+		  "symbol-spacing": 75
+		},
+		"minzoom": 15,
+		"paint": {
+		  "icon-opacity": 0.5
+		},
+		"source": "openmaptiles",
+		"source-layer": "transportation",
+		"type": "symbol"
+	  },
+	  {
+		"filter": [
+		  "all",
+		  [
+			"has",
+			"iata"
+		  ]
+		],
+		"id": "airport-label-major",
+		"layout": {
+		  "icon-image": "airport_11",
+		  "icon-size": 1,
+		  "text-anchor": "top",
+		  "text-field": "{name:latin}\n{name:nonlatin}",
+		  "text-max-width": 9,
+		  "text-offset": [
+			0,
+			0.6
+		  ],
+		  "text-optional": true,
+		  "text-padding": 2,
+		  "text-size": 12,
+		  "visibility": "visible"
+		},
+		"minzoom": 10,
+		"paint": {
+		  "text-color": "#666",
+		  "text-halo-blur": 0.5,
+		  "text-halo-color": "#ffffff",
+		  "text-halo-width": 1
+		},
+		"source": "openmaptiles",
+		"source-layer": "aerodrome_label",
+		"type": "symbol"
 	  }
+	],
+	"id": "osm-bright"
+  }
+  

--- a/components/map/styles/vector.json
+++ b/components/map/styles/vector.json
@@ -1,4247 +1,4246 @@
 {
-	"version": 8,
-	"name": "OSM Bright",
-	"metadata": {
-	  "mapbox:type": "template",
-	  "mapbox:groups": {
-		"1444849364238.8171": {
-		  "collapsed": false,
-		  "name": "Buildings"
-		},
-		"1444849354174.1904": {
-		  "collapsed": true,
-		  "name": "Tunnels"
-		},
-		"1444849388993.3071": {
-		  "collapsed": false,
-		  "name": "Land"
-		},
-		"1444849382550.77": {
-		  "collapsed": false,
-		  "name": "Water"
-		},
-		"1444849345966.4436": {
-		  "collapsed": false,
-		  "name": "Roads"
-		},
-		"1444849334699.1902": {
-		  "collapsed": true,
-		  "name": "Bridges"
-		}
-	  },
-	  "mapbox:autocomposite": false,
-	  "openmaptiles:version": "3.x",
-	  "openmaptiles:mapbox:owner": "openmaptiles",
-	  "openmaptiles:mapbox:source:url": "mapbox://openmaptiles.4qljc88t"
-	},
-	"sources": {
-	  "openmaptiles": {
-		"type": "vector",
-		"url": "https://openmaptiles.geo.data.gouv.fr/data/france-vector.json"
-	  },
-	  "cadastre": {
-		"type": "vector",
-		"url": "https://openmaptiles.geo.data.gouv.fr/data/cadastre.json"
-	  },
-	  "decoupage-administratif": {
-		"type": "vector",
-		"url": "https://openmaptiles.geo.data.gouv.fr/data/decoupage-administratif.json"
-	  }
-	},
-	"sprite": "https://openmaptiles.github.io/osm-bright-gl-style/sprite",
-	"glyphs": "https://openmaptiles.geo.data.gouv.fr/fonts/{fontstack}/{range}.pbf",
-	"layers": [
-	  {
-		"id": "background",
-		"type": "background",
-		"paint": {
-		  "background-color": "#f8f4f0"
-		}
-	  },
-	  {
-		"filter": [
-		  "==",
-		  "subclass",
-		  "glacier"
-		],
-		"id": "landcover-glacier",
-		"layout": {
-		  "visibility": "visible"
-		},
-		"metadata": {
-		  "mapbox:group": "1444849388993.3071"
-		},
-		"paint": {
-		  "fill-color": "#fff",
-		  "fill-opacity": {
-			"base": 1,
-			"stops": [
-			  [
-				0,
-				0.9
-			  ],
-			  [
-				10,
-				0.3
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "landcover",
-		"type": "fill"
-	  },
-	  {
-		"filter": [
-		  "==",
-		  "class",
-		  "residential"
-		],
-		"id": "landuse-residential",
-		"metadata": {
-		  "mapbox:group": "1444849388993.3071"
-		},
-		"paint": {
-		  "fill-color": {
-			"base": 1,
-			"stops": [
-			  [
-				12,
-				"hsla(30, 19%, 90%, 0.4)"
-			  ],
-			  [
-				16,
-				"hsla(30, 19%, 90%, 0.2)"
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "landuse",
-		"type": "fill"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"$type",
-			"Polygon"
-		  ],
-		  [
-			"==",
-			"class",
-			"commercial"
-		  ]
-		],
-		"id": "landuse-commercial",
-		"metadata": {
-		  "mapbox:group": "1444849388993.3071"
-		},
-		"paint": {
-		  "fill-color": "hsla(0, 60%, 87%, 0.23)"
-		},
-		"source": "openmaptiles",
-		"source-layer": "landuse",
-		"type": "fill"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"$type",
-			"Polygon"
-		  ],
-		  [
-			"==",
-			"class",
-			"industrial"
-		  ]
-		],
-		"id": "landuse-industrial",
-		"metadata": {
-		  "mapbox:group": "1444849388993.3071"
-		},
-		"paint": {
-		  "fill-color": "hsla(49, 100%, 88%, 0.34)"
-		},
-		"source": "openmaptiles",
-		"source-layer": "landuse",
-		"type": "fill"
-	  },
-	  {
-		"filter": [
-		  "==",
-		  "class",
-		  "cemetery"
-		],
-		"id": "landuse-cemetery",
-		"metadata": {
-		  "mapbox:group": "1444849388993.3071"
-		},
-		"paint": {
-		  "fill-color": "#e0e4dd"
-		},
-		"source": "openmaptiles",
-		"source-layer": "landuse",
-		"type": "fill"
-	  },
-	  {
-		"filter": [
-		  "==",
-		  "class",
-		  "hospital"
-		],
-		"id": "landuse-hospital",
-		"metadata": {
-		  "mapbox:group": "1444849388993.3071"
-		},
-		"paint": {
-		  "fill-color": "#fde"
-		},
-		"source": "openmaptiles",
-		"source-layer": "landuse",
-		"type": "fill"
-	  },
-	  {
-		"filter": [
-		  "==",
-		  "class",
-		  "school"
-		],
-		"id": "landuse-school",
-		"metadata": {
-		  "mapbox:group": "1444849388993.3071"
-		},
-		"paint": {
-		  "fill-color": "#f0e8f8"
-		},
-		"source": "openmaptiles",
-		"source-layer": "landuse",
-		"type": "fill"
-	  },
-	  {
-		"filter": [
-		  "==",
-		  "class",
-		  "railway"
-		],
-		"id": "landuse-railway",
-		"metadata": {
-		  "mapbox:group": "1444849388993.3071"
-		},
-		"paint": {
-		  "fill-color": "hsla(30, 19%, 90%, 0.4)"
-		},
-		"source": "openmaptiles",
-		"source-layer": "landuse",
-		"type": "fill"
-	  },
-	  {
-		"filter": [
-		  "==",
-		  "class",
-		  "wood"
-		],
-		"id": "landcover-wood",
-		"metadata": {
-		  "mapbox:group": "1444849388993.3071"
-		},
-		"paint": {
-		  "fill-antialias": {
-			"base": 1,
-			"stops": [
-			  [
-				0,
-				false
-			  ],
-			  [
-				9,
-				true
-			  ]
-			]
-		  },
-		  "fill-color": "#6a4",
-		  "fill-opacity": 0.1,
-		  "fill-outline-color": "hsla(0, 0%, 0%, 0.03)"
-		},
-		"source": "openmaptiles",
-		"source-layer": "landcover",
-		"type": "fill"
-	  },
-	  {
-		"filter": [
-		  "==",
-		  "class",
-		  "grass"
-		],
-		"id": "landcover-grass",
-		"metadata": {
-		  "mapbox:group": "1444849388993.3071"
-		},
-		"paint": {
-		  "fill-color": "#d8e8c8",
-		  "fill-opacity": 1
-		},
-		"source": "openmaptiles",
-		"source-layer": "landcover",
-		"type": "fill"
-	  },
-	  {
-		"filter": [
-		  "==",
-		  "class",
-		  "public_park"
-		],
-		"id": "landcover-grass-park",
-		"metadata": {
-		  "mapbox:group": "1444849388993.3071"
-		},
-		"paint": {
-		  "fill-color": "#d8e8c8",
-		  "fill-opacity": 0.8
-		},
-		"source": "openmaptiles",
-		"source-layer": "park",
-		"type": "fill"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"in",
-			"class",
-			"river",
-			"stream",
-			"canal"
-		  ],
-		  [
-			"==",
-			"brunnel",
-			"tunnel"
-		  ]
-		],
-		"id": "waterway_tunnel",
-		"layout": {
-		  "line-cap": "round"
-		},
-		"minzoom": 14,
-		"paint": {
-		  "line-color": "#a0c8f0",
-		  "line-dasharray": [
-			2,
-			4
-		  ],
-		  "line-width": {
-			"base": 1.3,
-			"stops": [
-			  [
-				13,
-				0.5
-			  ],
-			  [
-				20,
-				6
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "waterway",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "!in",
-		  "class",
-		  "canal",
-		  "river",
-		  "stream"
-		],
-		"id": "waterway-other",
-		"layout": {
-		  "line-cap": "round"
-		},
-		"metadata": {
-		  "mapbox:group": "1444849382550.77"
-		},
-		"paint": {
-		  "line-color": "#a0c8f0",
-		  "line-width": {
-			"base": 1.3,
-			"stops": [
-			  [
-				13,
-				0.5
-			  ],
-			  [
-				20,
-				2
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "waterway",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"in",
-			"class",
-			"canal",
-			"stream"
-		  ],
-		  [
-			"!=",
-			"brunnel",
-			"tunnel"
-		  ]
-		],
-		"id": "waterway-stream-canal",
-		"layout": {
-		  "line-cap": "round"
-		},
-		"metadata": {
-		  "mapbox:group": "1444849382550.77"
-		},
-		"paint": {
-		  "line-color": "#a0c8f0",
-		  "line-width": {
-			"base": 1.3,
-			"stops": [
-			  [
-				13,
-				0.5
-			  ],
-			  [
-				20,
-				6
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "waterway",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"class",
-			"river"
-		  ],
-		  [
-			"!=",
-			"brunnel",
-			"tunnel"
-		  ]
-		],
-		"id": "waterway-river",
-		"layout": {
-		  "line-cap": "round"
-		},
-		"metadata": {
-		  "mapbox:group": "1444849382550.77"
-		},
-		"paint": {
-		  "line-color": "#a0c8f0",
-		  "line-width": {
-			"base": 1.2,
-			"stops": [
-			  [
-				10,
-				0.8
-			  ],
-			  [
-				20,
-				6
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "waterway",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "==",
-		  "$type",
-		  "Polygon"
-		],
-		"id": "water-offset",
-		"layout": {
-		  "visibility": "visible"
-		},
-		"maxzoom": 8,
-		"metadata": {
-		  "mapbox:group": "1444849382550.77"
-		},
-		"paint": {
-		  "fill-color": "#a0c8f0",
-		  "fill-opacity": 1,
-		  "fill-translate": {
-			"base": 1,
-			"stops": [
-			  [
-				6,
-				[
-				  2,
-				  0
-				]
-			  ],
-			  [
-				8,
-				[
-				  0,
-				  0
-				]
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "water",
-		"type": "fill"
-	  },
-	  {
-		"id": "water",
-		"layout": {
-		  "visibility": "visible"
-		},
-		"metadata": {
-		  "mapbox:group": "1444849382550.77"
-		},
-		"paint": {
-		  "fill-color": "hsl(210, 67%, 85%)"
-		},
-		"source": "openmaptiles",
-		"source-layer": "water",
-		"type": "fill"
-	  },
-	  {
-		"filter": [
-		  "==",
-		  "subclass",
-		  "ice_shelf"
-		],
-		"id": "landcover-ice-shelf",
-		"layout": {
-		  "visibility": "visible"
-		},
-		"metadata": {
-		  "mapbox:group": "1444849382550.77"
-		},
-		"paint": {
-		  "fill-color": "#fff",
-		  "fill-opacity": {
-			"base": 1,
-			"stops": [
-			  [
-				0,
-				0.9
-			  ],
-			  [
-				10,
-				0.3
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "landcover",
-		"type": "fill"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"class",
-			"sand"
-		  ]
-		],
-		"id": "landcover-sand",
-		"layout": {
-		  "visibility": "visible"
-		},
-		"metadata": {
-		  "mapbox:group": "1444849382550.77"
-		},
-		"paint": {
-		  "fill-color": "rgba(245, 238, 188, 1)",
-		  "fill-opacity": 1
-		},
-		"source": "openmaptiles",
-		"source-layer": "landcover",
-		"type": "fill"
-	  },
-	  {
-		"id": "building",
-		"metadata": {
-		  "mapbox:group": "1444849364238.8171"
-		},
-		"paint": {
-		  "fill-antialias": true,
-		  "fill-color": {
-			"base": 1,
-			"stops": [
-			  [
-				15.5,
-				"#f2eae2"
-			  ],
-			  [
-				16,
-				"#dfdbd7"
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "building",
-		"type": "fill"
-	  },
-	  {
-		"id": "building-top",
-		"layout": {
-		  "visibility": "visible"
-		},
-		"metadata": {
-		  "mapbox:group": "1444849364238.8171"
-		},
-		"paint": {
-		  "fill-color": "#f2eae2",
-		  "fill-opacity": {
-			"base": 1,
-			"stops": [
-			  [
-				13,
-				0
-			  ],
-			  [
-				16,
-				1
-			  ]
-			]
-		  },
-		  "fill-outline-color": "#dfdbd7",
-		  "fill-translate": {
-			"base": 1,
-			"stops": [
-			  [
-				14,
-				[
-				  0,
-				  0
-				]
-			  ],
-			  [
-				16,
-				[
-				  -2,
-				  -2
-				]
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "building",
-		"type": "fill"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"brunnel",
-			"tunnel"
-		  ],
-		  [
-			"in",
-			"class",
-			"service",
-			"track"
-		  ]
-		],
-		"id": "tunnel-service-track-casing",
-		"layout": {
-		  "line-join": "round"
-		},
-		"metadata": {
-		  "mapbox:group": "1444849354174.1904"
-		},
-		"paint": {
-		  "line-color": "#cfcdca",
-		  "line-dasharray": [
-			0.5,
-			0.25
-		  ],
-		  "line-width": {
-			"base": 1.2,
-			"stops": [
-			  [
-				15,
-				1
-			  ],
-			  [
-				16,
-				4
-			  ],
-			  [
-				20,
-				11
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"brunnel",
-			"tunnel"
-		  ],
-		  [
-			"==",
-			"class",
-			"minor"
-		  ]
-		],
-		"id": "tunnel-minor-casing",
-		"layout": {
-		  "line-join": "round"
-		},
-		"metadata": {
-		  "mapbox:group": "1444849354174.1904"
-		},
-		"paint": {
-		  "line-color": "#cfcdca",
-		  "line-opacity": {
-			"stops": [
-			  [
-				12,
-				0
-			  ],
-			  [
-				12.5,
-				1
-			  ]
-			]
-		  },
-		  "line-width": {
-			"base": 1.2,
-			"stops": [
-			  [
-				12,
-				0.5
-			  ],
-			  [
-				13,
-				1
-			  ],
-			  [
-				14,
-				4
-			  ],
-			  [
-				20,
-				15
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"brunnel",
-			"tunnel"
-		  ],
-		  [
-			"in",
-			"class",
-			"secondary",
-			"tertiary"
-		  ]
-		],
-		"id": "tunnel-secondary-tertiary-casing",
-		"layout": {
-		  "line-join": "round"
-		},
-		"metadata": {
-		  "mapbox:group": "1444849354174.1904"
-		},
-		"paint": {
-		  "line-color": "#e9ac77",
-		  "line-opacity": 1,
-		  "line-width": {
-			"base": 1.2,
-			"stops": [
-			  [
-				8,
-				1.5
-			  ],
-			  [
-				20,
-				17
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"brunnel",
-			"tunnel"
-		  ],
-		  [
-			"in",
-			"class",
-			"primary",
-			"trunk"
-		  ]
-		],
-		"id": "tunnel-trunk-primary-casing",
-		"layout": {
-		  "line-join": "round"
-		},
-		"metadata": {
-		  "mapbox:group": "1444849354174.1904"
-		},
-		"paint": {
-		  "line-color": "#e9ac77",
-		  "line-width": {
-			"base": 1.2,
-			"stops": [
-			  [
-				5,
-				0.4
-			  ],
-			  [
-				6,
-				0.6
-			  ],
-			  [
-				7,
-				1.5
-			  ],
-			  [
-				20,
-				22
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"brunnel",
-			"tunnel"
-		  ],
-		  [
-			"==",
-			"class",
-			"motorway"
-		  ]
-		],
-		"id": "tunnel-motorway-casing",
-		"layout": {
-		  "line-join": "round",
-		  "visibility": "visible"
-		},
-		"metadata": {
-		  "mapbox:group": "1444849354174.1904"
-		},
-		"paint": {
-		  "line-color": "#e9ac77",
-		  "line-dasharray": [
-			0.5,
-			0.25
-		  ],
-		  "line-width": {
-			"base": 1.2,
-			"stops": [
-			  [
-				5,
-				0.4
-			  ],
-			  [
-				6,
-				0.6
-			  ],
-			  [
-				7,
-				1.5
-			  ],
-			  [
-				20,
-				22
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"$type",
-			"LineString"
-		  ],
-		  [
-			"all",
-			[
-			  "==",
-			  "brunnel",
-			  "tunnel"
-			],
-			[
-			  "==",
-			  "class",
-			  "path"
-			]
-		  ]
-		],
-		"id": "tunnel-path",
-		"metadata": {
-		  "mapbox:group": "1444849354174.1904"
-		},
-		"paint": {
-		  "line-color": "#cba",
-		  "line-dasharray": [
-			1.5,
-			0.75
-		  ],
-		  "line-width": {
-			"base": 1.2,
-			"stops": [
-			  [
-				15,
-				1.2
-			  ],
-			  [
-				20,
-				4
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"brunnel",
-			"tunnel"
-		  ],
-		  [
-			"in",
-			"class",
-			"service",
-			"track"
-		  ]
-		],
-		"id": "tunnel-service-track",
-		"layout": {
-		  "line-join": "round"
-		},
-		"metadata": {
-		  "mapbox:group": "1444849354174.1904"
-		},
-		"paint": {
-		  "line-color": "#fff",
-		  "line-width": {
-			"base": 1.2,
-			"stops": [
-			  [
-				15.5,
-				0
-			  ],
-			  [
-				16,
-				2
-			  ],
-			  [
-				20,
-				7.5
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"brunnel",
-			"tunnel"
-		  ],
-		  [
-			"==",
-			"class",
-			"minor_road"
-		  ]
-		],
-		"id": "tunnel-minor",
-		"layout": {
-		  "line-join": "round"
-		},
-		"metadata": {
-		  "mapbox:group": "1444849354174.1904"
-		},
-		"paint": {
-		  "line-color": "#fff",
-		  "line-opacity": 1,
-		  "line-width": {
-			"base": 1.2,
-			"stops": [
-			  [
-				13.5,
-				0
-			  ],
-			  [
-				14,
-				2.5
-			  ],
-			  [
-				20,
-				11.5
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"brunnel",
-			"tunnel"
-		  ],
-		  [
-			"in",
-			"class",
-			"secondary",
-			"tertiary"
-		  ]
-		],
-		"id": "tunnel-secondary-tertiary",
-		"layout": {
-		  "line-join": "round"
-		},
-		"metadata": {
-		  "mapbox:group": "1444849354174.1904"
-		},
-		"paint": {
-		  "line-color": "#fff4c6",
-		  "line-width": {
-			"base": 1.2,
-			"stops": [
-			  [
-				6.5,
-				0
-			  ],
-			  [
-				7,
-				0.5
-			  ],
-			  [
-				20,
-				10
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"brunnel",
-			"tunnel"
-		  ],
-		  [
-			"in",
-			"class",
-			"primary",
-			"trunk"
-		  ]
-		],
-		"id": "tunnel-trunk-primary",
-		"layout": {
-		  "line-join": "round"
-		},
-		"metadata": {
-		  "mapbox:group": "1444849354174.1904"
-		},
-		"paint": {
-		  "line-color": "#fff4c6",
-		  "line-width": {
-			"base": 1.2,
-			"stops": [
-			  [
-				6.5,
-				0
-			  ],
-			  [
-				7,
-				0.5
-			  ],
-			  [
-				20,
-				18
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"brunnel",
-			"tunnel"
-		  ],
-		  [
-			"==",
-			"class",
-			"motorway"
-		  ]
-		],
-		"id": "tunnel-motorway",
-		"layout": {
-		  "line-join": "round",
-		  "visibility": "visible"
-		},
-		"metadata": {
-		  "mapbox:group": "1444849354174.1904"
-		},
-		"paint": {
-		  "line-color": "#ffdaa6",
-		  "line-width": {
-			"base": 1.2,
-			"stops": [
-			  [
-				6.5,
-				0
-			  ],
-			  [
-				7,
-				0.5
-			  ],
-			  [
-				20,
-				18
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"brunnel",
-			"tunnel"
-		  ],
-		  [
-			"==",
-			"class",
-			"rail"
-		  ]
-		],
-		"id": "tunnel-railway",
-		"metadata": {
-		  "mapbox:group": "1444849354174.1904"
-		},
-		"paint": {
-		  "line-color": "#bbb",
-		  "line-dasharray": [
-			2,
-			2
-		  ],
-		  "line-width": {
-			"base": 1.4,
-			"stops": [
-			  [
-				14,
-				0.4
-			  ],
-			  [
-				15,
-				0.75
-			  ],
-			  [
-				20,
-				2
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"in",
-			"class",
-			"ferry"
-		  ]
-		],
-		"id": "ferry",
-		"layout": {
-		  "line-join": "round",
-		  "visibility": "visible"
-		},
-		"paint": {
-		  "line-color": "rgba(108, 159, 182, 1)",
-		  "line-dasharray": [
-			2,
-			2
-		  ],
-		  "line-width": 1.1
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"in",
-			"class",
-			"taxiway"
-		  ]
-		],
-		"id": "aeroway-taxiway-casing",
-		"layout": {
-		  "line-cap": "round",
-		  "line-join": "round",
-		  "visibility": "visible"
-		},
-		"metadata": {
-		  "mapbox:group": "1444849345966.4436"
-		},
-		"minzoom": 12,
-		"paint": {
-		  "line-color": "rgba(153, 153, 153, 1)",
-		  "line-opacity": 1,
-		  "line-width": {
-			"base": 1.5,
-			"stops": [
-			  [
-				11,
-				2
-			  ],
-			  [
-				17,
-				12
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "aeroway",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"in",
-			"class",
-			"runway"
-		  ]
-		],
-		"id": "aeroway-runway-casing",
-		"layout": {
-		  "line-cap": "round",
-		  "line-join": "round",
-		  "visibility": "visible"
-		},
-		"metadata": {
-		  "mapbox:group": "1444849345966.4436"
-		},
-		"minzoom": 12,
-		"paint": {
-		  "line-color": "rgba(153, 153, 153, 1)",
-		  "line-opacity": 1,
-		  "line-width": {
-			"base": 1.5,
-			"stops": [
-			  [
-				11,
-				5
-			  ],
-			  [
-				17,
-				55
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "aeroway",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"$type",
-			"Polygon"
-		  ],
-		  [
-			"in",
-			"class",
-			"runway",
-			"taxiway"
-		  ]
-		],
-		"id": "aeroway-area",
-		"layout": {
-		  "visibility": "visible"
-		},
-		"metadata": {
-		  "mapbox:group": "1444849345966.4436"
-		},
-		"minzoom": 4,
-		"paint": {
-		  "fill-color": "rgba(255, 255, 255, 1)",
-		  "fill-opacity": {
-			"base": 1,
-			"stops": [
-			  [
-				13,
-				0
-			  ],
-			  [
-				14,
-				1
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "aeroway",
-		"type": "fill"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"in",
-			"class",
-			"taxiway"
-		  ],
-		  [
-			"==",
-			"$type",
-			"LineString"
-		  ]
-		],
-		"id": "aeroway-taxiway",
-		"layout": {
-		  "line-cap": "round",
-		  "line-join": "round",
-		  "visibility": "visible"
-		},
-		"metadata": {
-		  "mapbox:group": "1444849345966.4436"
-		},
-		"minzoom": 4,
-		"paint": {
-		  "line-color": "rgba(255, 255, 255, 1)",
-		  "line-opacity": {
-			"base": 1,
-			"stops": [
-			  [
-				11,
-				0
-			  ],
-			  [
-				12,
-				1
-			  ]
-			]
-		  },
-		  "line-width": {
-			"base": 1.5,
-			"stops": [
-			  [
-				11,
-				1
-			  ],
-			  [
-				17,
-				10
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "aeroway",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"in",
-			"class",
-			"runway"
-		  ],
-		  [
-			"==",
-			"$type",
-			"LineString"
-		  ]
-		],
-		"id": "aeroway-runway",
-		"layout": {
-		  "line-cap": "round",
-		  "line-join": "round",
-		  "visibility": "visible"
-		},
-		"metadata": {
-		  "mapbox:group": "1444849345966.4436"
-		},
-		"minzoom": 4,
-		"paint": {
-		  "line-color": "rgba(255, 255, 255, 1)",
-		  "line-opacity": {
-			"base": 1,
-			"stops": [
-			  [
-				11,
-				0
-			  ],
-			  [
-				12,
-				1
-			  ]
-			]
-		  },
-		  "line-width": {
-			"base": 1.5,
-			"stops": [
-			  [
-				11,
-				4
-			  ],
-			  [
-				17,
-				50
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "aeroway",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"$type",
-			"Polygon"
-		  ],
-		  [
-			"==",
-			"class",
-			"pier"
-		  ]
-		],
-		"id": "road_area_pier",
-		"layout": {
-		  "visibility": "visible"
-		},
-		"metadata": {},
-		"paint": {
-		  "fill-antialias": true,
-		  "fill-color": "#f8f4f0"
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "fill"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"$type",
-			"LineString"
-		  ],
-		  [
-			"in",
-			"class",
-			"pier"
-		  ]
-		],
-		"id": "road_pier",
-		"layout": {
-		  "line-cap": "round",
-		  "line-join": "round"
-		},
-		"metadata": {},
-		"paint": {
-		  "line-color": "#f8f4f0",
-		  "line-width": {
-			"base": 1.2,
-			"stops": [
-			  [
-				15,
-				1
-			  ],
-			  [
-				17,
-				4
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"$type",
-			"Polygon"
-		  ],
-		  [
-			"!in",
-			"class",
-			"pier"
-		  ]
-		],
-		"id": "highway-area",
-		"layout": {
-		  "visibility": "visible"
-		},
-		"metadata": {
-		  "mapbox:group": "1444849345966.4436"
-		},
-		"paint": {
-		  "fill-antialias": false,
-		  "fill-color": "hsla(0, 0%, 89%, 0.56)",
-		  "fill-opacity": 0.9,
-		  "fill-outline-color": "#cfcdca"
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "fill"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"!in",
-			"brunnel",
-			"bridge",
-			"tunnel"
-		  ],
-		  [
-			"==",
-			"class",
-			"motorway_link"
-		  ]
-		],
-		"id": "highway-motorway-link-casing",
-		"layout": {
-		  "line-cap": "round",
-		  "line-join": "round"
-		},
-		"metadata": {
-		  "mapbox:group": "1444849345966.4436"
-		},
-		"minzoom": 12,
-		"paint": {
-		  "line-color": "#e9ac77",
-		  "line-opacity": 1,
-		  "line-width": {
-			"base": 1.2,
-			"stops": [
-			  [
-				12,
-				1
-			  ],
-			  [
-				13,
-				3
-			  ],
-			  [
-				14,
-				4
-			  ],
-			  [
-				20,
-				15
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"!in",
-			"brunnel",
-			"bridge",
-			"tunnel"
-		  ],
-		  [
-			"in",
-			"class",
-			"primary_link",
-			"secondary_link",
-			"tertiary_link",
-			"trunk_link"
-		  ]
-		],
-		"id": "highway-link-casing",
-		"layout": {
-		  "line-cap": "round",
-		  "line-join": "round",
-		  "visibility": "visible"
-		},
-		"metadata": {
-		  "mapbox:group": "1444849345966.4436"
-		},
-		"minzoom": 13,
-		"paint": {
-		  "line-color": "#e9ac77",
-		  "line-opacity": 1,
-		  "line-width": {
-			"base": 1.2,
-			"stops": [
-			  [
-				12,
-				1
-			  ],
-			  [
-				13,
-				3
-			  ],
-			  [
-				14,
-				4
-			  ],
-			  [
-				20,
-				15
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"$type",
-			"LineString"
-		  ],
-		  [
-			"all",
-			[
-			  "!=",
-			  "brunnel",
-			  "tunnel"
-			],
-			[
-			  "in",
-			  "class",
-			  "minor",
-			  "service",
-			  "track"
-			]
-		  ]
-		],
-		"id": "highway-minor-casing",
-		"layout": {
-		  "line-cap": "round",
-		  "line-join": "round"
-		},
-		"metadata": {
-		  "mapbox:group": "1444849345966.4436"
-		},
-		"paint": {
-		  "line-color": "#cfcdca",
-		  "line-opacity": {
-			"stops": [
-			  [
-				12,
-				0
-			  ],
-			  [
-				12.5,
-				1
-			  ]
-			]
-		  },
-		  "line-width": {
-			"base": 1.2,
-			"stops": [
-			  [
-				12,
-				0.5
-			  ],
-			  [
-				13,
-				1
-			  ],
-			  [
-				14,
-				4
-			  ],
-			  [
-				20,
-				15
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"!in",
-			"brunnel",
-			"bridge",
-			"tunnel"
-		  ],
-		  [
-			"in",
-			"class",
-			"secondary",
-			"tertiary"
-		  ]
-		],
-		"id": "highway-secondary-tertiary-casing",
-		"layout": {
-		  "line-cap": "butt",
-		  "line-join": "round",
-		  "visibility": "visible"
-		},
-		"metadata": {
-		  "mapbox:group": "1444849345966.4436"
-		},
-		"paint": {
-		  "line-color": "#e9ac77",
-		  "line-opacity": 1,
-		  "line-width": {
-			"base": 1.2,
-			"stops": [
-			  [
-				8,
-				1.5
-			  ],
-			  [
-				20,
-				17
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"!in",
-			"brunnel",
-			"bridge",
-			"tunnel"
-		  ],
-		  [
-			"in",
-			"class",
-			"primary"
-		  ]
-		],
-		"id": "highway-primary-casing",
-		"layout": {
-		  "line-cap": "butt",
-		  "line-join": "round",
-		  "visibility": "visible"
-		},
-		"metadata": {
-		  "mapbox:group": "1444849345966.4436"
-		},
-		"minzoom": 5,
-		"paint": {
-		  "line-color": "#e9ac77",
-		  "line-opacity": {
-			"stops": [
-			  [
-				7,
-				0
-			  ],
-			  [
-				8,
-				1
-			  ]
-			]
-		  },
-		  "line-width": {
-			"base": 1.2,
-			"stops": [
-			  [
-				7,
-				0
-			  ],
-			  [
-				8,
-				0.6
-			  ],
-			  [
-				9,
-				1.5
-			  ],
-			  [
-				20,
-				22
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"!in",
-			"brunnel",
-			"bridge",
-			"tunnel"
-		  ],
-		  [
-			"in",
-			"class",
-			"trunk"
-		  ]
-		],
-		"id": "highway-trunk-casing",
-		"layout": {
-		  "line-cap": "butt",
-		  "line-join": "round",
-		  "visibility": "visible"
-		},
-		"metadata": {
-		  "mapbox:group": "1444849345966.4436"
-		},
-		"minzoom": 5,
-		"paint": {
-		  "line-color": "#e9ac77",
-		  "line-opacity": {
-			"stops": [
-			  [
-				5,
-				0
-			  ],
-			  [
-				6,
-				1
-			  ]
-			]
-		  },
-		  "line-width": {
-			"base": 1.2,
-			"stops": [
-			  [
-				5,
-				0
-			  ],
-			  [
-				6,
-				0.6
-			  ],
-			  [
-				7,
-				1.5
-			  ],
-			  [
-				20,
-				22
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"!in",
-			"brunnel",
-			"bridge",
-			"tunnel"
-		  ],
-		  [
-			"==",
-			"class",
-			"motorway"
-		  ]
-		],
-		"id": "highway-motorway-casing",
-		"layout": {
-		  "line-cap": "butt",
-		  "line-join": "round",
-		  "visibility": "visible"
-		},
-		"metadata": {
-		  "mapbox:group": "1444849345966.4436"
-		},
-		"minzoom": 4,
-		"paint": {
-		  "line-color": "#e9ac77",
-		  "line-opacity": {
-			"stops": [
-			  [
-				4,
-				0
-			  ],
-			  [
-				5,
-				1
-			  ]
-			]
-		  },
-		  "line-width": {
-			"base": 1.2,
-			"stops": [
-			  [
-				4,
-				0
-			  ],
-			  [
-				5,
-				0.4
-			  ],
-			  [
-				6,
-				0.6
-			  ],
-			  [
-				7,
-				1.5
-			  ],
-			  [
-				20,
-				22
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"$type",
-			"LineString"
-		  ],
-		  [
-			"all",
-			[
-			  "!in",
-			  "brunnel",
-			  "bridge",
-			  "tunnel"
-			],
-			[
-			  "==",
-			  "class",
-			  "path"
-			]
-		  ]
-		],
-		"id": "highway-path",
-		"metadata": {
-		  "mapbox:group": "1444849345966.4436"
-		},
-		"paint": {
-		  "line-color": "#cba",
-		  "line-dasharray": [
-			1.5,
-			0.75
-		  ],
-		  "line-width": {
-			"base": 1.2,
-			"stops": [
-			  [
-				15,
-				1.2
-			  ],
-			  [
-				20,
-				4
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"!in",
-			"brunnel",
-			"bridge",
-			"tunnel"
-		  ],
-		  [
-			"==",
-			"class",
-			"motorway_link"
-		  ]
-		],
-		"id": "highway-motorway-link",
-		"layout": {
-		  "line-cap": "round",
-		  "line-join": "round"
-		},
-		"metadata": {
-		  "mapbox:group": "1444849345966.4436"
-		},
-		"minzoom": 12,
-		"paint": {
-		  "line-color": "#fc8",
-		  "line-width": {
-			"base": 1.2,
-			"stops": [
-			  [
-				12.5,
-				0
-			  ],
-			  [
-				13,
-				1.5
-			  ],
-			  [
-				14,
-				2.5
-			  ],
-			  [
-				20,
-				11.5
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"!in",
-			"brunnel",
-			"bridge",
-			"tunnel"
-		  ],
-		  [
-			"in",
-			"class",
-			"primary_link",
-			"secondary_link",
-			"tertiary_link",
-			"trunk_link"
-		  ]
-		],
-		"id": "highway-link",
-		"layout": {
-		  "line-cap": "round",
-		  "line-join": "round",
-		  "visibility": "visible"
-		},
-		"metadata": {
-		  "mapbox:group": "1444849345966.4436"
-		},
-		"minzoom": 13,
-		"paint": {
-		  "line-color": "#fea",
-		  "line-width": {
-			"base": 1.2,
-			"stops": [
-			  [
-				12.5,
-				0
-			  ],
-			  [
-				13,
-				1.5
-			  ],
-			  [
-				14,
-				2.5
-			  ],
-			  [
-				20,
-				11.5
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"$type",
-			"LineString"
-		  ],
-		  [
-			"all",
-			[
-			  "!=",
-			  "brunnel",
-			  "tunnel"
-			],
-			[
-			  "in",
-			  "class",
-			  "minor",
-			  "service",
-			  "track"
-			]
-		  ]
-		],
-		"id": "highway-minor",
-		"layout": {
-		  "line-cap": "round",
-		  "line-join": "round"
-		},
-		"metadata": {
-		  "mapbox:group": "1444849345966.4436"
-		},
-		"paint": {
-		  "line-color": "#fff",
-		  "line-opacity": 1,
-		  "line-width": {
-			"base": 1.2,
-			"stops": [
-			  [
-				13.5,
-				0
-			  ],
-			  [
-				14,
-				2.5
-			  ],
-			  [
-				20,
-				11.5
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"!in",
-			"brunnel",
-			"bridge",
-			"tunnel"
-		  ],
-		  [
-			"in",
-			"class",
-			"secondary",
-			"tertiary"
-		  ]
-		],
-		"id": "highway-secondary-tertiary",
-		"layout": {
-		  "line-cap": "round",
-		  "line-join": "round",
-		  "visibility": "visible"
-		},
-		"metadata": {
-		  "mapbox:group": "1444849345966.4436"
-		},
-		"paint": {
-		  "line-color": "#fea",
-		  "line-width": {
-			"base": 1.2,
-			"stops": [
-			  [
-				6.5,
-				0
-			  ],
-			  [
-				8,
-				0.5
-			  ],
-			  [
-				20,
-				13
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"$type",
-			"LineString"
-		  ],
-		  [
-			"all",
-			[
-			  "!in",
-			  "brunnel",
-			  "bridge",
-			  "tunnel"
-			],
-			[
-			  "in",
-			  "class",
-			  "primary"
-			]
-		  ]
-		],
-		"id": "highway-primary",
-		"layout": {
-		  "line-cap": "round",
-		  "line-join": "round",
-		  "visibility": "visible"
-		},
-		"metadata": {
-		  "mapbox:group": "1444849345966.4436"
-		},
-		"paint": {
-		  "line-color": "#fea",
-		  "line-width": {
-			"base": 1.2,
-			"stops": [
-			  [
-				8.5,
-				0
-			  ],
-			  [
-				9,
-				0.5
-			  ],
-			  [
-				20,
-				18
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"$type",
-			"LineString"
-		  ],
-		  [
-			"all",
-			[
-			  "!in",
-			  "brunnel",
-			  "bridge",
-			  "tunnel"
-			],
-			[
-			  "in",
-			  "class",
-			  "trunk"
-			]
-		  ]
-		],
-		"id": "highway-trunk",
-		"layout": {
-		  "line-cap": "round",
-		  "line-join": "round",
-		  "visibility": "visible"
-		},
-		"metadata": {
-		  "mapbox:group": "1444849345966.4436"
-		},
-		"paint": {
-		  "line-color": "#fea",
-		  "line-width": {
-			"base": 1.2,
-			"stops": [
-			  [
-				6.5,
-				0
-			  ],
-			  [
-				7,
-				0.5
-			  ],
-			  [
-				20,
-				18
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"$type",
-			"LineString"
-		  ],
-		  [
-			"all",
-			[
-			  "!in",
-			  "brunnel",
-			  "bridge",
-			  "tunnel"
-			],
-			[
-			  "==",
-			  "class",
-			  "motorway"
-			]
-		  ]
-		],
-		"id": "highway-motorway",
-		"layout": {
-		  "line-cap": "round",
-		  "line-join": "round",
-		  "visibility": "visible"
-		},
-		"metadata": {
-		  "mapbox:group": "1444849345966.4436"
-		},
-		"minzoom": 5,
-		"paint": {
-		  "line-color": "#fc8",
-		  "line-width": {
-			"base": 1.2,
-			"stops": [
-			  [
-				6.5,
-				0
-			  ],
-			  [
-				7,
-				0.5
-			  ],
-			  [
-				20,
-				18
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"$type",
-			"LineString"
-		  ],
-		  [
-			"all",
-			[
-			  "==",
-			  "class",
-			  "transit"
-			],
-			[
-			  "!in",
-			  "brunnel",
-			  "tunnel"
-			]
-		  ]
-		],
-		"id": "railway-transit",
-		"layout": {
-		  "visibility": "visible"
-		},
-		"metadata": {
-		  "mapbox:group": "1444849345966.4436"
-		},
-		"paint": {
-		  "line-color": "hsla(0, 0%, 73%, 0.77)",
-		  "line-width": {
-			"base": 1.4,
-			"stops": [
-			  [
-				14,
-				0.4
-			  ],
-			  [
-				20,
-				1
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"$type",
-			"LineString"
-		  ],
-		  [
-			"all",
-			[
-			  "==",
-			  "class",
-			  "transit"
-			],
-			[
-			  "!in",
-			  "brunnel",
-			  "tunnel"
-			]
-		  ]
-		],
-		"id": "railway-transit-hatching",
-		"layout": {
-		  "visibility": "visible"
-		},
-		"metadata": {
-		  "mapbox:group": "1444849345966.4436"
-		},
-		"paint": {
-		  "line-color": "hsla(0, 0%, 73%, 0.68)",
-		  "line-dasharray": [
-			0.2,
-			8
-		  ],
-		  "line-width": {
-			"base": 1.4,
-			"stops": [
-			  [
-				14.5,
-				0
-			  ],
-			  [
-				15,
-				2
-			  ],
-			  [
-				20,
-				6
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"$type",
-			"LineString"
-		  ],
-		  [
-			"all",
-			[
-			  "==",
-			  "class",
-			  "rail"
-			],
-			[
-			  "has",
-			  "service"
-			]
-		  ]
-		],
-		"id": "railway-service",
-		"metadata": {
-		  "mapbox:group": "1444849345966.4436"
-		},
-		"paint": {
-		  "line-color": "hsla(0, 0%, 73%, 0.77)",
-		  "line-width": {
-			"base": 1.4,
-			"stops": [
-			  [
-				14,
-				0.4
-			  ],
-			  [
-				20,
-				1
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"$type",
-			"LineString"
-		  ],
-		  [
-			"all",
-			[
-			  "==",
-			  "class",
-			  "rail"
-			],
-			[
-			  "has",
-			  "service"
-			]
-		  ]
-		],
-		"id": "railway-service-hatching",
-		"layout": {
-		  "visibility": "visible"
-		},
-		"metadata": {
-		  "mapbox:group": "1444849345966.4436"
-		},
-		"paint": {
-		  "line-color": "hsla(0, 0%, 73%, 0.68)",
-		  "line-dasharray": [
-			0.2,
-			8
-		  ],
-		  "line-width": {
-			"base": 1.4,
-			"stops": [
-			  [
-				14.5,
-				0
-			  ],
-			  [
-				15,
-				2
-			  ],
-			  [
-				20,
-				6
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"$type",
-			"LineString"
-		  ],
-		  [
-			"all",
-			[
-			  "!has",
-			  "service"
-			],
-			[
-			  "!in",
-			  "brunnel",
-			  "bridge",
-			  "tunnel"
-			],
-			[
-			  "==",
-			  "class",
-			  "rail"
-			]
-		  ]
-		],
-		"id": "railway",
-		"metadata": {
-		  "mapbox:group": "1444849345966.4436"
-		},
-		"paint": {
-		  "line-color": "#bbb",
-		  "line-width": {
-			"base": 1.4,
-			"stops": [
-			  [
-				14,
-				0.4
-			  ],
-			  [
-				15,
-				0.75
-			  ],
-			  [
-				20,
-				2
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"$type",
-			"LineString"
-		  ],
-		  [
-			"all",
-			[
-			  "!has",
-			  "service"
-			],
-			[
-			  "!in",
-			  "brunnel",
-			  "bridge",
-			  "tunnel"
-			],
-			[
-			  "==",
-			  "class",
-			  "rail"
-			]
-		  ]
-		],
-		"id": "railway-hatching",
-		"metadata": {
-		  "mapbox:group": "1444849345966.4436"
-		},
-		"paint": {
-		  "line-color": "#bbb",
-		  "line-dasharray": [
-			0.2,
-			8
-		  ],
-		  "line-width": {
-			"base": 1.4,
-			"stops": [
-			  [
-				14.5,
-				0
-			  ],
-			  [
-				15,
-				3
-			  ],
-			  [
-				20,
-				8
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"brunnel",
-			"bridge"
-		  ],
-		  [
-			"==",
-			"class",
-			"motorway_link"
-		  ]
-		],
-		"id": "bridge-motorway-link-casing",
-		"layout": {
-		  "line-join": "round"
-		},
-		"metadata": {
-		  "mapbox:group": "1444849334699.1902"
-		},
-		"paint": {
-		  "line-color": "#e9ac77",
-		  "line-opacity": 1,
-		  "line-width": {
-			"base": 1.2,
-			"stops": [
-			  [
-				12,
-				1
-			  ],
-			  [
-				13,
-				3
-			  ],
-			  [
-				14,
-				4
-			  ],
-			  [
-				20,
-				15
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"brunnel",
-			"bridge"
-		  ],
-		  [
-			"in",
-			"class",
-			"primary_link",
-			"secondary_link",
-			"tertiary_link",
-			"trunk_link"
-		  ]
-		],
-		"id": "bridge-link-casing",
-		"layout": {
-		  "line-join": "round"
-		},
-		"metadata": {
-		  "mapbox:group": "1444849334699.1902"
-		},
-		"paint": {
-		  "line-color": "#e9ac77",
-		  "line-opacity": 1,
-		  "line-width": {
-			"base": 1.2,
-			"stops": [
-			  [
-				12,
-				1
-			  ],
-			  [
-				13,
-				3
-			  ],
-			  [
-				14,
-				4
-			  ],
-			  [
-				20,
-				15
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"brunnel",
-			"bridge"
-		  ],
-		  [
-			"in",
-			"class",
-			"secondary",
-			"tertiary"
-		  ]
-		],
-		"id": "bridge-secondary-tertiary-casing",
-		"layout": {
-		  "line-join": "round"
-		},
-		"metadata": {
-		  "mapbox:group": "1444849334699.1902"
-		},
-		"paint": {
-		  "line-color": "#e9ac77",
-		  "line-opacity": 1,
-		  "line-width": {
-			"base": 1.2,
-			"stops": [
-			  [
-				8,
-				1.5
-			  ],
-			  [
-				20,
-				28
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"brunnel",
-			"bridge"
-		  ],
-		  [
-			"in",
-			"class",
-			"primary",
-			"trunk"
-		  ]
-		],
-		"id": "bridge-trunk-primary-casing",
-		"layout": {
-		  "line-join": "round"
-		},
-		"metadata": {
-		  "mapbox:group": "1444849334699.1902"
-		},
-		"paint": {
-		  "line-color": "hsl(28, 76%, 67%)",
-		  "line-width": {
-			"base": 1.2,
-			"stops": [
-			  [
-				5,
-				0.4
-			  ],
-			  [
-				6,
-				0.6
-			  ],
-			  [
-				7,
-				1.5
-			  ],
-			  [
-				20,
-				26
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"brunnel",
-			"bridge"
-		  ],
-		  [
-			"==",
-			"class",
-			"motorway"
-		  ]
-		],
-		"id": "bridge-motorway-casing",
-		"layout": {
-		  "line-join": "round"
-		},
-		"metadata": {
-		  "mapbox:group": "1444849334699.1902"
-		},
-		"paint": {
-		  "line-color": "#e9ac77",
-		  "line-width": {
-			"base": 1.2,
-			"stops": [
-			  [
-				5,
-				0.4
-			  ],
-			  [
-				6,
-				0.6
-			  ],
-			  [
-				7,
-				1.5
-			  ],
-			  [
-				20,
-				22
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"$type",
-			"LineString"
-		  ],
-		  [
-			"all",
-			[
-			  "==",
-			  "brunnel",
-			  "bridge"
-			],
-			[
-			  "==",
-			  "class",
-			  "path"
-			]
-		  ]
-		],
-		"id": "bridge-path-casing",
-		"metadata": {
-		  "mapbox:group": "1444849334699.1902"
-		},
-		"paint": {
-		  "line-color": "#f8f4f0",
-		  "line-width": {
-			"base": 1.2,
-			"stops": [
-			  [
-				15,
-				1.2
-			  ],
-			  [
-				20,
-				18
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"$type",
-			"LineString"
-		  ],
-		  [
-			"all",
-			[
-			  "==",
-			  "brunnel",
-			  "bridge"
-			],
-			[
-			  "==",
-			  "class",
-			  "path"
-			]
-		  ]
-		],
-		"id": "bridge-path",
-		"metadata": {
-		  "mapbox:group": "1444849334699.1902"
-		},
-		"paint": {
-		  "line-color": "#cba",
-		  "line-dasharray": [
-			1.5,
-			0.75
-		  ],
-		  "line-width": {
-			"base": 1.2,
-			"stops": [
-			  [
-				15,
-				1.2
-			  ],
-			  [
-				20,
-				4
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"brunnel",
-			"bridge"
-		  ],
-		  [
-			"==",
-			"class",
-			"motorway_link"
-		  ]
-		],
-		"id": "bridge-motorway-link",
-		"layout": {
-		  "line-join": "round"
-		},
-		"metadata": {
-		  "mapbox:group": "1444849334699.1902"
-		},
-		"paint": {
-		  "line-color": "#fc8",
-		  "line-width": {
-			"base": 1.2,
-			"stops": [
-			  [
-				12.5,
-				0
-			  ],
-			  [
-				13,
-				1.5
-			  ],
-			  [
-				14,
-				2.5
-			  ],
-			  [
-				20,
-				11.5
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"brunnel",
-			"bridge"
-		  ],
-		  [
-			"in",
-			"class",
-			"primary_link",
-			"secondary_link",
-			"tertiary_link",
-			"trunk_link"
-		  ]
-		],
-		"id": "bridge-link",
-		"layout": {
-		  "line-join": "round"
-		},
-		"metadata": {
-		  "mapbox:group": "1444849334699.1902"
-		},
-		"paint": {
-		  "line-color": "#fea",
-		  "line-width": {
-			"base": 1.2,
-			"stops": [
-			  [
-				12.5,
-				0
-			  ],
-			  [
-				13,
-				1.5
-			  ],
-			  [
-				14,
-				2.5
-			  ],
-			  [
-				20,
-				11.5
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"brunnel",
-			"bridge"
-		  ],
-		  [
-			"in",
-			"class",
-			"secondary",
-			"tertiary"
-		  ]
-		],
-		"id": "bridge-secondary-tertiary",
-		"layout": {
-		  "line-join": "round"
-		},
-		"metadata": {
-		  "mapbox:group": "1444849334699.1902"
-		},
-		"paint": {
-		  "line-color": "#fea",
-		  "line-width": {
-			"base": 1.2,
-			"stops": [
-			  [
-				6.5,
-				0
-			  ],
-			  [
-				7,
-				0.5
-			  ],
-			  [
-				20,
-				20
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"brunnel",
-			"bridge"
-		  ],
-		  [
-			"in",
-			"class",
-			"primary",
-			"trunk"
-		  ]
-		],
-		"id": "bridge-trunk-primary",
-		"layout": {
-		  "line-join": "round"
-		},
-		"metadata": {
-		  "mapbox:group": "1444849334699.1902"
-		},
-		"paint": {
-		  "line-color": "#fea",
-		  "line-width": {
-			"base": 1.2,
-			"stops": [
-			  [
-				6.5,
-				0
-			  ],
-			  [
-				7,
-				0.5
-			  ],
-			  [
-				20,
-				18
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"brunnel",
-			"bridge"
-		  ],
-		  [
-			"==",
-			"class",
-			"motorway"
-		  ]
-		],
-		"id": "bridge-motorway",
-		"layout": {
-		  "line-join": "round"
-		},
-		"metadata": {
-		  "mapbox:group": "1444849334699.1902"
-		},
-		"paint": {
-		  "line-color": "#fc8",
-		  "line-width": {
-			"base": 1.2,
-			"stops": [
-			  [
-				6.5,
-				0
-			  ],
-			  [
-				7,
-				0.5
-			  ],
-			  [
-				20,
-				18
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"brunnel",
-			"bridge"
-		  ],
-		  [
-			"==",
-			"class",
-			"rail"
-		  ]
-		],
-		"id": "bridge-railway",
-		"metadata": {
-		  "mapbox:group": "1444849334699.1902"
-		},
-		"paint": {
-		  "line-color": "#bbb",
-		  "line-width": {
-			"base": 1.4,
-			"stops": [
-			  [
-				14,
-				0.4
-			  ],
-			  [
-				15,
-				0.75
-			  ],
-			  [
-				20,
-				2
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"brunnel",
-			"bridge"
-		  ],
-		  [
-			"==",
-			"class",
-			"rail"
-		  ]
-		],
-		"id": "bridge-railway-hatching",
-		"metadata": {
-		  "mapbox:group": "1444849334699.1902"
-		},
-		"paint": {
-		  "line-color": "#bbb",
-		  "line-dasharray": [
-			0.2,
-			8
-		  ],
-		  "line-width": {
-			"base": 1.4,
-			"stops": [
-			  [
-				14.5,
-				0
-			  ],
-			  [
-				15,
-				3
-			  ],
-			  [
-				20,
-				8
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "==",
-		  "class",
-		  "cable_car"
-		],
-		"id": "cablecar",
-		"layout": {
-		  "line-cap": "round",
-		  "visibility": "visible"
-		},
-		"minzoom": 13,
-		"paint": {
-		  "line-color": "hsl(0, 0%, 70%)",
-		  "line-width": {
-			"base": 1,
-			"stops": [
-			  [
-				11,
-				1
-			  ],
-			  [
-				19,
-				2.5
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "==",
-		  "class",
-		  "cable_car"
-		],
-		"id": "cablecar-dash",
-		"layout": {
-		  "line-cap": "round",
-		  "visibility": "visible"
-		},
-		"minzoom": 13,
-		"paint": {
-		  "line-color": "hsl(0, 0%, 70%)",
-		  "line-dasharray": [
-			2,
-			3
-		  ],
-		  "line-width": {
-			"base": 1,
-			"stops": [
-			  [
-				11,
-				3
-			  ],
-			  [
-				19,
-				5.5
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			">=",
-			"admin_level",
-			4
-		  ],
-		  [
-			"<=",
-			"admin_level",
-			8
-		  ],
-		  [
-			"!=",
-			"maritime",
-			1
-		  ]
-		],
-		"id": "boundary-land-level-4",
-		"layout": {
-		  "line-join": "round"
-		},
-		"paint": {
-		  "line-color": "#9e9cab",
-		  "line-dasharray": [
-			3,
-			1,
-			1,
-			1
-		  ],
-		  "line-width": {
-			"base": 1.4,
-			"stops": [
-			  [
-				4,
-				0.4
-			  ],
-			  [
-				5,
-				1
-			  ],
-			  [
-				12,
-				3
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "boundary",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"admin_level",
-			2
-		  ],
-		  [
-			"!=",
-			"maritime",
-			1
-		  ],
-		  [
-			"!=",
-			"disputed",
-			1
-		  ]
-		],
-		"id": "boundary-land-level-2",
-		"layout": {
-		  "line-cap": "round",
-		  "line-join": "round"
-		},
-		"paint": {
-		  "line-color": "hsl(248, 7%, 66%)",
-		  "line-width": {
-			"base": 1,
-			"stops": [
-			  [
-				0,
-				0.6
-			  ],
-			  [
-				4,
-				1.4
-			  ],
-			  [
-				5,
-				2
-			  ],
-			  [
-				12,
-				8
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "boundary",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"!=",
-			"maritime",
-			1
-		  ],
-		  [
-			"==",
-			"disputed",
-			1
-		  ]
-		],
-		"id": "boundary-land-disputed",
-		"layout": {
-		  "line-cap": "round",
-		  "line-join": "round"
-		},
-		"paint": {
-		  "line-color": "hsl(248, 7%, 70%)",
-		  "line-dasharray": [
-			1,
-			3
-		  ],
-		  "line-width": {
-			"base": 1,
-			"stops": [
-			  [
-				0,
-				0.6
-			  ],
-			  [
-				4,
-				1.4
-			  ],
-			  [
-				5,
-				2
-			  ],
-			  [
-				12,
-				8
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "boundary",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"in",
-			"admin_level",
-			2,
-			4
-		  ],
-		  [
-			"==",
-			"maritime",
-			1
-		  ]
-		],
-		"id": "boundary-water",
-		"layout": {
-		  "line-cap": "round",
-		  "line-join": "round"
-		},
-		"paint": {
-		  "line-color": "rgba(154, 189, 214, 1)",
-		  "line-opacity": {
-			"stops": [
-			  [
-				6,
-				0.6
-			  ],
-			  [
-				10,
-				1
-			  ]
-			]
-		  },
-		  "line-width": {
-			"base": 1,
-			"stops": [
-			  [
-				0,
-				0.6
-			  ],
-			  [
-				4,
-				1.4
-			  ],
-			  [
-				5,
-				2
-			  ],
-			  [
-				12,
-				8
-			  ]
-			]
-		  }
-		},
-		"source": "openmaptiles",
-		"source-layer": "boundary",
-		"type": "line"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"$type",
-			"LineString"
-		  ],
-		  [
-			"has",
-			"name"
-		  ]
-		],
-		"id": "waterway-name",
-		"layout": {
-		  "symbol-placement": "line",
-		  "symbol-spacing": 350,
-		  "text-field": "{name:latin} {name:nonlatin}",
-		  "text-font": [
-			"Open Sans Regular"
-		  ],
-		  "text-letter-spacing": 0.2,
-		  "text-max-width": 5,
-		  "text-rotation-alignment": "map",
-		  "text-size": 14
-		},
-		"minzoom": 13,
-		"paint": {
-		  "text-color": "#74aee9",
-		  "text-halo-color": "rgba(255,255,255,0.7)",
-		  "text-halo-width": 1.5
-		},
-		"source": "openmaptiles",
-		"source-layer": "waterway",
-		"type": "symbol"
-	  },
-	  {
-		"filter": [
-		  "==",
-		  "$type",
-		  "LineString"
-		],
-		"id": "water-name-lakeline",
-		"layout": {
-		  "symbol-placement": "line",
-		  "symbol-spacing": 350,
-		  "text-field": "{name:latin}\n{name:nonlatin}",
-		  "text-font": [
-			"Open Sans Regular"
-		  ],
-		  "text-letter-spacing": 0.2,
-		  "text-max-width": 5,
-		  "text-rotation-alignment": "map",
-		  "text-size": 14
-		},
-		"paint": {
-		  "text-color": "#74aee9",
-		  "text-halo-color": "rgba(255,255,255,0.7)",
-		  "text-halo-width": 1.5
-		},
-		"source": "openmaptiles",
-		"source-layer": "water_name",
-		"type": "symbol"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"$type",
-			"Point"
-		  ],
-		  [
-			"==",
-			"class",
-			"ocean"
-		  ]
-		],
-		"id": "water-name-ocean",
-		"layout": {
-		  "symbol-placement": "point",
-		  "symbol-spacing": 350,
-		  "text-field": "{name:latin}",
-		  "text-font": [
-			"Open Sans Regular"
-		  ],
-		  "text-letter-spacing": 0.2,
-		  "text-max-width": 5,
-		  "text-rotation-alignment": "map",
-		  "text-size": 14
-		},
-		"paint": {
-		  "text-color": "#74aee9",
-		  "text-halo-color": "rgba(255,255,255,0.7)",
-		  "text-halo-width": 1.5
-		},
-		"source": "openmaptiles",
-		"source-layer": "water_name",
-		"type": "symbol"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"$type",
-			"Point"
-		  ],
-		  [
-			"!in",
-			"class",
-			"ocean"
-		  ]
-		],
-		"id": "water-name-other",
-		"layout": {
-		  "symbol-placement": "point",
-		  "symbol-spacing": 350,
-		  "text-field": "{name:latin}\n{name:nonlatin}",
-		  "text-font": [
-			"Open Sans Regular"
-		  ],
-		  "text-letter-spacing": 0.2,
-		  "text-max-width": 5,
-		  "text-rotation-alignment": "map",
-		  "text-size": {
-			"stops": [
-			  [
-				0,
-				10
-			  ],
-			  [
-				6,
-				14
-			  ]
-			]
-		  },
-		  "visibility": "visible"
-		},
-		"paint": {
-		  "text-color": "#74aee9",
-		  "text-halo-color": "rgba(255,255,255,0.7)",
-		  "text-halo-width": 1.5
-		},
-		"source": "openmaptiles",
-		"source-layer": "water_name",
-		"type": "symbol"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"$type",
-			"Point"
-		  ],
-		  [
-			">=",
-			"rank",
-			25
-		  ],
-		  [
-			"any",
-			[
-			  "!has",
-			  "level"
-			],
-			[
-			  "==",
-			  "level",
-			  0
-			]
-		  ]
-		],
-		"id": "poi-level-3",
-		"layout": {
-		  "icon-image": "{class}_11",
-		  "text-anchor": "top",
-		  "text-field": "{name:latin}\n{name:nonlatin}",
-		  "text-font": [
-			"Open Sans Regular"
-		  ],
-		  "text-max-width": 9,
-		  "text-offset": [
-			0,
-			0.6
-		  ],
-		  "text-padding": 2,
-		  "text-size": 12
-		},
-		"minzoom": 16,
-		"paint": {
-		  "text-color": "#666",
-		  "text-halo-blur": 0.5,
-		  "text-halo-color": "#ffffff",
-		  "text-halo-width": 1
-		},
-		"source": "openmaptiles",
-		"source-layer": "poi",
-		"type": "symbol"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"$type",
-			"Point"
-		  ],
-		  [
-			"<=",
-			"rank",
-			24
-		  ],
-		  [
-			">=",
-			"rank",
-			15
-		  ],
-		  [
-			"any",
-			[
-			  "!has",
-			  "level"
-			],
-			[
-			  "==",
-			  "level",
-			  0
-			]
-		  ]
-		],
-		"id": "poi-level-2",
-		"layout": {
-		  "icon-image": "{class}_11",
-		  "text-anchor": "top",
-		  "text-field": "{name:latin}\n{name:nonlatin}",
-		  "text-font": [
-			"Open Sans Regular"
-		  ],
-		  "text-max-width": 9,
-		  "text-offset": [
-			0,
-			0.6
-		  ],
-		  "text-padding": 2,
-		  "text-size": 12
-		},
-		"minzoom": 15,
-		"paint": {
-		  "text-color": "#666",
-		  "text-halo-blur": 0.5,
-		  "text-halo-color": "#ffffff",
-		  "text-halo-width": 1
-		},
-		"source": "openmaptiles",
-		"source-layer": "poi",
-		"type": "symbol"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"$type",
-			"Point"
-		  ],
-		  [
-			"<=",
-			"rank",
-			14
-		  ],
-		  [
-			"has",
-			"name"
-		  ],
-		  [
-			"any",
-			[
-			  "!has",
-			  "level"
-			],
-			[
-			  "==",
-			  "level",
-			  0
-			]
-		  ]
-		],
-		"id": "poi-level-1",
-		"layout": {
-		  "icon-image": "{class}_11",
-		  "text-anchor": "top",
-		  "text-field": "{name:latin}\n{name:nonlatin}",
-		  "text-font": [
-			"Open Sans Regular"
-		  ],
-		  "text-max-width": 9,
-		  "text-offset": [
-			0,
-			0.6
-		  ],
-		  "text-padding": 2,
-		  "text-size": 12
-		},
-		"minzoom": 14,
-		"paint": {
-		  "text-color": "#666",
-		  "text-halo-blur": 0.5,
-		  "text-halo-color": "#ffffff",
-		  "text-halo-width": 1
-		},
-		"source": "openmaptiles",
-		"source-layer": "poi",
-		"type": "symbol"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"$type",
-			"Point"
-		  ],
-		  [
-			"has",
-			"name"
-		  ],
-		  [
-			"==",
-			"class",
-			"railway"
-		  ],
-		  [
-			"==",
-			"subclass",
-			"station"
-		  ]
-		],
-		"id": "poi-railway",
-		"layout": {
-		  "icon-allow-overlap": false,
-		  "icon-ignore-placement": false,
-		  "icon-image": "{class}_11",
-		  "icon-optional": false,
-		  "text-allow-overlap": false,
-		  "text-anchor": "top",
-		  "text-field": "{name:latin}\n{name:nonlatin}",
-		  "text-font": [
-			"Open Sans Regular"
-		  ],
-		  "text-ignore-placement": false,
-		  "text-max-width": 9,
-		  "text-offset": [
-			0,
-			0.6
-		  ],
-		  "text-optional": true,
-		  "text-padding": 2,
-		  "text-size": 12
-		},
-		"minzoom": 13,
-		"paint": {
-		  "text-color": "#666",
-		  "text-halo-blur": 0.5,
-		  "text-halo-color": "#ffffff",
-		  "text-halo-width": 1
-		},
-		"source": "openmaptiles",
-		"source-layer": "poi",
-		"type": "symbol"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"oneway",
-			1
-		  ],
-		  [
-			"in",
-			"class",
-			"motorway",
-			"trunk",
-			"primary",
-			"secondary",
-			"tertiary",
-			"minor",
-			"service"
-		  ]
-		],
-		"id": "road_oneway",
-		"layout": {
-		  "icon-image": "oneway",
-		  "icon-padding": 2,
-		  "icon-rotate": 90,
-		  "icon-rotation-alignment": "map",
-		  "icon-size": {
-			"stops": [
-			  [
-				15,
-				0.5
-			  ],
-			  [
-				19,
-				1
-			  ]
-			]
-		  },
-		  "symbol-placement": "line",
-		  "symbol-spacing": 75
-		},
-		"minzoom": 15,
-		"paint": {
-		  "icon-opacity": 0.5
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "symbol"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"==",
-			"oneway",
-			-1
-		  ],
-		  [
-			"in",
-			"class",
-			"motorway",
-			"trunk",
-			"primary",
-			"secondary",
-			"tertiary",
-			"minor",
-			"service"
-		  ]
-		],
-		"id": "road_oneway_opposite",
-		"layout": {
-		  "icon-image": "oneway",
-		  "icon-padding": 2,
-		  "icon-rotate": -90,
-		  "icon-rotation-alignment": "map",
-		  "icon-size": {
-			"stops": [
-			  [
-				15,
-				0.5
-			  ],
-			  [
-				19,
-				1
-			  ]
-			]
-		  },
-		  "symbol-placement": "line",
-		  "symbol-spacing": 75
-		},
-		"minzoom": 15,
-		"paint": {
-		  "icon-opacity": 0.5
-		},
-		"source": "openmaptiles",
-		"source-layer": "transportation",
-		"type": "symbol"
-	  },
-	  {
-		"filter": [
-		  "all",
-		  [
-			"has",
-			"iata"
-		  ]
-		],
-		"id": "airport-label-major",
-		"layout": {
-		  "icon-image": "airport_11",
-		  "icon-size": 1,
-		  "text-anchor": "top",
-		  "text-field": "{name:latin}\n{name:nonlatin}",
-		  "text-font": [
-			"Open Sans Regular"
-		  ],
-		  "text-max-width": 9,
-		  "text-offset": [
-			0,
-			0.6
-		  ],
-		  "text-optional": true,
-		  "text-padding": 2,
-		  "text-size": 12,
-		  "visibility": "visible"
-		},
-		"minzoom": 10,
-		"paint": {
-		  "text-color": "#666",
-		  "text-halo-blur": 0.5,
-		  "text-halo-color": "#ffffff",
-		  "text-halo-width": 1
-		},
-		"source": "openmaptiles",
-		"source-layer": "aerodrome_label",
-		"type": "symbol"
-	  }
-	],
-	"id": "osm-bright"
-  }
-  
+  "version": 8,
+  "name": "OSM Bright",
+  "metadata": {
+    "mapbox:type": "template",
+    "mapbox:groups": {
+      "1444849364238.8171": {
+        "collapsed": false,
+        "name": "Buildings"
+      },
+      "1444849354174.1904": {
+        "collapsed": true,
+        "name": "Tunnels"
+      },
+      "1444849388993.3071": {
+        "collapsed": false,
+        "name": "Land"
+      },
+      "1444849382550.77": {
+        "collapsed": false,
+        "name": "Water"
+      },
+      "1444849345966.4436": {
+        "collapsed": false,
+        "name": "Roads"
+      },
+      "1444849334699.1902": {
+        "collapsed": true,
+        "name": "Bridges"
+      }
+    },
+    "mapbox:autocomposite": false,
+    "openmaptiles:version": "3.x",
+    "openmaptiles:mapbox:owner": "openmaptiles",
+    "openmaptiles:mapbox:source:url": "mapbox://openmaptiles.4qljc88t"
+  },
+  "sources": {
+    "openmaptiles": {
+      "type": "vector",
+      "url": "https://openmaptiles.geo.data.gouv.fr/data/france-vector.json"
+    },
+    "cadastre": {
+      "type": "vector",
+      "url": "https://openmaptiles.geo.data.gouv.fr/data/cadastre.json"
+    },
+    "decoupage-administratif": {
+      "type": "vector",
+      "url": "https://openmaptiles.geo.data.gouv.fr/data/decoupage-administratif.json"
+    }
+  },
+  "sprite": "https://openmaptiles.github.io/osm-bright-gl-style/sprite",
+  "glyphs": "https://openmaptiles.geo.data.gouv.fr/fonts/{fontstack}/{range}.pbf",
+  "layers": [
+    {
+      "id": "background",
+      "type": "background",
+      "paint": {
+        "background-color": "#f8f4f0"
+      }
+    },
+    {
+      "filter": [
+        "==",
+        "subclass",
+        "glacier"
+      ],
+      "id": "landcover-glacier",
+      "layout": {
+        "visibility": "visible"
+      },
+      "metadata": {
+        "mapbox:group": "1444849388993.3071"
+      },
+      "paint": {
+        "fill-color": "#fff",
+        "fill-opacity": {
+          "base": 1,
+          "stops": [
+            [
+              0,
+              0.9
+            ],
+            [
+              10,
+              0.3
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "landcover",
+      "type": "fill"
+    },
+    {
+      "filter": [
+        "==",
+        "class",
+        "residential"
+      ],
+      "id": "landuse-residential",
+      "metadata": {
+        "mapbox:group": "1444849388993.3071"
+      },
+      "paint": {
+        "fill-color": {
+          "base": 1,
+          "stops": [
+            [
+              12,
+              "hsla(30, 19%, 90%, 0.4)"
+            ],
+            [
+              16,
+              "hsla(30, 19%, 90%, 0.2)"
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "landuse",
+      "type": "fill"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Polygon"
+        ],
+        [
+          "==",
+          "class",
+          "commercial"
+        ]
+      ],
+      "id": "landuse-commercial",
+      "metadata": {
+        "mapbox:group": "1444849388993.3071"
+      },
+      "paint": {
+        "fill-color": "hsla(0, 60%, 87%, 0.23)"
+      },
+      "source": "openmaptiles",
+      "source-layer": "landuse",
+      "type": "fill"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Polygon"
+        ],
+        [
+          "==",
+          "class",
+          "industrial"
+        ]
+      ],
+      "id": "landuse-industrial",
+      "metadata": {
+        "mapbox:group": "1444849388993.3071"
+      },
+      "paint": {
+        "fill-color": "hsla(49, 100%, 88%, 0.34)"
+      },
+      "source": "openmaptiles",
+      "source-layer": "landuse",
+      "type": "fill"
+    },
+    {
+      "filter": [
+        "==",
+        "class",
+        "cemetery"
+      ],
+      "id": "landuse-cemetery",
+      "metadata": {
+        "mapbox:group": "1444849388993.3071"
+      },
+      "paint": {
+        "fill-color": "#e0e4dd"
+      },
+      "source": "openmaptiles",
+      "source-layer": "landuse",
+      "type": "fill"
+    },
+    {
+      "filter": [
+        "==",
+        "class",
+        "hospital"
+      ],
+      "id": "landuse-hospital",
+      "metadata": {
+        "mapbox:group": "1444849388993.3071"
+      },
+      "paint": {
+        "fill-color": "#fde"
+      },
+      "source": "openmaptiles",
+      "source-layer": "landuse",
+      "type": "fill"
+    },
+    {
+      "filter": [
+        "==",
+        "class",
+        "school"
+      ],
+      "id": "landuse-school",
+      "metadata": {
+        "mapbox:group": "1444849388993.3071"
+      },
+      "paint": {
+        "fill-color": "#f0e8f8"
+      },
+      "source": "openmaptiles",
+      "source-layer": "landuse",
+      "type": "fill"
+    },
+    {
+      "filter": [
+        "==",
+        "class",
+        "railway"
+      ],
+      "id": "landuse-railway",
+      "metadata": {
+        "mapbox:group": "1444849388993.3071"
+      },
+      "paint": {
+        "fill-color": "hsla(30, 19%, 90%, 0.4)"
+      },
+      "source": "openmaptiles",
+      "source-layer": "landuse",
+      "type": "fill"
+    },
+    {
+      "filter": [
+        "==",
+        "class",
+        "wood"
+      ],
+      "id": "landcover-wood",
+      "metadata": {
+        "mapbox:group": "1444849388993.3071"
+      },
+      "paint": {
+        "fill-antialias": {
+          "base": 1,
+          "stops": [
+            [
+              0,
+              false
+            ],
+            [
+              9,
+              true
+            ]
+          ]
+        },
+        "fill-color": "#6a4",
+        "fill-opacity": 0.1,
+        "fill-outline-color": "hsla(0, 0%, 0%, 0.03)"
+      },
+      "source": "openmaptiles",
+      "source-layer": "landcover",
+      "type": "fill"
+    },
+    {
+      "filter": [
+        "==",
+        "class",
+        "grass"
+      ],
+      "id": "landcover-grass",
+      "metadata": {
+        "mapbox:group": "1444849388993.3071"
+      },
+      "paint": {
+        "fill-color": "#d8e8c8",
+        "fill-opacity": 1
+      },
+      "source": "openmaptiles",
+      "source-layer": "landcover",
+      "type": "fill"
+    },
+    {
+      "filter": [
+        "==",
+        "class",
+        "public_park"
+      ],
+      "id": "landcover-grass-park",
+      "metadata": {
+        "mapbox:group": "1444849388993.3071"
+      },
+      "paint": {
+        "fill-color": "#d8e8c8",
+        "fill-opacity": 0.8
+      },
+      "source": "openmaptiles",
+      "source-layer": "park",
+      "type": "fill"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "in",
+          "class",
+          "river",
+          "stream",
+          "canal"
+        ],
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ]
+      ],
+      "id": "waterway_tunnel",
+      "layout": {
+        "line-cap": "round"
+      },
+      "minzoom": 14,
+      "paint": {
+        "line-color": "#a0c8f0",
+        "line-dasharray": [
+          2,
+          4
+        ],
+        "line-width": {
+          "base": 1.3,
+          "stops": [
+            [
+              13,
+              0.5
+            ],
+            [
+              20,
+              6
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "waterway",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "!in",
+        "class",
+        "canal",
+        "river",
+        "stream"
+      ],
+      "id": "waterway-other",
+      "layout": {
+        "line-cap": "round"
+      },
+      "metadata": {
+        "mapbox:group": "1444849382550.77"
+      },
+      "paint": {
+        "line-color": "#a0c8f0",
+        "line-width": {
+          "base": 1.3,
+          "stops": [
+            [
+              13,
+              0.5
+            ],
+            [
+              20,
+              2
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "waterway",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "in",
+          "class",
+          "canal",
+          "stream"
+        ],
+        [
+          "!=",
+          "brunnel",
+          "tunnel"
+        ]
+      ],
+      "id": "waterway-stream-canal",
+      "layout": {
+        "line-cap": "round"
+      },
+      "metadata": {
+        "mapbox:group": "1444849382550.77"
+      },
+      "paint": {
+        "line-color": "#a0c8f0",
+        "line-width": {
+          "base": 1.3,
+          "stops": [
+            [
+              13,
+              0.5
+            ],
+            [
+              20,
+              6
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "waterway",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "river"
+        ],
+        [
+          "!=",
+          "brunnel",
+          "tunnel"
+        ]
+      ],
+      "id": "waterway-river",
+      "layout": {
+        "line-cap": "round"
+      },
+      "metadata": {
+        "mapbox:group": "1444849382550.77"
+      },
+      "paint": {
+        "line-color": "#a0c8f0",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              10,
+              0.8
+            ],
+            [
+              20,
+              6
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "waterway",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "==",
+        "$type",
+        "Polygon"
+      ],
+      "id": "water-offset",
+      "layout": {
+        "visibility": "visible"
+      },
+      "maxzoom": 8,
+      "metadata": {
+        "mapbox:group": "1444849382550.77"
+      },
+      "paint": {
+        "fill-color": "#a0c8f0",
+        "fill-opacity": 1,
+        "fill-translate": {
+          "base": 1,
+          "stops": [
+            [
+              6,
+              [
+                2,
+                0
+              ]
+            ],
+            [
+              8,
+              [
+                0,
+                0
+              ]
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "water",
+      "type": "fill"
+    },
+    {
+      "id": "water",
+      "layout": {
+        "visibility": "visible"
+      },
+      "metadata": {
+        "mapbox:group": "1444849382550.77"
+      },
+      "paint": {
+        "fill-color": "hsl(210, 67%, 85%)"
+      },
+      "source": "openmaptiles",
+      "source-layer": "water",
+      "type": "fill"
+    },
+    {
+      "filter": [
+        "==",
+        "subclass",
+        "ice_shelf"
+      ],
+      "id": "landcover-ice-shelf",
+      "layout": {
+        "visibility": "visible"
+      },
+      "metadata": {
+        "mapbox:group": "1444849382550.77"
+      },
+      "paint": {
+        "fill-color": "#fff",
+        "fill-opacity": {
+          "base": 1,
+          "stops": [
+            [
+              0,
+              0.9
+            ],
+            [
+              10,
+              0.3
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "landcover",
+      "type": "fill"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "sand"
+        ]
+      ],
+      "id": "landcover-sand",
+      "layout": {
+        "visibility": "visible"
+      },
+      "metadata": {
+        "mapbox:group": "1444849382550.77"
+      },
+      "paint": {
+        "fill-color": "rgba(245, 238, 188, 1)",
+        "fill-opacity": 1
+      },
+      "source": "openmaptiles",
+      "source-layer": "landcover",
+      "type": "fill"
+    },
+    {
+      "id": "building",
+      "metadata": {
+        "mapbox:group": "1444849364238.8171"
+      },
+      "paint": {
+        "fill-antialias": true,
+        "fill-color": {
+          "base": 1,
+          "stops": [
+            [
+              15.5,
+              "#f2eae2"
+            ],
+            [
+              16,
+              "#dfdbd7"
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "building",
+      "type": "fill"
+    },
+    {
+      "id": "building-top",
+      "layout": {
+        "visibility": "visible"
+      },
+      "metadata": {
+        "mapbox:group": "1444849364238.8171"
+      },
+      "paint": {
+        "fill-color": "#f2eae2",
+        "fill-opacity": {
+          "base": 1,
+          "stops": [
+            [
+              13,
+              0
+            ],
+            [
+              16,
+              1
+            ]
+          ]
+        },
+        "fill-outline-color": "#dfdbd7",
+        "fill-translate": {
+          "base": 1,
+          "stops": [
+            [
+              14,
+              [
+                0,
+                0
+              ]
+            ],
+            [
+              16,
+              [
+                -2,
+                -2
+              ]
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "building",
+      "type": "fill"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "in",
+          "class",
+          "service",
+          "track"
+        ]
+      ],
+      "id": "tunnel-service-track-casing",
+      "layout": {
+        "line-join": "round"
+      },
+      "metadata": {
+        "mapbox:group": "1444849354174.1904"
+      },
+      "paint": {
+        "line-color": "#cfcdca",
+        "line-dasharray": [
+          0.5,
+          0.25
+        ],
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              15,
+              1
+            ],
+            [
+              16,
+              4
+            ],
+            [
+              20,
+              11
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "==",
+          "class",
+          "minor"
+        ]
+      ],
+      "id": "tunnel-minor-casing",
+      "layout": {
+        "line-join": "round"
+      },
+      "metadata": {
+        "mapbox:group": "1444849354174.1904"
+      },
+      "paint": {
+        "line-color": "#cfcdca",
+        "line-opacity": {
+          "stops": [
+            [
+              12,
+              0
+            ],
+            [
+              12.5,
+              1
+            ]
+          ]
+        },
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              12,
+              0.5
+            ],
+            [
+              13,
+              1
+            ],
+            [
+              14,
+              4
+            ],
+            [
+              20,
+              15
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "in",
+          "class",
+          "secondary",
+          "tertiary"
+        ]
+      ],
+      "id": "tunnel-secondary-tertiary-casing",
+      "layout": {
+        "line-join": "round"
+      },
+      "metadata": {
+        "mapbox:group": "1444849354174.1904"
+      },
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-opacity": 1,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              8,
+              1.5
+            ],
+            [
+              20,
+              17
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "in",
+          "class",
+          "primary",
+          "trunk"
+        ]
+      ],
+      "id": "tunnel-trunk-primary-casing",
+      "layout": {
+        "line-join": "round"
+      },
+      "metadata": {
+        "mapbox:group": "1444849354174.1904"
+      },
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              5,
+              0.4
+            ],
+            [
+              6,
+              0.6
+            ],
+            [
+              7,
+              1.5
+            ],
+            [
+              20,
+              22
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "==",
+          "class",
+          "motorway"
+        ]
+      ],
+      "id": "tunnel-motorway-casing",
+      "layout": {
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "metadata": {
+        "mapbox:group": "1444849354174.1904"
+      },
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-dasharray": [
+          0.5,
+          0.25
+        ],
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              5,
+              0.4
+            ],
+            [
+              6,
+              0.6
+            ],
+            [
+              7,
+              1.5
+            ],
+            [
+              20,
+              22
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "all",
+          [
+            "==",
+            "brunnel",
+            "tunnel"
+          ],
+          [
+            "==",
+            "class",
+            "path"
+          ]
+        ]
+      ],
+      "id": "tunnel-path",
+      "metadata": {
+        "mapbox:group": "1444849354174.1904"
+      },
+      "paint": {
+        "line-color": "#cba",
+        "line-dasharray": [
+          1.5,
+          0.75
+        ],
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              15,
+              1.2
+            ],
+            [
+              20,
+              4
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "in",
+          "class",
+          "service",
+          "track"
+        ]
+      ],
+      "id": "tunnel-service-track",
+      "layout": {
+        "line-join": "round"
+      },
+      "metadata": {
+        "mapbox:group": "1444849354174.1904"
+      },
+      "paint": {
+        "line-color": "#fff",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              15.5,
+              0
+            ],
+            [
+              16,
+              2
+            ],
+            [
+              20,
+              7.5
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "==",
+          "class",
+          "minor_road"
+        ]
+      ],
+      "id": "tunnel-minor",
+      "layout": {
+        "line-join": "round"
+      },
+      "metadata": {
+        "mapbox:group": "1444849354174.1904"
+      },
+      "paint": {
+        "line-color": "#fff",
+        "line-opacity": 1,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              13.5,
+              0
+            ],
+            [
+              14,
+              2.5
+            ],
+            [
+              20,
+              11.5
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "in",
+          "class",
+          "secondary",
+          "tertiary"
+        ]
+      ],
+      "id": "tunnel-secondary-tertiary",
+      "layout": {
+        "line-join": "round"
+      },
+      "metadata": {
+        "mapbox:group": "1444849354174.1904"
+      },
+      "paint": {
+        "line-color": "#fff4c6",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              6.5,
+              0
+            ],
+            [
+              7,
+              0.5
+            ],
+            [
+              20,
+              10
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "in",
+          "class",
+          "primary",
+          "trunk"
+        ]
+      ],
+      "id": "tunnel-trunk-primary",
+      "layout": {
+        "line-join": "round"
+      },
+      "metadata": {
+        "mapbox:group": "1444849354174.1904"
+      },
+      "paint": {
+        "line-color": "#fff4c6",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              6.5,
+              0
+            ],
+            [
+              7,
+              0.5
+            ],
+            [
+              20,
+              18
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "==",
+          "class",
+          "motorway"
+        ]
+      ],
+      "id": "tunnel-motorway",
+      "layout": {
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "metadata": {
+        "mapbox:group": "1444849354174.1904"
+      },
+      "paint": {
+        "line-color": "#ffdaa6",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              6.5,
+              0
+            ],
+            [
+              7,
+              0.5
+            ],
+            [
+              20,
+              18
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ],
+        [
+          "==",
+          "class",
+          "rail"
+        ]
+      ],
+      "id": "tunnel-railway",
+      "metadata": {
+        "mapbox:group": "1444849354174.1904"
+      },
+      "paint": {
+        "line-color": "#bbb",
+        "line-dasharray": [
+          2,
+          2
+        ],
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              14,
+              0.4
+            ],
+            [
+              15,
+              0.75
+            ],
+            [
+              20,
+              2
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "in",
+          "class",
+          "ferry"
+        ]
+      ],
+      "id": "ferry",
+      "layout": {
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(108, 159, 182, 1)",
+        "line-dasharray": [
+          2,
+          2
+        ],
+        "line-width": 1.1
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "in",
+          "class",
+          "taxiway"
+        ]
+      ],
+      "id": "aeroway-taxiway-casing",
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "minzoom": 12,
+      "paint": {
+        "line-color": "rgba(153, 153, 153, 1)",
+        "line-opacity": 1,
+        "line-width": {
+          "base": 1.5,
+          "stops": [
+            [
+              11,
+              2
+            ],
+            [
+              17,
+              12
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "aeroway",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "in",
+          "class",
+          "runway"
+        ]
+      ],
+      "id": "aeroway-runway-casing",
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "minzoom": 12,
+      "paint": {
+        "line-color": "rgba(153, 153, 153, 1)",
+        "line-opacity": 1,
+        "line-width": {
+          "base": 1.5,
+          "stops": [
+            [
+              11,
+              5
+            ],
+            [
+              17,
+              55
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "aeroway",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Polygon"
+        ],
+        [
+          "in",
+          "class",
+          "runway",
+          "taxiway"
+        ]
+      ],
+      "id": "aeroway-area",
+      "layout": {
+        "visibility": "visible"
+      },
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "minzoom": 4,
+      "paint": {
+        "fill-color": "rgba(255, 255, 255, 1)",
+        "fill-opacity": {
+          "base": 1,
+          "stops": [
+            [
+              13,
+              0
+            ],
+            [
+              14,
+              1
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "aeroway",
+      "type": "fill"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "in",
+          "class",
+          "taxiway"
+        ],
+        [
+          "==",
+          "$type",
+          "LineString"
+        ]
+      ],
+      "id": "aeroway-taxiway",
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "minzoom": 4,
+      "paint": {
+        "line-color": "rgba(255, 255, 255, 1)",
+        "line-opacity": {
+          "base": 1,
+          "stops": [
+            [
+              11,
+              0
+            ],
+            [
+              12,
+              1
+            ]
+          ]
+        },
+        "line-width": {
+          "base": 1.5,
+          "stops": [
+            [
+              11,
+              1
+            ],
+            [
+              17,
+              10
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "aeroway",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "in",
+          "class",
+          "runway"
+        ],
+        [
+          "==",
+          "$type",
+          "LineString"
+        ]
+      ],
+      "id": "aeroway-runway",
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "minzoom": 4,
+      "paint": {
+        "line-color": "rgba(255, 255, 255, 1)",
+        "line-opacity": {
+          "base": 1,
+          "stops": [
+            [
+              11,
+              0
+            ],
+            [
+              12,
+              1
+            ]
+          ]
+        },
+        "line-width": {
+          "base": 1.5,
+          "stops": [
+            [
+              11,
+              4
+            ],
+            [
+              17,
+              50
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "aeroway",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Polygon"
+        ],
+        [
+          "==",
+          "class",
+          "pier"
+        ]
+      ],
+      "id": "road_area_pier",
+      "layout": {
+        "visibility": "visible"
+      },
+      "metadata": {},
+      "paint": {
+        "fill-antialias": true,
+        "fill-color": "#f8f4f0"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "fill"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "in",
+          "class",
+          "pier"
+        ]
+      ],
+      "id": "road_pier",
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "metadata": {},
+      "paint": {
+        "line-color": "#f8f4f0",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              15,
+              1
+            ],
+            [
+              17,
+              4
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Polygon"
+        ],
+        [
+          "!in",
+          "class",
+          "pier"
+        ]
+      ],
+      "id": "highway-area",
+      "layout": {
+        "visibility": "visible"
+      },
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "paint": {
+        "fill-antialias": false,
+        "fill-color": "hsla(0, 0%, 89%, 0.56)",
+        "fill-opacity": 0.9,
+        "fill-outline-color": "#cfcdca"
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "fill"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "!in",
+          "brunnel",
+          "bridge",
+          "tunnel"
+        ],
+        [
+          "==",
+          "class",
+          "motorway_link"
+        ]
+      ],
+      "id": "highway-motorway-link-casing",
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "minzoom": 12,
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-opacity": 1,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              12,
+              1
+            ],
+            [
+              13,
+              3
+            ],
+            [
+              14,
+              4
+            ],
+            [
+              20,
+              15
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "!in",
+          "brunnel",
+          "bridge",
+          "tunnel"
+        ],
+        [
+          "in",
+          "class",
+          "primary_link",
+          "secondary_link",
+          "tertiary_link",
+          "trunk_link"
+        ]
+      ],
+      "id": "highway-link-casing",
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "minzoom": 13,
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-opacity": 1,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              12,
+              1
+            ],
+            [
+              13,
+              3
+            ],
+            [
+              14,
+              4
+            ],
+            [
+              20,
+              15
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "all",
+          [
+            "!=",
+            "brunnel",
+            "tunnel"
+          ],
+          [
+            "in",
+            "class",
+            "minor",
+            "service",
+            "track"
+          ]
+        ]
+      ],
+      "id": "highway-minor-casing",
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "paint": {
+        "line-color": "#cfcdca",
+        "line-opacity": {
+          "stops": [
+            [
+              12,
+              0
+            ],
+            [
+              12.5,
+              1
+            ]
+          ]
+        },
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              12,
+              0.5
+            ],
+            [
+              13,
+              1
+            ],
+            [
+              14,
+              4
+            ],
+            [
+              20,
+              15
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "!in",
+          "brunnel",
+          "bridge",
+          "tunnel"
+        ],
+        [
+          "in",
+          "class",
+          "secondary",
+          "tertiary"
+        ]
+      ],
+      "id": "highway-secondary-tertiary-casing",
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-opacity": 1,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              8,
+              1.5
+            ],
+            [
+              20,
+              17
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "!in",
+          "brunnel",
+          "bridge",
+          "tunnel"
+        ],
+        [
+          "in",
+          "class",
+          "primary"
+        ]
+      ],
+      "id": "highway-primary-casing",
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "minzoom": 5,
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-opacity": {
+          "stops": [
+            [
+              7,
+              0
+            ],
+            [
+              8,
+              1
+            ]
+          ]
+        },
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              7,
+              0
+            ],
+            [
+              8,
+              0.6
+            ],
+            [
+              9,
+              1.5
+            ],
+            [
+              20,
+              22
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "!in",
+          "brunnel",
+          "bridge",
+          "tunnel"
+        ],
+        [
+          "in",
+          "class",
+          "trunk"
+        ]
+      ],
+      "id": "highway-trunk-casing",
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "minzoom": 5,
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-opacity": {
+          "stops": [
+            [
+              5,
+              0
+            ],
+            [
+              6,
+              1
+            ]
+          ]
+        },
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              5,
+              0
+            ],
+            [
+              6,
+              0.6
+            ],
+            [
+              7,
+              1.5
+            ],
+            [
+              20,
+              22
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "!in",
+          "brunnel",
+          "bridge",
+          "tunnel"
+        ],
+        [
+          "==",
+          "class",
+          "motorway"
+        ]
+      ],
+      "id": "highway-motorway-casing",
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "minzoom": 4,
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-opacity": {
+          "stops": [
+            [
+              4,
+              0
+            ],
+            [
+              5,
+              1
+            ]
+          ]
+        },
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              4,
+              0
+            ],
+            [
+              5,
+              0.4
+            ],
+            [
+              6,
+              0.6
+            ],
+            [
+              7,
+              1.5
+            ],
+            [
+              20,
+              22
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "all",
+          [
+            "!in",
+            "brunnel",
+            "bridge",
+            "tunnel"
+          ],
+          [
+            "==",
+            "class",
+            "path"
+          ]
+        ]
+      ],
+      "id": "highway-path",
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "paint": {
+        "line-color": "#cba",
+        "line-dasharray": [
+          1.5,
+          0.75
+        ],
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              15,
+              1.2
+            ],
+            [
+              20,
+              4
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "!in",
+          "brunnel",
+          "bridge",
+          "tunnel"
+        ],
+        [
+          "==",
+          "class",
+          "motorway_link"
+        ]
+      ],
+      "id": "highway-motorway-link",
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "minzoom": 12,
+      "paint": {
+        "line-color": "#fc8",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              12.5,
+              0
+            ],
+            [
+              13,
+              1.5
+            ],
+            [
+              14,
+              2.5
+            ],
+            [
+              20,
+              11.5
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "!in",
+          "brunnel",
+          "bridge",
+          "tunnel"
+        ],
+        [
+          "in",
+          "class",
+          "primary_link",
+          "secondary_link",
+          "tertiary_link",
+          "trunk_link"
+        ]
+      ],
+      "id": "highway-link",
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "minzoom": 13,
+      "paint": {
+        "line-color": "#fea",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              12.5,
+              0
+            ],
+            [
+              13,
+              1.5
+            ],
+            [
+              14,
+              2.5
+            ],
+            [
+              20,
+              11.5
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "all",
+          [
+            "!=",
+            "brunnel",
+            "tunnel"
+          ],
+          [
+            "in",
+            "class",
+            "minor",
+            "service",
+            "track"
+          ]
+        ]
+      ],
+      "id": "highway-minor",
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "paint": {
+        "line-color": "#fff",
+        "line-opacity": 1,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              13.5,
+              0
+            ],
+            [
+              14,
+              2.5
+            ],
+            [
+              20,
+              11.5
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "!in",
+          "brunnel",
+          "bridge",
+          "tunnel"
+        ],
+        [
+          "in",
+          "class",
+          "secondary",
+          "tertiary"
+        ]
+      ],
+      "id": "highway-secondary-tertiary",
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "paint": {
+        "line-color": "#fea",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              6.5,
+              0
+            ],
+            [
+              8,
+              0.5
+            ],
+            [
+              20,
+              13
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "all",
+          [
+            "!in",
+            "brunnel",
+            "bridge",
+            "tunnel"
+          ],
+          [
+            "in",
+            "class",
+            "primary"
+          ]
+        ]
+      ],
+      "id": "highway-primary",
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "paint": {
+        "line-color": "#fea",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              8.5,
+              0
+            ],
+            [
+              9,
+              0.5
+            ],
+            [
+              20,
+              18
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "all",
+          [
+            "!in",
+            "brunnel",
+            "bridge",
+            "tunnel"
+          ],
+          [
+            "in",
+            "class",
+            "trunk"
+          ]
+        ]
+      ],
+      "id": "highway-trunk",
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "paint": {
+        "line-color": "#fea",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              6.5,
+              0
+            ],
+            [
+              7,
+              0.5
+            ],
+            [
+              20,
+              18
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "all",
+          [
+            "!in",
+            "brunnel",
+            "bridge",
+            "tunnel"
+          ],
+          [
+            "==",
+            "class",
+            "motorway"
+          ]
+        ]
+      ],
+      "id": "highway-motorway",
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round",
+        "visibility": "visible"
+      },
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "minzoom": 5,
+      "paint": {
+        "line-color": "#fc8",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              6.5,
+              0
+            ],
+            [
+              7,
+              0.5
+            ],
+            [
+              20,
+              18
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "all",
+          [
+            "==",
+            "class",
+            "transit"
+          ],
+          [
+            "!in",
+            "brunnel",
+            "tunnel"
+          ]
+        ]
+      ],
+      "id": "railway-transit",
+      "layout": {
+        "visibility": "visible"
+      },
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "paint": {
+        "line-color": "hsla(0, 0%, 73%, 0.77)",
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              14,
+              0.4
+            ],
+            [
+              20,
+              1
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "all",
+          [
+            "==",
+            "class",
+            "transit"
+          ],
+          [
+            "!in",
+            "brunnel",
+            "tunnel"
+          ]
+        ]
+      ],
+      "id": "railway-transit-hatching",
+      "layout": {
+        "visibility": "visible"
+      },
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "paint": {
+        "line-color": "hsla(0, 0%, 73%, 0.68)",
+        "line-dasharray": [
+          0.2,
+          8
+        ],
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              14.5,
+              0
+            ],
+            [
+              15,
+              2
+            ],
+            [
+              20,
+              6
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "all",
+          [
+            "==",
+            "class",
+            "rail"
+          ],
+          [
+            "has",
+            "service"
+          ]
+        ]
+      ],
+      "id": "railway-service",
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "paint": {
+        "line-color": "hsla(0, 0%, 73%, 0.77)",
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              14,
+              0.4
+            ],
+            [
+              20,
+              1
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "all",
+          [
+            "==",
+            "class",
+            "rail"
+          ],
+          [
+            "has",
+            "service"
+          ]
+        ]
+      ],
+      "id": "railway-service-hatching",
+      "layout": {
+        "visibility": "visible"
+      },
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "paint": {
+        "line-color": "hsla(0, 0%, 73%, 0.68)",
+        "line-dasharray": [
+          0.2,
+          8
+        ],
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              14.5,
+              0
+            ],
+            [
+              15,
+              2
+            ],
+            [
+              20,
+              6
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "all",
+          [
+            "!has",
+            "service"
+          ],
+          [
+            "!in",
+            "brunnel",
+            "bridge",
+            "tunnel"
+          ],
+          [
+            "==",
+            "class",
+            "rail"
+          ]
+        ]
+      ],
+      "id": "railway",
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "paint": {
+        "line-color": "#bbb",
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              14,
+              0.4
+            ],
+            [
+              15,
+              0.75
+            ],
+            [
+              20,
+              2
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "all",
+          [
+            "!has",
+            "service"
+          ],
+          [
+            "!in",
+            "brunnel",
+            "bridge",
+            "tunnel"
+          ],
+          [
+            "==",
+            "class",
+            "rail"
+          ]
+        ]
+      ],
+      "id": "railway-hatching",
+      "metadata": {
+        "mapbox:group": "1444849345966.4436"
+      },
+      "paint": {
+        "line-color": "#bbb",
+        "line-dasharray": [
+          0.2,
+          8
+        ],
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              14.5,
+              0
+            ],
+            [
+              15,
+              3
+            ],
+            [
+              20,
+              8
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ],
+        [
+          "==",
+          "class",
+          "motorway_link"
+        ]
+      ],
+      "id": "bridge-motorway-link-casing",
+      "layout": {
+        "line-join": "round"
+      },
+      "metadata": {
+        "mapbox:group": "1444849334699.1902"
+      },
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-opacity": 1,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              12,
+              1
+            ],
+            [
+              13,
+              3
+            ],
+            [
+              14,
+              4
+            ],
+            [
+              20,
+              15
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ],
+        [
+          "in",
+          "class",
+          "primary_link",
+          "secondary_link",
+          "tertiary_link",
+          "trunk_link"
+        ]
+      ],
+      "id": "bridge-link-casing",
+      "layout": {
+        "line-join": "round"
+      },
+      "metadata": {
+        "mapbox:group": "1444849334699.1902"
+      },
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-opacity": 1,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              12,
+              1
+            ],
+            [
+              13,
+              3
+            ],
+            [
+              14,
+              4
+            ],
+            [
+              20,
+              15
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ],
+        [
+          "in",
+          "class",
+          "secondary",
+          "tertiary"
+        ]
+      ],
+      "id": "bridge-secondary-tertiary-casing",
+      "layout": {
+        "line-join": "round"
+      },
+      "metadata": {
+        "mapbox:group": "1444849334699.1902"
+      },
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-opacity": 1,
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              8,
+              1.5
+            ],
+            [
+              20,
+              28
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ],
+        [
+          "in",
+          "class",
+          "primary",
+          "trunk"
+        ]
+      ],
+      "id": "bridge-trunk-primary-casing",
+      "layout": {
+        "line-join": "round"
+      },
+      "metadata": {
+        "mapbox:group": "1444849334699.1902"
+      },
+      "paint": {
+        "line-color": "hsl(28, 76%, 67%)",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              5,
+              0.4
+            ],
+            [
+              6,
+              0.6
+            ],
+            [
+              7,
+              1.5
+            ],
+            [
+              20,
+              26
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ],
+        [
+          "==",
+          "class",
+          "motorway"
+        ]
+      ],
+      "id": "bridge-motorway-casing",
+      "layout": {
+        "line-join": "round"
+      },
+      "metadata": {
+        "mapbox:group": "1444849334699.1902"
+      },
+      "paint": {
+        "line-color": "#e9ac77",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              5,
+              0.4
+            ],
+            [
+              6,
+              0.6
+            ],
+            [
+              7,
+              1.5
+            ],
+            [
+              20,
+              22
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "all",
+          [
+            "==",
+            "brunnel",
+            "bridge"
+          ],
+          [
+            "==",
+            "class",
+            "path"
+          ]
+        ]
+      ],
+      "id": "bridge-path-casing",
+      "metadata": {
+        "mapbox:group": "1444849334699.1902"
+      },
+      "paint": {
+        "line-color": "#f8f4f0",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              15,
+              1.2
+            ],
+            [
+              20,
+              18
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "all",
+          [
+            "==",
+            "brunnel",
+            "bridge"
+          ],
+          [
+            "==",
+            "class",
+            "path"
+          ]
+        ]
+      ],
+      "id": "bridge-path",
+      "metadata": {
+        "mapbox:group": "1444849334699.1902"
+      },
+      "paint": {
+        "line-color": "#cba",
+        "line-dasharray": [
+          1.5,
+          0.75
+        ],
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              15,
+              1.2
+            ],
+            [
+              20,
+              4
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ],
+        [
+          "==",
+          "class",
+          "motorway_link"
+        ]
+      ],
+      "id": "bridge-motorway-link",
+      "layout": {
+        "line-join": "round"
+      },
+      "metadata": {
+        "mapbox:group": "1444849334699.1902"
+      },
+      "paint": {
+        "line-color": "#fc8",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              12.5,
+              0
+            ],
+            [
+              13,
+              1.5
+            ],
+            [
+              14,
+              2.5
+            ],
+            [
+              20,
+              11.5
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ],
+        [
+          "in",
+          "class",
+          "primary_link",
+          "secondary_link",
+          "tertiary_link",
+          "trunk_link"
+        ]
+      ],
+      "id": "bridge-link",
+      "layout": {
+        "line-join": "round"
+      },
+      "metadata": {
+        "mapbox:group": "1444849334699.1902"
+      },
+      "paint": {
+        "line-color": "#fea",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              12.5,
+              0
+            ],
+            [
+              13,
+              1.5
+            ],
+            [
+              14,
+              2.5
+            ],
+            [
+              20,
+              11.5
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ],
+        [
+          "in",
+          "class",
+          "secondary",
+          "tertiary"
+        ]
+      ],
+      "id": "bridge-secondary-tertiary",
+      "layout": {
+        "line-join": "round"
+      },
+      "metadata": {
+        "mapbox:group": "1444849334699.1902"
+      },
+      "paint": {
+        "line-color": "#fea",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              6.5,
+              0
+            ],
+            [
+              7,
+              0.5
+            ],
+            [
+              20,
+              20
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ],
+        [
+          "in",
+          "class",
+          "primary",
+          "trunk"
+        ]
+      ],
+      "id": "bridge-trunk-primary",
+      "layout": {
+        "line-join": "round"
+      },
+      "metadata": {
+        "mapbox:group": "1444849334699.1902"
+      },
+      "paint": {
+        "line-color": "#fea",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              6.5,
+              0
+            ],
+            [
+              7,
+              0.5
+            ],
+            [
+              20,
+              18
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ],
+        [
+          "==",
+          "class",
+          "motorway"
+        ]
+      ],
+      "id": "bridge-motorway",
+      "layout": {
+        "line-join": "round"
+      },
+      "metadata": {
+        "mapbox:group": "1444849334699.1902"
+      },
+      "paint": {
+        "line-color": "#fc8",
+        "line-width": {
+          "base": 1.2,
+          "stops": [
+            [
+              6.5,
+              0
+            ],
+            [
+              7,
+              0.5
+            ],
+            [
+              20,
+              18
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ],
+        [
+          "==",
+          "class",
+          "rail"
+        ]
+      ],
+      "id": "bridge-railway",
+      "metadata": {
+        "mapbox:group": "1444849334699.1902"
+      },
+      "paint": {
+        "line-color": "#bbb",
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              14,
+              0.4
+            ],
+            [
+              15,
+              0.75
+            ],
+            [
+              20,
+              2
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ],
+        [
+          "==",
+          "class",
+          "rail"
+        ]
+      ],
+      "id": "bridge-railway-hatching",
+      "metadata": {
+        "mapbox:group": "1444849334699.1902"
+      },
+      "paint": {
+        "line-color": "#bbb",
+        "line-dasharray": [
+          0.2,
+          8
+        ],
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              14.5,
+              0
+            ],
+            [
+              15,
+              3
+            ],
+            [
+              20,
+              8
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "==",
+        "class",
+        "cable_car"
+      ],
+      "id": "cablecar",
+      "layout": {
+        "line-cap": "round",
+        "visibility": "visible"
+      },
+      "minzoom": 13,
+      "paint": {
+        "line-color": "hsl(0, 0%, 70%)",
+        "line-width": {
+          "base": 1,
+          "stops": [
+            [
+              11,
+              1
+            ],
+            [
+              19,
+              2.5
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "==",
+        "class",
+        "cable_car"
+      ],
+      "id": "cablecar-dash",
+      "layout": {
+        "line-cap": "round",
+        "visibility": "visible"
+      },
+      "minzoom": 13,
+      "paint": {
+        "line-color": "hsl(0, 0%, 70%)",
+        "line-dasharray": [
+          2,
+          3
+        ],
+        "line-width": {
+          "base": 1,
+          "stops": [
+            [
+              11,
+              3
+            ],
+            [
+              19,
+              5.5
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          ">=",
+          "admin_level",
+          4
+        ],
+        [
+          "<=",
+          "admin_level",
+          8
+        ],
+        [
+          "!=",
+          "maritime",
+          1
+        ]
+      ],
+      "id": "boundary-land-level-4",
+      "layout": {
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "#9e9cab",
+        "line-dasharray": [
+          3,
+          1,
+          1,
+          1
+        ],
+        "line-width": {
+          "base": 1.4,
+          "stops": [
+            [
+              4,
+              0.4
+            ],
+            [
+              5,
+              1
+            ],
+            [
+              12,
+              3
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "boundary",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "admin_level",
+          2
+        ],
+        [
+          "!=",
+          "maritime",
+          1
+        ],
+        [
+          "!=",
+          "disputed",
+          1
+        ]
+      ],
+      "id": "boundary-land-level-2",
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "hsl(248, 7%, 66%)",
+        "line-width": {
+          "base": 1,
+          "stops": [
+            [
+              0,
+              0.6
+            ],
+            [
+              4,
+              1.4
+            ],
+            [
+              5,
+              2
+            ],
+            [
+              12,
+              8
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "boundary",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "!=",
+          "maritime",
+          1
+        ],
+        [
+          "==",
+          "disputed",
+          1
+        ]
+      ],
+      "id": "boundary-land-disputed",
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "hsl(248, 7%, 70%)",
+        "line-dasharray": [
+          1,
+          3
+        ],
+        "line-width": {
+          "base": 1,
+          "stops": [
+            [
+              0,
+              0.6
+            ],
+            [
+              4,
+              1.4
+            ],
+            [
+              5,
+              2
+            ],
+            [
+              12,
+              8
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "boundary",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "in",
+          "admin_level",
+          2,
+          4
+        ],
+        [
+          "==",
+          "maritime",
+          1
+        ]
+      ],
+      "id": "boundary-water",
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "rgba(154, 189, 214, 1)",
+        "line-opacity": {
+          "stops": [
+            [
+              6,
+              0.6
+            ],
+            [
+              10,
+              1
+            ]
+          ]
+        },
+        "line-width": {
+          "base": 1,
+          "stops": [
+            [
+              0,
+              0.6
+            ],
+            [
+              4,
+              1.4
+            ],
+            [
+              5,
+              2
+            ],
+            [
+              12,
+              8
+            ]
+          ]
+        }
+      },
+      "source": "openmaptiles",
+      "source-layer": "boundary",
+      "type": "line"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "LineString"
+        ],
+        [
+          "has",
+          "name"
+        ]
+      ],
+      "id": "waterway-name",
+      "layout": {
+        "symbol-placement": "line",
+        "symbol-spacing": 350,
+        "text-field": "{name:latin} {name:nonlatin}",
+        "text-font": [
+          "Noto Sans Italic"
+        ],
+        "text-letter-spacing": 0.2,
+        "text-max-width": 5,
+        "text-rotation-alignment": "map",
+        "text-size": 14
+      },
+      "minzoom": 13,
+      "paint": {
+        "text-color": "#74aee9",
+        "text-halo-color": "rgba(255,255,255,0.7)",
+        "text-halo-width": 1.5
+      },
+      "source": "openmaptiles",
+      "source-layer": "waterway",
+      "type": "symbol"
+    },
+    {
+      "filter": [
+        "==",
+        "$type",
+        "LineString"
+      ],
+      "id": "water-name-lakeline",
+      "layout": {
+        "symbol-placement": "line",
+        "symbol-spacing": 350,
+        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-font": [
+          "Noto Sans Italic"
+        ],
+        "text-letter-spacing": 0.2,
+        "text-max-width": 5,
+        "text-rotation-alignment": "map",
+        "text-size": 14
+      },
+      "paint": {
+        "text-color": "#74aee9",
+        "text-halo-color": "rgba(255,255,255,0.7)",
+        "text-halo-width": 1.5
+      },
+      "source": "openmaptiles",
+      "source-layer": "water_name",
+      "type": "symbol"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Point"
+        ],
+        [
+          "==",
+          "class",
+          "ocean"
+        ]
+      ],
+      "id": "water-name-ocean",
+      "layout": {
+        "symbol-placement": "point",
+        "symbol-spacing": 350,
+        "text-field": "{name:latin}",
+        "text-font": [
+          "Noto Sans Italic"
+        ],
+        "text-letter-spacing": 0.2,
+        "text-max-width": 5,
+        "text-rotation-alignment": "map",
+        "text-size": 14
+      },
+      "paint": {
+        "text-color": "#74aee9",
+        "text-halo-color": "rgba(255,255,255,0.7)",
+        "text-halo-width": 1.5
+      },
+      "source": "openmaptiles",
+      "source-layer": "water_name",
+      "type": "symbol"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Point"
+        ],
+        [
+          "!in",
+          "class",
+          "ocean"
+        ]
+      ],
+      "id": "water-name-other",
+      "layout": {
+        "symbol-placement": "point",
+        "symbol-spacing": 350,
+        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-font": [
+          "Noto Sans Italic"
+        ],
+        "text-letter-spacing": 0.2,
+        "text-max-width": 5,
+        "text-rotation-alignment": "map",
+        "text-size": {
+          "stops": [
+            [
+              0,
+              10
+            ],
+            [
+              6,
+              14
+            ]
+          ]
+        },
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "#74aee9",
+        "text-halo-color": "rgba(255,255,255,0.7)",
+        "text-halo-width": 1.5
+      },
+      "source": "openmaptiles",
+      "source-layer": "water_name",
+      "type": "symbol"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Point"
+        ],
+        [
+          ">=",
+          "rank",
+          25
+        ],
+        [
+          "any",
+          [
+            "!has",
+            "level"
+          ],
+          [
+            "==",
+            "level",
+            0
+          ]
+        ]
+      ],
+      "id": "poi-level-3",
+      "layout": {
+        "icon-image": "{class}_11",
+        "text-anchor": "top",
+        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-max-width": 9,
+        "text-offset": [
+          0,
+          0.6
+        ],
+        "text-padding": 2,
+        "text-size": 12
+      },
+      "minzoom": 16,
+      "paint": {
+        "text-color": "#666",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1
+      },
+      "source": "openmaptiles",
+      "source-layer": "poi",
+      "type": "symbol"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Point"
+        ],
+        [
+          "<=",
+          "rank",
+          24
+        ],
+        [
+          ">=",
+          "rank",
+          15
+        ],
+        [
+          "any",
+          [
+            "!has",
+            "level"
+          ],
+          [
+            "==",
+            "level",
+            0
+          ]
+        ]
+      ],
+      "id": "poi-level-2",
+      "layout": {
+        "icon-image": "{class}_11",
+        "text-anchor": "top",
+        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-max-width": 9,
+        "text-offset": [
+          0,
+          0.6
+        ],
+        "text-padding": 2,
+        "text-size": 12
+      },
+      "minzoom": 15,
+      "paint": {
+        "text-color": "#666",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1
+      },
+      "source": "openmaptiles",
+      "source-layer": "poi",
+      "type": "symbol"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Point"
+        ],
+        [
+          "<=",
+          "rank",
+          14
+        ],
+        [
+          "has",
+          "name"
+        ],
+        [
+          "any",
+          [
+            "!has",
+            "level"
+          ],
+          [
+            "==",
+            "level",
+            0
+          ]
+        ]
+      ],
+      "id": "poi-level-1",
+      "layout": {
+        "icon-image": "{class}_11",
+        "text-anchor": "top",
+        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-max-width": 9,
+        "text-offset": [
+          0,
+          0.6
+        ],
+        "text-padding": 2,
+        "text-size": 12
+      },
+      "minzoom": 14,
+      "paint": {
+        "text-color": "#666",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1
+      },
+      "source": "openmaptiles",
+      "source-layer": "poi",
+      "type": "symbol"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Point"
+        ],
+        [
+          "has",
+          "name"
+        ],
+        [
+          "==",
+          "class",
+          "railway"
+        ],
+        [
+          "==",
+          "subclass",
+          "station"
+        ]
+      ],
+      "id": "poi-railway",
+      "layout": {
+        "icon-allow-overlap": false,
+        "icon-ignore-placement": false,
+        "icon-image": "{class}_11",
+        "icon-optional": false,
+        "text-allow-overlap": false,
+        "text-anchor": "top",
+        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-ignore-placement": false,
+        "text-max-width": 9,
+        "text-offset": [
+          0,
+          0.6
+        ],
+        "text-optional": true,
+        "text-padding": 2,
+        "text-size": 12
+      },
+      "minzoom": 13,
+      "paint": {
+        "text-color": "#666",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1
+      },
+      "source": "openmaptiles",
+      "source-layer": "poi",
+      "type": "symbol"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "oneway",
+          1
+        ],
+        [
+          "in",
+          "class",
+          "motorway",
+          "trunk",
+          "primary",
+          "secondary",
+          "tertiary",
+          "minor",
+          "service"
+        ]
+      ],
+      "id": "road_oneway",
+      "layout": {
+        "icon-image": "oneway",
+        "icon-padding": 2,
+        "icon-rotate": 90,
+        "icon-rotation-alignment": "map",
+        "icon-size": {
+          "stops": [
+            [
+              15,
+              0.5
+            ],
+            [
+              19,
+              1
+            ]
+          ]
+        },
+        "symbol-placement": "line",
+        "symbol-spacing": 75
+      },
+      "minzoom": 15,
+      "paint": {
+        "icon-opacity": 0.5
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "symbol"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "==",
+          "oneway",
+          -1
+        ],
+        [
+          "in",
+          "class",
+          "motorway",
+          "trunk",
+          "primary",
+          "secondary",
+          "tertiary",
+          "minor",
+          "service"
+        ]
+      ],
+      "id": "road_oneway_opposite",
+      "layout": {
+        "icon-image": "oneway",
+        "icon-padding": 2,
+        "icon-rotate": -90,
+        "icon-rotation-alignment": "map",
+        "icon-size": {
+          "stops": [
+            [
+              15,
+              0.5
+            ],
+            [
+              19,
+              1
+            ]
+          ]
+        },
+        "symbol-placement": "line",
+        "symbol-spacing": 75
+      },
+      "minzoom": 15,
+      "paint": {
+        "icon-opacity": 0.5
+      },
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "type": "symbol"
+    },
+    {
+      "filter": [
+        "all",
+        [
+          "has",
+          "iata"
+        ]
+      ],
+      "id": "airport-label-major",
+      "layout": {
+        "icon-image": "airport_11",
+        "icon-size": 1,
+        "text-anchor": "top",
+        "text-field": "{name:latin}\n{name:nonlatin}",
+        "text-font": [
+          "Noto Sans Regular"
+        ],
+        "text-max-width": 9,
+        "text-offset": [
+          0,
+          0.6
+        ],
+        "text-optional": true,
+        "text-padding": 2,
+        "text-size": 12,
+        "visibility": "visible"
+      },
+      "minzoom": 10,
+      "paint": {
+        "text-color": "#666",
+        "text-halo-blur": 0.5,
+        "text-halo-color": "#ffffff",
+        "text-halo-width": 1
+      },
+      "source": "openmaptiles",
+      "source-layer": "aerodrome_label",
+      "type": "symbol"
+    }
+  ],
+  "id": "osm-bright"
+}

--- a/components/map/styles/vector.json
+++ b/components/map/styles/vector.json
@@ -4,14881 +4,14882 @@
     "glyphs":"https://wxs.ign.fr/static/vectorTiles/fonts/{fontstack}/{range}.pbf",
 	"sprite": "https://wxs.ign.fr/static/vectorTiles/styles/PLAN.IGN/sprite/PlanIgn",
     "sources": {
-		"plan_ign": {
-			"type": "vector",
-			"tiles": [
-			 "https://wxs.ign.fr/essentiels/geoportail/tms/1.0.0/PLAN.IGN/{z}/{x}/{y}.pbf"
-			],
-			"scheme": "xyz"
-		},
-		"cadastre": {
-			"type": "vector",
-			"url": "https://openmaptiles.geo.data.gouv.fr/data/cadastre.json"
-		  },
-		  "decoupage-administratif": {
-			"type": "vector",
-			"url": "https://openmaptiles.geo.data.gouv.fr/data/decoupage-administratif.json"
-		  }
+	  "plan_ign": {
+        "type": "vector",
+		"tiles": [
+		  "https://wxs.ign.fr/essentiels/geoportail/tms/1.0.0/PLAN.IGN/{z}/{x}/{y}.pbf"
+		],
+		"scheme": "xyz",
+		"attribution": "<a target='_blank' href='https://geoservices.ign.fr/'>© IGN</a>"
+	  },
+	  "cadastre": {
+		"type": "vector",
+		"url": "https://openmaptiles.geo.data.gouv.fr/data/cadastre.json"
+	  },
+	  "decoupage-administratif": {
+		"type": "vector",
+		"url": "https://openmaptiles.geo.data.gouv.fr/data/decoupage-administratif.json"
+	  }
     },
 	"transition": {
-	 "duration": 50,
-	 "delay": 0
+      "duration": 50,
+	  "delay": 0
 	},
 	"layers": [
-	 {
-	  "id": "bckgrd",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "fond_opaque",
-	  "minzoom": 0,
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "paint": {
-	   "fill-color": "#FFFFFF",
-	   "fill-opacity": 1
-	  }
-	 },
-	 {
-	  "id": "orographie : relief - 0m",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "oro_relief",
-	  "minzoom": 0,
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "HYPSO_0"
-	  ],
-	  "paint": {
-	   "fill-color": "#D6E5BA",
-	   "fill-opacity": 1
-	  }
-	 },
-	 {
-	  "id": "orographie : relief - 100m",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "oro_relief",
-	  "minzoom": 0,
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "HYPSO_100"
-	  ],
-	  "paint": {
-	   "fill-color": "#F7F2DA",
-	   "fill-opacity": 1
-	  }
-	 },
-	 {
-	  "id": "orographie : relief - 200m",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "oro_relief",
-	  "minzoom": 0,
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "HYPSO_200"
-	  ],
-	  "paint": {
-	   "fill-color": "#EBDEBF",
-	   "fill-opacity": 1
-	  }
-	 },
-	 {
-	  "id": "orographie : relief - 1000m",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "oro_relief",
-	  "minzoom": 0,
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "HYPSO_1000"
-	  ],
-	  "paint": {
-	   "fill-color": "#DABE97",
-	   "fill-opacity": 1
-	  }
-	 },
-	 {
-	  "id": "orographie : relief - 3000m",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "oro_relief",
-	  "minzoom": 0,
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "HYPSO_3000"
-	  ],
-	  "paint": {
-	   "fill-color": "#B28773",
-	   "fill-opacity": 1
-	  }
-	 },
-	 {
-	  "id": "orographie : relief - 4000m",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "oro_relief",
-	  "minzoom": 0,
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "HYPSO_4000"
-	  ],
-	  "paint": {
-	   "fill-color": "#9E6A54",
-	   "fill-opacity": 1
-	  }
-	 },
-	 {
-	  "id": "orographie : relief - 5000m",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "oro_relief",
-	  "minzoom": 0,
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "HYPSO_5000"
-	  ],
-	  "paint": {
-	   "fill-color": "#773A2B",
-	   "fill-opacity": 1
-	  }
-	 },
-	 {
-	  "id": "orographie : relief - glacier",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "oro_relief",
-	  "minzoom": 0,
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "GLACIER"
-	  ],
-	  "paint": {
-	   "fill-color": "#FFFFFF",
-	   "fill-opacity": 0.7
-	  }
-	 },
-	 {
-	  "id": "ocs - vegetation - zone boiséee, foret fermee, peupleraie",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "ocs_vegetation_surf",
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "ZONE_BOISEE",
-	   "ZONE_FORET_FERMEE_FEUIL",
-	   "ZONE_FORET_FERMEE_CONI",
-	   "ZONE_FORET_FERMEE_MIXTE",
-	   "ZONE_PEUPLERAIE"
-	  ],
-	  "paint": {
-	   "fill-color": "#DFE8D5",
-	   "fill-outline-color": "#DFE8D5"
-	  }
-	 },
-	 {
-	  "id": "ocs - vegetation - forêt ouverte",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "ocs_vegetation_surf",
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "ZONE_FORET_OUVERTE"
-	  ],
-	  "paint": {
-	   "fill-color": "#EDF2D9",
-	   "fill-outline-color": "#EDF2D9"
-	  }
-	 },
-	 {
-	  "id": "ocs - vegetation - lande ligneuse",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "ocs_vegetation_surf",
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "ZONE_LANDE_LIGNEUSE"
-	  ],
-	  "paint": {
-	   "fill-color": "#F2EECD"
-	  }
-	 },
-	 {
-	  "id": "ocs - vegetation - vigne",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "ocs_vegetation_surf",
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "ZONE_VIGNE"
-	  ],
-	  "paint": {
-	   "fill-color": "#FFEDD9"
-	  }
-	 },
-	 {
-	  "id": "ocs - vegetation - verger",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "ocs_vegetation_surf",
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "ZONE_VERGER"
-	  ],
-	  "paint": {
-	   "fill-color": "#FAE2C5"
-	  }
-	 },
-	 {
-	  "id": "ocs - vegetation - canne à sucre, bananeraie",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "ocs_vegetation_surf",
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "ZONE_CANNE_BANANE"
-	  ],
-	  "paint": {
-	   "fill-color": "#FAEDFA"
-	  }
-	 },
-	 {
-	  "id": "hydro surfacique - Estran",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "hydro_surf",
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "ZONE_D_ESTRAN"
-	  ],
-	  "paint": {
-	   "fill-color": "#C3DDE9",
-	   "fill-outline-color": "#C3DDE9"
-	  }
-	 },
-	 {
-	  "id": "ocs - vegetation - mangrovre",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "ocs_vegetation_surf",
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "ZONE_MANGROVE"
-	  ],
-	  "paint": {
-	   "fill-color": {
-		"stops": [
-		 [
-		  9,
-		  "#85CCCB"
-		 ],
-		 [
-		  10,
-		  "#90CCCB"
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "ocs - vegetation - marais",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "ocs_vegetation_surf",
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "ZONE_MARAIS"
-	  ],
-	  "paint": {
-	   "fill-pattern": "Marais"
-	  }
-	 },
-	 {
-	  "id": "ocs - vegetation - marais salant",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "ocs_vegetation_surf",
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "ZONE_MARAIS_SALANT"
-	  ],
-	  "paint": {
-	   "fill-pattern": "MaraisSalant"
-	  }
-	 },
-	 {
-	  "id": "ocs - Zone",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "ocs_nature_sol_surf",
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "ZONE_ROCHEUSE"
-	  ],
-	  "paint": {
-	   "fill-color": "#D0D0D0",
-	   "fill-opacity": 0.3
-	  }
-	 },
-	 {
-	  "id": "ocs - Zone sable sec",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "ocs_nature_sol_surf",
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "ZONE_SABLE_SEC"
-	  ],
-	  "paint": {
-	   "fill-pattern": "Sable"
-	  }
-	 },
-	 {
-	  "id": "ocs - Zone sable humide",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "ocs_nature_sol_surf",
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "ZONE_SABLE_HUMIDE",
-	   "FOND_CUVETTE_HUMIDE"
-	  ],
-	  "paint": {
-	   "fill-pattern": "SableHumide"
-	  }
-	 },
-	 {
-	  "id": "ocs - Zone graviers galets secs",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "ocs_nature_sol_surf",
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "GRAVIERS_GALETS_SEC"
-	  ],
-	  "paint": {
-	   "fill-pattern": "GravierSec"
-	  }
-	 },
-	 {
-	  "id": "ocs - Zone graviers galets humides",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "ocs_nature_sol_surf",
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "GRAVIERS_GALETS_HUM"
-	  ],
-	  "paint": {
-	   "fill-pattern": "Gravier"
-	  }
-	 },
-	 {
-	  "id": "ocs - Zone rocher hydro",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "ocs_nature_sol_surf",
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "ZONE_ROCHER_HYDRO"
-	  ],
-	  "paint": {
-	   "fill-pattern": "RocherHydro"
-	  }
-	 },
-	 {
-	  "id": "ocs - Zone glacier",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "ocs_nature_sol_surf",
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "ZONE_GLACIER"
-	  ],
-	  "paint": {
-	   "fill-pattern": "Glacier",
-	   "fill-opacity": {
-		"stops": [
-		 [
-		  10,
-		  0.5
-		 ],
-		 [
-		  12,
-		  0.3
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "zone batie",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "bati_zone_surf",
-	  "minzoom": 7,
-	  "maxzoom": 15,
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "ZONE_BATI"
-	  ],
-	  "paint": {
-	   "fill-color": "#E8E2D1",
-	   "fill-opacity": {
-		"stops": [
-		 [
-		  12,
-		  1
-		 ],
-		 [
-		  13,
-		  0.9
-		 ],
-		 [
-		  14,
-		  0.5
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "zone d'activité",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "bati_zone_surf",
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "ZONE_INDUS_ACTI"
-	  ],
-	  "paint": {
-	   "fill-color": "#D9D9D9"
-	  }
-	 },
-	 {
-	  "id": "oro - courbe et cuvette maitresse",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "oro_courbe",
-	  "maxzoom": 16,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "CNV_MAITRESSE",
-	   "CUVETTE_MAITRESSE"
-	  ],
-	  "paint": {
-	   "line-color": "#D9C8A9",
-	   "line-width": {
-		"stops": [
-		 [
-		  13,
-		  1.7
-		 ],
-		 [
-		  15,
-		  2
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "oro - courbe et cuvette normale",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "oro_courbe",
-	  "maxzoom": 16,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "CNV_NORMALE",
-	   "CUVETTE_NORMALE"
-	  ],
-	  "paint": {
-	   "line-color": "#D9C8A9",
-	   "line-width": {
-		"stops": [
-		 [
-		  13,
-		  1
-		 ],
-		 [
-		  15,
-		  1.2
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "oro - courbe et cuvette intercalaire",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "oro_courbe",
-	  "maxzoom": 16,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "CNV_INTERCALAIRE",
-	   "CUVETTE_INTERCAL",
-	   "CNV_SS_INTERCALAIRE"
-	  ],
-	  "paint": {
-	   "line-color": "#D9C8A9",
-	   "line-width": 0.7,
-	   "line-dasharray": [
-		20,
-		7
-	   ]
-	  }
-	 },
-	 {
-	  "id": "oro - courbe et cuvette glacier maitresse",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "oro_courbe",
-	  "maxzoom": 16,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "CNV_GLACIER_MAITRESSE",
-	   "CUV_GLACIER_MAITRESSE"
-	  ],
-	  "paint": {
-	   "line-color": "#A4BFD9",
-	   "line-width": {
-		"stops": [
-		 [
-		  13,
-		  1.7
-		 ],
-		 [
-		  15,
-		  2
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "oro - courbe et cuvette glacier normale",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "oro_courbe",
-	  "maxzoom": 16,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "CNV_GLACIER_NORMALE",
-	   "CUV_GLACIER_NORMALE"
-	  ],
-	  "paint": {
-	   "line-color": "#A4BFD9",
-	   "line-width": {
-		"stops": [
-		 [
-		  13,
-		  1
-		 ],
-		 [
-		  15,
-		  1.2
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "oro - courbe et cuvette glacier intercalaire",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "oro_courbe",
-	  "maxzoom": 16,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "CNV_GLACIER_INTERCAL",
-	   "CUV_GLACIER_INTERCAL"
-	  ],
-	  "paint": {
-	   "line-color": "#A4BFD9",
-	   "line-width": {
-		"stops": [
-		 [
-		  13,
-		  0.7
-		 ],
-		 [
-		  15,
-		  0.9
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		20,
-		7
-	   ]
-	  }
-	 },
-	 {
-	  "id": "oro - courbe et cuvette rocher maitresse",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "oro_courbe",
-	  "maxzoom": 16,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "CNV_ROCHER_MAITRESSE",
-	   "CUV_ROCHER_MAITRESSE"
-	  ],
-	  "paint": {
-	   "line-color": "#AAAAAA",
-	   "line-width": 1.7
-	  }
-	 },
-	 {
-	  "id": "oro - courbe et cuvette rocher normale",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "oro_courbe",
-	  "maxzoom": 16,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "CNV_ROCHER_NORMALE",
-	   "CUV_ROCHER_NORMALE"
-	  ],
-	  "paint": {
-	   "line-color": "#AAAAAA",
-	   "line-width": 1
-	  }
-	 },
-	 {
-	  "id": "oro - courbe et cuvette rocher intercalaire",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "oro_courbe",
-	  "maxzoom": 16,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "CNV_ROCHER_INTERCAL",
-	   "CUV_ROCHER_INTERCAL"
-	  ],
-	  "paint": {
-	   "line-color": "#AAAAAA",
-	   "line-width": {
-		"stops": [
-		 [
-		  13,
-		  0.7
-		 ],
-		 [
-		  15,
-		  0.9
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		20,
-		7
-	   ]
-	  }
-	 },
-	 {
-	  "id": "oro - courbe et cuvette bathymetrique",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "oro_courbe",
-	  "maxzoom": 16,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "CNV_BATHYMETRIQUE",
-	   "CUV_BATHYMETRIQUE"
-	  ],
-	  "paint": {
-	   "line-color": "#0000FF",
-	   "line-width": 1
-	  }
-	 },
-	 {
-	  "id": "oro lin - talus",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "oro_lin",
-	  "minzoom": 14,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "TALUS"
-	  ],
-	  "paint": {
-	   "line-color": "#D9C8A9",
-	   "line-width": 1
-	  }
-	 },
-	 {
-	  "id": "oro lin - talus - trait perpendiculaire",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "oro_lin",
-	  "minzoom": 14,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "TALUS"
-	  ],
-	  "paint": {
-	   "line-color": "#D9C8A9",
-	   "line-width": {
-		"stops": [
-		 [
-		  14,
-		  7
-		 ],
-		 [
-		  16,
-		  9
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		0.1,
-		1
-	   ],
-	   "line-translate": [
-		0,
-		4
-	   ]
-	  }
-	 },
-	 {
-	  "id": "toponyme - cote de courbe normale",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "oro_courbe",
-	  "minzoom": 13,
-	  "maxzoom": 16,
-	  "layout": {
-	   "symbol-placement": "line",
-	   "text-field": "{texte}",
-	   "text-size": {
-		"stops": [
-		 [
-		  13,
-		  10
-		 ],
-		 [
-		  15,
-		  13
-		 ]
-		]
-	   },
-	   "text-anchor": "center",
-	   "text-rotation-alignment": "map",
-	   "text-pitch-alignment": "viewport",
-	   "text-keep-upright": false,
-	   "text-max-angle": 20,
-	   "text-max-width": 100,
-	   "text-font": [
-		"Source Sans Pro Italic"
-	   ],
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "all",
-	   [
-		"!=",
-		"texte",
-		"0"
-	   ],
-	   [
-		"==",
-		"hors_zone",
-		"true"
-	   ],
-	   [
-		"in",
-		"symbo",
-		"CNV_MAITRESSE",
-		"CUVETTE_MAITRESSE"
-	   ]
-	  ],
-	  "paint": {
-	   "text-color": "#604A2F",
-	   "text-halo-width": 0.5,
-	   "text-halo-color": "#FFFFFF"
-	  }
-	 },
-	 {
-	  "id": "toponyme - cote de courbe rocher",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "oro_courbe",
-	  "minzoom": 13,
-	  "maxzoom": 16,
-	  "layout": {
-	   "symbol-placement": "line",
-	   "text-field": "{texte}",
-	   "text-size": {
-		"stops": [
-		 [
-		  13,
-		  10
-		 ],
-		 [
-		  15,
-		  13
-		 ]
-		]
-	   },
-	   "text-anchor": "center",
-	   "text-rotation-alignment": "map",
-	   "text-pitch-alignment": "viewport",
-	   "text-keep-upright": false,
-	   "text-max-angle": 20,
-	   "text-max-width": 100,
-	   "text-font": [
-		"Source Sans Pro Italic"
-	   ],
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "all",
-	   [
-		"!=",
-		"texte",
-		"0"
-	   ],
-	   [
-		"==",
-		"hors_zone",
-		"true"
-	   ],
-	   [
-		"in",
-		"symbo",
-		"CNV_ROCHER_MAITRESSE",
-		"CUV_ROCHER_MAITRESSE"
-	   ]
-	  ],
-	  "paint": {
-	   "text-color": "#333333",
-	   "text-halo-width": 0.5,
-	   "text-halo-color": "#FFFFFF"
-	  }
-	 },
-	 {
-	  "id": "toponyme - cote de courbe glacier",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "oro_courbe",
-	  "minzoom": 13,
-	  "maxzoom": 16,
-	  "layout": {
-	   "symbol-placement": "line",
-	   "text-field": "{texte}",
-	   "text-size": {
-		"stops": [
-		 [
-		  13,
-		  10
-		 ],
-		 [
-		  15,
-		  13
-		 ]
-		]
-	   },
-	   "text-anchor": "center",
-	   "text-rotation-alignment": "map",
-	   "text-pitch-alignment": "viewport",
-	   "text-keep-upright": false,
-	   "text-max-angle": 20,
-	   "text-max-width": 100,
-	   "text-font": [
-		"Source Sans Pro Italic"
-	   ],
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "all",
-	   [
-		"!=",
-		"texte",
-		"0"
-	   ],
-	   [
-		"==",
-		"hors_zone",
-		"true"
-	   ],
-	   [
-		"in",
-		"symbo",
-		"CNV_GLACIER_MAITRESSE",
-		"CUV_GLACIER_MAITRESSE"
-	   ]
-	  ],
-	  "paint": {
-	   "text-color": "#629FD9",
-	   "text-halo-width": 0.5,
-	   "text-halo-color": "#FFFFFF"
-	  }
-	 },
-	 {
-	  "id": "hydro surfacique",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "hydro_surf",
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "SURFACE_D_EAU",
-	   "BASSIN",
-	   "ZONE_MARINE"
-	  ],
-	  "paint": {
-	   "fill-color": "#AAD5E9",
-	   "fill-outline-color": "#AAD5E9"
-	  }
-	 },
-	 {
-	  "id": "hydro surfacique temporaire",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "hydro_surf",
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "SURFACE_D_EAU_TEMP"
-	  ],
-	  "paint": {
-	   "fill-color": "rgba(168, 203, 220, 0.5)"
-	  }
-	 },
-	 {
-	  "id": "réseau hydro  - cours d'eau souterrain",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "hydro_reseau_sou",
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "COURS_D_EAU_SOU",
-	   "COURS_D_EAU_MOY_SOU"
-	  ],
-	  "paint": {
-	   "line-color": "#AAD5E9",
-	   "line-width": {
-		"stops": [
-		 [
-		  12,
-		  1.5
-		 ],
-		 [
-		  17,
-		  6.5
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		2,
-		2
-	   ]
-	  }
-	 },
-	 {
-	  "id": "réseau hydro - filet interieur - aqueduc souterrain",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "hydro_reseau_sou",
-	  "minzoom": 12,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "AQUEDUC_SOU"
-	  ],
-	  "paint": {
-	   "line-color": "#AAD5E9",
-	   "line-width": {
-		"stops": [
-		 [
-		  12,
-		  1.4
-		 ],
-		 [
-		  16,
-		  3.5
-		 ],
-		 [
-		  17,
-		  5.9
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		2,
-		2
-	   ]
-	  }
-	 },
-	 {
-	  "id": "réseau hydro - carre - aqueduc souterrain",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "hydro_reseau_sou",
-	  "minzoom": 12,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "AQUEDUC_SOU"
-	  ],
-	  "paint": {
-	   "line-color": "#AAD5E9",
-	   "line-width": {
-		"stops": [
-		 [
-		  12,
-		  3.5
-		 ],
-		 [
-		  16,
-		  8.7
-		 ],
-		 [
-		  17,
-		  14.7
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		1,
-		5
-	   ]
-	  }
-	 },
-	 {
-	  "id": "Ferre souterrain - voie normale",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "ferre_sou",
-	  "minzoom": 10,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "VF_1_SOU",
-	   "VF_2_SOU",
-	   "VF_ELEC_1_SOU",
-	   "VF_FERRO_ROUTIER_SOU"
-	  ],
-	  "paint": {
-	   "line-color": "#B4B4B4",
-	   "line-width": {
-		"stops": [
-		 [
-		  10,
-		  0.8
-		 ],
-		 [
-		  17,
-		  2.5
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Ferre souterrain - trait perpendic épais",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "ferre_sou",
-	  "minzoom": 10,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "VF_1_SOU",
-	   "VF_2_SOU",
-	   "VF_ELEC_1_SOU",
-	   "VF_FERRO_ROUTIER_SOU"
-	  ],
-	  "paint": {
-	   "line-color": "#B4B4B4",
-	   "line-width": {
-		"stops": [
-		 [
-		  10,
-		  3.5
-		 ],
-		 [
-		  17,
-		  14.7
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		0.1,
-		10
-	   ]
-	  }
-	 },
-	 {
-	  "id": "Ferre souterrain - voie etroite",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "ferre_sou",
-	  "minzoom": 10,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "VF_ETROITE_1_SOU",
-	   "VF_ETROITE_SOU"
-	  ],
-	  "paint": {
-	   "line-color": "#B4B4B4",
-	   "line-width": {
-		"stops": [
-		 [
-		  10,
-		  0.3
-		 ],
-		 [
-		  17,
-		  1.8
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Ferre souterrain - trait perpendic fin",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "ferre_sou",
-	  "minzoom": 10,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "VF_ETROITE_1_SOU",
-	   "VF_ETROITE_SOU"
-	  ],
-	  "paint": {
-	   "line-color": "#B4B4B4",
-	   "line-width": {
-		"stops": [
-		 [
-		  10,
-		  3.5
-		 ],
-		 [
-		  17,
-		  14.7
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		0.1,
-		10
-	   ]
-	  }
-	 },
-	 {
-	  "id": "Ferre souterrain - voie service",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "ferre_sou",
-	  "minzoom": 14,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "VF_SERVICE_SOU",
-	   "VF_NON_EXPLOITEE_SOU"
-	  ],
-	  "paint": {
-	   "line-color": "#B4B4B4",
-	   "line-width": {
-		"stops": [
-		 [
-		  10,
-		  0.3
-		 ],
-		 [
-		  17,
-		  1.8
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		5,
-		2,
-		1,
-		2
-	   ]
-	  }
-	 },
-	 {
-	  "id": "Ferre souterrain - funic/urbain",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "ferre_sou",
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "FUNI_CREMAILLERE_SOU",
-	   "TRANSPORT_URBAIN_SOU"
-	  ],
-	  "paint": {
-	   "line-color": "#B4B4B4",
-	   "line-width": {
-		"stops": [
-		 [
-		  10,
-		  0.3
-		 ],
-		 [
-		  17,
-		  1.8
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Ferre souterrain - 2 trait perpendic - funic/urbain",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "ferre_sou",
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "FUNI_CREMAILLERE_SOU",
-	   "TRANSPORT_URBAIN_SOU"
-	  ],
-	  "paint": {
-	   "line-color": "#B4B4B4",
-	   "line-width": {
-		"stops": [
-		 [
-		  10,
-		  3.5
-		 ],
-		 [
-		  17,
-		  17
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		0.1,
-		0.2,
-		0.1,
-		10
-	   ]
-	  }
-	 },
-	 {
-	  "id": "Chemin souterrain - piste cyclable",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_chemin_sou",
-	  "minzoom": 13,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "PISTE_CYCLABLE_SOU"
-	  ],
-	  "paint": {
-	   "line-color": "#AB81CC",
-	   "line-width": {
-		"stops": [
-		 [
-		  14,
-		  1.1
-		 ],
-		 [
-		  15,
-		  1.7
-		 ],
-		 [
-		  16,
-		  2
-		 ],
-		 [
-		  17,
-		  3.5
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		6,
-		2
-	   ]
-	  }
-	 },
-	 {
-	  "id": "Chemin souterrain - filet exterieur - escalier",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_chemin_sou",
-	  "minzoom": 14,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "ESCALIER_SOU"
-	  ],
-	  "paint": {
-	   "line-color": "#B3989A",
-	   "line-width": {
-		"stops": [
-		 [
-		  14,
-		  1.75
-		 ],
-		 [
-		  15,
-		  3
-		 ],
-		 [
-		  16,
-		  4.2
-		 ],
-		 [
-		  17,
-		  9.5
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Chemin souterrain - filet interieur - escalier",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_chemin_sou",
-	  "minzoom": 14,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "ESCALIER_SOU"
-	  ],
-	  "paint": {
-	   "line-color": "#FFFFFF",
-	   "line-width": {
-		"stops": [
-		 [
-		  14,
-		  1
-		 ],
-		 [
-		  15,
-		  1.9
-		 ],
-		 [
-		  16,
-		  2.7
-		 ],
-		 [
-		  17,
-		  5.8
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		1,
-		0.2
-	   ]
-	  }
-	 },
-	 {
-	  "id": "Chemin souterrain - Rue pietonne",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_chemin_sou",
-	  "minzoom": 14,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "RUE_PIETONNE_SOU"
-	  ],
-	  "paint": {
-	   "line-color": "#B3989A",
-	   "line-width": {
-		"stops": [
-		 [
-		  14,
-		  1
-		 ],
-		 [
-		  15,
-		  1.2
-		 ],
-		 [
-		  16,
-		  1.4
-		 ],
-		 [
-		  17,
-		  2
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		1,
-		3
-	   ]
-	  }
-	 },
-	 {
-	  "id": "Chemin souterrain - sentier",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_chemin_sou",
-	  "minzoom": 13,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "SENTIER_SOU"
-	  ],
-	  "paint": {
-	   "line-color": "#B3989A",
-	   "line-width": {
-		"stops": [
-		 [
-		  14,
-		  1
-		 ],
-		 [
-		  15,
-		  1.2
-		 ],
-		 [
-		  16,
-		  1.4
-		 ],
-		 [
-		  17,
-		  2
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		4,
-		3
-	   ]
-	  }
-	 },
-	 {
-	  "id": "Chemin souterrain - chemin",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_chemin_sou",
-	  "minzoom": 12,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "CHEMIN_SOU"
-	  ],
-	  "paint": {
-	   "line-color": "#B3989A",
-	   "line-width": {
-		"stops": [
-		 [
-		  14,
-		  1
-		 ],
-		 [
-		  15,
-		  1.2
-		 ],
-		 [
-		  16,
-		  1.4
-		 ],
-		 [
-		  17,
-		  2
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier souterrain - filet extérieur - route non revetu carrosable",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route_sou",
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "NON_REVETUE_CARRO_SOU"
-	  ],
-	  "paint": {
-	   "line-color": "#AFAFAF",
-	   "line-width": {
-		"stops": [
-		 [
-		  14,
-		  3.2
-		 ],
-		 [
-		  15,
-		  5.4
-		 ],
-		 [
-		  16,
-		  7.7
-		 ],
-		 [
-		  17,
-		  16.8
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		2,
-		2
-	   ]
-	  }
-	 },
-	 {
-	  "id": "Routier souterrain - filet extérieur - bretelle autoroute",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route_sou",
-	  "minzoom": 12,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "BRET_AUTO_PEAGE_3_SOU",
-	   "BRET_AUTO_PEAGE_2_SOU",
-	   "BRET_AUTO_PEAGE_1_SOU",
-	   "BRET_AUTO_LIBRE_3_SOU",
-	   "BRET_AUTO_LIBRE_2_SOU",
-	   "BRET_AUTO_LIBRE_1_SOU"
-	  ],
-	  "paint": {
-	   "line-color": "rgba(222, 70, 14, 0.5)",
-	   "line-width": {
-		"stops": [
-		 [
-		  12,
-		  2.5
-		 ],
-		 [
-		  14,
-		  3.7
-		 ],
-		 [
-		  15,
-		  6.8
-		 ],
-		 [
-		  16,
-		  8.4
-		 ],
-		 [
-		  17,
-		  14
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier souterrain - filet extérieur - route non classee restreint",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route_sou",
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "NON_CLASSEE_RESTREINT_SOU"
-	  ],
-	  "paint": {
-	   "line-color": "#AFAFAF",
-	   "line-width": {
-		"stops": [
-		 [
-		  14,
-		  3.2
-		 ],
-		 [
-		  15,
-		  5.4
-		 ],
-		 [
-		  16,
-		  7.7
-		 ],
-		 [
-		  17,
-		  16.8
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier souterrain - filet extérieur - route non classee",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route_sou",
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "NON_CLASSEE_4_SOU",
-	   "NON_CLASSEE_SOU"
-	  ],
-	  "paint": {
-	   "line-color": "#AFAFAF",
-	   "line-width": {
-		"stops": [
-		 [
-		  14,
-		  3.2
-		 ],
-		 [
-		  15,
-		  5.4
-		 ],
-		 [
-		  16,
-		  7.7
-		 ],
-		 [
-		  17,
-		  16.8
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier souterrain - filet extérieur - route locale",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route_sou",
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "BRET_LOCALE_SOU",
-	   "LOCALE_4_SOU",
-	   "LOCALE_3_SOU",
-	   "LOCALE_2_SOU",
-	   "LOCALE_1_SOU"
-	  ],
-	  "paint": {
-	   "line-color": "rgba(130, 130, 130, 0.5)",
-	   "line-width": {
-		"stops": [
-		 [
-		  9,
-		  2
-		 ],
-		 [
-		  14,
-		  3.5
-		 ],
-		 [
-		  15,
-		  6
-		 ],
-		 [
-		  16,
-		  8.4
-		 ],
-		 [
-		  17,
-		  18.3
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier souterrain - filet extérieur - route locale en construction",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route_sou",
-	  "minzoom": 11,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "LOCALE_CONSTR_SOU"
-	  ],
-	  "paint": {
-	   "line-color": "#C8C8C8",
-	   "line-width": {
-		"stops": [
-		 [
-		  9,
-		  2
-		 ],
-		 [
-		  14,
-		  3.5
-		 ],
-		 [
-		  15,
-		  6
-		 ],
-		 [
-		  16,
-		  8.4
-		 ],
-		 [
-		  17,
-		  18.3
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier souterrain - filet extérieur - route regionale",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route_sou",
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "BRET_REGIONALE_SOU",
-	   "REGIONALE_4_SOU",
-	   "REGIONALE_3_SOU",
-	   "REGIONALE_2_SOU",
-	   "REGIONALE_1_SOU"
-	  ],
-	  "paint": {
-	   "line-color": "rgba(130, 130, 130, 0.5)",
-	   "line-width": {
-		"stops": [
-		 [
-		  6,
-		  1.5
-		 ],
-		 [
-		  9,
-		  2.3
-		 ],
-		 [
-		  14,
-		  5
-		 ],
-		 [
-		  15,
-		  8.1
-		 ],
-		 [
-		  16,
-		  11.2
-		 ],
-		 [
-		  17,
-		  22
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier souterrain - filet extérieur - route regionale en construction",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route_sou",
-	  "minzoom": 10,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "REGIONALE_CONSTR_SOU"
-	  ],
-	  "paint": {
-	   "line-color": "#C8C8C8",
-	   "line-width": {
-		"stops": [
-		 [
-		  6,
-		  1.5
-		 ],
-		 [
-		  9,
-		  2.3
-		 ],
-		 [
-		  14,
-		  5
-		 ],
-		 [
-		  15,
-		  8.1
-		 ],
-		 [
-		  16,
-		  11.2
-		 ],
-		 [
-		  17,
-		  22
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier souterrain - filet extérieur - route principale",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route_sou",
-	  "minzoom": 7,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "BRET_PRINCIPALE_SOU",
-	   "PRINCIPALE_4_SOU",
-	   "PRINCIPALE_3_SOU",
-	   "PRINCIPALE_2_SOU",
-	   "PRINCIPALE_1_SOU"
-	  ],
-	  "paint": {
-	   "line-color": "rgba(222, 70, 14, 0.5)",
-	   "line-width": {
-		"stops": [
-		 [
-		  6,
-		  1.8
-		 ],
-		 [
-		  9,
-		  2.7
-		 ],
-		 [
-		  14,
-		  5.9
-		 ],
-		 [
-		  15,
-		  9
-		 ],
-		 [
-		  16,
-		  12.2
-		 ],
-		 [
-		  17,
-		  22.5
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier souterrain - filet extérieur - route principale en construction",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route_sou",
-	  "minzoom": 10,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "PRINCIPALE_CONSTR_SOU"
-	  ],
-	  "paint": {
-	   "line-color": "#C8C8C8",
-	   "line-width": {
-		"stops": [
-		 [
-		  6,
-		  1.8
-		 ],
-		 [
-		  9,
-		  2.7
-		 ],
-		 [
-		  14,
-		  5.9
-		 ],
-		 [
-		  15,
-		  9
-		 ],
-		 [
-		  16,
-		  12.2
-		 ],
-		 [
-		  17,
-		  22.5
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier souterrain - filet extérieur - autoroute",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route_sou",
-	  "minzoom": 7,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "AUTOROU_PEAGE_SOU",
-	   "AUTOROU_LIBRE_SOU"
-	  ],
-	  "paint": {
-	   "line-color": "rgba(222, 70, 14, 0.5)",
-	   "line-width": {
-		"stops": [
-		 [
-		  6,
-		  2.5
-		 ],
-		 [
-		  9,
-		  3.5
-		 ],
-		 [
-		  14,
-		  7.5
-		 ],
-		 [
-		  15,
-		  11
-		 ],
-		 [
-		  16,
-		  15
-		 ],
-		 [
-		  17,
-		  26
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier souterrain - filet extérieur - autoroute en construction",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route_sou",
-	  "minzoom": 10,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "AUTOROU_CONSTR_SOU"
-	  ],
-	  "paint": {
-	   "line-color": "#C8C8C8",
-	   "line-width": {
-		"stops": [
-		 [
-		  6,
-		  2.5
-		 ],
-		 [
-		  9,
-		  3.5
-		 ],
-		 [
-		  14,
-		  7.5
-		 ],
-		 [
-		  15,
-		  11
-		 ],
-		 [
-		  16,
-		  15
-		 ],
-		 [
-		  17,
-		  26
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier souterrain - filet interieur - route non revetu carrosable",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route_sou",
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "NON_REVETUE_CARRO_SOU"
-	  ],
-	  "paint": {
-	   "line-color": "#DCDCDC",
-	   "line-width": {
-		"stops": [
-		 [
-		  14,
-		  2.3
-		 ],
-		 [
-		  15,
-		  4.1
-		 ],
-		 [
-		  16,
-		  6.3
-		 ],
-		 [
-		  17,
-		  13.5
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier souterrain - filet interieur - bretelle autoroute",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route_sou",
-	  "minzoom": 12,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "BRET_AUTO_PEAGE_3_SOU",
-	   "BRET_AUTO_PEAGE_2_SOU",
-	   "BRET_AUTO_PEAGE_1_SOU",
-	   "BRET_AUTO_LIBRE_3_SOU",
-	   "BRET_AUTO_LIBRE_2_SOU",
-	   "BRET_AUTO_LIBRE_1_SOU"
-	  ],
-	  "paint": {
-	   "line-color": "rgba(255, 255, 255, 0.5)",
-	   "line-width": {
-		"stops": [
-		 [
-		  12,
-		  1.5
-		 ],
-		 [
-		  14,
-		  2.6
-		 ],
-		 [
-		  15,
-		  5.2
-		 ],
-		 [
-		  16,
-		  6.7
-		 ],
-		 [
-		  17,
-		  10.8
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier souterrain - filet interieur - route non classee restreint",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route_sou",
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "NON_CLASSEE_RESTREINT_SOU"
-	  ],
-	  "paint": {
-	   "line-color": "#F2F5FF",
-	   "line-width": {
-		"stops": [
-		 [
-		  14,
-		  2.3
-		 ],
-		 [
-		  15,
-		  4.1
-		 ],
-		 [
-		  16,
-		  6.3
-		 ],
-		 [
-		  17,
-		  13.5
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier souterrain - filet interieur - route non classee",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route_sou",
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "NON_CLASSEE_4_SOU",
-	   "NON_CLASSEE_SOU"
-	  ],
-	  "paint": {
-	   "line-color": "#DCDCDC",
-	   "line-width": {
-		"stops": [
-		 [
-		  14,
-		  2.3
-		 ],
-		 [
-		  15,
-		  4.1
-		 ],
-		 [
-		  16,
-		  6.3
-		 ],
-		 [
-		  17,
-		  13.5
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier souterrain - filet interieur - route locale",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route_sou",
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "BRET_LOCALE_SOU",
-	   "LOCALE_4_SOU",
-	   "LOCALE_3_SOU",
-	   "LOCALE_2_SOU",
-	   "LOCALE_1_SOU"
-	  ],
-	  "paint": {
-	   "line-color": "rgba(255, 255, 255, 0.5)",
-	   "line-width": {
-		"stops": [
-		 [
-		  9,
-		  1.3
-		 ],
-		 [
-		  14,
-		  2.3
-		 ],
-		 [
-		  15,
-		  4.1
-		 ],
-		 [
-		  16,
-		  6.1
-		 ],
-		 [
-		  17,
-		  13.1
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier souterrain - filet interieur - route locale en construction",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route_sou",
-	  "minzoom": 11,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "LOCALE_CONSTR_SOU"
-	  ],
-	  "paint": {
-	   "line-color": {
-		"stops": [
-		 [
-		  12,
-		  "#FFFFFF"
-		 ],
-		 [
-		  13,
-		  "#FCF4A8"
-		 ],
-		 [
-		  17,
-		  "#FCF7C1"
-		 ]
-		]
-	   },
-	   "line-width": {
-		"stops": [
-		 [
-		  9,
-		  2
-		 ],
-		 [
-		  14,
-		  3.5
-		 ],
-		 [
-		  15,
-		  6
-		 ],
-		 [
-		  16,
-		  8.4
-		 ],
-		 [
-		  17,
-		  18.3
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		2,
-		2
-	   ]
-	  }
-	 },
-	 {
-	  "id": "Routier souterrain - filet interieur - route regionale",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route_sou",
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "BRET_REGIONALE_SOU",
-	   "REGIONALE_4_SOU",
-	   "REGIONALE_3_SOU",
-	   "REGIONALE_2_SOU",
-	   "REGIONALE_1_SOU"
-	  ],
-	  "paint": {
-	   "line-color": "rgba(255, 255, 255, 0.5)",
-	   "line-width": {
-		"stops": [
-		 [
-		  6,
-		  1.4
-		 ],
-		 [
-		  9,
-		  1.5
-		 ],
-		 [
-		  14,
-		  3.2
-		 ],
-		 [
-		  15,
-		  5.8
-		 ],
-		 [
-		  16,
-		  8.3
-		 ],
-		 [
-		  17,
-		  16.2
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier souterrain - filet interieur - route regionale en construction",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route_sou",
-	  "minzoom": 10,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "REGIONALE_CONSTR_SOU"
-	  ],
-	  "paint": {
-	   "line-color": {
-		"stops": [
-		 [
-		  9,
-		  "#FFFFFF"
-		 ],
-		 [
-		  10,
-		  "#FDF28B"
-		 ],
-		 [
-		  17,
-		  "#FCF6BD"
-		 ]
-		]
-	   },
-	   "line-width": {
-		"stops": [
-		 [
-		  4,
-		  0.4
-		 ],
-		 [
-		  6,
-		  1.5
-		 ],
-		 [
-		  9,
-		  2.3
-		 ],
-		 [
-		  14,
-		  5
-		 ],
-		 [
-		  15,
-		  8.1
-		 ],
-		 [
-		  16,
-		  11.2
-		 ],
-		 [
-		  17,
-		  22
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		2,
-		2
-	   ]
-	  }
-	 },
-	 {
-	  "id": "Routier souterrain - filet interieur - route principale",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route_sou",
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "BRET_PRINCIPALE_SOU",
-	   "PRINCIPALE_4_SOU",
-	   "PRINCIPALE_3_SOU",
-	   "PRINCIPALE_2_SOU",
-	   "PRINCIPALE_1_SOU"
-	  ],
-	  "paint": {
-	   "line-color": "rgba(255, 255, 255, 0.5)",
-	   "line-width": {
-		"stops": [
-		 [
-		  4,
-		  0.5
-		 ],
-		 [
-		  6,
-		  1.8
-		 ],
-		 [
-		  9,
-		  2.1
-		 ],
-		 [
-		  14,
-		  4.4
-		 ],
-		 [
-		  15,
-		  7.3
-		 ],
-		 [
-		  16,
-		  10
-		 ],
-		 [
-		  17,
-		  18.5
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier souterrain - filet interieur - route principale en construction",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route_sou",
-	  "minzoom": 10,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "PRINCIPALE_CONSTR_SOU"
-	  ],
-	  "paint": {
-	   "line-color": {
-		"stops": [
-		 [
-		  9,
-		  "#F3C66D"
-		 ],
-		 [
-		  17,
-		  "#F2DDB3"
-		 ]
-		]
-	   },
-	   "line-width": {
-		"stops": [
-		 [
-		  4,
-		  0.5
-		 ],
-		 [
-		  6,
-		  1.8
-		 ],
-		 [
-		  9,
-		  2.7
-		 ],
-		 [
-		  14,
-		  5.9
-		 ],
-		 [
-		  15,
-		  9
-		 ],
-		 [
-		  16,
-		  12.2
-		 ],
-		 [
-		  17,
-		  22.5
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		2,
-		2
-	   ]
-	  }
-	 },
-	 {
-	  "id": "Routier souterrain - filet interieur - autoroute",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route_sou",
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "AUTOROU_PEAGE_SOU",
-	   "AUTOROU_LIBRE_SOU"
-	  ],
-	  "paint": {
-	   "line-color": "rgba(255, 255, 255, 0.5)",
-	   "line-width": {
-		"stops": [
-		 [
-		  4,
-		  0.7
-		 ],
-		 [
-		  6,
-		  2.5
-		 ],
-		 [
-		  9,
-		  2.7
-		 ],
-		 [
-		  14,
-		  5.8
-		 ],
-		 [
-		  15,
-		  9
-		 ],
-		 [
-		  16,
-		  12
-		 ],
-		 [
-		  17,
-		  20.8
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier souterrain - axe central - autoroute",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route_sou",
-	  "minzoom": 13,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "AUTOROU_PEAGE_SOU",
-	   "AUTOROU_LIBRE_SOU"
-	  ],
-	  "paint": {
-	   "line-color": "#FFFFFF",
-	   "line-width": {
-		"stops": [
-		 [
-		  9,
-		  0.6
-		 ],
-		 [
-		  14,
-		  0.7
-		 ],
-		 [
-		  15,
-		  1
-		 ],
-		 [
-		  16,
-		  1.2
-		 ],
-		 [
-		  17,
-		  2.1
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier souterrain - filet interieur - autoroute en construction",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route_sou",
-	  "minzoom": 10,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "AUTOROU_CONSTR_SOU"
-	  ],
-	  "paint": {
-	   "line-color": {
-		"stops": [
-		 [
-		  9,
-		  "#F2BA59"
-		 ],
-		 [
-		  17,
-		  "#F2C261"
-		 ]
-		]
-	   },
-	   "line-width": {
-		"stops": [
-		 [
-		  4,
-		  0.7
-		 ],
-		 [
-		  6,
-		  2.5
-		 ],
-		 [
-		  9,
-		  3.5
-		 ],
-		 [
-		  14,
-		  7.5
-		 ],
-		 [
-		  15,
-		  11
-		 ],
-		 [
-		  16,
-		  15
-		 ],
-		 [
-		  17,
-		  26
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		2,
-		2
-	   ]
-	  }
-	 },
-	 {
-	  "id": "Routier souterrain - axe central - autoroute en construction",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route_sou",
-	  "minzoom": 13,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "AUTOROU_CONSTR_SOU"
-	  ],
-	  "paint": {
-	   "line-color": "#808080",
-	   "line-width": {
-		"stops": [
-		 [
-		  9,
-		  0.6
-		 ],
-		 [
-		  14,
-		  0.7
-		 ],
-		 [
-		  15,
-		  1
-		 ],
-		 [
-		  16,
-		  1.2
-		 ],
-		 [
-		  17,
-		  2.1
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "réseau hydro - cours d'eau temporaire",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "hydro_reseau",
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "COURS_D_EAU_TEMP",
-	   "COURS_D_EAU_TEMP_MOY"
-	  ],
-	  "paint": {
-	   "line-color": "#AAD5E9",
-	   "line-width": {
-		"stops": [
-		 [
-		  12,
-		  1.5
-		 ],
-		 [
-		  17,
-		  4
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		6,
-		2
-	   ]
-	  }
-	 },
-	 {
-	  "id": "réseau hydro - cours d'eau",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "hydro_reseau",
-	  "minzoom": 3,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "COURS_D_EAU"
-	  ],
-	  "paint": {
-	   "line-color": "#AAD5E9",
-	   "line-width": {
-		"stops": [
-		 [
-		  4,
-		  0.3
-		 ],
-		 [
-		  7,
-		  1.5
-		 ],
-		 [
-		  12,
-		  1.5
-		 ],
-		 [
-		  17,
-		  6.5
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "réseau hydro - canal",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "hydro_reseau",
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "CANAL"
-	  ],
-	  "paint": {
-	   "line-color": "#AAD5E9",
-	   "line-width": {
-		"stops": [
-		 [
-		  12,
-		  1.4
-		 ],
-		 [
-		  17,
-		  5.9
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "réseau hydro - filet interieur - aqueduc",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "hydro_reseau",
-	  "minzoom": 12,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "AQUEDUC_AU_SOL"
-	  ],
-	  "paint": {
-	   "line-color": "#AAD5E9",
-	   "line-width": {
-		"stops": [
-		 [
-		  12,
-		  1.4
-		 ],
-		 [
-		  16,
-		  3.5
-		 ],
-		 [
-		  17,
-		  5.9
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "réseau hydro - carre - aqueduc",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "hydro_reseau",
-	  "minzoom": 12,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "AQUEDUC_AU_SOL"
-	  ],
-	  "paint": {
-	   "line-color": "#AAD5E9",
-	   "line-width": {
-		"stops": [
-		 [
-		  12,
-		  3.5
-		 ],
-		 [
-		  16,
-		  8.7
-		 ],
-		 [
-		  17,
-		  14.7
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		1,
-		5
-	   ]
-	  }
-	 },
-	 {
-	  "id": "réseau hydro - cours d'eau moyen ",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "hydro_reseau",
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "COURS_D_EAU_MOY"
-	  ],
-	  "paint": {
-	   "line-color": "#AAD5E9",
-	   "line-width": {
-		"stops": [
-		 [
-		  7,
-		  2
-		 ],
-		 [
-		  12,
-		  2.5
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "réseau hydro - cours d'eau large ",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "hydro_reseau",
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "COURS_D_EAU_LAR"
-	  ],
-	  "paint": {
-	   "line-color": "#AAD5E9",
-	   "line-width": {
-		"stops": [
-		 [
-		  7,
-		  3
-		 ],
-		 [
-		  11,
-		  5
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "parcellaire - parcelle surface",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "parcellaire_parcelle",
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "PARCELLE"
-	  ],
-	  "paint": {
-	   "fill-color": "#FFFFD1",
-	   "fill-opacity": 0.7
-	  }
-	 },
-	 {
-	  "id": "bati surfacique mairie - Zoom 14",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "bati_surf",
-	  "maxzoom": 14,
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "MAIRIE",
-	   "MAIRIE_ANNEXE"
-	  ],
-	  "paint": {
-	   "fill-color": "#FFA6A6"
-	  }
-	 },
-	 {
-	  "id": "bati surfacique mairie - Zoom 15,16,17,18",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "bati_surf",
-	  "minzoom": 14,
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "MAIRIE",
-	   "MAIRIE_ANNEXE"
-	  ],
-	  "paint": {
-	   "fill-color": {
-		"stops": [
-		 [
-		  14,
-		  "#FFA6A6"
-		 ],
-		 [
-		  15,
-		  "#FFAEAE"
-		 ]
-		]
-	   },
-	   "fill-outline-color": "#FF7C7C"
-	  }
-	 },
-	 {
-	  "id": "bati surfacique fonctionnel industriel ou commercial - Zoom 14,15",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "bati_surf",
-	  "maxzoom": 15,
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "BATI_COMMERCIAL",
-	   "BATI_INDUSTRIEL",
-	   "HANGAR",
-	   "HANGAR_COMMERCIAL",
-	   "HANGAR_INDUSTRIEL"
-	  ],
-	  "paint": {
-	   "fill-color": "#C8C8C8"
-	  }
-	 },
-	 {
-	  "id": "bati surfacique fonctionnel industriel ou commercial - Zoom 16,17,18",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "bati_surf",
-	  "minzoom": 15,
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "BATI_COMMERCIAL",
-	   "BATI_INDUSTRIEL",
-	   "HANGAR",
-	   "HANGAR_COMMERCIAL",
-	   "HANGAR_INDUSTRIEL"
-	  ],
-	  "paint": {
-	   "fill-color": {
-		"stops": [
-		 [
-		  15,
-		  "#D1D1D1"
-		 ],
-		 [
-		  16,
-		  "#E6E6E6"
-		 ]
-		]
-	   },
-	   "fill-outline-color": "#B8B8B8"
-	  }
-	 },
-	 {
-	  "id": "bati surfacique fonctionnel public - Zoom 14,15",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "bati_surf",
-	  "maxzoom": 15,
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "BATI_PUBLIC",
-	   "HANGAR_PUBLIC"
-	  ],
-	  "paint": {
-	   "fill-color": "#B9B6D6"
-	  }
-	 },
-	 {
-	  "id": "bati surfacique fonctionnel public - Zoom 16,17,18",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "bati_surf",
-	  "minzoom": 15,
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "BATI_PUBLIC",
-	   "HANGAR_PUBLIC"
-	  ],
-	  "paint": {
-	   "fill-color": {
-		"stops": [
-		 [
-		  15,
-		  "#CFC5DE"
-		 ],
-		 [
-		  16,
-		  "#E4DAF3"
-		 ]
-		]
-	   },
-	   "fill-outline-color": "#A6A1D6"
-	  }
-	 },
-	 {
-	  "id": "bati surfacique fonctionnel sportif - bordure",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "bati_surf",
-	  "minzoom": 15,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "BATI_SPORTIF"
-	  ],
-	  "paint": {
-	   "line-color": "#BCD9AB",
-	   "line-width": 4
-	  }
-	 },
-	 {
-	  "id": "bati surfacique fonctionnel sportif",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "bati_surf",
-	  "minzoom": 13,
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "BATI_SPORTIF"
-	  ],
-	  "paint": {
-	   "fill-color": {
-		"stops": [
-		 [
-		  14,
-		  "#C9E1DD"
-		 ],
-		 [
-		  15,
-		  "#DCE6E4"
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "bati surfacique fonctionnel gare - Zoom 14,15",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "bati_surf",
-	  "maxzoom": 15,
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "BATI_GARE"
-	  ],
-	  "paint": {
-	   "fill-color": "#B3B5F5"
-	  }
-	 },
-	 {
-	  "id": "bati surfacique fonctionnel gare - Zoom 16,17,18",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "bati_surf",
-	  "minzoom": 15,
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "BATI_GARE"
-	  ],
-	  "paint": {
-	   "fill-color": {
-		"stops": [
-		 [
-		  15,
-		  "#BFC1F5"
-		 ],
-		 [
-		  16,
-		  "#CBCDF5"
-		 ]
-		]
-	   },
-	   "fill-outline-color": "#9B9EF6"
-	  }
-	 },
-	 {
-	  "id": "bati surfacique quelconque - Zoom 15",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "bati_surf",
-	  "minzoom": 14,
-	  "maxzoom": 15,
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "BATI_QQUE"
-	  ],
-	  "paint": {
-	   "fill-color": "#D6C6B8"
-	  }
-	 },
-	 {
-	  "id": "bati surfacique quelconque - Zoom 16,17,18",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "bati_surf",
-	  "minzoom": 15,
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "BATI_QQUE"
-	  ],
-	  "paint": {
-	   "fill-color": {
-		"stops": [
-		 [
-		  15,
-		  "#E6E0CF"
-		 ],
-		 [
-		  16,
-		  "#F1EBD9"
-		 ]
-		]
-	   },
-	   "fill-outline-color": "#C3AA8E"
-	  }
-	 },
-	 {
-	  "id": "cimetiere surfacique 1",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "bati_surf",
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "CIMETIERE_SURF",
-	   "CIMETIERE_MILI_SURF",
-	   "NECROPOLE_NATIONALE"
-	  ],
-	  "paint": {
-	   "fill-color": "#F0F0F0",
-	   "fill-opacity": 0.5,
-	   "fill-outline-color": "#818181"
-	  }
-	 },
-	 {
-	  "id": "cimetiere surfacique 2",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "bati_surf",
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "CIMETIERE_SURF",
-	   "CIMETIERE_MILI_SURF",
-	   "NECROPOLE_NATIONALE"
-	  ],
-	  "paint": {
-	   "fill-pattern": "Cimetiere"
-	  }
-	 },
-	 {
-	  "id": "bati hydro surfacique - Autre",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "bati_surf",
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "ECLUSE_SURF",
-	   "RESERVOIR_EAU_SURF"
-	  ],
-	  "paint": {
-	   "fill-color": "#ADCCD9",
-	   "fill-outline-color": "#336699"
-	  }
-	 },
-	 {
-	  "id": "bati hydro surfacique - Pecherie",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "bati_surf",
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "PECHERIE_SURF"
-	  ],
-	  "paint": {
-	   "fill-color": "#BFE2F0",
-	   "fill-outline-color": "#509FEF"
-	  }
-	 },
-	 {
-	  "id": "bati hydro surfacique - Barrage",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "bati_surf",
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "BARRAGE_SURF"
-	  ],
-	  "paint": {
-	   "fill-color": "#FFFFFF",
-	   "fill-outline-color": "#464646"
-	  }
-	 },
-	 {
-	  "id": "bati hydro surfacique - Chateau d'eau",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "bati_surf",
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "CHATEAU_EAU_SURF"
-	  ],
-	  "paint": {
-	   "fill-color": "#1466B2"
-	  }
-	 },
-	 {
-	  "id": "bati infra surfacique - Silo",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "bati_surf",
-	  "minzoom": 15,
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "SILO_SURF"
-	  ],
-	  "paint": {
-	   "fill-color": "#C7A9AA",
-	   "fill-outline-color": "#696969"
-	  }
-	 },
-	 {
-	  "id": "bati infra surfacique - Reservoir indus",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "bati_surf",
-	  "minzoom": 14,
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "RESERVOIR_INDUS_SURF"
-	  ],
-	  "paint": {
-	   "fill-color": "#8D9DAA",
-	   "fill-outline-color": "#464646"
-	  }
-	 },
-	 {
-	  "id": "bati infra surfacique - Serre",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "bati_surf",
-	  "minzoom": 13,
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "SERRE_SURF"
-	  ],
-	  "paint": {
-	   "fill-color": "#CAD6D9",
-	   "fill-outline-color": "#8C8C8C"
-	  }
-	 },
-	 {
-	  "id": "bati infra surfacique - poste electrique",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "bati_surf",
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "POSTE_ELEC_SURF"
-	  ],
-	  "paint": {
-	   "fill-color": "#7993B6",
-	   "fill-opacity": 0.3
-	  }
-	 },
-	 {
-	  "id": "bati infra surfacique - poste electrique bord",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "bati_surf",
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "POSTE_ELEC_SURF"
-	  ],
-	  "paint": {
-	   "line-color": "#000000",
-	   "line-width": {
-		"stops": [
-		 [
-		  12,
-		  0.3
-		 ],
-		 [
-		  17,
-		  1.2
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "bati religieux surfacique - Zoom 14",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "bati_surf",
-	  "maxzoom": 14,
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "CHAPELLE_SURF",
-	   "EGLISE_SURF",
-	   "CHRETIEN_SURF",
-	   "SYNAGOGUE_SURF",
-	   "MOSQUEE_SURF",
-	   "AUTRE_CULTE_SURF"
-	  ],
-	  "paint": {
-	   "fill-color": "#F7CBCB"
-	  }
-	 },
-	 {
-	  "id": "bati religieux surfacique - Zoom 15,16,17,18",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "bati_surf",
-	  "minzoom": 14,
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "CHAPELLE_SURF",
-	   "EGLISE_SURF",
-	   "CHRETIEN_SURF",
-	   "SYNAGOGUE_SURF",
-	   "MOSQUEE_SURF",
-	   "AUTRE_CULTE_SURF"
-	  ],
-	  "paint": {
-	   "fill-color": {
-		"stops": [
-		 [
-		  14,
-		  "#F7CBCB"
-		 ],
-		 [
-		  15,
-		  "#F7E1E1"
-		 ]
-		]
-	   },
-	   "fill-outline-color": {
-		"stops": [
-		 [
-		  14,
-		  "#F7A8A8"
-		 ],
-		 [
-		  15,
-		  "#F7B7B7"
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "bati remarquable surfacique",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "bati_surf",
-	  "minzoom": 13,
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "FORTIF_SURF",
-	   "CHATEAU_SURF",
-	   "TOUR_MOULIN_SURF",
-	   "ARENE_THEATRE",
-	   "ARC_TRIOMPHE_SURF",
-	   "MONUMENT_SURF"
-	  ],
-	  "paint": {
-	   "fill-color": "#9B9B9B",
-	   "fill-outline-color": "#6E6E6E"
-	  }
-	 },
-	 {
-	  "id": "bati sportif surfacique fond",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "bati_surf",
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "TENNIS_SURF",
-	   "SPORT_INDIF_SURF",
-	   "FOOT_SURF",
-	   "MULTI_SPORT_SURF",
-	   "PISTE_SPORT_SURF",
-	   "NATATION_SURF"
-	  ],
-	  "paint": {
-	   "fill-color": "#FFFFFF",
-	   "fill-outline-color": "#FFFFFF"
-	  }
-	 },
-	 {
-	  "id": "bati sportif surfacique",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "bati_surf",
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "TENNIS_SURF",
-	   "SPORT_INDIF_SURF",
-	   "FOOT_SURF",
-	   "MULTI_SPORT_SURF",
-	   "PISTE_SPORT_SURF",
-	   "NATATION_SURF"
-	  ],
-	  "paint": {
-	   "line-color": "#BCD9AB",
-	   "line-width": 2
-	  }
-	 },
-	 {
-	  "id": "bati transport surfacique - piste",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "bati_surf",
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "PISTE_DUR",
-	   "PISTE_HERBE"
-	  ],
-	  "paint": {
-	   "fill-color": "#DBDBDB",
-	   "fill-outline-color": "#808080"
-	  }
-	 },
-	 {
-	  "id": "bati ZAI - Autres",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "bati_zai",
-	  "minzoom": 15,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "in",
-	   "nature",
-	   "Lycée",
-	   "Université",
-	   "Capitainerie",
-	   "Gendarmerie",
-	   "Siège d'EPCI",
-	   "Musée",
-	   "Collège",
-	   "Maison de retraite",
-	   "Etablissement thermal",
-	   "Autre service déconcentré de l'Etat",
-	   "Etablissement pénitentiaire",
-	   "Divers public ou administratif",
-	   "Autre établissement d'enseignement",
-	   "Maison du parc",
-	   "Palais de justice",
-	   "Enseignement primaire",
-	   "Office de tourisme",
-	   "Hôpital",
-	   "Police",
-	   "Piscine",
-	   "Enseignement supérieur",
-	   "Poste",
-	   "Caserne",
-	   "Etablissement hospitalier",
-	   "Etablissement extraterritorial",
-	   "Science",
-	   "Structure d'accueil pour personnes handicapées",
-	   "Administration centrale de l'Etat",
-	   "Caserne de pompiers"
-	  ],
-	  "paint": {
-	   "fill-color": "#E3BFE2",
-	   "fill-opacity": 0.5,
-	   "fill-outline-color": "#E39FE1"
-	  }
-	 },
-	 {
-	  "id": "bati ZAI - Commandement",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "bati_zai",
-	  "minzoom": 15,
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "in",
-	   "nature",
-	   "Hôtel de département",
-	   "Hôtel de région",
-	   "Préfecture de région",
-	   "Préfecture",
-	   "Sous-préfecture"
-	  ],
-	  "paint": {
-	   "fill-color": "#FF0000",
-	   "fill-opacity": 0.3,
-	   "fill-outline-color": "#B40000"
-	  }
-	 },
-	 {
-	  "id": "construction linéaire - mur",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "bati_lin",
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "MUR"
-	  ],
-	  "paint": {
-	   "line-color": "#8C8C8C",
-	   "line-width": 0.3
-	  }
-	 },
-	 {
-	  "id": "construction linéaire - autre",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "bati_lin",
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "RUINE_LIN",
-	   "MUR_SOUTENEMENT",
-	   "FORTIF_LIN"
-	  ],
-	  "paint": {
-	   "line-color": "#646464",
-	   "line-width": 0.5
-	  }
-	 },
-	 {
-	  "id": "construction hydrographique linéaire - Barrage",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "bati_lin",
-	  "minzoom": 13,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "BARRAGE_LIN"
-	  ],
-	  "paint": {
-	   "line-color": "#646464",
-	   "line-width": {
-		"stops": [
-		 [
-		  13,
-		  1.5
-		 ],
-		 [
-		  17,
-		  5
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "construction hydrographique linéaire - Quai",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "bati_lin",
-	  "minzoom": 12,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "QUAI",
-	   "DIGUE"
-	  ],
-	  "paint": {
-	   "line-color": "#828282",
-	   "line-width": {
-		"stops": [
-		 [
-		  14,
-		  1
-		 ],
-		 [
-		  17,
-		  2.5
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "construction hydrographique linéaire - Pecherie",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "bati_lin",
-	  "minzoom": 12,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "PECHERIE_LIN"
-	  ],
-	  "paint": {
-	   "line-color": "#0066CC",
-	   "line-width": {
-		"stops": [
-		 [
-		  14,
-		  1
-		 ],
-		 [
-		  17,
-		  2.5
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Chemin a niveau - piste cyclable",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_chemin",
-	  "minzoom": 13,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "PISTE_CYCLABLE"
-	  ],
-	  "paint": {
-	   "line-color": {
-		"stops": [
-		 [
-		  17,
-		  "#9B5CCC"
-		 ],
-		 [
-		  18,
-		  "#FFFFFF"
-		 ]
-		]
-	   },
-	   "line-width": {
-		"stops": [
-		 [
-		  14,
-		  1.1
-		 ],
-		 [
-		  15,
-		  1.7
-		 ],
-		 [
-		  16,
-		  2
-		 ],
-		 [
-		  17,
-		  3.5
-		 ],
-		 [
-		  18,
-		  6
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		6,
-		2
-	   ]
-	  }
-	 },
-	 {
-	  "id": "Chemin a niveau - filet exterieur - escalier",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_chemin",
-	  "minzoom": 14,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "ESCALIER"
-	  ],
-	  "paint": {
-	   "line-color": {
-		"stops": [
-		 [
-		  17,
-		  "#8C7274"
-		 ],
-		 [
-		  18,
-		  "#C8C8C8"
-		 ]
-		]
-	   },
-	   "line-width": {
-		"stops": [
-		 [
-		  14,
-		  1.75
-		 ],
-		 [
-		  15,
-		  3
-		 ],
-		 [
-		  16,
-		  4.2
-		 ],
-		 [
-		  17,
-		  9.5
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Chemin a niveau - filet interieur - escalier",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_chemin",
-	  "minzoom": 14,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "ESCALIER"
-	  ],
-	  "paint": {
-	   "line-color": "#FFFFFF",
-	   "line-width": {
-		"stops": [
-		 [
-		  14,
-		  1
-		 ],
-		 [
-		  15,
-		  1.9
-		 ],
-		 [
-		  16,
-		  2.7
-		 ],
-		 [
-		  17,
-		  5.8
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		1,
-		0.2
-	   ]
-	  }
-	 },
-	 {
-	  "id": "Chemin a niveau - Rue pietonne",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_chemin",
-	  "minzoom": 14,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "RUE_PIETONNE"
-	  ],
-	  "paint": {
-	   "line-color": {
-		"stops": [
-		 [
-		  17,
-		  "#8C7274"
-		 ],
-		 [
-		  18,
-		  "#F8E5D5"
-		 ]
-		]
-	   },
-	   "line-width": {
-		"stops": [
-		 [
-		  14,
-		  1
-		 ],
-		 [
-		  15,
-		  1.2
-		 ],
-		 [
-		  16,
-		  1.4
-		 ],
-		 [
-		  17,
-		  2
-		 ],
-		 [
-		  18,
-		  5
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		1,
-		3
-	   ]
-	  }
-	 },
-	 {
-	  "id": "Chemin a niveau - sentier",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_chemin",
-	  "minzoom": 13,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "SENTIER"
-	  ],
-	  "paint": {
-	   "line-color": {
-		"stops": [
-		 [
-		  17,
-		  "#8C7274"
-		 ],
-		 [
-		  18,
-		  "#FFFFFF"
-		 ]
-		]
-	   },
-	   "line-width": {
-		"stops": [
-		 [
-		  14,
-		  1
-		 ],
-		 [
-		  15,
-		  1.2
-		 ],
-		 [
-		  16,
-		  1.4
-		 ],
-		 [
-		  17,
-		  2
-		 ],
-		 [
-		  18,
-		  6
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		4,
-		3
-	   ]
-	  }
-	 },
-	 {
-	  "id": "Chemin a niveau - chemin",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_chemin",
-	  "minzoom": 12,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "CHEMIN"
-	  ],
-	  "paint": {
-	   "line-color": {
-		"stops": [
-		 [
-		  17,
-		  "#8C7274"
-		 ],
-		 [
-		  18,
-		  "#FFFFFF"
-		 ]
-		]
-	   },
-	   "line-width": {
-		"stops": [
-		 [
-		  14,
-		  1
-		 ],
-		 [
-		  15,
-		  1.2
-		 ],
-		 [
-		  16,
-		  1.4
-		 ],
-		 [
-		  17,
-		  2
-		 ],
-		 [
-		  18,
-		  7
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier a niveau - filet extérieur - route non revetu carrosable",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route",
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "NON_REVETUE_CARRO"
-	  ],
-	  "paint": {
-	   "line-color": {
-		"stops": [
-		 [
-		  12,
-		  "#646464"
-		 ],
-		 [
-		  17,
-		  "#8C8C8C"
-		 ]
-		]
-	   },
-	   "line-width": {
-		"stops": [
-		 [
-		  14,
-		  3.2
-		 ],
-		 [
-		  15,
-		  5.4
-		 ],
-		 [
-		  16,
-		  7.7
-		 ],
-		 [
-		  17,
-		  16.8
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		2,
-		2
-	   ]
-	  }
-	 },
-	 {
-	  "id": "Routier a niveau - filet interieur - route non revetu carrosable",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route",
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "NON_REVETUE_CARRO"
-	  ],
-	  "paint": {
-	   "line-color": "#FFFFFF",
-	   "line-width": {
-		"stops": [
-		 [
-		  14,
-		  2.3
-		 ],
-		 [
-		  15,
-		  4.1
-		 ],
-		 [
-		  16,
-		  6.3
-		 ],
-		 [
-		  17,
-		  13.5
-		 ],
-		 [
-		  18,
-		  16.8
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier a niveau - filet extérieur - bretelle autoroute",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route",
-	  "minzoom": 12,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "BRET_AUTO_PEAGE_3",
-	   "BRET_AUTO_PEAGE_2",
-	   "BRET_AUTO_PEAGE_1",
-	   "BRET_AUTO_LIBRE_3",
-	   "BRET_AUTO_LIBRE_2",
-	   "BRET_AUTO_LIBRE_1"
-	  ],
-	  "paint": {
-	   "line-color": {
-		"stops": [
-		 [
-		  9,
-		  "#DE460E"
-		 ],
-		 [
-		  17,
-		  "#F18800"
-		 ],
-		 [
-		  18,
-		  "#FFFFFF"
-		 ]
-		]
-	   },
-	   "line-width": {
-		"stops": [
-		 [
-		  12,
-		  2.5
-		 ],
-		 [
-		  14,
-		  3.7
-		 ],
-		 [
-		  15,
-		  6.8
-		 ],
-		 [
-		  16,
-		  8.4
-		 ],
-		 [
-		  17,
-		  14
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier a niveau - filet extérieur - route non classee restreint",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route",
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "NON_CLASSEE_RESTREINT"
-	  ],
-	  "paint": {
-	   "line-color": {
-		"stops": [
-		 [
-		  17,
-		  "#969696"
-		 ],
-		 [
-		  18,
-		  "#FFFFFF"
-		 ]
-		]
-	   },
-	   "line-width": {
-		"stops": [
-		 [
-		  14,
-		  3.2
-		 ],
-		 [
-		  15,
-		  5.4
-		 ],
-		 [
-		  16,
-		  7.7
-		 ],
-		 [
-		  17,
-		  16.8
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier a niveau - filet extérieur - route non classee",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route",
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "NON_CLASSEE_4",
-	   "NON_CLASSEE"
-	  ],
-	  "paint": {
-	   "line-color": {
-		"stops": [
-		 [
-		  17,
-		  "#969696"
-		 ],
-		 [
-		  18,
-		  "#FFFFFF"
-		 ]
-		]
-	   },
-	   "line-width": {
-		"stops": [
-		 [
-		  14,
-		  3.2
-		 ],
-		 [
-		  15,
-		  5.4
-		 ],
-		 [
-		  16,
-		  7.7
-		 ],
-		 [
-		  17,
-		  16.8
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier a niveau - filet extérieur - route locale",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route",
-	  "minzoom": 7,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "BRET_LOCALE",
-	   "LOCALE_4",
-	   "LOCALE_3",
-	   "LOCALE_2",
-	   "LOCALE_1"
-	  ],
-	  "paint": {
-	   "line-color": {
-		"stops": [
-		 [
-		  12,
-		  "#8C8C8C"
-		 ],
-		 [
-		  13,
-		  "#B4B4B4"
-		 ],
-		 [
-		  17,
-		  "#B4B4B4"
-		 ],
-		 [
-		  18,
-		  "#FFFFFF"
-		 ]
-		]
-	   },
-	   "line-width": {
-		"stops": [
-		 [
-		  9,
-		  2
-		 ],
-		 [
-		  14,
-		  3.5
-		 ],
-		 [
-		  15,
-		  6
-		 ],
-		 [
-		  16,
-		  8.4
-		 ],
-		 [
-		  17,
-		  18.3
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier a niveau - filet extérieur - route locale en construction",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route",
-	  "minzoom": 11,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "LOCALE_CONSTR"
-	  ],
-	  "paint": {
-	   "line-color": "#C8C8C8",
-	   "line-width": {
-		"stops": [
-		 [
-		  9,
-		  2
-		 ],
-		 [
-		  14,
-		  3.5
-		 ],
-		 [
-		  15,
-		  6
-		 ],
-		 [
-		  16,
-		  8.4
-		 ],
-		 [
-		  17,
-		  18.3
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier a niveau - filet extérieur - route regionale",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route",
-	  "minzoom": 8,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "BRET_REGIONALE",
-	   "REGIONALE_4",
-	   "REGIONALE_3",
-	   "REGIONALE_2",
-	   "REGIONALE_1"
-	  ],
-	  "paint": {
-	   "line-color": {
-		"stops": [
-		 [
-		  9,
-		  "#828282"
-		 ],
-		 [
-		  10,
-		  "#B4B4B4"
-		 ],
-		 [
-		  17,
-		  "#B4B4B4"
-		 ],
-		 [
-		  18,
-		  "#FFFFFF"
-		 ]
-		]
-	   },
-	   "line-width": {
-		"stops": [
-		 [
-		  6,
-		  1.5
-		 ],
-		 [
-		  9,
-		  2.3
-		 ],
-		 [
-		  14,
-		  5
-		 ],
-		 [
-		  15,
-		  8.1
-		 ],
-		 [
-		  16,
-		  11.2
-		 ],
-		 [
-		  17,
-		  22
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier a niveau - filet extérieur - route regionale en construction",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route",
-	  "minzoom": 10,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "REGIONALE_CONSTR"
-	  ],
-	  "paint": {
-	   "line-color": "#C8C8C8",
-	   "line-width": {
-		"stops": [
-		 [
-		  6,
-		  1.5
-		 ],
-		 [
-		  9,
-		  2.3
-		 ],
-		 [
-		  14,
-		  5
-		 ],
-		 [
-		  15,
-		  8.1
-		 ],
-		 [
-		  16,
-		  11.2
-		 ],
-		 [
-		  17,
-		  22
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier a niveau - filet extérieur - route principale",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route",
-	  "minzoom": 8,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "BRET_PRINCIPALE",
-	   "PRINCIPALE_4",
-	   "PRINCIPALE_3",
-	   "PRINCIPALE_2",
-	   "PRINCIPALE_1"
-	  ],
-	  "paint": {
-	   "line-color": {
-		"stops": [
-		 [
-		  17,
-		  "#E2A52A"
-		 ],
-		 [
-		  18,
-		  "#FFFFFF"
-		 ]
-		]
-	   },
-	   "line-width": {
-		"stops": [
-		 [
-		  6,
-		  1.8
-		 ],
-		 [
-		  9,
-		  2.7
-		 ],
-		 [
-		  14,
-		  5.9
-		 ],
-		 [
-		  15,
-		  9
-		 ],
-		 [
-		  16,
-		  12.2
-		 ],
-		 [
-		  17,
-		  22.5
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier a niveau - filet extérieur - route principale en construction",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route",
-	  "minzoom": 10,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "PRINCIPALE_CONSTR"
-	  ],
-	  "paint": {
-	   "line-color": "#C8C8C8",
-	   "line-width": {
-		"stops": [
-		 [
-		  6,
-		  1.8
-		 ],
-		 [
-		  9,
-		  2.7
-		 ],
-		 [
-		  14,
-		  5.9
-		 ],
-		 [
-		  15,
-		  9
-		 ],
-		 [
-		  16,
-		  12.2
-		 ],
-		 [
-		  17,
-		  22.5
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier a niveau - filet extérieur - autoroute",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route",
-	  "minzoom": 8,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "AUTOROU_PEAGE",
-	   "AUTOROU_LIBRE"
-	  ],
-	  "paint": {
-	   "line-color": {
-		"stops": [
-		 [
-		  9,
-		  "#DE460E"
-		 ],
-		 [
-		  17,
-		  "#F18800"
-		 ],
-		 [
-		  18,
-		  "#FFFFFF"
-		 ]
-		]
-	   },
-	   "line-width": {
-		"stops": [
-		 [
-		  6,
-		  2.5
-		 ],
-		 [
-		  9,
-		  3.5
-		 ],
-		 [
-		  14,
-		  7.5
-		 ],
-		 [
-		  15,
-		  11
-		 ],
-		 [
-		  16,
-		  15
-		 ],
-		 [
-		  17,
-		  26
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier a niveau - filet extérieur - autoroute en construction",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route",
-	  "minzoom": 8,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "AUTOROU_CONSTR"
-	  ],
-	  "paint": {
-	   "line-color": "#C8C8C8",
-	   "line-width": {
-		"stops": [
-		 [
-		  6,
-		  2.5
-		 ],
-		 [
-		  9,
-		  3.5
-		 ],
-		 [
-		  14,
-		  7.5
-		 ],
-		 [
-		  15,
-		  11
-		 ],
-		 [
-		  16,
-		  15
-		 ],
-		 [
-		  17,
-		  26
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier a niveau - filet interieur - bretelle autoroute",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route",
-	  "minzoom": 12,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "BRET_AUTO_PEAGE_3",
-	   "BRET_AUTO_PEAGE_2",
-	   "BRET_AUTO_PEAGE_1",
-	   "BRET_AUTO_LIBRE_3",
-	   "BRET_AUTO_LIBRE_2",
-	   "BRET_AUTO_LIBRE_1"
-	  ],
-	  "paint": {
-	   "line-color": {
-		"stops": [
-		 [
-		  9,
-		  "#F18800"
-		 ],
-		 [
-		  17,
-		  "#F2B230"
-		 ]
-		]
-	   },
-	   "line-width": {
-		"stops": [
-		 [
-		  12,
-		  1.5
-		 ],
-		 [
-		  14,
-		  2.6
-		 ],
-		 [
-		  15,
-		  5.2
-		 ],
-		 [
-		  16,
-		  6.7
-		 ],
-		 [
-		  17,
-		  10.8
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier a niveau - filet interieur - route non classee restreint",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route",
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "NON_CLASSEE_RESTREINT"
-	  ],
-	  "paint": {
-	   "line-color": "#EDF1FF",
-	   "line-width": {
-		"stops": [
-		 [
-		  14,
-		  2.3
-		 ],
-		 [
-		  15,
-		  4.1
-		 ],
-		 [
-		  16,
-		  6.3
-		 ],
-		 [
-		  17,
-		  13.5
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier a niveau - filet interieur - route non classee",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route",
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "NON_CLASSEE_4",
-	   "NON_CLASSEE"
-	  ],
-	  "paint": {
-	   "line-color": "#FFFFFF",
-	   "line-width": {
-		"stops": [
-		 [
-		  14,
-		  2.3
-		 ],
-		 [
-		  15,
-		  4.1
-		 ],
-		 [
-		  16,
-		  6.3
-		 ],
-		 [
-		  17,
-		  13.5
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier a niveau - filet interieur - route locale",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route",
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "BRET_LOCALE",
-	   "LOCALE_4",
-	   "LOCALE_3",
-	   "LOCALE_2",
-	   "LOCALE_1"
-	  ],
-	  "paint": {
-	   "line-color": {
-		"stops": [
-		 [
-		  6,
-		  "#F2B361"
-		 ],
-		 [
-		  7,
-		  "#FFFFFF"
-		 ],
-		 [
-		  12,
-		  "#FFFFFF"
-		 ],
-		 [
-		  13,
-		  "#FCF4A8"
-		 ],
-		 [
-		  17,
-		  "#FCF7C1"
-		 ]
-		]
-	   },
-	   "line-width": {
-		"stops": [
-		 [
-		  9,
-		  1.3
-		 ],
-		 [
-		  14,
-		  2.3
-		 ],
-		 [
-		  15,
-		  4.1
-		 ],
-		 [
-		  16,
-		  6.1
-		 ],
-		 [
-		  17,
-		  13.1
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier a niveau - filet interieur - route locale en construction",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route",
-	  "minzoom": 11,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "LOCALE_CONSTR"
-	  ],
-	  "paint": {
-	   "line-color": {
-		"stops": [
-		 [
-		  12,
-		  "#FFFFFF"
-		 ],
-		 [
-		  13,
-		  "#FCF4A8"
-		 ],
-		 [
-		  17,
-		  "#FCF7C1"
-		 ],
-		 [
-		  18,
-		  "#EDEDED"
-		 ]
-		]
-	   },
-	   "line-width": {
-		"stops": [
-		 [
-		  9,
-		  2
-		 ],
-		 [
-		  14,
-		  3.5
-		 ],
-		 [
-		  15,
-		  6
-		 ],
-		 [
-		  16,
-		  8.4
-		 ],
-		 [
-		  17,
-		  18.3
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		2,
-		2
-	   ]
-	  }
-	 },
-	 {
-	  "id": "Routier a niveau - filet interieur - route regionale",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route",
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "BRET_REGIONALE",
-	   "REGIONALE_4",
-	   "REGIONALE_3",
-	   "REGIONALE_2",
-	   "REGIONALE_1"
-	  ],
-	  "paint": {
-	   "line-color": {
-		"stops": [
-		 [
-		  6,
-		  "#F2A949"
-		 ],
-		 [
-		  7,
-		  "#FFFFFF"
-		 ],
-		 [
-		  9,
-		  "#FFFFFF"
-		 ],
-		 [
-		  10,
-		  "#FDF28B"
-		 ],
-		 [
-		  17,
-		  "#FCF6BD"
-		 ]
-		]
-	   },
-	   "line-width": {
-		"stops": [
-		 [
-		  4,
-		  1.1
-		 ],
-		 [
-		  6,
-		  1.4
-		 ],
-		 [
-		  9,
-		  1.5
-		 ],
-		 [
-		  14,
-		  3.2
-		 ],
-		 [
-		  15,
-		  5.8
-		 ],
-		 [
-		  16,
-		  8.3
-		 ],
-		 [
-		  17,
-		  16.2
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier a niveau - filet interieur - route regionale en construction",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route",
-	  "minzoom": 10,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "REGIONALE_CONSTR"
-	  ],
-	  "paint": {
-	   "line-color": {
-		"stops": [
-		 [
-		  9,
-		  "#FFFFFF"
-		 ],
-		 [
-		  10,
-		  "#FDF28B"
-		 ],
-		 [
-		  17,
-		  "#FCF6BD"
-		 ],
-		 [
-		  18,
-		  "#EDEDED"
-		 ]
-		]
-	   },
-	   "line-width": {
-		"stops": [
-		 [
-		  4,
-		  0.4
-		 ],
-		 [
-		  6,
-		  1.5
-		 ],
-		 [
-		  9,
-		  2.3
-		 ],
-		 [
-		  14,
-		  5
-		 ],
-		 [
-		  15,
-		  8.1
-		 ],
-		 [
-		  16,
-		  11.2
-		 ],
-		 [
-		  17,
-		  22
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		2,
-		2
-	   ]
-	  }
-	 },
-	 {
-	  "id": "Routier a niveau - filet interieur - route principale",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route",
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "BRET_PRINCIPALE",
-	   "PRINCIPALE_4",
-	   "PRINCIPALE_3",
-	   "PRINCIPALE_2",
-	   "PRINCIPALE_1"
-	  ],
-	  "paint": {
-	   "line-color": {
-		"stops": [
-		 [
-		  6,
-		  "#F29924"
-		 ],
-		 [
-		  7,
-		  "#F3C66D"
-		 ],
-		 [
-		  9,
-		  "#F3C66D"
-		 ],
-		 [
-		  17,
-		  "#F2DDB3"
-		 ]
-		]
-	   },
-	   "line-width": {
-		"stops": [
-		 [
-		  4,
-		  0.6
-		 ],
-		 [
-		  6,
-		  1.8
-		 ],
-		 [
-		  9,
-		  2.1
-		 ],
-		 [
-		  14,
-		  4.4
-		 ],
-		 [
-		  15,
-		  7.3
-		 ],
-		 [
-		  16,
-		  10
-		 ],
-		 [
-		  17,
-		  18.5
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier a niveau - filet interieur - route principale en construction",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route",
-	  "minzoom": 10,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "PRINCIPALE_CONSTR"
-	  ],
-	  "paint": {
-	   "line-color": {
-		"stops": [
-		 [
-		  9,
-		  "#F3C66D"
-		 ],
-		 [
-		  17,
-		  "#F2DDB3"
-		 ],
-		 [
-		  18,
-		  "#EDEDED"
-		 ]
-		]
-	   },
-	   "line-width": {
-		"stops": [
-		 [
-		  4,
-		  0.5
-		 ],
-		 [
-		  6,
-		  1.8
-		 ],
-		 [
-		  9,
-		  2.7
-		 ],
-		 [
-		  14,
-		  5.9
-		 ],
-		 [
-		  15,
-		  9
-		 ],
-		 [
-		  16,
-		  12.2
-		 ],
-		 [
-		  17,
-		  22.5
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		2,
-		2
-	   ]
-	  }
-	 },
-	 {
-	  "id": "Routier a niveau - filet interieur - autoroute",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route",
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "AUTOROU_PEAGE",
-	   "AUTOROU_LIBRE"
-	  ],
-	  "paint": {
-	   "line-color": {
-		"stops": [
-		 [
-		  9,
-		  "#F18800"
-		 ],
-		 [
-		  17,
-		  "#F2B230"
-		 ]
-		]
-	   },
-	   "line-width": {
-		"stops": [
-		 [
-		  4,
-		  0.7
-		 ],
-		 [
-		  6,
-		  2.5
-		 ],
-		 [
-		  9,
-		  2.7
-		 ],
-		 [
-		  14,
-		  5.8
-		 ],
-		 [
-		  15,
-		  9
-		 ],
-		 [
-		  16,
-		  12
-		 ],
-		 [
-		  17,
-		  20.8
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier a niveau - axe central - autoroute",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route",
-	  "minzoom": 13,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "AUTOROU_PEAGE",
-	   "AUTOROU_LIBRE"
-	  ],
-	  "paint": {
-	   "line-color": "#FFFFFF",
-	   "line-width": {
-		"stops": [
-		 [
-		  9,
-		  0.6
-		 ],
-		 [
-		  14,
-		  0.7
-		 ],
-		 [
-		  15,
-		  1
-		 ],
-		 [
-		  16,
-		  1.2
-		 ],
-		 [
-		  17,
-		  2.1
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier a niveau - filet interieur - autoroute en construction",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route",
-	  "minzoom": 8,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "AUTOROU_CONSTR"
-	  ],
-	  "paint": {
-	   "line-color": {
-		"stops": [
-		 [
-		  9,
-		  "#F18800"
-		 ],
-		 [
-		  17,
-		  "#F2B230"
-		 ],
-		 [
-		  18,
-		  "#EDEDED"
-		 ]
-		]
-	   },
-	   "line-width": {
-		"stops": [
-		 [
-		  4,
-		  0.7
-		 ],
-		 [
-		  6,
-		  2.5
-		 ],
-		 [
-		  9,
-		  3.5
-		 ],
-		 [
-		  14,
-		  7.5
-		 ],
-		 [
-		  15,
-		  11
-		 ],
-		 [
-		  16,
-		  15
-		 ],
-		 [
-		  17,
-		  26
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		2,
-		2
-	   ]
-	  }
-	 },
-	 {
-	  "id": "Routier a niveau - axe centrale - autoroute en construction",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route",
-	  "minzoom": 13,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "AUTOROU_CONSTR"
-	  ],
-	  "paint": {
-	   "line-color": "#808080",
-	   "line-width": {
-		"stops": [
-		 [
-		  9,
-		  0.6
-		 ],
-		 [
-		  14,
-		  0.7
-		 ],
-		 [
-		  15,
-		  1
-		 ],
-		 [
-		  16,
-		  1.2
-		 ],
-		 [
-		  17,
-		  2.1
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Ferre a niveau - voie normale",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "ferre",
-	  "minzoom": 10,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "VF_1",
-	   "VF_2",
-	   "VF_3",
-	   "VF_4",
-	   "VF_ELEC_1",
-	   "VF_ELEC_2",
-	   "VF_ELEC_3",
-	   "VF_ELEC_4"
-	  ],
-	  "paint": {
-	   "line-color": "#787878",
-	   "line-width": {
-		"stops": [
-		 [
-		  10,
-		  0.8
-		 ],
-		 [
-		  17,
-		  2.5
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Ferre a niveau - voie normale trait perpendic",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "ferre",
-	  "minzoom": 10,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "VF_1",
-	   "VF_2",
-	   "VF_3",
-	   "VF_4",
-	   "VF_ELEC_1",
-	   "VF_ELEC_2",
-	   "VF_ELEC_3",
-	   "VF_ELEC_4"
-	  ],
-	  "paint": {
-	   "line-color": "#787878",
-	   "line-width": {
-		"stops": [
-		 [
-		  10,
-		  3.5
-		 ],
-		 [
-		  17,
-		  14.7
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		0.1,
-		10
-	   ]
-	  }
-	 },
-	 {
-	  "id": "Ferre a niveau - voie etroite",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "ferre",
-	  "minzoom": 10,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "VF_ETROITE_1",
-	   "VF_ETROITE_2",
-	   "VF_ETROITE"
-	  ],
-	  "paint": {
-	   "line-color": "#787878",
-	   "line-width": {
-		"stops": [
-		 [
-		  10,
-		  0.3
-		 ],
-		 [
-		  17,
-		  1.8
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Ferre a niveau - voie etroite trait perpendic",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "ferre",
-	  "minzoom": 10,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "VF_ETROITE_1",
-	   "VF_ETROITE_2",
-	   "VF_ETROITE"
-	  ],
-	  "paint": {
-	   "line-color": "#787878",
-	   "line-width": {
-		"stops": [
-		 [
-		  10,
-		  3.5
-		 ],
-		 [
-		  17,
-		  14.7
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		0.1,
-		10
-	   ]
-	  }
-	 },
-	 {
-	  "id": "Ferre a niveau - voie service",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "ferre",
-	  "minzoom": 14,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "VF_SERVICE",
-	   "VF_NON_EXPLOITEE"
-	  ],
-	  "paint": {
-	   "line-color": "#787878",
-	   "line-width": {
-		"stops": [
-		 [
-		  10,
-		  0.3
-		 ],
-		 [
-		  17,
-		  1.8
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		5,
-		2,
-		1,
-		2
-	   ]
-	  }
-	 },
-	 {
-	  "id": "Ferre a niveau - voie en construction",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "ferre",
-	  "minzoom": 10,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "VF_EN_CONSTR"
-	  ],
-	  "paint": {
-	   "line-color": "#787878",
-	   "line-width": {
-		"stops": [
-		 [
-		  10,
-		  0.3
-		 ],
-		 [
-		  17,
-		  1.8
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		2,
-		2
-	   ]
-	  }
-	 },
-	 {
-	  "id": "Ferre a niveau - voie en construction trait perpendic",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "ferre",
-	  "minzoom": 10,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "VF_EN_CONSTR"
-	  ],
-	  "paint": {
-	   "line-color": "#787878",
-	   "line-width": {
-		"stops": [
-		 [
-		  10,
-		  3.5
-		 ],
-		 [
-		  17,
-		  14.7
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		0.1,
-		10
-	   ]
-	  }
-	 },
-	 {
-	  "id": "Ferre a niveau - funic/urbain",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "ferre",
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "FUNI_CREMAILLERE",
-	   "TRANSPORT_URBAIN"
-	  ],
-	  "paint": {
-	   "line-color": "#787878",
-	   "line-width": {
-		"stops": [
-		 [
-		  10,
-		  0.3
-		 ],
-		 [
-		  17,
-		  1.8
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Ferre a niveau - 2 trait perpendic - funic/urbain",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "ferre",
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "FUNI_CREMAILLERE",
-	   "TRANSPORT_URBAIN"
-	  ],
-	  "paint": {
-	   "line-color": "#787878",
-	   "line-width": {
-		"stops": [
-		 [
-		  10,
-		  3.5
-		 ],
-		 [
-		  17,
-		  17
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		0.1,
-		0.2,
-		0.1,
-		10
-	   ]
-	  }
-	 },
-	 {
-	  "id": "liaison routiere - Bac Liaison Maritime",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_liaison",
-	  "minzoom": 8,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "BAC_AUTO",
-	   "LIAISON_MARITIME",
-	   "BAC_LIAISON_MARITIME"
-	  ],
-	  "paint": {
-	   "line-color": "#5792C2",
-	   "line-width": {
-		"stops": [
-		 [
-		  8,
-		  1
-		 ],
-		 [
-		  13,
-		  2.5
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "liaison routiere - Gue route",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_liaison",
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "GUE_ROUTE"
-	  ],
-	  "paint": {
-	   "line-color": {
-		"stops": [
-		 [
-		  13,
-		  "#BEBEBE"
-		 ],
-		 [
-		  17,
-		  "#646464"
-		 ],
-		 [
-		  18,
-		  "#FFFFFF"
-		 ]
-		]
-	   },
-	   "line-width": {
-		"stops": [
-		 [
-		  14,
-		  2.3
-		 ],
-		 [
-		  15,
-		  4.1
-		 ],
-		 [
-		  16,
-		  6.3
-		 ],
-		 [
-		  17,
-		  13.5
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "liaison routiere - Gue chemin",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_liaison",
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "GUE_CHEMIN"
-	  ],
-	  "paint": {
-	   "line-color": {
-		"stops": [
-		 [
-		  13,
-		  "#BEBEBE"
-		 ],
-		 [
-		  17,
-		  "#646464"
-		 ]
-		]
-	   },
-	   "line-width": {
-		"stops": [
-		 [
-		  14,
-		  1.6
-		 ],
-		 [
-		  15,
-		  2.9
-		 ],
-		 [
-		  16,
-		  4.4
-		 ],
-		 [
-		  17,
-		  6.5
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "liaison routiere - filet extérieur - Pont passerelle",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_liaison",
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "PONT_PASSERELLE",
-	   "PONT_LIN",
-	   "PONT_MOBILE_LIN"
-	  ],
-	  "paint": {
-	   "line-color": {
-		"stops": [
-		 [
-		  17,
-		  "#C8C8C8"
-		 ],
-		 [
-		  18,
-		  "#FFFFFF"
-		 ]
-		]
-	   },
-	   "line-width": {
-		"stops": [
-		 [
-		  14,
-		  2.2
-		 ],
-		 [
-		  15,
-		  3.8
-		 ],
-		 [
-		  16,
-		  5.4
-		 ],
-		 [
-		  17,
-		  11.8
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "liaison routiere - filet intérieur - Pont passerelle",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_liaison",
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "PONT_PASSERELLE",
-	   "PONT_LIN",
-	   "PONT_MOBILE_LIN"
-	  ],
-	  "paint": {
-	   "line-color": "#FFFFFF",
-	   "line-width": {
-		"stops": [
-		 [
-		  14,
-		  0.7
-		 ],
-		 [
-		  15,
-		  1.1
-		 ],
-		 [
-		  16,
-		  1.7
-		 ],
-		 [
-		  17,
-		  3.8
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier surfacique",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "routier_surf",
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "SURF_ROUT_PRINC",
-	   "SURF_ROUT_REG",
-	   "SURF_ROUT_LOC",
-	   "SURF_ROUT_NON_CLA"
-	  ],
-	  "paint": {
-	   "fill-color": "#FFFFFF",
-	   "fill-outline-color": "#000000"
-	  }
-	 },
-	 {
-	  "id": "Routier surfacique - Dalle de protection",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "routier_surf",
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "DALLE_DE_PROTECTION"
-	  ],
-	  "paint": {
-	   "fill-opacity": 0.5,
-	   "fill-color": "#FFFFFF",
-	   "fill-outline-color": "#000000"
-	  }
-	 },
-	 {
-	  "id": "Routier surfacique - Escalier surfacique",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "routier_surf",
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "ESCALIER_SURF"
-	  ],
-	  "paint": {
-	   "fill-opacity": 0.8,
-	   "fill-color": "#FFFFFF",
-	   "fill-outline-color": "#918091"
-	  }
-	 },
-	 {
-	  "id": "Routier surfacique - Péage surfacique",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "routier_surf",
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "SURF_PEAGE"
-	  ],
-	  "paint": {
-	   "fill-color": "#F2DAAA",
-	   "fill-outline-color": "#E2A52A"
-	  }
-	 },
-	 {
-	  "id": "bati transport surfacique - bati peage",
-	  "type": "fill",
-	  "source": "plan_ign",
-	  "source-layer": "bati_surf",
-	  "minzoom": 13,
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "BATI_PEAGE"
-	  ],
-	  "paint": {
-	   "fill-color": "#DCDCDC",
-	   "fill-outline-color": "#808080"
-	  }
-	 },
-	 {
-	  "id": "réseau hydro  - cours d'eau superieur",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "hydro_reseau_sup",
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "COURS_D_EAU_SUP",
-	   "COURS_D_EAU_MOY_SUP"
-	  ],
-	  "paint": {
-	   "line-color": "#AAD5E9",
-	   "line-width": {
-		"stops": [
-		 [
-		  12,
-		  1.5
-		 ],
-		 [
-		  17,
-		  6.5
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "réseau hydro - canal superieur",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "hydro_reseau_sup",
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "CANAL_SUP"
-	  ],
-	  "paint": {
-	   "line-color": "#AAD5E9",
-	   "line-width": {
-		"stops": [
-		 [
-		  12,
-		  1.4
-		 ],
-		 [
-		  17,
-		  5.9
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "réseau hydro - filet interieur - aqueduc superieur",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "hydro_reseau_sup",
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "AQUEDUC_SUP"
-	  ],
-	  "paint": {
-	   "line-color": "#AAD5E9",
-	   "line-width": {
-		"stops": [
-		 [
-		  12,
-		  1.4
-		 ],
-		 [
-		  16,
-		  3.5
-		 ],
-		 [
-		  17,
-		  5.9
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "réseau hydro - carre - aqueduc superieur",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "hydro_reseau_sup",
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "AQUEDUC_SUP"
-	  ],
-	  "paint": {
-	   "line-color": "#AAD5E9",
-	   "line-width": {
-		"stops": [
-		 [
-		  12,
-		  3.5
-		 ],
-		 [
-		  16,
-		  8.7
-		 ],
-		 [
-		  17,
-		  14.7
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		1,
-		5
-	   ]
-	  }
-	 },
-	 {
-	  "id": "Chemin superieur - piste cyclable",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_chemin_sup",
-	  "minzoom": 13,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "PISTE_CYCLABLE_SUP"
-	  ],
-	  "paint": {
-	   "line-color": {
-		"stops": [
-		 [
-		  17,
-		  "#9B5CCC"
-		 ],
-		 [
-		  18,
-		  "#FFFFFF"
-		 ]
-		]
-	   },
-	   "line-width": {
-		"stops": [
-		 [
-		  14,
-		  1.1
-		 ],
-		 [
-		  15,
-		  1.7
-		 ],
-		 [
-		  16,
-		  2
-		 ],
-		 [
-		  17,
-		  3.5
-		 ],
-		 [
-		  18,
-		  6
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		6,
-		2
-	   ]
-	  }
-	 },
-	 {
-	  "id": "Chemin superieur - filet exterieur - escalier",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_chemin_sup",
-	  "minzoom": 14,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "ESCALIER_SUP"
-	  ],
-	  "paint": {
-	   "line-color": {
-		"stops": [
-		 [
-		  17,
-		  "#8C7274"
-		 ],
-		 [
-		  18,
-		  "#C8C8C8"
-		 ]
-		]
-	   },
-	   "line-width": {
-		"stops": [
-		 [
-		  14,
-		  1.75
-		 ],
-		 [
-		  15,
-		  3
-		 ],
-		 [
-		  16,
-		  4.2
-		 ],
-		 [
-		  17,
-		  9.5
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Chemin superieur - filet interieur - escalier",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_chemin_sup",
-	  "minzoom": 14,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "ESCALIER_SUP"
-	  ],
-	  "paint": {
-	   "line-color": "#FFFFFF",
-	   "line-width": {
-		"stops": [
-		 [
-		  14,
-		  1
-		 ],
-		 [
-		  15,
-		  1.9
-		 ],
-		 [
-		  16,
-		  2.7
-		 ],
-		 [
-		  17,
-		  5.8
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		1,
-		0.2
-	   ]
-	  }
-	 },
-	 {
-	  "id": "Chemin superieur - Rue pietonne",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_chemin_sup",
-	  "minzoom": 14,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "RUE_PIETONNE_SUP"
-	  ],
-	  "paint": {
-	   "line-color": {
-		"stops": [
-		 [
-		  17,
-		  "#8C7274"
-		 ],
-		 [
-		  18,
-		  "#EBEBEB"
-		 ]
-		]
-	   },
-	   "line-width": {
-		"stops": [
-		 [
-		  14,
-		  1
-		 ],
-		 [
-		  15,
-		  1.2
-		 ],
-		 [
-		  16,
-		  1.4
-		 ],
-		 [
-		  17,
-		  2
-		 ],
-		 [
-		  18,
-		  5
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		1,
-		3
-	   ]
-	  }
-	 },
-	 {
-	  "id": "Chemin superieur - sentier",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_chemin_sup",
-	  "minzoom": 13,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "SENTIER_SUP"
-	  ],
-	  "paint": {
-	   "line-color": {
-		"stops": [
-		 [
-		  17,
-		  "#8C7274"
-		 ],
-		 [
-		  18,
-		  "#FFFFFF"
-		 ]
-		]
-	   },
-	   "line-width": {
-		"stops": [
-		 [
-		  14,
-		  1
-		 ],
-		 [
-		  15,
-		  1.2
-		 ],
-		 [
-		  16,
-		  1.4
-		 ],
-		 [
-		  17,
-		  2
-		 ],
-		 [
-		  18,
-		  6
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		4,
-		3
-	   ]
-	  }
-	 },
-	 {
-	  "id": "Chemin superieur - chemin",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_chemin_sup",
-	  "minzoom": 12,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "CHEMIN_SUP"
-	  ],
-	  "paint": {
-	   "line-color": {
-		"stops": [
-		 [
-		  17,
-		  "#8C7274"
-		 ],
-		 [
-		  18,
-		  "#FFFFFF"
-		 ]
-		]
-	   },
-	   "line-width": {
-		"stops": [
-		 [
-		  14,
-		  1
-		 ],
-		 [
-		  15,
-		  1.2
-		 ],
-		 [
-		  16,
-		  1.4
-		 ],
-		 [
-		  17,
-		  2
-		 ],
-		 [
-		  18,
-		  7
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier superieur - filet extérieur - route non revetu carrosable",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route_sup",
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "NON_REVETUE_CARRO_SUP"
-	  ],
-	  "paint": {
-	   "line-color": {
-		"stops": [
-		 [
-		  12,
-		  "#646464"
-		 ],
-		 [
-		  17,
-		  "#8C8C8C"
-		 ]
-		]
-	   },
-	   "line-width": {
-		"stops": [
-		 [
-		  14,
-		  3.2
-		 ],
-		 [
-		  15,
-		  5.4
-		 ],
-		 [
-		  16,
-		  7.7
-		 ],
-		 [
-		  17,
-		  16.8
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		2,
-		2
-	   ]
-	  }
-	 },
-	 {
-	  "id": "Routier superieur - filet extérieur - bretelle autoroute",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route_sup",
-	  "minzoom": 12,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "BRET_AUTO_PEAGE_3_SUP",
-	   "BRET_AUTO_PEAGE_2_SUP",
-	   "BRET_AUTO_PEAGE_1_SUP",
-	   "BRET_AUTO_LIBRE_3_SUP",
-	   "BRET_AUTO_LIBRE_2_SUP",
-	   "BRET_AUTO_LIBRE_1_SUP"
-	  ],
-	  "paint": {
-	   "line-color": {
-		"stops": [
-		 [
-		  9,
-		  "#DE460E"
-		 ],
-		 [
-		  17,
-		  "#F18800"
-		 ],
-		 [
-		  18,
-		  "#FFFFFF"
-		 ]
-		]
-	   },
-	   "line-width": {
-		"stops": [
-		 [
-		  12,
-		  2.5
-		 ],
-		 [
-		  14,
-		  3.7
-		 ],
-		 [
-		  15,
-		  6.8
-		 ],
-		 [
-		  16,
-		  8.4
-		 ],
-		 [
-		  17,
-		  14
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier superieur - filet extérieur - route non classee restreint",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route_sup",
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "NON_CLASSEE_RESTREINT_SUP"
-	  ],
-	  "paint": {
-	   "line-color": {
-		"stops": [
-		 [
-		  17,
-		  "#969696"
-		 ],
-		 [
-		  18,
-		  "#FFFFFF"
-		 ]
-		]
-	   },
-	   "line-width": {
-		"stops": [
-		 [
-		  14,
-		  3.2
-		 ],
-		 [
-		  15,
-		  5.4
-		 ],
-		 [
-		  16,
-		  7.7
-		 ],
-		 [
-		  17,
-		  16.8
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier superieur - filet extérieur - route non classee",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route_sup",
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "NON_CLASSEE_4_SUP",
-	   "NON_CLASSEE_SUP"
-	  ],
-	  "paint": {
-	   "line-color": {
-		"stops": [
-		 [
-		  17,
-		  "#969696"
-		 ],
-		 [
-		  18,
-		  "#FFFFFF"
-		 ]
-		]
-	   },
-	   "line-width": {
-		"stops": [
-		 [
-		  14,
-		  3.2
-		 ],
-		 [
-		  15,
-		  5.4
-		 ],
-		 [
-		  16,
-		  7.7
-		 ],
-		 [
-		  17,
-		  16.8
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier superieur - filet extérieur - route locale",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route_sup",
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "BRET_LOCALE_SUP",
-	   "LOCALE_4_SUP",
-	   "LOCALE_3_SUP",
-	   "LOCALE_2_SUP",
-	   "LOCALE_1_SUP"
-	  ],
-	  "paint": {
-	   "line-color": {
-		"stops": [
-		 [
-		  12,
-		  "#8C8C8C"
-		 ],
-		 [
-		  13,
-		  "#B4B4B4"
-		 ],
-		 [
-		  17,
-		  "#B4B4B4"
-		 ],
-		 [
-		  18,
-		  "#FFFFFF"
-		 ]
-		]
-	   },
-	   "line-width": {
-		"stops": [
-		 [
-		  9,
-		  2
-		 ],
-		 [
-		  14,
-		  3.5
-		 ],
-		 [
-		  15,
-		  6
-		 ],
-		 [
-		  16,
-		  8.4
-		 ],
-		 [
-		  17,
-		  18.3
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier superieur - filet extérieur - route locale en construction",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route_sup",
-	  "minzoom": 11,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "LOCALE_CONSTR_SUP"
-	  ],
-	  "paint": {
-	   "line-color": "#C8C8C8",
-	   "line-width": {
-		"stops": [
-		 [
-		  9,
-		  2
-		 ],
-		 [
-		  14,
-		  3.5
-		 ],
-		 [
-		  15,
-		  6
-		 ],
-		 [
-		  16,
-		  8.4
-		 ],
-		 [
-		  17,
-		  18.3
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier superieur - filet extérieur - route regionale",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route_sup",
-	  "minzoom": 8,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "BRET_REGIONALE_SUP",
-	   "REGIONALE_4_SUP",
-	   "REGIONALE_3_SUP",
-	   "REGIONALE_2_SUP",
-	   "REGIONALE_1_SUP"
-	  ],
-	  "paint": {
-	   "line-color": {
-		"stops": [
-		 [
-		  9,
-		  "#828282"
-		 ],
-		 [
-		  10,
-		  "#B4B4B4"
-		 ],
-		 [
-		  17,
-		  "#B4B4B4"
-		 ],
-		 [
-		  18,
-		  "#FFFFFF"
-		 ]
-		]
-	   },
-	   "line-width": {
-		"stops": [
-		 [
-		  6,
-		  1.5
-		 ],
-		 [
-		  9,
-		  2.3
-		 ],
-		 [
-		  14,
-		  5
-		 ],
-		 [
-		  15,
-		  8.1
-		 ],
-		 [
-		  16,
-		  11.2
-		 ],
-		 [
-		  17,
-		  22
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier superieur - filet extérieur - route regionale en construction",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route_sup",
-	  "minzoom": 10,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "REGIONALE_CONSTR_SUP"
-	  ],
-	  "paint": {
-	   "line-color": "#C8C8C8",
-	   "line-width": {
-		"stops": [
-		 [
-		  6,
-		  1.5
-		 ],
-		 [
-		  9,
-		  2.3
-		 ],
-		 [
-		  14,
-		  5
-		 ],
-		 [
-		  15,
-		  8.1
-		 ],
-		 [
-		  16,
-		  11.2
-		 ],
-		 [
-		  17,
-		  22
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier superieur - filet extérieur - route principale",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route_sup",
-	  "minzoom": 8,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "BRET_PRINCIPALE_SUP",
-	   "PRINCIPALE_4_SUP",
-	   "PRINCIPALE_3_SUP",
-	   "PRINCIPALE_2_SUP",
-	   "PRINCIPALE_1_SUP"
-	  ],
-	  "paint": {
-	   "line-color": {
-		"stops": [
-		 [
-		  17,
-		  "#E2A52A"
-		 ],
-		 [
-		  18,
-		  "#FFFFFF"
-		 ]
-		]
-	   },
-	   "line-width": {
-		"stops": [
-		 [
-		  6,
-		  1.8
-		 ],
-		 [
-		  9,
-		  2.7
-		 ],
-		 [
-		  14,
-		  5.9
-		 ],
-		 [
-		  15,
-		  9
-		 ],
-		 [
-		  16,
-		  12.2
-		 ],
-		 [
-		  17,
-		  22.5
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier superieur - filet extérieur - route principale en construction",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route_sup",
-	  "minzoom": 10,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "PRINCIPALE_CONSTR_SUP"
-	  ],
-	  "paint": {
-	   "line-color": "#C8C8C8",
-	   "line-width": {
-		"stops": [
-		 [
-		  6,
-		  1.8
-		 ],
-		 [
-		  9,
-		  2.7
-		 ],
-		 [
-		  14,
-		  5.9
-		 ],
-		 [
-		  15,
-		  9
-		 ],
-		 [
-		  16,
-		  12.2
-		 ],
-		 [
-		  17,
-		  22.5
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier superieur - filet extérieur - autoroute",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route_sup",
-	  "minzoom": 8,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "AUTOROU_PEAGE_SUP",
-	   "AUTOROU_LIBRE_SUP"
-	  ],
-	  "paint": {
-	   "line-color": {
-		"stops": [
-		 [
-		  9,
-		  "#DE460E"
-		 ],
-		 [
-		  17,
-		  "#F18800"
-		 ],
-		 [
-		  18,
-		  "#FFFFFF"
-		 ]
-		]
-	   },
-	   "line-width": {
-		"stops": [
-		 [
-		  6,
-		  2.5
-		 ],
-		 [
-		  9,
-		  3.5
-		 ],
-		 [
-		  14,
-		  7.5
-		 ],
-		 [
-		  15,
-		  11
-		 ],
-		 [
-		  16,
-		  15
-		 ],
-		 [
-		  17,
-		  26
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier superieur - filet extérieur - autoroute en construction",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route_sup",
-	  "minzoom": 10,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "AUTOROU_CONSTR_SUP"
-	  ],
-	  "paint": {
-	   "line-color": "#C8C8C8",
-	   "line-width": {
-		"stops": [
-		 [
-		  6,
-		  2.5
-		 ],
-		 [
-		  9,
-		  3.5
-		 ],
-		 [
-		  14,
-		  7.5
-		 ],
-		 [
-		  15,
-		  11
-		 ],
-		 [
-		  16,
-		  15
-		 ],
-		 [
-		  17,
-		  26
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier superieur - filet interieur - route non revetu carrosable",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route_sup",
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "NON_REVETUE_CARRO_SUP"
-	  ],
-	  "paint": {
-	   "line-color": "#FFFFFF",
-	   "line-width": {
-		"stops": [
-		 [
-		  14,
-		  2.3
-		 ],
-		 [
-		  15,
-		  4.1
-		 ],
-		 [
-		  16,
-		  6.3
-		 ],
-		 [
-		  17,
-		  13.5
-		 ],
-		 [
-		  18,
-		  16.8
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier superieur - filet interieur - bretelle autoroute",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route_sup",
-	  "minzoom": 12,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "BRET_AUTO_PEAGE_3_SUP",
-	   "BRET_AUTO_PEAGE_2_SUP",
-	   "BRET_AUTO_PEAGE_1_SUP",
-	   "BRET_AUTO_LIBRE_3_SUP",
-	   "BRET_AUTO_LIBRE_2_SUP",
-	   "BRET_AUTO_LIBRE_1_SUP"
-	  ],
-	  "paint": {
-	   "line-color": {
-		"stops": [
-		 [
-		  9,
-		  "#F18800"
-		 ],
-		 [
-		  17,
-		  "#F2B230"
-		 ]
-		]
-	   },
-	   "line-width": {
-		"stops": [
-		 [
-		  12,
-		  1.5
-		 ],
-		 [
-		  14,
-		  2.6
-		 ],
-		 [
-		  15,
-		  5.2
-		 ],
-		 [
-		  16,
-		  6.7
-		 ],
-		 [
-		  17,
-		  10.8
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier superieur - filet interieur - route non classee restreint",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route_sup",
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "NON_CLASSEE_RESTREINT_SUP"
-	  ],
-	  "paint": {
-	   "line-color": "#EDF1FF",
-	   "line-width": {
-		"stops": [
-		 [
-		  14,
-		  2.3
-		 ],
-		 [
-		  15,
-		  4.1
-		 ],
-		 [
-		  16,
-		  6.3
-		 ],
-		 [
-		  17,
-		  13.5
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier superieur - filet interieur - route non classee",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route_sup",
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "NON_CLASSEE_4_SUP",
-	   "NON_CLASSEE_SUP"
-	  ],
-	  "paint": {
-	   "line-color": "#FFFFFF",
-	   "line-width": {
-		"stops": [
-		 [
-		  14,
-		  2.3
-		 ],
-		 [
-		  15,
-		  4.1
-		 ],
-		 [
-		  16,
-		  6.3
-		 ],
-		 [
-		  17,
-		  13.5
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier superieur - filet interieur - route locale",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route_sup",
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "BRET_LOCALE_SUP",
-	   "LOCALE_4_SUP",
-	   "LOCALE_3_SUP",
-	   "LOCALE_2_SUP",
-	   "LOCALE_1_SUP"
-	  ],
-	  "paint": {
-	   "line-color": {
-		"stops": [
-		 [
-		  12,
-		  "#FFFFFF"
-		 ],
-		 [
-		  13,
-		  "#FCF4A8"
-		 ],
-		 [
-		  17,
-		  "#FCF7C1"
-		 ]
-		]
-	   },
-	   "line-width": {
-		"stops": [
-		 [
-		  9,
-		  1.3
-		 ],
-		 [
-		  14,
-		  2.3
-		 ],
-		 [
-		  15,
-		  4.1
-		 ],
-		 [
-		  16,
-		  6.1
-		 ],
-		 [
-		  17,
-		  13.1
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier superieur - filet interieur - route locale en construction",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route_sup",
-	  "minzoom": 11,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "LOCALE_CONSTR_SUP"
-	  ],
-	  "paint": {
-	   "line-color": {
-		"stops": [
-		 [
-		  12,
-		  "#FFFFFF"
-		 ],
-		 [
-		  13,
-		  "#FCF4A8"
-		 ],
-		 [
-		  17,
-		  "#FCF7C1"
-		 ]
-		]
-	   },
-	   "line-width": {
-		"stops": [
-		 [
-		  9,
-		  2
-		 ],
-		 [
-		  14,
-		  3.5
-		 ],
-		 [
-		  15,
-		  6
-		 ],
-		 [
-		  16,
-		  8.4
-		 ],
-		 [
-		  17,
-		  18.3
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		2,
-		2
-	   ]
-	  }
-	 },
-	 {
-	  "id": "Routier superieur - filet interieur - route regionale",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route_sup",
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "BRET_REGIONALE_SUP",
-	   "REGIONALE_4_SUP",
-	   "REGIONALE_3_SUP",
-	   "REGIONALE_2_SUP",
-	   "REGIONALE_1_SUP"
-	  ],
-	  "paint": {
-	   "line-color": {
-		"stops": [
-		 [
-		  9,
-		  "#FFFFFF"
-		 ],
-		 [
-		  10,
-		  "#FDF28B"
-		 ],
-		 [
-		  17,
-		  "#FCF6BD"
-		 ]
-		]
-	   },
-	   "line-width": {
-		"stops": [
-		 [
-		  6,
-		  1.4
-		 ],
-		 [
-		  9,
-		  1.5
-		 ],
-		 [
-		  14,
-		  3.2
-		 ],
-		 [
-		  15,
-		  5.8
-		 ],
-		 [
-		  16,
-		  8.3
-		 ],
-		 [
-		  17,
-		  16.2
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier superieur - filet interieur - route regionale en construction",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route_sup",
-	  "minzoom": 10,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "REGIONALE_CONSTR_SUP"
-	  ],
-	  "paint": {
-	   "line-color": {
-		"stops": [
-		 [
-		  9,
-		  "#FFFFFF"
-		 ],
-		 [
-		  10,
-		  "#FDF28B"
-		 ],
-		 [
-		  17,
-		  "#FCF6BD"
-		 ]
-		]
-	   },
-	   "line-width": {
-		"stops": [
-		 [
-		  6,
-		  1.5
-		 ],
-		 [
-		  9,
-		  2.3
-		 ],
-		 [
-		  14,
-		  5
-		 ],
-		 [
-		  15,
-		  8.1
-		 ],
-		 [
-		  16,
-		  11.2
-		 ],
-		 [
-		  17,
-		  22
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		2,
-		2
-	   ]
-	  }
-	 },
-	 {
-	  "id": "Routier superieur - filet interieur - route principale",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route_sup",
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "BRET_PRINCIPALE_SUP",
-	   "PRINCIPALE_4_SUP",
-	   "PRINCIPALE_3_SUP",
-	   "PRINCIPALE_2_SUP",
-	   "PRINCIPALE_1_SUP"
-	  ],
-	  "paint": {
-	   "line-color": {
-		"stops": [
-		 [
-		  9,
-		  "#F3C66D"
-		 ],
-		 [
-		  17,
-		  "#F2DDB3"
-		 ]
-		]
-	   },
-	   "line-width": {
-		"stops": [
-		 [
-		  4,
-		  0.5
-		 ],
-		 [
-		  6,
-		  1.8
-		 ],
-		 [
-		  9,
-		  2.1
-		 ],
-		 [
-		  14,
-		  4.4
-		 ],
-		 [
-		  15,
-		  7.3
-		 ],
-		 [
-		  16,
-		  10
-		 ],
-		 [
-		  17,
-		  18.5
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier superieur - filet interieur - route principale en construction",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route_sup",
-	  "minzoom": 10,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "PRINCIPALE_CONSTR_SUP"
-	  ],
-	  "paint": {
-	   "line-color": {
-		"stops": [
-		 [
-		  9,
-		  "#F3C66D"
-		 ],
-		 [
-		  17,
-		  "#F2DDB3"
-		 ]
-		]
-	   },
-	   "line-width": {
-		"stops": [
-		 [
-		  6,
-		  1.8
-		 ],
-		 [
-		  9,
-		  2.7
-		 ],
-		 [
-		  14,
-		  5.9
-		 ],
-		 [
-		  15,
-		  9
-		 ],
-		 [
-		  16,
-		  12.2
-		 ],
-		 [
-		  17,
-		  22.5
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		2,
-		2
-	   ]
-	  }
-	 },
-	 {
-	  "id": "Routier superieur - filet interieur - autoroute",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route_sup",
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "AUTOROU_PEAGE_SUP",
-	   "AUTOROU_LIBRE_SUP"
-	  ],
-	  "paint": {
-	   "line-color": {
-		"stops": [
-		 [
-		  9,
-		  "#F18800"
-		 ],
-		 [
-		  17,
-		  "#F2B230"
-		 ]
-		]
-	   },
-	   "line-width": {
-		"stops": [
-		 [
-		  4,
-		  0.7
-		 ],
-		 [
-		  6,
-		  2.5
-		 ],
-		 [
-		  9,
-		  2.7
-		 ],
-		 [
-		  14,
-		  5.8
-		 ],
-		 [
-		  15,
-		  9
-		 ],
-		 [
-		  16,
-		  12
-		 ],
-		 [
-		  17,
-		  20.8
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier superieur - axe central - autoroute",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route_sup",
-	  "minzoom": 13,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "AUTOROU_PEAGE_SUP",
-	   "AUTOROU_LIBRE_SUP"
-	  ],
-	  "paint": {
-	   "line-color": "#FFFFFF",
-	   "line-width": {
-		"stops": [
-		 [
-		  9,
-		  0.6
-		 ],
-		 [
-		  14,
-		  0.7
-		 ],
-		 [
-		  15,
-		  1
-		 ],
-		 [
-		  16,
-		  1.2
-		 ],
-		 [
-		  17,
-		  2.1
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Routier superieur - filet interieur - autoroute en construction",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route_sup",
-	  "minzoom": 10,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "AUTOROU_CONSTR_SUP"
-	  ],
-	  "paint": {
-	   "line-color": {
-		"stops": [
-		 [
-		  9,
-		  "#F18800"
-		 ],
-		 [
-		  17,
-		  "#F2B230"
-		 ]
-		]
-	   },
-	   "line-width": {
-		"stops": [
-		 [
-		  4,
-		  0.7
-		 ],
-		 [
-		  6,
-		  2.5
-		 ],
-		 [
-		  9,
-		  3.5
-		 ],
-		 [
-		  14,
-		  7.5
-		 ],
-		 [
-		  15,
-		  11
-		 ],
-		 [
-		  16,
-		  15
-		 ],
-		 [
-		  17,
-		  26
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		2,
-		2
-	   ]
-	  }
-	 },
-	 {
-	  "id": "Routier superieur - axe centrale - autoroute en construction",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "routier_route_sup",
-	  "minzoom": 13,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "AUTOROU_CONSTR_SUP"
-	  ],
-	  "paint": {
-	   "line-color": "#808080",
-	   "line-width": {
-		"stops": [
-		 [
-		  9,
-		  0.6
-		 ],
-		 [
-		  14,
-		  0.7
-		 ],
-		 [
-		  15,
-		  1
-		 ],
-		 [
-		  16,
-		  1.2
-		 ],
-		 [
-		  17,
-		  2.1
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Ferre superieur - voie normale",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "ferre_sup",
-	  "minzoom": 10,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "VF_1_SUP",
-	   "VF_2_SUP",
-	   "VF_ELEC_1_SUP"
-	  ],
-	  "paint": {
-	   "line-color": "#787878",
-	   "line-width": {
-		"stops": [
-		 [
-		  10,
-		  0.8
-		 ],
-		 [
-		  17,
-		  2.5
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Ferre superieur - voie normale trait perpendic",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "ferre_sup",
-	  "minzoom": 10,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "VF_1_SUP",
-	   "VF_2_SUP",
-	   "VF_ELEC_1_SUP"
-	  ],
-	  "paint": {
-	   "line-color": "#787878",
-	   "line-width": {
-		"stops": [
-		 [
-		  10,
-		  3.5
-		 ],
-		 [
-		  17,
-		  14.7
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		0.1,
-		10
-	   ]
-	  }
-	 },
-	 {
-	  "id": "Ferre superieur - voie etroite",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "ferre_sup",
-	  "minzoom": 10,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "VF_ETROITE_1_SUP",
-	   "VF_ETROITE_SUP"
-	  ],
-	  "paint": {
-	   "line-color": "#787878",
-	   "line-width": {
-		"stops": [
-		 [
-		  10,
-		  0.3
-		 ],
-		 [
-		  17,
-		  1.8
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Ferre superieur - voie etroite trait perpendic",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "ferre_sup",
-	  "minzoom": 10,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "VF_ETROITE_1_SUP",
-	   "VF_ETROITE_SUP"
-	  ],
-	  "paint": {
-	   "line-color": "#787878",
-	   "line-width": {
-		"stops": [
-		 [
-		  10,
-		  3.5
-		 ],
-		 [
-		  17,
-		  14.7
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		0.1,
-		10
-	   ]
-	  }
-	 },
-	 {
-	  "id": "Ferre superieur - voie service",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "ferre_sup",
-	  "minzoom": 14,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "VF_SERVICE_SUP",
-	   "VF_NON_EXPLOITEE_SUP"
-	  ],
-	  "paint": {
-	   "line-color": "#787878",
-	   "line-width": {
-		"stops": [
-		 [
-		  10,
-		  0.3
-		 ],
-		 [
-		  17,
-		  1.8
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		5,
-		2,
-		1,
-		2
-	   ]
-	  }
-	 },
-	 {
-	  "id": "Ferre superieur - voie en construction",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "ferre_sup",
-	  "minzoom": 10,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "VF_EN_CONSTR_SUP"
-	  ],
-	  "paint": {
-	   "line-color": "#787878",
-	   "line-width": {
-		"stops": [
-		 [
-		  10,
-		  0.3
-		 ],
-		 [
-		  17,
-		  1.8
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		2,
-		2
-	   ]
-	  }
-	 },
-	 {
-	  "id": "Ferre superieur - voie en construction trait perpendic",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "ferre_sup",
-	  "minzoom": 10,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "VF_EN_CONSTR_SUP"
-	  ],
-	  "paint": {
-	   "line-color": "#787878",
-	   "line-width": {
-		"stops": [
-		 [
-		  10,
-		  3.5
-		 ],
-		 [
-		  17,
-		  14.7
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		0.1,
-		10
-	   ]
-	  }
-	 },
-	 {
-	  "id": "Ferre superieur - funic/urbain",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "ferre_sup",
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "FUNI_CREMAILLERE_SUP",
-	   "TRANSPORT_URBAIN_SUP"
-	  ],
-	  "paint": {
-	   "line-color": "#787878",
-	   "line-width": {
-		"stops": [
-		 [
-		  10,
-		  0.3
-		 ],
-		 [
-		  17,
-		  1.8
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "Ferre superieur - 2 trait perpendic - funic/urbain",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "ferre_sup",
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "FUNI_CREMAILLERE_SUP",
-	   "TRANSPORT_URBAIN_SUP"
-	  ],
-	  "paint": {
-	   "line-color": "#787878",
-	   "line-width": {
-		"stops": [
-		 [
-		  10,
-		  3.5
-		 ],
-		 [
-		  17,
-		  17
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		0.1,
-		0.2,
-		0.1,
-		10
-	   ]
-	  }
-	 },
-	 {
-	  "id": "Limite - cloture",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "limite_lin",
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "CLOTURE"
-	  ],
-	  "paint": {
-	   "line-color": "#000000",
-	   "line-width": {
-		"stops": [
-		 [
-		  13,
-		  0.6
-		 ],
-		 [
-		  17,
-		  1
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		1.5,
-		4
-	   ]
-	  }
-	 },
-	 {
-	  "id": "Limite - layon",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "limite_lin",
-	  "minzoom": 14,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "LAYON"
-	  ],
-	  "paint": {
-	   "line-color": "#B3989A",
-	   "line-width": {
-		"stops": [
-		 [
-		  14,
-		  1
-		 ],
-		 [
-		  15,
-		  1.2
-		 ],
-		 [
-		  16,
-		  1.4
-		 ],
-		 [
-		  17,
-		  2
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		4,
-		7
-	   ]
-	  }
-	 },
-	 {
-	  "id": "Zone Règlementee - Enceinte militaire",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "limite_lin",
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "LIM_ZONE_REGLEMENTEE",
-	   "LIM_ENCEINTE_MILITAIRE",
-	   "LIM_ENCEINTE_MILI",
-	   "LIM_CHAMP_TIR"
-	  ],
-	  "paint": {
-	   "line-color": "rgba(226, 130, 92, 0.8)",
-	   "line-width": {
-		"stops": [
-		 [
-		  13,
-		  1.7
-		 ],
-		 [
-		  17,
-		  3.1
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		4,
-		1,
-		2,
-		5
-	   ]
-	  }
-	 },
-	 {
-	  "id": "limite zone naturelle",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "limite_lin",
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "LIM_ZONE_NATURELLE",
-	   "LIM_ZONE_NATURELLE_ILE",
-	   "LIM_RESERVE_NATURELLE"
-	  ],
-	  "paint": {
-	   "line-color": "#FFC2CB",
-	   "line-width": {
-		"stops": [
-		 [
-		  13,
-		  2
-		 ],
-		 [
-		  17,
-		  4
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		2,
-		1
-	   ]
-	  }
-	 },
-	 {
-	  "id": "limite zone naturelle - Parc naturel 10",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "limite_lin",
-	  "maxzoom": 10,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "LIM_PARC_NATUREL",
-	   "LIM_PARC_NATUREL_ILE"
-	  ],
-	  "paint": {
-	   "line-color": "#42A266",
-	   "line-width": {
-		"stops": [
-		 [
-		  13,
-		  2
-		 ],
-		 [
-		  17,
-		  4
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		2,
-		1
-	   ]
-	  }
-	 },
-	 {
-	  "id": "limite zone naturelle - Parc naturel 11",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "limite_lin",
-	  "minzoom": 10,
-	  "maxzoom": 11,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "LIM_PARC_NATUREL",
-	   "LIM_PARC_NATUREL_ILE"
-	  ],
-	  "paint": {
-	   "line-color": "#42A266",
-	   "line-width": {
-		"stops": [
-		 [
-		  13,
-		  2
-		 ],
-		 [
-		  17,
-		  4
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		2,
-		2
-	   ]
-	  }
-	 },
-	 {
-	  "id": "limite zone naturelle - Parc naturel 12",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "limite_lin",
-	  "minzoom": 11,
-	  "maxzoom": 12,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "LIM_PARC_NATUREL",
-	   "LIM_PARC_NATUREL_ILE"
-	  ],
-	  "paint": {
-	   "line-color": "#42A266",
-	   "line-width": {
-		"stops": [
-		 [
-		  13,
-		  2
-		 ],
-		 [
-		  17,
-		  4
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		2,
-		3
-	   ]
-	  }
-	 },
-	 {
-	  "id": "limite zone naturelle - Parc naturel 13",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "limite_lin",
-	  "minzoom": 12,
-	  "maxzoom": 13,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "LIM_PARC_NATUREL",
-	   "LIM_PARC_NATUREL_ILE"
-	  ],
-	  "paint": {
-	   "line-color": "#42A266",
-	   "line-width": {
-		"stops": [
-		 [
-		  13,
-		  2
-		 ],
-		 [
-		  17,
-		  4
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		2,
-		4
-	   ]
-	  }
-	 },
-	 {
-	  "id": "limite zone naturelle - Parc naturel 14",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "limite_lin",
-	  "minzoom": 13,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "LIM_PARC_NATUREL",
-	   "LIM_PARC_NATUREL_ILE"
-	  ],
-	  "paint": {
-	   "line-color": "rgba(66, 162, 102, 0.7)",
-	   "line-width": {
-		"stops": [
-		 [
-		  13,
-		  2
-		 ],
-		 [
-		  17,
-		  4
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		2,
-		5
-	   ]
-	  }
-	 },
-	 {
-	  "id": "limite zone naturelle - Parc marin",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "limite_lin",
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "LIM_PARC_NATUREL_MARIN"
-	  ],
-	  "paint": {
-	   "line-color": "#2A81A2",
-	   "line-width": {
-		"stops": [
-		 [
-		  13,
-		  2
-		 ],
-		 [
-		  17,
-		  4
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		2,
-		1
-	   ]
-	  }
-	 },
-	 {
-	  "id": "parcellaire - parcelle bordure",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "parcellaire_parcelle",
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "PARCELLE"
-	  ],
-	  "paint": {
-	   "line-color": "#9933FF",
-	   "line-width": 1
-	  }
-	 },
-	 {
-	  "id": "parcellaire - section",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "parcellaire_section",
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "SECTION"
-	  ],
-	  "paint": {
-	   "line-color": "#287B00",
-	   "line-width": 1.9,
-	   "line-dasharray": [
-		2,
-		4,
-		2
-	   ]
-	  }
-	 },
-	 {
-	  "id": "toponyme - parcellaire - section",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_parcellaire_section",
-	  "filter": [
-	   "==",
-	   "txt_typo",
-	   "SECTION"
-	  ],
-	  "layout": {
-	   "symbol-placement": "line",
-	   "text-offset": [
-		0,
-		0
-	   ],
-	   "text-field": "{texte}",
-	   "text-size": 15,
-	   "text-anchor": "center",
-	   "text-keep-upright": true,
-	   "text-max-angle": 45,
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ],
-	   "visibility": "visible"
-	  },
-	  "paint": {
-	   "text-color": "#287B00"
-	  }
-	 },
-	 {
-	  "id": "toponyme - parcellaire - parcelle",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_parcellaire_parcelle",
-	  "filter": [
-	   "==",
-	   "txt_typo",
-	   "PARCELLE"
-	  ],
-	  "layout": {
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-size": 11,
-	   "text-anchor": "center",
-	   "text-keep-upright": true,
-	   "text-max-angle": 45,
-	   "text-font": [
-		"Source Sans Pro Bold"
-	   ],
-	   "visibility": "visible"
-	  },
-	  "paint": {
-	   "text-color": "#9933FF",
-	   "text-halo-width": 1,
-	   "text-halo-color": "#FFFFFF"
-	  }
-	 },
-	 {
-	  "id": "toponyme - parcellaire - adresse",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_parcellaire_adresse_ponc",
-	  "filter": [
-	   "==",
-	   "txt_typo",
-	   "ADRESSE"
-	  ],
-	  "layout": {
-	   "symbol-placement": "point",
-	   "text-field": [
-		"concat",
-		"{numero}",
-		"{indice_de_repetition}"
-	   ],
-	   "text-size": 11,
-	   "text-anchor": "center",
-	   "text-keep-upright": true,
-	   "text-max-angle": 45,
-	   "text-font": [
-		"Source Sans Pro Bold"
-	   ],
-	   "visibility": "visible"
-	  },
-	  "paint": {
-	   "text-color": "#695744",
-	   "text-halo-width": 1,
-	   "text-halo-color": "#FFFFFF"
-	  }
-	 },
-	 {
-	  "id": "limite admin - limite de commune",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "limite_lin",
-	  "minzoom": 13,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "LIM_COMMUNE",
-	   "LIM_CANTON",
-	   "LIM_ARRONDISSEMENT"
-	  ],
-	  "paint": {
-	   "line-color": "rgba(126, 119, 184, 0.5)",
-	   "line-width": {
-		"stops": [
-		 [
-		  13,
-		  3
-		 ],
-		 [
-		  17,
-		  5.5
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		4,
-		2,
-		1,
-		1,
-		1,
-		1,
-		1,
-		2
-	   ]
-	  }
-	 },
-	 {
-	  "id": "limite admin - limite de département bandeau",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "limite_lin",
-	  "minzoom": 8,
-	  "maxzoom": 13,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "LIM_DEPARTEMENT"
-	  ],
-	  "paint": {
-	   "line-color": "rgba(178, 175, 219, 0.4)",
-	   "line-width": {
-		"stops": [
-		 [
-		  9,
-		  4.1
-		 ],
-		 [
-		  12,
-		  6
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "limite admin - limite de département tiret",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "limite_lin",
-	  "minzoom": 13,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "LIM_DEPARTEMENT"
-	  ],
-	  "paint": {
-	   "line-color": "rgba(126, 119, 184, 0.5)",
-	   "line-width": {
-		"stops": [
-		 [
-		  13,
-		  3
-		 ],
-		 [
-		  17,
-		  5.5
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		4,
-		2,
-		1,
-		1,
-		1,
-		2
-	   ]
-	  }
-	 },
-	 {
-	  "id": "limite admin - limite de région bandeau",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "limite_lin",
-	  "minzoom": 7,
-	  "maxzoom": 13,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "LIM_REGION"
-	  ],
-	  "paint": {
-	   "line-color": "rgba(178, 175, 219, 0.5)",
-	   "line-width": {
-		"stops": [
-		 [
-		  9,
-		  4.5
-		 ],
-		 [
-		  12,
-		  6.7
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "limite admin - limite de région tiret",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "limite_lin",
-	  "minzoom": 13,
-	  "maxzoom": 18,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "LIM_REGION"
-	  ],
-	  "paint": {
-	   "line-color": "rgba(126, 119, 184, 0.5)",
-	   "line-width": {
-		"stops": [
-		 [
-		  13,
-		  3
-		 ],
-		 [
-		  17,
-		  5.5
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		4,
-		2,
-		1,
-		2
-	   ]
-	  }
-	 },
-	 {
-	  "id": "limite etat 1",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "limite_lin",
-	  "minzoom": 2,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "LIM_ETAT",
-	   "LIM_ETAT_ETRANGER"
-	  ],
-	  "paint": {
-	   "line-color": "rgba(178, 175, 219, 0.6)",
-	   "line-width": {
-		"stops": [
-		 [
-		  2,
-		  2
-		 ],
-		 [
-		  3,
-		  3.5
-		 ],
-		 [
-		  9,
-		  5
-		 ],
-		 [
-		  14,
-		  13
-		 ],
-		 [
-		  15,
-		  20
-		 ],
-		 [
-		  16,
-		  24
-		 ],
-		 [
-		  17,
-		  42
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "limite etat 2",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "limite_lin",
-	  "minzoom": 7,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "LIM_ETAT",
-	   "LIM_ETAT_ETRANGER"
-	  ],
-	  "paint": {
-	   "line-color": "#9F9CB8",
-	   "line-width": {
-		"stops": [
-		 [
-		  9,
-		  1.5
-		 ],
-		 [
-		  14,
-		  3.5
-		 ],
-		 [
-		  15,
-		  5.5
-		 ],
-		 [
-		  16,
-		  6.5
-		 ],
-		 [
-		  17,
-		  11
-		 ]
-		]
-	   },
-	   "line-dasharray": [
-		4,
-		2
-	   ]
-	  }
-	 },
-	 {
-	  "id": "limite cote",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "limite_lin",
-	  "minzoom": 7,
-	  "maxzoom": 10,
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "LIM_COTE"
-	  ],
-	  "paint": {
-	   "line-color": "#82A3B2",
-	   "line-width": 1
-	  }
-	 },
-	 {
-	  "id": "ligne electrique",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "bati_lin",
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "LIGNE_ELECTRIQUE"
-	  ],
-	  "paint": {
-	   "line-color": "#808080",
-	   "line-width": {
-		"stops": [
-		 [
-		  13,
-		  1
-		 ],
-		 [
-		  17,
-		  2
-		 ]
-		]
-	   }
-	  }
-	 },
-	 {
-	  "id": "autre construction linéaire",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "bati_lin",
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "round",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "CABLE",
-	   "REMONTEE_MEC",
-	   "HYDROCARBURES",
-	   "CONDUITE_MATIERES_P",
-	   "SPORT_MONTAGNE_LIN",
-	   "PISTE_BOBSLEIGH",
-	   "PISTE_LUGE",
-	   "PISTE_AERO_LIN"
-	  ],
-	  "paint": {
-	   "line-color": "#808080",
-	   "line-width": 1
-	  }
-	 },
-	 {
-	  "id": "autre construction linéaire - trait perpend cable",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "bati_lin",
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "CABLE"
-	  ],
-	  "paint": {
-	   "line-color": "#808080",
-	   "line-width": 5,
-	   "line-dasharray": [
-		0.5,
-		10
-	   ]
-	  }
-	 },
-	 {
-	  "id": "autre construction linéaire - trait perpend 1 remont",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "bati_lin",
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "REMONTEE_MEC"
-	  ],
-	  "paint": {
-	   "line-color": "#808080",
-	   "line-width": 6,
-	   "line-dasharray": [
-		1,
-		10
-	   ]
-	  }
-	 },
-	 {
-	  "id": "autre construction linéaire - trait perpend 2 remont",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "bati_lin",
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "REMONTEE_MEC"
-	  ],
-	  "paint": {
-	   "line-color": "#BEBEBE",
-	   "line-width": 6,
-	   "line-dasharray": [
-		0.3,
-		0.4,
-		0.3,
-		10
-	   ]
-	  }
-	 },
-	 {
-	  "id": "autre construction linéaire - trait perpend carbur",
-	  "type": "line",
-	  "source": "plan_ign",
-	  "source-layer": "bati_lin",
-	  "layout": {
-	   "visibility": "visible",
-	   "line-cap": "butt",
-	   "line-join": "round"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "HYDROCARBURES",
-	   "CONDUITE_MATIERES_P"
-	  ],
-	  "paint": {
-	   "line-color": "#808080",
-	   "line-width": 5,
-	   "line-dasharray": [
-		1,
-		10
-	   ]
-	  }
-	 },
-	 {
-	  "id": "routier ponctuel - peage ponctuel",
-	  "type": "circle",
-	  "source": "plan_ign",
-	  "source-layer": "routier_ponc",
-	  "minzoom": 8,
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "PEAGE_PONC"
-	  ],
-	  "paint": {
-	   "circle-radius": {
-		"stops": [
-		 [
-		  9,
-		  3.5
-		 ],
-		 [
-		  12,
-		  6.5
-		 ]
-		]
-	   },
-	   "circle-color": "#E2A52A",
-	   "circle-stroke-width": 1,
-	   "circle-stroke-color": "#808080"
-	  }
-	 },
-	 {
-	  "id": "routier ponctuel - barriere",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "routier_ponc",
-	  "minzoom": 12,
-	  "layout": {
-	   "visibility": "visible",
-	   "icon-image": "Barriere",
-	   "icon-size": {
-		"stops": [
-		 [
-		  13,
-		  0.25
-		 ],
-		 [
-		  16,
-		  0.45
-		 ],
-		 [
-		  17,
-		  0.7
-		 ]
-		]
-	   },
-	   "icon-allow-overlap": true,
-	   "icon-rotate": [
-		"get",
-		"rotation"
-	   ]
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "BARRIERE"
-	  ],
-	  "paint": {
-	   "icon-color": "#969696"
-	  }
-	 },
-	 {
-	  "id": "hydro ponctuel",
-	  "type": "circle",
-	  "source": "plan_ign",
-	  "source-layer": "hydro_ponc",
-	  "minzoom": 13,
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "FONTAINE",
-	   "POINT_D_EAU",
-	   "SOURCE",
-	   "SOURCE_CAPTEE",
-	   "PERTE",
-	   "RESURGENCE",
-	   "CASCADE",
-	   "AUTRE_HYDRO_PONC"
-	  ],
-	  "paint": {
-	   "circle-radius": {
-		"stops": [
-		 [
-		  14,
-		  3
-		 ],
-		 [
-		  17,
-		  7
-		 ]
-		]
-	   },
-	   "circle-color": "#FFFFFF",
-	   "circle-opacity": 1,
-	   "circle-stroke-width": {
-		"stops": [
-		 [
-		  14,
-		  2
-		 ],
-		 [
-		  17,
-		  5
-		 ]
-		]
-	   },
-	   "circle-stroke-color": "#1466B2"
-	  }
-	 },
-	 {
-	  "id": "point coté",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "oro_ponc",
-	  "minzoom": 11,
-	  "maxzoom": 16,
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "POINT_COTE",
-	   "POINT_COTE_TOPO",
-	   "POINT_COTE_RESEAU",
-	   "POINT_RBF"
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "icon-image": "Localite",
-	   "icon-size": 0.1,
-	   "text-field": "{texte}",
-	   "text-size": 10,
-	   "text-allow-overlap": false,
-	   "text-anchor": "bottom-left",
-	   "text-offset": [
-		0.2,
-		0.4
-	   ],
-	   "text-padding": 2,
-	   "text-font": [
-		"Source Sans Pro Italic"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#505050"
-	  }
-	 },
-	 {
-	  "id": "bati ponctuel : Hopital",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "bati_ponc",
-	  "layout": {
-	   "visibility": "visible",
-	   "icon-image": "Hopital",
-	   "icon-size": 0.33
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "HOPITAL_PONC"
-	  ],
-	  "paint": {
-	   "icon-color": "#646464"
-	  }
-	 },
-	 {
-	  "id": "bati ponctuel hydrographique",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "bati_ponc",
-	  "minzoom": 14,
-	  "layout": {
-	   "visibility": "visible",
-	   "icon-image": "Pompage",
-	   "icon-size": {
-		"stops": [
-		 [
-		  13,
-		  0.2
-		 ],
-		 [
-		  17,
-		  0.6
-		 ]
-		]
-	   },
-	   "icon-allow-overlap": true
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "CITERNE",
-	   "LAVOIR",
-	   "STATION_EPURATION",
-	   "STATION_DE_POMPAGE",
-	   "USINE_PRODUCTION_EAU",
-	   "USINE_ELEVATRICE"
-	  ],
-	  "paint": {
-	   "icon-color": "#1C62A6"
-	  }
-	 },
-	 {
-	  "id": "bati ponctuel hydrographique - Puits-Abreuvoir",
-	  "type": "circle",
-	  "source": "plan_ign",
-	  "source-layer": "bati_ponc",
-	  "minzoom": 13,
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "PUITS",
-	   "ABREUVOIR"
-	  ],
-	  "paint": {
-	   "circle-radius": {
-		"stops": [
-		 [
-		  14,
-		  3
-		 ],
-		 [
-		  17,
-		  7
-		 ]
-		]
-	   },
-	   "circle-color": "#FFFFFF",
-	   "circle-opacity": 1,
-	   "circle-stroke-width": {
-		"stops": [
-		 [
-		  14,
-		  2
-		 ],
-		 [
-		  17,
-		  5
-		 ]
-		]
-	   },
-	   "circle-stroke-color": "#1466B2"
-	  }
-	 },
-	 {
-	  "id": "bati ponctuel hydrographique - Phare",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "bati_ponc",
-	  "minzoom": 13,
-	  "layout": {
-	   "visibility": "visible",
-	   "icon-image": "Phare",
-	   "icon-size": {
-		"stops": [
-		 [
-		  13,
-		  0.7
-		 ],
-		 [
-		  17,
-		  1.3
-		 ]
-		]
-	   }
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "PHARE"
-	  ],
-	  "paint": {
-	   "icon-color": "#646464"
-	  }
-	 },
-	 {
-	  "id": "bati ponctuel hydrographique - Amer-Feu",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "bati_ponc",
-	  "minzoom": 13,
-	  "layout": {
-	   "visibility": "visible",
-	   "icon-image": "Feu",
-	   "icon-size": {
-		"stops": [
-		 [
-		  13,
-		  0.7
-		 ],
-		 [
-		  17,
-		  1.3
-		 ]
-		]
-	   }
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "AMER",
-	   "FEU",
-	   "FEU_PONC",
-	   "TOURELLE_LUMINEUSE"
-	  ],
-	  "paint": {
-	   "icon-color": "#646464"
-	  }
-	 },
-	 {
-	  "id": "bati ponctuel hydrographique - Balise",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "bati_ponc",
-	  "minzoom": 13,
-	  "layout": {
-	   "visibility": "visible",
-	   "icon-image": "Balise",
-	   "icon-size": {
-		"stops": [
-		 [
-		  13,
-		  0.7
-		 ],
-		 [
-		  17,
-		  1.3
-		 ]
-		]
-	   }
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "BALISE",
-	   "TOURELLE"
-	  ],
-	  "paint": {
-	   "icon-color": "#646464"
-	  }
-	 },
-	 {
-	  "id": "bati ponctuel hydrographique - Ecluse",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "bati_ponc",
-	  "minzoom": 12,
-	  "maxzoom": 15,
-	  "layout": {
-	   "visibility": "visible",
-	   "icon-image": "Ecluse",
-	   "icon-size": 0.2
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "ECLUSE_PONC"
-	  ],
-	  "paint": {
-	   "icon-color": "#1C62A6"
-	  }
-	 },
-	 {
-	  "id": "bati ponctuel hydrographique - Barrage",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "bati_ponc",
-	  "minzoom": 12,
-	  "maxzoom": 14,
-	  "layout": {
-	   "visibility": "visible",
-	   "icon-image": "Barrage",
-	   "icon-size": 0.25
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "BARRAGE_PONC"
-	  ],
-	  "paint": {
-	   "icon-color": "#1C62A6"
-	  }
-	 },
-	 {
-	  "id": "bati ponctuel hydrographique - Chateau d'eau",
-	  "type": "circle",
-	  "source": "plan_ign",
-	  "source-layer": "bati_ponc",
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "CHATEAU_EAU_PONC"
-	  ],
-	  "paint": {
-	   "circle-radius": {
-		"stops": [
-		 [
-		  14,
-		  3
-		 ],
-		 [
-		  17,
-		  8
-		 ]
-		]
-	   },
-	   "circle-color": "#1466B2"
-	  }
-	 },
-	 {
-	  "id": "bati ponctuel hydrographique - Réservoir d'eau",
-	  "type": "circle",
-	  "source": "plan_ign",
-	  "source-layer": "bati_ponc",
-	  "maxzoom": 15,
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "RESERVOIR_EAU_PONC"
-	  ],
-	  "paint": {
-	   "circle-radius": {
-		"stops": [
-		 [
-		  14,
-		  3
-		 ],
-		 [
-		  17,
-		  8
-		 ]
-		]
-	   },
-	   "circle-color": "#AAD5E9",
-	   "circle-opacity": 1,
-	   "circle-stroke-width": {
-		"stops": [
-		 [
-		  14,
-		  1
-		 ],
-		 [
-		  17,
-		  2.5
-		 ]
-		]
-	   },
-	   "circle-stroke-color": "#1466B2"
-	  }
-	 },
-	 {
-	  "id": "bati ponctuel infrastructure - Constr spé",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "bati_ponc",
-	  "layout": {
-	   "visibility": "visible",
-	   "icon-image": "ConstrSpeciale",
-	   "icon-size": {
-		"stops": [
-		 [
-		  13,
-		  0.22
-		 ],
-		 [
-		  17,
-		  0.5
-		 ]
-		]
-	   }
-	  },
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "ANTENNE",
-	   "CONSTR_SPE_TECHNIQUE",
-	   "CONSTR_INDIF_PONC",
-	   "CHEMINEE",
-	   "CHEVALEMENT",
-	   "PUITS_GAZ",
-	   "PUITS_PETROLE",
-	   "PYLONE_METEO",
-	   "TORCHERE",
-	   "TOUR_GUET",
-	   "TOUR_HERTZIENNE"
-	  ],
-	  "paint": {
-	   "icon-color": "#646464"
-	  }
-	 },
-	 {
-	  "id": "bati ponctuel infrastructure - Silo",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "bati_ponc",
-	  "maxzoom": 15,
-	  "layout": {
-	   "visibility": "visible",
-	   "icon-image": "Silo",
-	   "icon-size": {
-		"stops": [
-		 [
-		  13,
-		  0.22
-		 ],
-		 [
-		  17,
-		  0.5
-		 ]
-		]
-	   }
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "SILO_PONC"
-	  ],
-	  "paint": {
-	   "icon-color": "#646464"
-	  }
-	 },
-	 {
-	  "id": "bati ponctuel infrastructure - Eolienne",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "bati_ponc",
-	  "layout": {
-	   "visibility": "visible",
-	   "icon-image": "Eolienne",
-	   "icon-size": {
-		"stops": [
-		 [
-		  13,
-		  0.4
-		 ],
-		 [
-		  17,
-		  1
-		 ],
-		 [
-		  18,
-		  0.8
-		 ]
-		]
-	   }
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "EOLIENNE"
-	  ],
-	  "paint": {
-	   "icon-color": "#646464"
-	  }
-	 },
-	 {
-	  "id": "bati ponctuel infrastructure - Reservoir",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "bati_ponc",
-	  "maxzoom": 15,
-	  "layout": {
-	   "visibility": "visible",
-	   "icon-image": "Reservoir",
-	   "icon-size": {
-		"stops": [
-		 [
-		  13,
-		  0.26
-		 ],
-		 [
-		  17,
-		  0.5
-		 ]
-		]
-	   }
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "RESERVOIR_PONC"
-	  ],
-	  "paint": {
-	   "icon-color": "#646464"
-	  }
-	 },
-	 {
-	  "id": "bati ponctuel infrastructure - pylone électrique",
-	  "type": "circle",
-	  "source": "plan_ign",
-	  "source-layer": "bati_ponc",
-	  "layout": {
-	   "visibility": "visible"
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "PYLONE_ELEC"
-	  ],
-	  "paint": {
-	   "circle-radius": {
-		"stops": [
-		 [
-		  13,
-		  1
-		 ],
-		 [
-		  17,
-		  2
-		 ]
-		]
-	   },
-	   "circle-color": "#000000"
-	  }
-	 },
-	 {
-	  "id": "bati ponctuel montagne - Abri",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "bati_ponc",
-	  "layout": {
-	   "visibility": "visible",
-	   "icon-image": "Abri",
-	   "icon-size": {
-		"stops": [
-		 [
-		  13,
-		  0.4
-		 ],
-		 [
-		  15,
-		  0.6
-		 ],
-		 [
-		  17,
-		  0.9
-		 ]
-		]
-	   }
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "ABRI"
-	  ],
-	  "paint": {
-	   "icon-color": "#246138"
-	  }
-	 },
-	 {
-	  "id": "bati ponctuel montagne - Refuge Garde",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "bati_ponc",
-	  "layout": {
-	   "visibility": "visible",
-	   "icon-image": "Refugegard",
-	   "icon-size": {
-		"stops": [
-		 [
-		  13,
-		  0.4
-		 ],
-		 [
-		  15,
-		  0.6
-		 ],
-		 [
-		  17,
-		  0.9
-		 ]
-		]
-	   }
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "REFUGE_GARDE"
-	  ],
-	  "paint": {
-	   "icon-color": "#246138"
-	  }
-	 },
-	 {
-	  "id": "bati ponctuel montagne - Refuge Non Garde",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "bati_ponc",
-	  "layout": {
-	   "visibility": "visible",
-	   "icon-image": "Refugenongard",
-	   "icon-size": {
-		"stops": [
-		 [
-		  13,
-		  0.4
-		 ],
-		 [
-		  15,
-		  0.6
-		 ],
-		 [
-		  17,
-		  0.9
-		 ]
-		]
-	   }
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "REFUGE"
-	  ],
-	  "paint": {
-	   "icon-color": "#246138"
-	  }
-	 },
-	 {
-	  "id": "bati ponctuel transport aerien - Aeroport FXX",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "bati_ponc",
-	  "layout": {
-	   "visibility": "visible",
-	   "icon-image": "Aeroport",
-	   "icon-size": 0.5
-	  },
-	  "filter": [
-	   "all",
-	   [
-		"==",
-		"symbo",
-		"AEROPORT_PONC"
-	   ],
-	   [
-		"==",
-		"territoire",
-		"FXX"
-	   ]
-	  ],
-	  "paint": {
-	   "icon-color": "#646464"
-	  }
-	 },
-	 {
-	  "id": "bati ponctuel transport aerien - Aerodrome FXX",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "bati_ponc",
-	  "layout": {
-	   "visibility": "visible",
-	   "icon-image": "Aerodrome",
-	   "icon-size": 0.4
-	  },
-	  "filter": [
-	   "all",
-	   [
-		"==",
-		"symbo",
-		"AERODROME_PONC"
-	   ],
-	   [
-		"==",
-		"territoire",
-		"FXX"
-	   ]
-	  ],
-	  "paint": {
-	   "icon-color": "#646464"
-	  }
-	 },
-	 {
-	  "id": "bati ponctuel transport aerien - Aeroport DOM",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "bati_ponc",
-	  "minzoom": 8,
-	  "layout": {
-	   "visibility": "visible",
-	   "icon-image": "Aeroport",
-	   "icon-size": 0.5
-	  },
-	  "filter": [
-	   "all",
-	   [
-		"==",
-		"symbo",
-		"AEROPORT_PONC"
-	   ],
-	   [
-		"!=",
-		"territoire",
-		"FXX"
-	   ]
-	  ],
-	  "paint": {
-	   "icon-color": "#646464"
-	  }
-	 },
-	 {
-	  "id": "bati ponctuel transport aerien - Aerodrome DOM",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "bati_ponc",
-	  "minzoom": 8,
-	  "layout": {
-	   "visibility": "visible",
-	   "icon-image": "Aerodrome",
-	   "icon-size": 0.4
-	  },
-	  "filter": [
-	   "all",
-	   [
-		"==",
-		"symbo",
-		"AERODROME_PONC"
-	   ],
-	   [
-		"!=",
-		"territoire",
-		"FXX"
-	   ]
-	  ],
-	  "paint": {
-	   "icon-color": "#646464"
-	  }
-	 },
-	 {
-	  "id": "bati ponctuel transport ferroviaire",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "bati_ponc",
-	  "layout": {
-	   "visibility": "visible",
-	   "icon-image": "Gare",
-	   "icon-size": 0.33
-	  },
-	  "filter": [
-	   "==",
-	   "symbo",
-	   "GARE_VOYAGEURS"
-	  ],
-	  "paint": {
-	   "icon-color": "#787878"
-	  }
-	 },
-	 {
-	  "id": "toponyme - bornes postales haute - chemins",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_routier_borne",
-	  "minzoom": 17,
-	  "maxzoom": 18,
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "CHEMIN",
-	   "CHEMIN_SOU",
-	   "CHEMIN_SUP",
-	   "PISTE_CYCLABLE",
-	   "PISTE_CYCLABLE_SOU",
-	   "PISTE_CYCLABLE_SUP",
-	   "RUE_PIETONNE",
-	   "RUE_PIETONNE_SOU",
-	   "RUE_PIETONNE_SUP",
-	   "SENTIER",
-	   "SENTIER_SOU",
-	   "SENTIER_SUP",
-	   "ESCALIER",
-	   "ESCALIER_SUP"
-	  ],
-	  "layout": {
-	   "symbol-placement": "line",
-	   "text-field": "{borne_sur}",
-	   "text-size": 11,
-	   "text-anchor": "center",
-	   "text-allow-overlap": true,
-	   "text-offset": [
-		0,
-		-1
-	   ],
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ],
-	   "visibility": "none"
-	  },
-	  "paint": {
-	   "text-color": "#79654F",
-	   "text-halo-width": 1,
-	   "text-halo-color": "#FFFFFF"
-	  }
-	 },
-	 {
-	  "id": "toponyme - bornes postales haute - non revetue, non classee",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_routier_borne",
-	  "minzoom": 17,
-	  "maxzoom": 18,
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "NON_CLASSEE",
-	   "NON_CLASSEE_4",
-	   "NON_CLASSEE_4_SUP",
-	   "NON_CLASSEE_RESTREINT",
-	   "NON_CLASSEE_RESTREINT_SUP",
-	   "NON_CLASSEE_SOU",
-	   "NON_CLASSEE_SUP",
-	   "NON_REVETUE_CARRO",
-	   "NON_REVETUE_CARRO_SUP"
-	  ],
-	  "layout": {
-	   "symbol-placement": "line",
-	   "text-field": "{borne_sur}",
-	   "text-size": 11,
-	   "text-anchor": "center",
-	   "text-allow-overlap": true,
-	   "text-offset": [
-		0,
-		-1.3
-	   ],
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ],
-	   "visibility": "none"
-	  },
-	  "paint": {
-	   "text-color": "#79654F",
-	   "text-halo-width": 1,
-	   "text-halo-color": "#FFFFFF"
-	  }
-	 },
-	 {
-	  "id": "toponyme - bornes postales haute - locales",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_routier_borne",
-	  "minzoom": 17,
-	  "maxzoom": 18,
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "LOCALE_1",
-	   "LOCALE_1_SOU",
-	   "LOCALE_1_SUP",
-	   "LOCALE_2",
-	   "LOCALE_2_SOU",
-	   "LOCALE_2_SUP",
-	   "LOCALE_3",
-	   "LOCALE_3_SOU",
-	   "LOCALE_3_SUP",
-	   "LOCALE_4",
-	   "LOCALE_4_SOU",
-	   "LOCALE_4_SUP",
-	   "LOCALE_CONSTR",
-	   "LOCALE_CONSTR_SUP"
-	  ],
-	  "layout": {
-	   "symbol-placement": "line",
-	   "text-field": "{borne_sur}",
-	   "text-size": 11,
-	   "text-anchor": "center",
-	   "text-allow-overlap": true,
-	   "text-offset": [
-		0,
-		-1.4
-	   ],
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ],
-	   "visibility": "none"
-	  },
-	  "paint": {
-	   "text-color": "#79654F",
-	   "text-halo-width": 1,
-	   "text-halo-color": "#FFFFFF"
-	  }
-	 },
-	 {
-	  "id": "toponyme - bornes postales haute - regionales",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_routier_borne",
-	  "minzoom": 17,
-	  "maxzoom": 18,
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "REGIONALE_1",
-	   "REGIONALE_1_SOU",
-	   "REGIONALE_1_SUP",
-	   "REGIONALE_2",
-	   "REGIONALE_2_SOU",
-	   "REGIONALE_2_SUP",
-	   "REGIONALE_3",
-	   "REGIONALE_3_SOU",
-	   "REGIONALE_3_SUP",
-	   "REGIONALE_4",
-	   "REGIONALE_4_SUP",
-	   "REGIONALE_CONSTR"
-	  ],
-	  "layout": {
-	   "symbol-placement": "line",
-	   "text-field": "{borne_sur}",
-	   "text-size": 11,
-	   "text-anchor": "center",
-	   "text-allow-overlap": true,
-	   "text-offset": [
-		0,
-		-1.5
-	   ],
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ],
-	   "visibility": "none"
-	  },
-	  "paint": {
-	   "text-color": "#79654F",
-	   "text-halo-width": 1,
-	   "text-halo-color": "#FFFFFF"
-	  }
-	 },
-	 {
-	  "id": "toponyme - bornes postales haute - principales",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_routier_borne",
-	  "minzoom": 17,
-	  "maxzoom": 18,
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "PRINCIPALE_1",
-	   "PRINCIPALE_1_SOU",
-	   "PRINCIPALE_1_SUP",
-	   "PRINCIPALE_2",
-	   "PRINCIPALE_2_SOU",
-	   "PRINCIPALE_2_SUP",
-	   "PRINCIPALE_3",
-	   "PRINCIPALE_3_SOU",
-	   "PRINCIPALE_3_SUP",
-	   "PRINCIPALE_4",
-	   "PRINCIPALE_4_SOU",
-	   "PRINCIPALE_4_SUP",
-	   "PRINCIPALE_CONSTR"
-	  ],
-	  "layout": {
-	   "symbol-placement": "line",
-	   "text-field": "{borne_sur}",
-	   "text-size": 11,
-	   "text-anchor": "center",
-	   "text-allow-overlap": true,
-	   "text-offset": [
-		0,
-		-1.6
-	   ],
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ],
-	   "visibility": "none"
-	  },
-	  "paint": {
-	   "text-color": "#79654F",
-	   "text-halo-width": 1,
-	   "text-halo-color": "#FFFFFF"
-	  }
-	 },
-	 {
-	  "id": "toponyme - bornes postales bas - chemins",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_routier_borne",
-	  "minzoom": 17,
-	  "maxzoom": 18,
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "CHEMIN",
-	   "CHEMIN_SOU",
-	   "CHEMIN_SUP",
-	   "PISTE_CYCLABLE",
-	   "PISTE_CYCLABLE_SOU",
-	   "PISTE_CYCLABLE_SUP",
-	   "RUE_PIETONNE",
-	   "RUE_PIETONNE_SOU",
-	   "RUE_PIETONNE_SUP",
-	   "SENTIER",
-	   "SENTIER_SOU",
-	   "SENTIER_SUP",
-	   "ESCALIER",
-	   "ESCALIER_SUP"
-	  ],
-	  "layout": {
-	   "symbol-placement": "line",
-	   "text-field": "{borne_sous}",
-	   "text-size": 11,
-	   "text-anchor": "center",
-	   "text-allow-overlap": true,
-	   "text-offset": [
-		0,
-		1
-	   ],
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ],
-	   "visibility": "none"
-	  },
-	  "paint": {
-	   "text-color": "#79654F",
-	   "text-halo-width": 1,
-	   "text-halo-color": "#FFFFFF"
-	  }
-	 },
-	 {
-	  "id": "toponyme - bornes postales bas - non revetue, non classee",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_routier_borne",
-	  "minzoom": 17,
-	  "maxzoom": 18,
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "NON_CLASSEE",
-	   "NON_CLASSEE_4",
-	   "NON_CLASSEE_4_SUP",
-	   "NON_CLASSEE_RESTREINT",
-	   "NON_CLASSEE_RESTREINT_SUP",
-	   "NON_CLASSEE_SOU",
-	   "NON_CLASSEE_SUP",
-	   "NON_REVETUE_CARRO",
-	   "NON_REVETUE_CARRO_SUP"
-	  ],
-	  "layout": {
-	   "symbol-placement": "line",
-	   "text-field": "{borne_sous}",
-	   "text-size": 11,
-	   "text-anchor": "center",
-	   "text-allow-overlap": true,
-	   "text-offset": [
-		0,
-		1.3
-	   ],
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ],
-	   "visibility": "none"
-	  },
-	  "paint": {
-	   "text-color": "#79654F",
-	   "text-halo-width": 1,
-	   "text-halo-color": "#FFFFFF"
-	  }
-	 },
-	 {
-	  "id": "toponyme - bornes postales bas - locales",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_routier_borne",
-	  "minzoom": 17,
-	  "maxzoom": 18,
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "LOCALE_1",
-	   "LOCALE_1_SOU",
-	   "LOCALE_1_SUP",
-	   "LOCALE_2",
-	   "LOCALE_2_SOU",
-	   "LOCALE_2_SUP",
-	   "LOCALE_3",
-	   "LOCALE_3_SOU",
-	   "LOCALE_3_SUP",
-	   "LOCALE_4",
-	   "LOCALE_4_SOU",
-	   "LOCALE_4_SUP",
-	   "LOCALE_CONSTR",
-	   "LOCALE_CONSTR_SUP"
-	  ],
-	  "layout": {
-	   "symbol-placement": "line",
-	   "text-field": "{borne_sous}",
-	   "text-size": 11,
-	   "text-anchor": "center",
-	   "text-allow-overlap": true,
-	   "text-offset": [
-		0,
-		1.4
-	   ],
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ],
-	   "visibility": "none"
-	  },
-	  "paint": {
-	   "text-color": "#79654F",
-	   "text-halo-width": 1,
-	   "text-halo-color": "#FFFFFF"
-	  }
-	 },
-	 {
-	  "id": "toponyme - bornes postales bas - regionales",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_routier_borne",
-	  "minzoom": 17,
-	  "maxzoom": 18,
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "REGIONALE_1",
-	   "REGIONALE_1_SOU",
-	   "REGIONALE_1_SUP",
-	   "REGIONALE_2",
-	   "REGIONALE_2_SOU",
-	   "REGIONALE_2_SUP",
-	   "REGIONALE_3",
-	   "REGIONALE_3_SOU",
-	   "REGIONALE_3_SUP",
-	   "REGIONALE_4",
-	   "REGIONALE_4_SUP",
-	   "REGIONALE_CONSTR"
-	  ],
-	  "layout": {
-	   "symbol-placement": "line",
-	   "text-field": "{borne_sous}",
-	   "text-size": 11,
-	   "text-anchor": "center",
-	   "text-allow-overlap": true,
-	   "text-offset": [
-		0,
-		1.5
-	   ],
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ],
-	   "visibility": "none"
-	  },
-	  "paint": {
-	   "text-color": "#79654F",
-	   "text-halo-width": 1,
-	   "text-halo-color": "#FFFFFF"
-	  }
-	 },
-	 {
-	  "id": "toponyme - bornes postales bas - principales",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_routier_borne",
-	  "minzoom": 17,
-	  "maxzoom": 18,
-	  "filter": [
-	   "in",
-	   "symbo",
-	   "PRINCIPALE_1",
-	   "PRINCIPALE_1_SOU",
-	   "PRINCIPALE_1_SUP",
-	   "PRINCIPALE_2",
-	   "PRINCIPALE_2_SOU",
-	   "PRINCIPALE_2_SUP",
-	   "PRINCIPALE_3",
-	   "PRINCIPALE_3_SOU",
-	   "PRINCIPALE_3_SUP",
-	   "PRINCIPALE_4",
-	   "PRINCIPALE_4_SOU",
-	   "PRINCIPALE_4_SUP",
-	   "PRINCIPALE_CONSTR"
-	  ],
-	  "layout": {
-	   "symbol-placement": "line",
-	   "text-field": "{borne_sous}",
-	   "text-size": 11,
-	   "text-anchor": "center",
-	   "text-allow-overlap": true,
-	   "text-offset": [
-		0,
-		1.6
-	   ],
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ],
-	   "visibility": "none"
-	  },
-	  "paint": {
-	   "text-color": "#79654F",
-	   "text-halo-width": 1,
-	   "text-halo-color": "#FFFFFF"
-	  }
-	 },
-	 {
-	  "id": "toponyme - courbe rocher maitresse",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_oro_ponc",
-	  "filter": [
-	   "==",
-	   "txt_typo",
-	   "ORO_COURBE_ROCHER"
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-size": 10,
-	   "text-allow-overlap": false,
-	   "text-padding": 30,
-	   "text-rotate": {
-		"type": "identity",
-		"property": "rotation"
-	   },
-	   "text-font": [
-		"Source Sans Pro Italic"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#333333",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 1
-	  }
-	 },
-	 {
-	  "id": "toponyme - courbe glacier maitresse",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_oro_ponc",
-	  "filter": [
-	   "==",
-	   "txt_typo",
-	   "ORO_COURBE_GLACIER"
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-size": 10,
-	   "text-allow-overlap": false,
-	   "text-padding": 30,
-	   "text-rotate": {
-		"type": "identity",
-		"property": "rotation"
-	   },
-	   "text-font": [
-		"Source Sans Pro Italic"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#629FD9",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 1
-	  }
-	 },
-	 {
-	  "id": "toponyme - courbe maitresse",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_oro_ponc",
-	  "filter": [
-	   "==",
-	   "txt_typo",
-	   "ORO_COURBE"
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-size": 10,
-	   "text-allow-overlap": false,
-	   "text-padding": 30,
-	   "text-rotate": {
-		"type": "identity",
-		"property": "rotation"
-	   },
-	   "text-font": [
-		"Source Sans Pro Italic"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#604A2F",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 1
-	  }
-	 },
-	 {
-	  "id": "toponyme - liaison maritime",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_routier_liaison_lin",
-	  "minzoom": 8,
-	  "maxzoom": 18,
-	  "filter": [
-	   "==",
-	   "txt_typo",
-	   "LIAISON_MARITIME"
-	  ],
-	  "layout": {
-	   "symbol-placement": "line",
-	   "text-field": "{texte}",
-	   "text-size": 15,
-	   "text-anchor": "center",
-	   "text-keep-upright": true,
-	   "text-max-angle": 45,
-	   "text-padding": 10,
-	   "text-font": [
-		"Source Sans Pro Italic"
-	   ],
-	   "visibility": "visible"
-	  },
-	  "paint": {
-	   "text-color": "#5792C2",
-	   "text-halo-width": 5,
-	   "text-halo-color": "#AAD5E9"
-	  }
-	 },
-	 {
-	  "id": "toponyme bati station de métro + bati ponctuel metro",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_bati_ponc",
-	  "minzoom": 14,
-	  "filter": [
-	   "all",
-	   [
-		"==",
-		"txt_typo",
-		"TYPO_E_1"
-	   ],
-	   [
-		"==",
-		"symbo",
-		"STATION_METRO"
-	   ]
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-size": 11,
-	   "text-allow-overlap": false,
-	   "text-offset": [
-		0.3,
-		-0.25
-	   ],
-	   "text-padding": 3,
-	   "text-anchor": "bottom-left",
-	   "text-font": [
-		"Source Sans Pro"
-	   ],
-	   "icon-image": "Metro",
-	   "icon-size": {
-		"stops": [
-		 [
-		  15,
-		  0.33
-		 ],
-		 [
-		  17,
-		  0.6
-		 ]
-		]
-	   }
-	  },
-	  "paint": {
-	   "text-color": "#3C3C3C",
-	   "icon-color": "#646464"
-	  }
-	 },
-	 {
-	  "id": "toponyme ferre lineaire",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_ferre_lin",
-	  "minzoom": 12,
-	  "filter": [
-	   "in",
-	   "txt_typo",
-	   "FER_NOM",
-	   "FER_OUVRAGE"
-	  ],
-	  "layout": {
-	   "symbol-placement": "line",
-	   "text-field": "{texte}",
-	   "text-size": 10,
-	   "text-anchor": "center",
-	   "text-offset": [
-		0,
-		-1
-	   ],
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ],
-	   "visibility": "visible"
-	  },
-	  "paint": {
-	   "text-color": "#000000",
-	   "text-halo-width": 1,
-	   "text-halo-color": "rgba(255, 255, 255, 1)"
-	  }
-	 },
-	 {
-	  "id": "toponyme station epuration, de pompage, usine de production eau",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_bati_ponc",
-	  "minzoom": 14,
-	  "filter": [
-	   "==",
-	   "txt_typo",
-	   "station"
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{designation}",
-	   "text-anchor": "left",
-	   "text-offset": [
-		0.8,
-		0
-	   ],
-	   "text-size": 11,
-	   "text-allow-overlap": false,
-	   "text-padding": 1,
-	   "text-font": [
-		"Source Sans Pro Italic"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#447FB3"
-	  }
-	 },
-	 {
-	  "id": "toponyme bati ponc gare",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_bati_ponc",
-	  "minzoom": 15,
-	  "filter": [
-	   "==",
-	   "txt_typo",
-	   "gore"
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{designation}",
-	   "text-size": 11,
-	   "text-allow-overlap": false,
-	   "text-padding": 1,
-	   "text-font": [
-		"Source Sans Pro Italic"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#000000"
-	  }
-	 },
-	 {
-	  "id": "toponyme bati ponc barrage",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_bati_ponc",
-	  "minzoom": 12,
-	  "filter": [
-	   "==",
-	   "txt_typo",
-	   "BARRAGE_PONC"
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-anchor": "left",
-	   "text-offset": [
-		0.8,
-		0
-	   ],
-	   "text-size": 11,
-	   "text-allow-overlap": false,
-	   "text-padding": 1,
-	   "text-font": [
-		"Source Sans Pro"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#447FB3"
-	  }
-	 },
-	 {
-	  "id": "toponyme bati ponc phare - niveau 13",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_bati_ponc",
-	  "maxzoom": 13,
-	  "filter": [
-	   "==",
-	   "txt_typo",
-	   "PHARE"
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-anchor": "right",
-	   "text-size": 11,
-	   "text-allow-overlap": false,
-	   "text-padding": 1,
-	   "text-font": [
-		"Source Sans Pro"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#532A2A"
-	  }
-	 },
-	 {
-	  "id": "toponyme bati ponc phare - niveau 14à19",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_bati_ponc",
-	  "minzoom": 13,
-	  "filter": [
-	   "all",
-	   [
-		"==",
-		"symbo",
-		"PHARE"
-	   ],
-	   [
-		"in",
-		"txt_typo",
-		"TYPO_C_6",
-		"TYPO_C_7",
-		"TYPO_C_8",
-		"TYPO_E_GE"
-	   ]
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-anchor": "right",
-	   "text-size": {
-		"stops": [
-		 [
-		  13,
-		  12
-		 ],
-		 [
-		  18,
-		  18
-		 ]
-		]
-	   },
-	   "text-allow-overlap": false,
-	   "text-offset": [
-		-2,
-		0
-	   ],
-	   "text-padding": 3,
-	   "text-font": [
-		"Source Sans Pro"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#532A2A"
-	  }
-	 },
-	 {
-	  "id": "toponyme bati ponc autre",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_bati_ponc",
-	  "minzoom": 12,
-	  "filter": [
-	   "in",
-	   "txt_typo",
-	   "BAT_ACTIVITE",
-	   "BAT_FORTIF",
-	   "BAT_VILLAGE_DETRUIT"
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-anchor": "center",
-	   "text-size": 11,
-	   "text-allow-overlap": false,
-	   "text-padding": 1,
-	   "text-font": [
-		"Source Sans Pro"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#532A2A"
-	  }
-	 },
-	 {
-	  "id": "toponyme bati ponc aerogare",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_bati_ponc",
-	  "minzoom": 14,
-	  "maxzoom": 17,
-	  "filter": [
-	   "all",
-	   [
-		"==",
-		"txt_typo",
-		"TYPO_E_GE"
-	   ],
-	   [
-		"==",
-		"symbo",
-		"AEROGARE"
-	   ]
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-anchor": "center",
-	   "text-size": {
-		"stops": [
-		 [
-		  12,
-		  9
-		 ],
-		 [
-		  16,
-		  11
-		 ]
-		]
-	   },
-	   "text-allow-overlap": false,
-	   "text-padding": 1,
-	   "text-font": [
-		"Source Sans Pro Italic"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#120049",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 1
-	  }
-	 },
-	 {
-	  "id": "toponyme bati ponc aeroport 12",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_bati_ponc",
-	  "minzoom": 11,
-	  "maxzoom": 12,
-	  "filter": [
-	   "==",
-	   "txt_typo",
-	   "AEROPORT_PONC"
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-anchor": "bottom",
-	   "text-offset": [
-		0,
-		-1.3
-	   ],
-	   "text-size": 10.5,
-	   "text-allow-overlap": false,
-	   "text-padding": 1,
-	   "text-font": [
-		"Source Sans Pro"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#120049",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 2
-	  }
-	 },
-	 {
-	  "id": "toponyme bati ponc aeroport 13",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_bati_ponc",
-	  "minzoom": 12,
-	  "maxzoom": 13,
-	  "filter": [
-	   "==",
-	   "txt_typo",
-	   "AEROPORT_PONC"
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-anchor": "bottom",
-	   "text-offset": [
-		0,
-		-2
-	   ],
-	   "text-size": 11,
-	   "text-allow-overlap": false,
-	   "text-padding": 1,
-	   "text-font": [
-		"Source Sans Pro"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#120049",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 2
-	  }
-	 },
-	 {
-	  "id": "toponyme bati ponc aeroport",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_bati_ponc",
-	  "minzoom": 13,
-	  "maxzoom": 17,
-	  "filter": [
-	   "all",
-	   [
-		"==",
-		"txt_typo",
-		"TYPO_A_5"
-	   ],
-	   [
-		"==",
-		"symbo",
-		"AEROPORT"
-	   ]
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-anchor": "center",
-	   "text-size": {
-		"stops": [
-		 [
-		  12,
-		  11
-		 ],
-		 [
-		  16,
-		  13
-		 ]
-		]
-	   },
-	   "text-allow-overlap": false,
-	   "text-padding": 1,
-	   "text-font": [
-		"Source Sans Pro"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#120049",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 2
-	  }
-	 },
-	 {
-	  "id": "toponyme bati ponc aerodrome 12",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_bati_ponc",
-	  "minzoom": 11,
-	  "maxzoom": 12,
-	  "filter": [
-	   "==",
-	   "txt_typo",
-	   "AERODROME_PONC"
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-anchor": "bottom",
-	   "text-offset": [
-		0,
-		-1.3
-	   ],
-	   "text-size": 9.5,
-	   "text-allow-overlap": false,
-	   "text-padding": 1,
-	   "text-font": [
-		"Source Sans Pro"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#120049",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 2
-	  }
-	 },
-	 {
-	  "id": "toponyme bati ponc aerodrome 13",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_bati_ponc",
-	  "minzoom": 12,
-	  "maxzoom": 13,
-	  "filter": [
-	   "==",
-	   "txt_typo",
-	   "AERODROME_PONC"
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-anchor": "bottom",
-	   "text-offset": [
-		0,
-		-2
-	   ],
-	   "text-size": 10,
-	   "text-allow-overlap": false,
-	   "text-padding": 1,
-	   "text-font": [
-		"Source Sans Pro"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#120049",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 2
-	  }
-	 },
-	 {
-	  "id": "toponyme bati ponc aerodrome",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_bati_ponc",
-	  "minzoom": 13,
-	  "maxzoom": 17,
-	  "filter": [
-	   "all",
-	   [
-		"==",
-		"txt_typo",
-		"TYPO_A_7"
-	   ],
-	   [
-		"==",
-		"symbo",
-		"AERODROME"
-	   ]
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-anchor": "center",
-	   "text-size": {
-		"stops": [
-		 [
-		  12,
-		  10
-		 ],
-		 [
-		  16,
-		  12
-		 ]
-		]
-	   },
-	   "text-allow-overlap": false,
-	   "text-padding": 1,
-	   "text-font": [
-		"Source Sans Pro"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#120049",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 2
-	  }
-	 },
-	 {
-	  "id": "toponyme - hydro ponc 5",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_hydro_ponc",
-	  "filter": [
-	   "in",
-	   "txt_typo",
-	   "TYPO_D_9",
-	   "TYPO_D_10",
-	   "TYPO_E_1_cyan"
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-size": {
-		"stops": [
-		 [
-		  15,
-		  11
-		 ],
-		 [
-		  17,
-		  14
-		 ]
-		]
-	   },
-	   "text-allow-overlap": true,
-	   "text-padding": 5,
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#447FB3",
-	   "text-halo-color": "#FFFFFF",
-	   "text-halo-width": 1
-	  }
-	 },
-	 {
-	  "id": "toponyme - hydro ponc glacier",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_hydro_ponc",
-	  "filter": [
-	   "==",
-	   "txt_typo",
-	   "ORO_GLACIER_2"
-	  ],
-	  "layout": {
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-size": 14,
-	   "text-anchor": "center",
-	   "text-allow-overlap": true,
-	   "text-padding": 1,
-	   "text-font": [
-		"Source Sans Pro Italic"
-	   ],
-	   "visibility": "visible"
-	  },
-	  "paint": {
-	   "text-color": "#447FB3",
-	   "text-halo-width": 2,
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)"
-	  }
-	 },
-	 {
-	  "id": "toponyme - limite militaire ponc 3 et 4",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_limite_ponc",
-	  "filter": [
-	   "in",
-	   "txt_typo",
-	   "LIM_MILI_3",
-	   "LIM_MILI_4"
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-size": 12,
-	   "text-allow-overlap": false,
-	   "text-padding": 2,
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#0D2000",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 1
-	  }
-	 },
-	 {
-	  "id": "toponyme - limite parc ponc 3 et 4",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_limite_ponc",
-	  "filter": [
-	   "in",
-	   "txt_typo",
-	   "LIM_PARC_3",
-	   "LIM_PARC_4",
-	   "RESERVE_NATURELLE_PONC"
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-size": 13,
-	   "text-allow-overlap": false,
-	   "text-padding": 2,
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#287B00",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 1
-	  }
-	 },
-	 {
-	  "id": "toponyme numéro de route - départementale",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_routier_numero_lin",
-	  "minzoom": 11,
-	  "maxzoom": 16,
-	  "filter": [
-	   "==",
-	   "txt_typo",
-	   "Départementale"
-	  ],
-	  "layout": {
-	   "visibility": "none",
-	   "symbol-placement": "line",
-	   "text-field": "{texte}",
-	   "text-size": 10.5,
-	   "text-allow-overlap": false,
-	   "text-padding": 2,
-	   "text-anchor": "center",
-	   "text-font": [
-		"Source Sans Pro Semibold"
-	   ],
-	   "text-rotation-alignment": "viewport"
-	  },
-	  "paint": {
-	   "text-color": "#4D4D4D",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 4
-	  }
-	 },
-	 {
-	  "id": "toponyme numéro de route - nationale",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_routier_numero_lin",
-	  "minzoom": 7,
-	  "maxzoom": 16,
-	  "filter": [
-	   "==",
-	   "txt_typo",
-	   "Nationale"
-	  ],
-	  "layout": {
-	   "visibility": "none",
-	   "symbol-placement": "line",
-	   "text-field": "{texte}",
-	   "text-size": 12,
-	   "text-allow-overlap": false,
-	   "text-padding": 0,
-	   "text-anchor": "center",
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ],
-	   "icon-image": "Ecluse",
-	   "icon-rotation-alignment": "viewport",
-	   "text-rotation-alignment": "viewport",
-	   "icon-text-fit": "both",
-	   "icon-size": 0
-	  },
-	  "paint": {
-	   "text-color": "#F0F0F0",
-	   "icon-color": "#646464",
-	   "text-halo-color": "rgba(80, 80, 80, 0.5)",
-	   "text-halo-width": 4
-	  }
-	 },
-	 {
-	  "id": "toponyme numéro de route - autoroute",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_routier_numero_lin",
-	  "minzoom": 7,
-	  "maxzoom": 16,
-	  "filter": [
-	   "==",
-	   "txt_typo",
-	   "Autoroute"
-	  ],
-	  "layout": {
-	   "visibility": "none",
-	   "symbol-placement": "line",
-	   "text-field": "{texte}",
-	   "text-size": 15,
-	   "text-allow-overlap": false,
-	   "text-padding": 0,
-	   "text-anchor": "center",
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ],
-	   "icon-image": "Ecluse",
-	   "icon-rotation-alignment": "viewport",
-	   "text-rotation-alignment": "viewport",
-	   "icon-text-fit": "both",
-	   "icon-size": 0
-	  },
-	  "paint": {
-	   "text-color": "#F0F0F0",
-	   "icon-color": "#646464",
-	   "text-halo-color": "rgba(80, 80, 80, 0.5)",
-	   "text-halo-width": 5
-	  }
-	 },
-	 {
-	  "id": "toponyme - odonyme abrégé",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_routier_odonyme_lin",
-	  "minzoom": 15,
-	  "maxzoom": 17,
-	  "layout": {
-	   "symbol-placement": "line",
-	   "text-field": "{nom_gauche}",
-	   "text-size": 10,
-	   "text-anchor": "center",
-	   "text-max-angle": 30,
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ],
-	   "visibility": "none"
-	  },
-	  "paint": {
-	   "text-color": "#000000",
-	   "text-halo-width": 2,
-	   "text-halo-color": "rgba(255, 255, 255, 1)"
-	  }
-	 },
-	 {
-	  "id": "toponyme - odonyme desabrégé",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_routier_odonyme_lin",
-	  "minzoom": 17,
-	  "layout": {
-	   "symbol-placement": "line",
-	   "text-field": "{nom_desabrege}",
-	   "text-size": 11,
-	   "text-anchor": "center",
-	   "text-max-angle": 30,
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ],
-	   "visibility": "none"
-	  },
-	  "paint": {
-	   "text-color": "#000000",
-	   "text-halo-width": 2,
-	   "text-halo-color": "rgba(255, 255, 255, 1)"
-	  }
-	 },
-	 {
-	  "id": "toponyme - lieu dit non habité 3",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_ocs_ponc",
-	  "filter": [
-	   "all",
-	   [
-		"==",
-		"symbo",
-		"LIEU-DIT_NON_HABITE"
-	   ],
-	   [
-		"in",
-		"txt_typo",
-		"TYPO_B_10",
-		"TYPO_B_11"
-	   ]
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-size": 11,
-	   "text-allow-overlap": false,
-	   "text-padding": 1,
-	   "text-font": [
-		"Source Sans Pro Italic"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#000000",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 1
-	  }
-	 },
-	 {
-	  "id": "toponyme - bois",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_ocs_ponc",
-	  "filter": [
-	   "all",
-	   [
-		"==",
-		"symbo",
-		"BOIS"
-	   ],
-	   [
-		"in",
-		"txt_typo",
-		"TYPO_F_10",
-		"TYPO_F_11"
-	   ]
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-size": 13,
-	   "text-allow-overlap": false,
-	   "text-padding": 1,
-	   "text-font": [
-		"Source Sans Pro Italic"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#287B00",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 1
-	  }
-	 },
-	 {
-	  "id": "toponyme - oro lineaire 4",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_oro_lin",
-	  "filter": [
-	   "in",
-	   "txt_typo",
-	   "ORO_SOMMET_3",
-	   "ORO_GORGE_2"
-	  ],
-	  "layout": {
-	   "symbol-placement": "line",
-	   "text-field": "{texte}",
-	   "text-size": 11,
-	   "text-anchor": "center",
-	   "text-keep-upright": true,
-	   "text-max-angle": 45,
-	   "text-padding": 1,
-	   "text-font": [
-		"Source Sans Pro Italic"
-	   ],
-	   "visibility": "visible"
-	  },
-	  "paint": {
-	   "text-color": "#863831",
-	   "text-halo-width": 1.5,
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)"
-	  }
-	 },
-	 {
-	  "id": "toponyme - oro ponc 4",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_oro_ponc",
-	  "filter": [
-	   "in",
-	   "txt_typo",
-	   "ORO_SOMMET_3",
-	   "ORO_GORGE_2",
-	   "GROTTE",
-	   "GORGE",
-	   "TYPO_G_9",
-	   "TYPO_G_10"
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-size": {
-		"stops": [
-		 [
-		  13,
-		  11
-		 ],
-		 [
-		  16,
-		  16
-		 ]
-		]
-	   },
-	   "text-allow-overlap": true,
-	   "text-padding": 1,
-	   "text-font": [
-		"Source Sans Pro Italic"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#863831",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 1.5
-	  }
-	 },
-	 {
-	  "id": "toponyme - hydro ponc 4",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_hydro_ponc",
-	  "filter": [
-	   "in",
-	   "txt_typo",
-	   "lac - étang - bassin",
-	   "HYD_SURF_4",
-	   "HYD_SURF_4_T",
-	   "HYD_SURF_5",
-	   "HYD_SURF_5_T",
-	   "TYPO_D_8",
-	   "SOURCE"
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-size": {
-		"stops": [
-		 [
-		  14,
-		  13
-		 ],
-		 [
-		  17,
-		  16
-		 ]
-		]
-	   },
-	   "text-allow-overlap": true,
-	   "text-padding": 5,
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#447FB3",
-	   "text-halo-color": "#FFFFFF",
-	   "text-halo-width": 1
-	  }
-	 },
-	 {
-	  "id": "toponyme quartier ",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_localite_ponc",
-	  "filter": [
-	   "in",
-	   "txt_typo",
-	   "BAT_QUARTIER",
-	   "BAT_QUARTIER_T"
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-size": 11,
-	   "text-allow-overlap": false,
-	   "text-padding": 1,
-	   "text-font": [
-		"Source Sans Pro Italic"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#000000",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 2
-	  }
-	 },
-	 {
-	  "id": "toponyme localite n0 typoA10",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_localite_ponc",
-	  "maxzoom": 18,
-	  "filter": [
-	   "==",
-	   "txt_typo",
-	   "TYPO_A_10"
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-size": {
-		"stops": [
-		 [
-		  15,
-		  11
-		 ],
-		 [
-		  17,
-		  13.5
-		 ]
-		]
-	   },
-	   "text-allow-overlap": true,
-	   "text-anchor": "center",
-	   "text-padding": 1,
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#000000",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 2
-	  }
-	 },
-	 {
-	  "id": "toponyme - lieu dit non habité",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_ocs_ponc",
-	  "filter": [
-	   "all",
-	   [
-		"==",
-		"symbo",
-		"LIEU-DIT_NON_HABITE"
-	   ],
-	   [
-		"in",
-		"txt_typo",
-		"TYPO_B_7",
-		"TYPO_B_8",
-		"TYPO_B_9"
-	   ]
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-size": 12,
-	   "text-allow-overlap": false,
-	   "text-padding": 1,
-	   "text-font": [
-		"Source Sans Pro Italic"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#000000",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 1
-	  }
-	 },
-	 {
-	  "id": "toponyme - bois 2",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_ocs_ponc",
-	  "filter": [
-	   "all",
-	   [
-		"==",
-		"symbo",
-		"BOIS"
-	   ],
-	   [
-		"in",
-		"txt_typo",
-		"TYPO_F_7",
-		"TYPO_F_8",
-		"TYPO_F_9"
-	   ]
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-size": 16,
-	   "text-allow-overlap": false,
-	   "text-padding": 1,
-	   "text-font": [
-		"Source Sans Pro Italic"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#287B00",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 2
-	  }
-	 },
-	 {
-	  "id": "toponyme localite hameau ",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_localite_ponc",
-	  "minzoom": 11,
-	  "maxzoom": 13,
-	  "filter": [
-	   "in",
-	   "txt_typo",
-	   "BAT_HAMEAU",
-	   "BAT_HAMEAU_T"
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "icon-image": "Localite",
-	   "icon-size": 0.17,
-	   "text-field": "{texte}",
-	   "text-size": 11,
-	   "text-allow-overlap": false,
-	   "text-anchor": "bottom-left",
-	   "text-offset": [
-		0.3,
-		0.1
-	   ],
-	   "text-padding": 1,
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#000000",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 2
-	  }
-	 },
-	 {
-	  "id": "toponyme localite importance 5",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_localite_ponc",
-	  "minzoom": 9,
-	  "filter": [
-	   "in",
-	   "txt_typo",
-	   "commune 5",
-	   "BAT_COMMUNE_5",
-	   "BAT_COMMUNE_5_T",
-	   "BAT_CHEF_LIEU_COM",
-	   "BAT_CHEF_LIEU_COM_T",
-	   "BAT_CHEF_LIEU_COM-T",
-	   "BAT_ANCIENNE_COM",
-	   "BAT_ANCIENNE_COM_T",
-	   "BAT_COMMUNE_ASSOCIEE",
-	   "BAT_COMMUNE_ASSOCIEE_T",
-	   "Commune très petite"
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "icon-image": "Localite",
-	   "icon-size": 0.21,
-	   "text-field": "{texte}",
-	   "text-size": 11.5,
-	   "text-allow-overlap": false,
-	   "text-anchor": "bottom-left",
-	   "text-offset": [
-		0.3,
-		0.1
-	   ],
-	   "text-padding": 1,
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#000000",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 2
-	  }
-	 },
-	 {
-	  "id": "toponyme - ocs lineaire 3",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_ocs_lin",
-	  "filter": [
-	   "==",
-	   "txt_typo",
-	   "OCS_FORET_3"
-	  ],
-	  "layout": {
-	   "symbol-placement": "line",
-	   "text-field": "{texte}",
-	   "text-size": {
-		"stops": [
-		 [
-		  10,
-		  12
-		 ],
-		 [
-		  12,
-		  15
-		 ]
-		]
-	   },
-	   "text-anchor": "center",
-	   "text-keep-upright": true,
-	   "text-max-angle": 45,
-	   "text-padding": 1,
-	   "text-font": [
-		"Source Sans Pro Italic"
-	   ],
-	   "visibility": "visible"
-	  },
-	  "paint": {
-	   "text-color": "#287B00",
-	   "text-halo-width": 1,
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)"
-	  }
-	 },
-	 {
-	  "id": "toponyme - lieu dit non habité 1",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_ocs_ponc",
-	  "filter": [
-	   "all",
-	   [
-		"==",
-		"symbo",
-		"LIEU-DIT_NON_HABITE"
-	   ],
-	   [
-		"in",
-		"txt_typo",
-		"TYPO_B_5",
-		"TYPO_B_4"
-	   ]
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-size": 15,
-	   "text-allow-overlap": false,
-	   "text-padding": 1,
-	   "text-font": [
-		"Source Sans Pro Italic"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#000000",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 1
-	  }
-	 },
-	 {
-	  "id": "toponyme - bois 1",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_ocs_ponc",
-	  "filter": [
-	   "all",
-	   [
-		"==",
-		"symbo",
-		"BOIS"
-	   ],
-	   [
-		"in",
-		"txt_typo",
-		"TYPO_F_5",
-		"TYPO_F_4"
-	   ]
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-size": 19,
-	   "text-allow-overlap": false,
-	   "text-padding": 1,
-	   "text-font": [
-		"Source Sans Pro Italic"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#287B00",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 2
-	  }
-	 },
-	 {
-	  "id": "toponyme - bois 0",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_ocs_ponc",
-	  "filter": [
-	   "all",
-	   [
-		"==",
-		"symbo",
-		"BOIS"
-	   ],
-	   [
-		"in",
-		"txt_typo",
-		"TYPO_F_3",
-		"TYPO_F_2"
-	   ]
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-size": 22,
-	   "text-allow-overlap": false,
-	   "text-padding": 1,
-	   "text-font": [
-		"Source Sans Pro Italic"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#287B00",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 2
-	  }
-	 },
-	 {
-	  "id": "toponyme - ocs ponc 3",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_ocs_ponc",
-	  "filter": [
-	   "==",
-	   "txt_typo",
-	   "OCS_FORET_3"
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-size": {
-		"stops": [
-		 [
-		  10,
-		  12
-		 ],
-		 [
-		  12,
-		  15
-		 ]
-		]
-	   },
-	   "text-allow-overlap": false,
-	   "text-padding": 1,
-	   "text-anchor": "center",
-	   "text-font": [
-		"Source Sans Pro Italic"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#287B00",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 1
-	  }
-	 },
-	 {
-	  "id": "toponyme - oro lineaire 3",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_oro_lin",
-	  "filter": [
-	   "in",
-	   "txt_typo",
-	   "ORO_ILE_3",
-	   "ORO_RELIEF_3",
-	   "ORO_RELIEF_3_T",
-	   "ORO_RELIEF_4",
-	   "ORO_RELIEF_4_T",
-	   "ORO_CAP_2",
-	   "ORO_CAP_3",
-	   "ORO_SOMMET_2",
-	   "ORO_COL_2",
-	   "ORO_GORGE_1",
-	   "ORO_GORGE-1"
-	  ],
-	  "layout": {
-	   "symbol-placement": "line",
-	   "text-field": "{texte}",
-	   "text-size": 12,
-	   "text-anchor": "center",
-	   "text-keep-upright": true,
-	   "text-max-angle": 45,
-	   "text-padding": 10,
-	   "text-font": [
-		"Source Sans Pro Italic"
-	   ],
-	   "visibility": "visible"
-	  },
-	  "paint": {
-	   "text-color": "#863831",
-	   "text-halo-width": 1.5,
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)"
-	  }
-	 },
-	 {
-	  "id": "toponyme - oro ponc 3",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_oro_ponc",
-	  "filter": [
-	   "in",
-	   "txt_typo",
-	   "ORO_ILE_3",
-	   "ORO_RELIEF_3",
-	   "ORO_RELIEF_3_T",
-	   "ORO_RELIEF_4",
-	   "ORO_RELIEF_4_T",
-	   "ORO_CAP_2",
-	   "ORO_CAP_3",
-	   "ORO_SOMMET_2",
-	   "ORO_COL_2",
-	   "ORO_GORGE_1",
-	   "ORO_GORGE-1",
-	   "TYPO_G_7",
-	   "TYPO_G_8"
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-size": {
-		"stops": [
-		 [
-		  13,
-		  12
-		 ],
-		 [
-		  16,
-		  17
-		 ]
-		]
-	   },
-	   "text-allow-overlap": true,
-	   "text-padding": 1,
-	   "text-font": [
-		"Source Sans Pro Italic"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#863831",
-	   "text-halo-color": "#FFFFFF",
-	   "text-halo-width": 1.5
-	  }
-	 },
-	 {
-	  "id": "toponyme - hydro lineaire 3",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_hydro_lin",
-	  "filter": [
-	   "in",
-	   "txt_typo",
-	   "HYD_LIN_3",
-	   "HYD_LIN_4",
-	   "HYD_LIN_5",
-	   "petite rivière",
-	   "canal",
-	   "HYD_SURF_3",
-	   "HYD_SURF_3_T",
-	   "HYD_SURF_4",
-	   "HYD_SURF_4_T",
-	   "HYD_SURF_5",
-	   "HYD_SURF_5_T",
-	   "TYPO_D_5"
-	  ],
-	  "layout": {
-	   "symbol-placement": "line",
-	   "text-field": "{texte}",
-	   "text-size": {
-		"stops": [
-		 [
-		  14,
-		  12
-		 ],
-		 [
-		  18,
-		  19
-		 ]
-		]
-	   },
-	   "text-anchor": "center",
-	   "text-keep-upright": true,
-	   "text-max-angle": 45,
-	   "text-padding": 10,
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ],
-	   "visibility": "visible"
-	  },
-	  "paint": {
-	   "text-color": "#447FB3",
-	   "text-halo-width": 1.5,
-	   "text-halo-color": "rgba(255, 255, 255, 0.7)"
-	  }
-	 },
-	 {
-	  "id": "toponyme - hydro lineaire 4",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_hydro_lin",
-	  "minzoom": 14,
-	  "filter": [
-	   "in",
-	   "txt_typo",
-	   "TYPO_D_6",
-	   "TYPO_D_8",
-	   "TYPO_D_9",
-	   "TYPO_D_10"
-	  ],
-	  "layout": {
-	   "symbol-placement": "line",
-	   "text-field": "{texte}",
-	   "text-size": {
-		"stops": [
-		 [
-		  14,
-		  10
-		 ],
-		 [
-		  18,
-		  16
-		 ]
-		]
-	   },
-	   "text-anchor": "center",
-	   "text-keep-upright": true,
-	   "text-max-angle": 45,
-	   "text-padding": 10,
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ],
-	   "visibility": "visible"
-	  },
-	  "paint": {
-	   "text-color": "#447FB3",
-	   "text-halo-width": 1.5,
-	   "text-halo-color": "rgba(255, 255, 255, 0.7)"
-	  }
-	 },
-	 {
-	  "id": "toponyme - hydro ponc 3",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_hydro_ponc",
-	  "filter": [
-	   "in",
-	   "txt_typo",
-	   "petit golfe",
-	   "grande baie",
-	   "baie",
-	   "HYD_SURF_3",
-	   "TYPO_D_5",
-	   "TYPO_D_6",
-	   "TYPO_D_7"
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-size": {
-		"stops": [
-		 [
-		  15,
-		  15
-		 ],
-		 [
-		  17,
-		  18
-		 ]
-		]
-	   },
-	   "text-allow-overlap": true,
-	   "text-padding": 10,
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#447FB3",
-	   "text-halo-color": "#FFFFFF",
-	   "text-halo-width": 2
-	  }
-	 },
-	 {
-	  "id": "toponyme bati ponc zai zoom 16",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_bati_ponc",
-	  "minzoom": 15,
-	  "maxzoom": 16,
-	  "filter": [
-	   "==",
-	   "txt_typo",
-	   "zai"
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{designation}",
-	   "text-size": 11,
-	   "text-allow-overlap": false,
-	   "text-padding": 1,
-	   "text-font": [
-		"Source Sans Pro Italic"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#000000"
-	  }
-	 },
-	 {
-	  "id": "toponyme bati ponc zai zoom 17 et 18",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_bati_ponc",
-	  "minzoom": 16,
-	  "filter": [
-	   "==",
-	   "txt_typo",
-	   "zai"
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-size": 11,
-	   "text-allow-overlap": false,
-	   "text-padding": 1,
-	   "text-font": [
-		"Source Sans Pro Italic"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#000000"
-	  }
-	 },
-	 {
-	  "id": "toponyme localite importance 4",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_localite_ponc",
-	  "minzoom": 7,
-	  "filter": [
-	   "in",
-	   "txt_typo",
-	   "commune 4",
-	   "BAT_COMMUNE_4",
-	   "BAT_COMMUNE_4_T"
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "icon-image": "Localite",
-	   "icon-size": 0.21,
-	   "text-field": "{texte}",
-	   "text-size": 13,
-	   "text-allow-overlap": false,
-	   "text-anchor": "bottom-left",
-	   "text-offset": [
-		0.3,
-		0.1
-	   ],
-	   "text-padding": 1,
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#000000",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 2
-	  }
-	 },
-	 {
-	  "id": "toponyme localite n0 typoA9",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_localite_ponc",
-	  "maxzoom": 18,
-	  "filter": [
-	   "==",
-	   "txt_typo",
-	   "TYPO_A_9"
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-size": {
-		"stops": [
-		 [
-		  15,
-		  11.5
-		 ],
-		 [
-		  17,
-		  14
-		 ]
-		]
-	   },
-	   "text-allow-overlap": true,
-	   "text-anchor": "center",
-	   "text-padding": 1,
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#000000",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 2
-	  }
-	 },
-	 {
-	  "id": "toponyme localite n0 typoA8",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_localite_ponc",
-	  "maxzoom": 18,
-	  "filter": [
-	   "==",
-	   "txt_typo",
-	   "TYPO_A_8"
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-size": {
-		"stops": [
-		 [
-		  15,
-		  12
-		 ],
-		 [
-		  17,
-		  15
-		 ]
-		]
-	   },
-	   "text-allow-overlap": true,
-	   "text-anchor": "center",
-	   "text-padding": 1,
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#000000",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 2
-	  }
-	 },
-	 {
-	  "id": "toponyme - limite militaire ponc 1 et 2",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_limite_ponc",
-	  "filter": [
-	   "in",
-	   "txt_typo",
-	   "LIM_MILI_1",
-	   "LIM_MILI_2"
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-size": 15,
-	   "text-allow-overlap": false,
-	   "text-padding": 5,
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#0D2000",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 2
-	  }
-	 },
-	 {
-	  "id": "toponyme - limite parc marin",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_limite_ponc",
-	  "minzoom": 8,
-	  "filter": [
-	   "==",
-	   "txt_typo",
-	   "LIM_PARC_NATUREL_MARIN"
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-size": 15,
-	   "text-allow-overlap": false,
-	   "text-padding": 10,
-	   "text-transform": "uppercase",
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#2A81A2",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 2
-	  }
-	 },
-	 {
-	  "id": "toponyme - limite parc ponc 1 et 2",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_limite_ponc",
-	  "minzoom": 8,
-	  "filter": [
-	   "in",
-	   "txt_typo",
-	   "LIM_PARC_1",
-	   "LIM_PARC_2",
-	   "LIM_PARC_NATUREL"
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-size": 15,
-	   "text-allow-overlap": false,
-	   "text-padding": 10,
-	   "text-transform": "uppercase",
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#287B00",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 2
-	  }
-	 },
-	 {
-	  "id": "toponyme - ocs lineaire 2",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_ocs_lin",
-	  "filter": [
-	   "==",
-	   "txt_typo",
-	   "OCS_FORET_2"
-	  ],
-	  "layout": {
-	   "symbol-placement": "line",
-	   "text-field": "{texte}",
-	   "text-size": {
-		"stops": [
-		 [
-		  10,
-		  15
-		 ],
-		 [
-		  12,
-		  18
-		 ]
-		]
-	   },
-	   "text-anchor": "center",
-	   "text-keep-upright": true,
-	   "text-max-angle": 45,
-	   "text-padding": 1,
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ],
-	   "visibility": "visible"
-	  },
-	  "paint": {
-	   "text-color": "#287B00",
-	   "text-halo-width": 2,
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)"
-	  }
-	 },
-	 {
-	  "id": "toponyme - ocs ponc 2",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_ocs_ponc",
-	  "filter": [
-	   "==",
-	   "txt_typo",
-	   "OCS_FORET_2"
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-size": {
-		"stops": [
-		 [
-		  10,
-		  15
-		 ],
-		 [
-		  12,
-		  18
-		 ]
-		]
-	   },
-	   "text-allow-overlap": false,
-	   "text-padding": 1,
-	   "text-anchor": "center",
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#287B00",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 2
-	  }
-	 },
-	 {
-	  "id": "toponyme - oro lineaire 2",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_oro_lin",
-	  "filter": [
-	   "in",
-	   "txt_typo",
-	   "ORO_ILE_2",
-	   "ORO_RELIEF_2",
-	   "ORO_RELIEF_2_T",
-	   "ORO_CAP_1",
-	   "ORO_SOMMET_1"
-	  ],
-	  "layout": {
-	   "symbol-placement": "line",
-	   "text-field": "{texte}",
-	   "text-size": 15,
-	   "text-anchor": "center",
-	   "text-keep-upright": true,
-	   "text-padding": 10,
-	   "text-max-angle": 45,
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ],
-	   "visibility": "visible"
-	  },
-	  "paint": {
-	   "text-color": "#863831",
-	   "text-halo-width": 2,
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)"
-	  }
-	 },
-	 {
-	  "id": "toponyme - oro ponc 2",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_oro_ponc",
-	  "minzoom": 9,
-	  "filter": [
-	   "in",
-	   "txt_typo",
-	   "ORO_ILE_2",
-	   "ORO_RELIEF_2",
-	   "ORO_RELIEF_2_T",
-	   "ORO_CAP_1",
-	   "ORO_COL_1",
-	   "sommet ou col",
-	   "ORO_SOMMET_1",
-	   "TYPO_G_4",
-	   "TYPO_G_6"
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-size": {
-		"stops": [
-		 [
-		  9,
-		  13
-		 ],
-		 [
-		  10,
-		  15
-		 ],
-		 [
-		  13,
-		  15
-		 ],
-		 [
-		  16,
-		  19
-		 ]
-		]
-	   },
-	   "text-allow-overlap": false,
-	   "text-padding": 1,
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#863831",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 2
-	  }
-	 },
-	 {
-	  "id": "toponyme - oro ponc 2B",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_oro_ponc",
-	  "minzoom": 8,
-	  "filter": [
-	   "in",
-	   "txt_typo",
-	   "île",
-	   "cap ou pointe"
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-size": 15,
-	   "text-allow-overlap": false,
-	   "text-padding": 1,
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#863831",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 2
-	  }
-	 },
-	 {
-	  "id": "toponyme - hydro lineaire 2",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_hydro_lin",
-	  "filter": [
-	   "in",
-	   "txt_typo",
-	   "HYD_LIN_2",
-	   "rivière moyenne",
-	   "HYD_SURF_2",
-	   "HYD_SURF_2_T",
-	   "TYPO_D_3"
-	  ],
-	  "layout": {
-	   "symbol-placement": "line",
-	   "text-field": "{texte}",
-	   "text-size": {
-		"stops": [
-		 [
-		  14,
-		  15
-		 ],
-		 [
-		  18,
-		  21
-		 ]
-		]
-	   },
-	   "text-anchor": "center",
-	   "text-keep-upright": true,
-	   "text-max-angle": 45,
-	   "text-padding": 10,
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ],
-	   "visibility": "visible"
-	  },
-	  "paint": {
-	   "text-color": "#447FB3",
-	   "text-halo-width": 2,
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)"
-	  }
-	 },
-	 {
-	  "id": "toponyme - hydro ponc 2",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_hydro_ponc",
-	  "minzoom": 5,
-	  "filter": [
-	   "in",
-	   "txt_typo",
-	   "moyen",
-	   "golfe moyen",
-	   "HYD_SURF_2",
-	   "TYPO_D_2",
-	   "TYPO_D_3",
-	   "TYPO_D_4"
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-size": {
-		"stops": [
-		 [
-		  5,
-		  12
-		 ],
-		 [
-		  6,
-		  18
-		 ],
-		 [
-		  10,
-		  17
-		 ],
-		 [
-		  18,
-		  21
-		 ]
-		]
-	   },
-	   "text-allow-overlap": false,
-	   "text-padding": 10,
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#447FB3",
-	   "text-halo-color": "#FFFFFF",
-	   "text-halo-width": 2
-	  }
-	 },
-	 {
-	  "id": "toponyme localite importance 3",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_localite_ponc",
-	  "minzoom": 5,
-	  "filter": [
-	   "in",
-	   "txt_typo",
-	   "commune 3",
-	   "BAT_COMMUNE_3",
-	   "BAT_COMMUNE_3_T"
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "icon-image": "Localite",
-	   "icon-size": 0.21,
-	   "text-field": "{texte}",
-	   "text-size": {
-		"stops": [
-		 [
-		  5,
-		  10
-		 ],
-		 [
-		  6,
-		  15
-		 ]
-		]
-	   },
-	   "text-allow-overlap": false,
-	   "text-anchor": "bottom-left",
-	   "text-offset": [
-		0.3,
-		0.1
-	   ],
-	   "text-padding": 1,
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#000000",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 2
-	  }
-	 },
-	 {
-	  "id": "toponyme localite n0 typoA7 non commune",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_localite_ponc",
-	  "maxzoom": 18,
-	  "filter": [
-	   "all",
-	   [
-		"!=",
-		"symbo",
-		"COMMUNE_FUSIONNEE"
-	   ],
-	   [
-		"!=",
-		"symbo",
-		"COMMUNE_CHEF_LIEU"
-	   ],
-	   [
-		"==",
-		"txt_typo",
-		"TYPO_A_7"
-	   ]
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-size": {
-		"stops": [
-		 [
-		  15,
-		  13
-		 ],
-		 [
-		  17,
-		  16
-		 ]
-		]
-	   },
-	   "text-allow-overlap": true,
-	   "text-anchor": "center",
-	   "text-padding": 1,
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#000000",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 2
-	  }
-	 },
-	 {
-	  "id": "toponyme localite n0 typoA6 non commune",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_localite_ponc",
-	  "maxzoom": 18,
-	  "filter": [
-	   "all",
-	   [
-		"!=",
-		"symbo",
-		"COMMUNE_FUSIONNEE"
-	   ],
-	   [
-		"!=",
-		"symbo",
-		"COMMUNE_CHEF_LIEU"
-	   ],
-	   [
-		"==",
-		"txt_typo",
-		"TYPO_A_6"
-	   ]
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-size": {
-		"stops": [
-		 [
-		  15,
-		  15
-		 ],
-		 [
-		  17,
-		  18
-		 ]
-		]
-	   },
-	   "text-allow-overlap": true,
-	   "text-anchor": "center",
-	   "text-padding": 1,
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#000000",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 2
-	  }
-	 },
-	 {
-	  "id": "toponyme - oro lineaire 1",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_oro_lin",
-	  "filter": [
-	   "in",
-	   "txt_typo",
-	   "ORO_ILE_1",
-	   "ORO_RELIEF_1",
-	   "ORO_RELIEF_1_T"
-	  ],
-	  "layout": {
-	   "symbol-placement": "line",
-	   "text-field": "{texte}",
-	   "text-size": 20,
-	   "text-anchor": "center",
-	   "text-keep-upright": true,
-	   "text-padding": 5,
-	   "text-max-angle": 45,
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ],
-	   "visibility": "visible"
-	  },
-	  "paint": {
-	   "text-color": "#863831",
-	   "text-halo-width": 2,
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)"
-	  }
-	 },
-	 {
-	  "id": "toponyme - oro ponc monde",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_oro_ponc",
-	  "minzoom": 5,
-	  "filter": [
-	   "in",
-	   "txt_typo",
-	   "Basin",
-	   "Depression",
-	   "Desert",
-	   "Geoarea",
-	   "Gorge",
-	   "Isthmus",
-	   "Lake",
-	   "Lowland",
-	   "Pen/cape",
-	   "Plain",
-	   "Plateau",
-	   "Range/mtn",
-	   "Tundra",
-	   "Valley",
-	   "Island",
-	   "Island group"
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-size": 11,
-	   "text-allow-overlap": false,
-	   "text-padding": 1,
-	   "text-font": [
-		"Source Sans Pro Italic"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#863831",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 2
-	  }
-	 },
-	 {
-	  "id": "toponyme localite n0 typoA4 non commune",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_localite_ponc",
-	  "maxzoom": 16,
-	  "filter": [
-	   "all",
-	   [
-		"!=",
-		"symbo",
-		"COMMUNE_FUSIONNEE"
-	   ],
-	   [
-		"!=",
-		"symbo",
-		"COMMUNE_CHEF_LIEU"
-	   ],
-	   [
-		"==",
-		"txt_typo",
-		"TYPO_A_4"
-	   ]
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-size": 17,
-	   "text-allow-overlap": true,
-	   "text-anchor": "center",
-	   "text-padding": 1,
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#000000",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 3
-	  }
-	 },
-	 {
-	  "id": "toponyme - ocs lineaire 1",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_ocs_lin",
-	  "filter": [
-	   "==",
-	   "txt_typo",
-	   "OCS_FORET_1"
-	  ],
-	  "layout": {
-	   "symbol-placement": "line",
-	   "text-field": "{texte}",
-	   "text-size": {
-		"stops": [
-		 [
-		  10,
-		  18
-		 ],
-		 [
-		  12,
-		  22
-		 ]
-		]
-	   },
-	   "text-anchor": "center",
-	   "text-keep-upright": true,
-	   "text-padding": 1,
-	   "text-max-angle": 45,
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ],
-	   "visibility": "visible"
-	  },
-	  "paint": {
-	   "text-color": "#287B00",
-	   "text-halo-width": 2,
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)"
-	  }
-	 },
-	 {
-	  "id": "toponyme - ocs ponc 1",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_ocs_ponc",
-	  "filter": [
-	   "==",
-	   "txt_typo",
-	   "OCS_FORET_1"
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-size": {
-		"stops": [
-		 [
-		  10,
-		  18
-		 ],
-		 [
-		  12,
-		  22
-		 ]
-		]
-	   },
-	   "text-allow-overlap": true,
-	   "text-padding": 1,
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#287B00",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 2
-	  }
-	 },
-	 {
-	  "id": "toponyme - oro ponc 1",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_oro_ponc",
-	  "minzoom": 8,
-	  "filter": [
-	   "in",
-	   "txt_typo",
-	   "grande île",
-	   "ORO_ILE_1",
-	   "ORO_RELIEF_1",
-	   "ORO_RELIEF_1_T",
-	   "TYPO_G_3",
-	   "TYPO_G_2",
-	   "TYPO_G_1"
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-size": 21,
-	   "text-allow-overlap": true,
-	   "text-padding": 1,
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#863831",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 2
-	  }
-	 },
-	 {
-	  "id": "toponyme - hydro lineaire glacier",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_hydro_lin",
-	  "filter": [
-	   "in",
-	   "txt_typo",
-	   "ORO_GLACIER_1",
-	   "ORO_GLACIER_2"
-	  ],
-	  "layout": {
-	   "symbol-placement": "line",
-	   "text-field": "{texte}",
-	   "text-size": 15,
-	   "text-anchor": "center",
-	   "text-keep-upright": true,
-	   "text-max-angle": 45,
-	   "text-font": [
-		"Source Sans Pro Italic"
-	   ],
-	   "visibility": "visible"
-	  },
-	  "paint": {
-	   "text-color": "#447FB3",
-	   "text-halo-width": 2,
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)"
-	  }
-	 },
-	 {
-	  "id": "toponyme - hydro lineaire 1",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_hydro_lin",
-	  "filter": [
-	   "in",
-	   "txt_typo",
-	   "HYD_LIN_1",
-	   "HYD-LIN-1",
-	   "grande rivière",
-	   "HYD_SURF_1",
-	   "HYD_SURF_1_T",
-	   "TYPO_D_1",
-	   "TYPO_D_2"
-	  ],
-	  "layout": {
-	   "symbol-placement": "line",
-	   "text-field": "{texte}",
-	   "text-size": 18,
-	   "text-anchor": "center",
-	   "text-keep-upright": true,
-	   "text-max-angle": 45,
-	   "text-padding": 10,
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ],
-	   "visibility": "visible"
-	  },
-	  "paint": {
-	   "text-color": "#447FB3",
-	   "text-halo-width": 2,
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)"
-	  }
-	 },
-	 {
-	  "id": "toponyme - hydro lineaire ocean",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_hydro_lin",
-	  "filter": [
-	   "==",
-	   "txt_typo",
-	   "mer et océan"
-	  ],
-	  "layout": {
-	   "symbol-placement": "line",
-	   "text-field": "{texte}",
-	   "text-size": 30,
-	   "text-anchor": "center",
-	   "text-keep-upright": true,
-	   "text-max-angle": 45,
-	   "text-padding": 10,
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ],
-	   "visibility": "visible"
-	  },
-	  "paint": {
-	   "text-color": "#447FB3",
-	   "text-halo-width": 4,
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)"
-	  }
-	 },
-	 {
-	  "id": "toponyme - hydro ponc 1",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_hydro_ponc",
-	  "minzoom": 4,
-	  "filter": [
-	   "in",
-	   "txt_typo",
-	   "mer",
-	   "grand",
-	   "grand golfe",
-	   "HYD_SURF_1",
-	   "TYPO_D_1"
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-size": {
-		"stops": [
-		 [
-		  4,
-		  16
-		 ],
-		 [
-		  6,
-		  30
-		 ],
-		 [
-		  10,
-		  25
-		 ]
-		]
-	   },
-	   "text-allow-overlap": true,
-	   "text-padding": 10,
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#447FB3",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 4
-	  }
-	 },
-	 {
-	  "id": "toponyme localite importance 2",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_localite_ponc",
-	  "minzoom": 4,
-	  "filter": [
-	   "in",
-	   "txt_typo",
-	   "commune 2",
-	   "BAT_COMMUNE_2",
-	   "BAT_COMMUNE-2",
-	   "BAT_COMMUNE_2_T"
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "icon-image": "Localite",
-	   "icon-size": 0.25,
-	   "text-field": "{texte}",
-	   "text-size": {
-		"stops": [
-		 [
-		  4,
-		  10
-		 ],
-		 [
-		  6,
-		  17
-		 ]
-		]
-	   },
-	   "text-allow-overlap": true,
-	   "text-anchor": "bottom-left",
-	   "text-offset": [
-		0.3,
-		0.2
-	   ],
-	   "text-padding": 1,
-	   "text-transform": "uppercase",
-	   "text-font": {
-		"stops": [
-		 [
-		  1,
+		{
+		 "id": "bckgrd",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "fond_opaque",
+		 "minzoom": 0,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "paint": {
+		  "fill-color": "#FFFFFF",
+		  "fill-opacity": 1
+		 }
+		},
+		{
+		 "id": "orographie : relief - 0m",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "oro_relief",
+		 "minzoom": 0,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "HYPSO_0"
+		 ],
+		 "paint": {
+		  "fill-color": "#D6E5BA",
+		  "fill-opacity": 1
+		 }
+		},
+		{
+		 "id": "orographie : relief - 100m",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "oro_relief",
+		 "minzoom": 0,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "HYPSO_100"
+		 ],
+		 "paint": {
+		  "fill-color": "#F7F2DA",
+		  "fill-opacity": 1
+		 }
+		},
+		{
+		 "id": "orographie : relief - 200m",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "oro_relief",
+		 "minzoom": 0,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "HYPSO_200"
+		 ],
+		 "paint": {
+		  "fill-color": "#EBDEBF",
+		  "fill-opacity": 1
+		 }
+		},
+		{
+		 "id": "orographie : relief - 1000m",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "oro_relief",
+		 "minzoom": 0,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "HYPSO_1000"
+		 ],
+		 "paint": {
+		  "fill-color": "#DABE97",
+		  "fill-opacity": 1
+		 }
+		},
+		{
+		 "id": "orographie : relief - 3000m",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "oro_relief",
+		 "minzoom": 0,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "HYPSO_3000"
+		 ],
+		 "paint": {
+		  "fill-color": "#B28773",
+		  "fill-opacity": 1
+		 }
+		},
+		{
+		 "id": "orographie : relief - 4000m",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "oro_relief",
+		 "minzoom": 0,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "HYPSO_4000"
+		 ],
+		 "paint": {
+		  "fill-color": "#9E6A54",
+		  "fill-opacity": 1
+		 }
+		},
+		{
+		 "id": "orographie : relief - 5000m",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "oro_relief",
+		 "minzoom": 0,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "HYPSO_5000"
+		 ],
+		 "paint": {
+		  "fill-color": "#773A2B",
+		  "fill-opacity": 1
+		 }
+		},
+		{
+		 "id": "orographie : relief - glacier",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "oro_relief",
+		 "minzoom": 0,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "GLACIER"
+		 ],
+		 "paint": {
+		  "fill-color": "#FFFFFF",
+		  "fill-opacity": 0.7
+		 }
+		},
+		{
+		 "id": "ocs - vegetation - zone boiséee, foret fermee, peupleraie",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "ocs_vegetation_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "ZONE_BOISEE",
+		  "ZONE_FORET_FERMEE_FEUIL",
+		  "ZONE_FORET_FERMEE_CONI",
+		  "ZONE_FORET_FERMEE_MIXTE",
+		  "ZONE_PEUPLERAIE"
+		 ],
+		 "paint": {
+		  "fill-color": "#DFE8D5",
+		  "fill-outline-color": "#DFE8D5"
+		 }
+		},
+		{
+		 "id": "ocs - vegetation - forêt ouverte",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "ocs_vegetation_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "ZONE_FORET_OUVERTE"
+		 ],
+		 "paint": {
+		  "fill-color": "#EDF2D9",
+		  "fill-outline-color": "#EDF2D9"
+		 }
+		},
+		{
+		 "id": "ocs - vegetation - lande ligneuse",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "ocs_vegetation_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "ZONE_LANDE_LIGNEUSE"
+		 ],
+		 "paint": {
+		  "fill-color": "#F2EECD"
+		 }
+		},
+		{
+		 "id": "ocs - vegetation - vigne",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "ocs_vegetation_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "ZONE_VIGNE"
+		 ],
+		 "paint": {
+		  "fill-color": "#FFEDD9"
+		 }
+		},
+		{
+		 "id": "ocs - vegetation - verger",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "ocs_vegetation_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "ZONE_VERGER"
+		 ],
+		 "paint": {
+		  "fill-color": "#FAE2C5"
+		 }
+		},
+		{
+		 "id": "ocs - vegetation - canne à sucre, bananeraie",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "ocs_vegetation_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "ZONE_CANNE_BANANE"
+		 ],
+		 "paint": {
+		  "fill-color": "#FAEDFA"
+		 }
+		},
+		{
+		 "id": "hydro surfacique - Estran",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "hydro_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "ZONE_D_ESTRAN"
+		 ],
+		 "paint": {
+		  "fill-color": "#C3DDE9",
+		  "fill-outline-color": "#C3DDE9"
+		 }
+		},
+		{
+		 "id": "ocs - vegetation - mangrovre",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "ocs_vegetation_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "ZONE_MANGROVE"
+		 ],
+		 "paint": {
+		  "fill-color": {
+		   "stops": [
+			[
+			 9,
+			 "#85CCCB"
+			],
+			[
+			 10,
+			 "#90CCCB"
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "ocs - vegetation - marais",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "ocs_vegetation_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "ZONE_MARAIS"
+		 ],
+		 "paint": {
+		  "fill-pattern": "Marais"
+		 }
+		},
+		{
+		 "id": "ocs - vegetation - marais salant",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "ocs_vegetation_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "ZONE_MARAIS_SALANT"
+		 ],
+		 "paint": {
+		  "fill-pattern": "MaraisSalant"
+		 }
+		},
+		{
+		 "id": "ocs - Zone",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "ocs_nature_sol_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "ZONE_ROCHEUSE"
+		 ],
+		 "paint": {
+		  "fill-color": "#D0D0D0",
+		  "fill-opacity": 0.3
+		 }
+		},
+		{
+		 "id": "ocs - Zone sable sec",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "ocs_nature_sol_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "ZONE_SABLE_SEC"
+		 ],
+		 "paint": {
+		  "fill-pattern": "Sable"
+		 }
+		},
+		{
+		 "id": "ocs - Zone sable humide",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "ocs_nature_sol_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "ZONE_SABLE_HUMIDE",
+		  "FOND_CUVETTE_HUMIDE"
+		 ],
+		 "paint": {
+		  "fill-pattern": "SableHumide"
+		 }
+		},
+		{
+		 "id": "ocs - Zone graviers galets secs",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "ocs_nature_sol_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "GRAVIERS_GALETS_SEC"
+		 ],
+		 "paint": {
+		  "fill-pattern": "GravierSec"
+		 }
+		},
+		{
+		 "id": "ocs - Zone graviers galets humides",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "ocs_nature_sol_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "GRAVIERS_GALETS_HUM"
+		 ],
+		 "paint": {
+		  "fill-pattern": "Gravier"
+		 }
+		},
+		{
+		 "id": "ocs - Zone rocher hydro",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "ocs_nature_sol_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "ZONE_ROCHER_HYDRO"
+		 ],
+		 "paint": {
+		  "fill-pattern": "RocherHydro"
+		 }
+		},
+		{
+		 "id": "ocs - Zone glacier",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "ocs_nature_sol_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "ZONE_GLACIER"
+		 ],
+		 "paint": {
+		  "fill-pattern": "Glacier",
+		  "fill-opacity": {
+		   "stops": [
+			[
+			 10,
+			 0.5
+			],
+			[
+			 12,
+			 0.3
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "zone batie",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_zone_surf",
+		 "minzoom": 7,
+		 "maxzoom": 15,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "ZONE_BATI"
+		 ],
+		 "paint": {
+		  "fill-color": "#E8E2D1",
+		  "fill-opacity": {
+		   "stops": [
+			[
+			 12,
+			 1
+			],
+			[
+			 13,
+			 0.9
+			],
+			[
+			 14,
+			 0.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "zone d'activité",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_zone_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "ZONE_INDUS_ACTI"
+		 ],
+		 "paint": {
+		  "fill-color": "#D9D9D9"
+		 }
+		},
+		{
+		 "id": "oro - courbe et cuvette maitresse",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "oro_courbe",
+		 "maxzoom": 16,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "CNV_MAITRESSE",
+		  "CUVETTE_MAITRESSE"
+		 ],
+		 "paint": {
+		  "line-color": "#D9C8A9",
+		  "line-width": {
+		   "stops": [
+			[
+			 13,
+			 1.7
+			],
+			[
+			 15,
+			 2
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "oro - courbe et cuvette normale",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "oro_courbe",
+		 "maxzoom": 16,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "CNV_NORMALE",
+		  "CUVETTE_NORMALE"
+		 ],
+		 "paint": {
+		  "line-color": "#D9C8A9",
+		  "line-width": {
+		   "stops": [
+			[
+			 13,
+			 1
+			],
+			[
+			 15,
+			 1.2
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "oro - courbe et cuvette intercalaire",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "oro_courbe",
+		 "maxzoom": 16,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "CNV_INTERCALAIRE",
+		  "CUVETTE_INTERCAL",
+		  "CNV_SS_INTERCALAIRE"
+		 ],
+		 "paint": {
+		  "line-color": "#D9C8A9",
+		  "line-width": 0.7,
+		  "line-dasharray": [
+		   20,
+		   7
+		  ]
+		 }
+		},
+		{
+		 "id": "oro - courbe et cuvette glacier maitresse",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "oro_courbe",
+		 "maxzoom": 16,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "CNV_GLACIER_MAITRESSE",
+		  "CUV_GLACIER_MAITRESSE"
+		 ],
+		 "paint": {
+		  "line-color": "#A4BFD9",
+		  "line-width": {
+		   "stops": [
+			[
+			 13,
+			 1.7
+			],
+			[
+			 15,
+			 2
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "oro - courbe et cuvette glacier normale",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "oro_courbe",
+		 "maxzoom": 16,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "CNV_GLACIER_NORMALE",
+		  "CUV_GLACIER_NORMALE"
+		 ],
+		 "paint": {
+		  "line-color": "#A4BFD9",
+		  "line-width": {
+		   "stops": [
+			[
+			 13,
+			 1
+			],
+			[
+			 15,
+			 1.2
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "oro - courbe et cuvette glacier intercalaire",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "oro_courbe",
+		 "maxzoom": 16,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "CNV_GLACIER_INTERCAL",
+		  "CUV_GLACIER_INTERCAL"
+		 ],
+		 "paint": {
+		  "line-color": "#A4BFD9",
+		  "line-width": {
+		   "stops": [
+			[
+			 13,
+			 0.7
+			],
+			[
+			 15,
+			 0.9
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   20,
+		   7
+		  ]
+		 }
+		},
+		{
+		 "id": "oro - courbe et cuvette rocher maitresse",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "oro_courbe",
+		 "maxzoom": 16,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "CNV_ROCHER_MAITRESSE",
+		  "CUV_ROCHER_MAITRESSE"
+		 ],
+		 "paint": {
+		  "line-color": "#AAAAAA",
+		  "line-width": 1.7
+		 }
+		},
+		{
+		 "id": "oro - courbe et cuvette rocher normale",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "oro_courbe",
+		 "maxzoom": 16,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "CNV_ROCHER_NORMALE",
+		  "CUV_ROCHER_NORMALE"
+		 ],
+		 "paint": {
+		  "line-color": "#AAAAAA",
+		  "line-width": 1
+		 }
+		},
+		{
+		 "id": "oro - courbe et cuvette rocher intercalaire",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "oro_courbe",
+		 "maxzoom": 16,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "CNV_ROCHER_INTERCAL",
+		  "CUV_ROCHER_INTERCAL"
+		 ],
+		 "paint": {
+		  "line-color": "#AAAAAA",
+		  "line-width": {
+		   "stops": [
+			[
+			 13,
+			 0.7
+			],
+			[
+			 15,
+			 0.9
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   20,
+		   7
+		  ]
+		 }
+		},
+		{
+		 "id": "oro - courbe et cuvette bathymetrique",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "oro_courbe",
+		 "maxzoom": 16,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "CNV_BATHYMETRIQUE",
+		  "CUV_BATHYMETRIQUE"
+		 ],
+		 "paint": {
+		  "line-color": "#0000FF",
+		  "line-width": 1
+		 }
+		},
+		{
+		 "id": "oro lin - talus",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "oro_lin",
+		 "minzoom": 14,
+		 "maxzoom": 18,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "TALUS"
+		 ],
+		 "paint": {
+		  "line-color": "#D9C8A9",
+		  "line-width": 1
+		 }
+		},
+		{
+		 "id": "oro lin - talus - trait perpendiculaire",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "oro_lin",
+		 "minzoom": 14,
+		 "maxzoom": 18,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "TALUS"
+		 ],
+		 "paint": {
+		  "line-color": "#D9C8A9",
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 7
+			],
+			[
+			 16,
+			 9
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   0.1,
+		   1
+		  ],
+		  "line-translate": [
+		   0,
+		   4
+		  ]
+		 }
+		},
+		{
+		 "id": "toponyme - cote de courbe normale",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "oro_courbe",
+		 "minzoom": 13,
+		 "maxzoom": 16,
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 13,
+			 10
+			],
+			[
+			 15,
+			 13
+			]
+		   ]
+		  },
+		  "text-anchor": "center",
+		  "text-rotation-alignment": "map",
+		  "text-pitch-alignment": "viewport",
+		  "text-keep-upright": false,
+		  "text-max-angle": 20,
+		  "text-max-width": 100,
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ],
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "all",
 		  [
-		   "Source Sans Pro Regular"
+		   "!=",
+		   "texte",
+		   "0"
+		  ],
+		  [
+		   "==",
+		   "hors_zone",
+		   "true"
+		  ],
+		  [
+		   "in",
+		   "symbo",
+		   "CNV_MAITRESSE",
+		   "CUVETTE_MAITRESSE"
 		  ]
 		 ],
-		 [
-		  7,
+		 "paint": {
+		  "text-color": "#604A2F",
+		  "text-halo-width": 0.5,
+		  "text-halo-color": "#FFFFFF"
+		 }
+		},
+		{
+		 "id": "toponyme - cote de courbe rocher",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "oro_courbe",
+		 "minzoom": 13,
+		 "maxzoom": 16,
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 13,
+			 10
+			],
+			[
+			 15,
+			 13
+			]
+		   ]
+		  },
+		  "text-anchor": "center",
+		  "text-rotation-alignment": "map",
+		  "text-pitch-alignment": "viewport",
+		  "text-keep-upright": false,
+		  "text-max-angle": 20,
+		  "text-max-width": 100,
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ],
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "all",
 		  [
+		   "!=",
+		   "texte",
+		   "0"
+		  ],
+		  [
+		   "==",
+		   "hors_zone",
+		   "true"
+		  ],
+		  [
+		   "in",
+		   "symbo",
+		   "CNV_ROCHER_MAITRESSE",
+		   "CUV_ROCHER_MAITRESSE"
+		  ]
+		 ],
+		 "paint": {
+		  "text-color": "#333333",
+		  "text-halo-width": 0.5,
+		  "text-halo-color": "#FFFFFF"
+		 }
+		},
+		{
+		 "id": "toponyme - cote de courbe glacier",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "oro_courbe",
+		 "minzoom": 13,
+		 "maxzoom": 16,
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 13,
+			 10
+			],
+			[
+			 15,
+			 13
+			]
+		   ]
+		  },
+		  "text-anchor": "center",
+		  "text-rotation-alignment": "map",
+		  "text-pitch-alignment": "viewport",
+		  "text-keep-upright": false,
+		  "text-max-angle": 20,
+		  "text-max-width": 100,
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ],
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "all",
+		  [
+		   "!=",
+		   "texte",
+		   "0"
+		  ],
+		  [
+		   "==",
+		   "hors_zone",
+		   "true"
+		  ],
+		  [
+		   "in",
+		   "symbo",
+		   "CNV_GLACIER_MAITRESSE",
+		   "CUV_GLACIER_MAITRESSE"
+		  ]
+		 ],
+		 "paint": {
+		  "text-color": "#629FD9",
+		  "text-halo-width": 0.5,
+		  "text-halo-color": "#FFFFFF"
+		 }
+		},
+		{
+		 "id": "hydro surfacique",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "hydro_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "SURFACE_D_EAU",
+		  "BASSIN",
+		  "ZONE_MARINE"
+		 ],
+		 "paint": {
+		  "fill-color": "#AAD5E9",
+		  "fill-outline-color": "#AAD5E9"
+		 }
+		},
+		{
+		 "id": "hydro surfacique temporaire",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "hydro_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "SURFACE_D_EAU_TEMP"
+		 ],
+		 "paint": {
+		  "fill-color": "rgba(168, 203, 220, 0.5)"
+		 }
+		},
+		{
+		 "id": "réseau hydro  - cours d'eau souterrain",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "hydro_reseau_sou",
+		 "maxzoom": 18,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "COURS_D_EAU_SOU",
+		  "COURS_D_EAU_MOY_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#AAD5E9",
+		  "line-width": {
+		   "stops": [
+			[
+			 12,
+			 1.5
+			],
+			[
+			 17,
+			 6.5
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   2,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "réseau hydro - filet interieur - aqueduc souterrain",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "hydro_reseau_sou",
+		 "minzoom": 12,
+		 "maxzoom": 18,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "AQUEDUC_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#AAD5E9",
+		  "line-width": {
+		   "stops": [
+			[
+			 12,
+			 1.4
+			],
+			[
+			 16,
+			 3.5
+			],
+			[
+			 17,
+			 5.9
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   2,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "réseau hydro - carre - aqueduc souterrain",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "hydro_reseau_sou",
+		 "minzoom": 12,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "AQUEDUC_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#AAD5E9",
+		  "line-width": {
+		   "stops": [
+			[
+			 12,
+			 3.5
+			],
+			[
+			 16,
+			 8.7
+			],
+			[
+			 17,
+			 14.7
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   1,
+		   5
+		  ]
+		 }
+		},
+		{
+		 "id": "Ferre souterrain - voie normale",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "ferre_sou",
+		 "minzoom": 10,
+		 "maxzoom": 18,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "VF_1_SOU",
+		  "VF_2_SOU",
+		  "VF_ELEC_1_SOU",
+		  "VF_FERRO_ROUTIER_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#B4B4B4",
+		  "line-width": {
+		   "stops": [
+			[
+			 10,
+			 0.8
+			],
+			[
+			 17,
+			 2.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Ferre souterrain - trait perpendic épais",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "ferre_sou",
+		 "minzoom": 10,
+		 "maxzoom": 18,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "VF_1_SOU",
+		  "VF_2_SOU",
+		  "VF_ELEC_1_SOU",
+		  "VF_FERRO_ROUTIER_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#B4B4B4",
+		  "line-width": {
+		   "stops": [
+			[
+			 10,
+			 3.5
+			],
+			[
+			 17,
+			 14.7
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   0.1,
+		   10
+		  ]
+		 }
+		},
+		{
+		 "id": "Ferre souterrain - voie etroite",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "ferre_sou",
+		 "minzoom": 10,
+		 "maxzoom": 18,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "VF_ETROITE_1_SOU",
+		  "VF_ETROITE_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#B4B4B4",
+		  "line-width": {
+		   "stops": [
+			[
+			 10,
+			 0.3
+			],
+			[
+			 17,
+			 1.8
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Ferre souterrain - trait perpendic fin",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "ferre_sou",
+		 "minzoom": 10,
+		 "maxzoom": 18,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "VF_ETROITE_1_SOU",
+		  "VF_ETROITE_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#B4B4B4",
+		  "line-width": {
+		   "stops": [
+			[
+			 10,
+			 3.5
+			],
+			[
+			 17,
+			 14.7
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   0.1,
+		   10
+		  ]
+		 }
+		},
+		{
+		 "id": "Ferre souterrain - voie service",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "ferre_sou",
+		 "minzoom": 14,
+		 "maxzoom": 18,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "VF_SERVICE_SOU",
+		  "VF_NON_EXPLOITEE_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#B4B4B4",
+		  "line-width": {
+		   "stops": [
+			[
+			 10,
+			 0.3
+			],
+			[
+			 17,
+			 1.8
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   5,
+		   2,
+		   1,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "Ferre souterrain - funic/urbain",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "ferre_sou",
+		 "maxzoom": 18,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "FUNI_CREMAILLERE_SOU",
+		  "TRANSPORT_URBAIN_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#B4B4B4",
+		  "line-width": {
+		   "stops": [
+			[
+			 10,
+			 0.3
+			],
+			[
+			 17,
+			 1.8
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Ferre souterrain - 2 trait perpendic - funic/urbain",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "ferre_sou",
+		 "maxzoom": 18,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "FUNI_CREMAILLERE_SOU",
+		  "TRANSPORT_URBAIN_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#B4B4B4",
+		  "line-width": {
+		   "stops": [
+			[
+			 10,
+			 3.5
+			],
+			[
+			 17,
+			 17
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   0.1,
+		   0.2,
+		   0.1,
+		   10
+		  ]
+		 }
+		},
+		{
+		 "id": "Chemin souterrain - piste cyclable",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_chemin_sou",
+		 "minzoom": 13,
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "PISTE_CYCLABLE_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#AB81CC",
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 1.1
+			],
+			[
+			 15,
+			 1.7
+			],
+			[
+			 16,
+			 2
+			],
+			[
+			 17,
+			 3.5
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   6,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "Chemin souterrain - filet exterieur - escalier",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_chemin_sou",
+		 "minzoom": 14,
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "ESCALIER_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#B3989A",
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 1.75
+			],
+			[
+			 15,
+			 3
+			],
+			[
+			 16,
+			 4.2
+			],
+			[
+			 17,
+			 9.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Chemin souterrain - filet interieur - escalier",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_chemin_sou",
+		 "minzoom": 14,
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "ESCALIER_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#FFFFFF",
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 1
+			],
+			[
+			 15,
+			 1.9
+			],
+			[
+			 16,
+			 2.7
+			],
+			[
+			 17,
+			 5.8
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   1,
+		   0.2
+		  ]
+		 }
+		},
+		{
+		 "id": "Chemin souterrain - Rue pietonne",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_chemin_sou",
+		 "minzoom": 14,
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "RUE_PIETONNE_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#B3989A",
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 1
+			],
+			[
+			 15,
+			 1.2
+			],
+			[
+			 16,
+			 1.4
+			],
+			[
+			 17,
+			 2
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   1,
+		   3
+		  ]
+		 }
+		},
+		{
+		 "id": "Chemin souterrain - sentier",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_chemin_sou",
+		 "minzoom": 13,
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "SENTIER_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#B3989A",
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 1
+			],
+			[
+			 15,
+			 1.2
+			],
+			[
+			 16,
+			 1.4
+			],
+			[
+			 17,
+			 2
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   4,
+		   3
+		  ]
+		 }
+		},
+		{
+		 "id": "Chemin souterrain - chemin",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_chemin_sou",
+		 "minzoom": 12,
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "CHEMIN_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#B3989A",
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 1
+			],
+			[
+			 15,
+			 1.2
+			],
+			[
+			 16,
+			 1.4
+			],
+			[
+			 17,
+			 2
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier souterrain - filet extérieur - route non revetu carrosable",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sou",
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "NON_REVETUE_CARRO_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#AFAFAF",
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 3.2
+			],
+			[
+			 15,
+			 5.4
+			],
+			[
+			 16,
+			 7.7
+			],
+			[
+			 17,
+			 16.8
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   2,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "Routier souterrain - filet extérieur - bretelle autoroute",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sou",
+		 "minzoom": 12,
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BRET_AUTO_PEAGE_3_SOU",
+		  "BRET_AUTO_PEAGE_2_SOU",
+		  "BRET_AUTO_PEAGE_1_SOU",
+		  "BRET_AUTO_LIBRE_3_SOU",
+		  "BRET_AUTO_LIBRE_2_SOU",
+		  "BRET_AUTO_LIBRE_1_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "rgba(222, 70, 14, 0.5)",
+		  "line-width": {
+		   "stops": [
+			[
+			 12,
+			 2.5
+			],
+			[
+			 14,
+			 3.7
+			],
+			[
+			 15,
+			 6.8
+			],
+			[
+			 16,
+			 8.4
+			],
+			[
+			 17,
+			 14
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier souterrain - filet extérieur - route non classee restreint",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sou",
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "NON_CLASSEE_RESTREINT_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#AFAFAF",
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 3.2
+			],
+			[
+			 15,
+			 5.4
+			],
+			[
+			 16,
+			 7.7
+			],
+			[
+			 17,
+			 16.8
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier souterrain - filet extérieur - route non classee",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sou",
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "NON_CLASSEE_4_SOU",
+		  "NON_CLASSEE_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#AFAFAF",
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 3.2
+			],
+			[
+			 15,
+			 5.4
+			],
+			[
+			 16,
+			 7.7
+			],
+			[
+			 17,
+			 16.8
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier souterrain - filet extérieur - route locale",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sou",
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BRET_LOCALE_SOU",
+		  "LOCALE_4_SOU",
+		  "LOCALE_3_SOU",
+		  "LOCALE_2_SOU",
+		  "LOCALE_1_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "rgba(130, 130, 130, 0.5)",
+		  "line-width": {
+		   "stops": [
+			[
+			 9,
+			 2
+			],
+			[
+			 14,
+			 3.5
+			],
+			[
+			 15,
+			 6
+			],
+			[
+			 16,
+			 8.4
+			],
+			[
+			 17,
+			 18.3
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier souterrain - filet extérieur - route locale en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sou",
+		 "minzoom": 11,
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "LOCALE_CONSTR_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#C8C8C8",
+		  "line-width": {
+		   "stops": [
+			[
+			 9,
+			 2
+			],
+			[
+			 14,
+			 3.5
+			],
+			[
+			 15,
+			 6
+			],
+			[
+			 16,
+			 8.4
+			],
+			[
+			 17,
+			 18.3
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier souterrain - filet extérieur - route regionale",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sou",
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BRET_REGIONALE_SOU",
+		  "REGIONALE_4_SOU",
+		  "REGIONALE_3_SOU",
+		  "REGIONALE_2_SOU",
+		  "REGIONALE_1_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "rgba(130, 130, 130, 0.5)",
+		  "line-width": {
+		   "stops": [
+			[
+			 6,
+			 1.5
+			],
+			[
+			 9,
+			 2.3
+			],
+			[
+			 14,
+			 5
+			],
+			[
+			 15,
+			 8.1
+			],
+			[
+			 16,
+			 11.2
+			],
+			[
+			 17,
+			 22
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier souterrain - filet extérieur - route regionale en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sou",
+		 "minzoom": 10,
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "REGIONALE_CONSTR_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#C8C8C8",
+		  "line-width": {
+		   "stops": [
+			[
+			 6,
+			 1.5
+			],
+			[
+			 9,
+			 2.3
+			],
+			[
+			 14,
+			 5
+			],
+			[
+			 15,
+			 8.1
+			],
+			[
+			 16,
+			 11.2
+			],
+			[
+			 17,
+			 22
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier souterrain - filet extérieur - route principale",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sou",
+		 "minzoom": 7,
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BRET_PRINCIPALE_SOU",
+		  "PRINCIPALE_4_SOU",
+		  "PRINCIPALE_3_SOU",
+		  "PRINCIPALE_2_SOU",
+		  "PRINCIPALE_1_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "rgba(222, 70, 14, 0.5)",
+		  "line-width": {
+		   "stops": [
+			[
+			 6,
+			 1.8
+			],
+			[
+			 9,
+			 2.7
+			],
+			[
+			 14,
+			 5.9
+			],
+			[
+			 15,
+			 9
+			],
+			[
+			 16,
+			 12.2
+			],
+			[
+			 17,
+			 22.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier souterrain - filet extérieur - route principale en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sou",
+		 "minzoom": 10,
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "PRINCIPALE_CONSTR_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#C8C8C8",
+		  "line-width": {
+		   "stops": [
+			[
+			 6,
+			 1.8
+			],
+			[
+			 9,
+			 2.7
+			],
+			[
+			 14,
+			 5.9
+			],
+			[
+			 15,
+			 9
+			],
+			[
+			 16,
+			 12.2
+			],
+			[
+			 17,
+			 22.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier souterrain - filet extérieur - autoroute",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sou",
+		 "minzoom": 7,
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "AUTOROU_PEAGE_SOU",
+		  "AUTOROU_LIBRE_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "rgba(222, 70, 14, 0.5)",
+		  "line-width": {
+		   "stops": [
+			[
+			 6,
+			 2.5
+			],
+			[
+			 9,
+			 3.5
+			],
+			[
+			 14,
+			 7.5
+			],
+			[
+			 15,
+			 11
+			],
+			[
+			 16,
+			 15
+			],
+			[
+			 17,
+			 26
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier souterrain - filet extérieur - autoroute en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sou",
+		 "minzoom": 10,
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "AUTOROU_CONSTR_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#C8C8C8",
+		  "line-width": {
+		   "stops": [
+			[
+			 6,
+			 2.5
+			],
+			[
+			 9,
+			 3.5
+			],
+			[
+			 14,
+			 7.5
+			],
+			[
+			 15,
+			 11
+			],
+			[
+			 16,
+			 15
+			],
+			[
+			 17,
+			 26
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier souterrain - filet interieur - route non revetu carrosable",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sou",
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "NON_REVETUE_CARRO_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#DCDCDC",
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 2.3
+			],
+			[
+			 15,
+			 4.1
+			],
+			[
+			 16,
+			 6.3
+			],
+			[
+			 17,
+			 13.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier souterrain - filet interieur - bretelle autoroute",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sou",
+		 "minzoom": 12,
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BRET_AUTO_PEAGE_3_SOU",
+		  "BRET_AUTO_PEAGE_2_SOU",
+		  "BRET_AUTO_PEAGE_1_SOU",
+		  "BRET_AUTO_LIBRE_3_SOU",
+		  "BRET_AUTO_LIBRE_2_SOU",
+		  "BRET_AUTO_LIBRE_1_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "rgba(255, 255, 255, 0.5)",
+		  "line-width": {
+		   "stops": [
+			[
+			 12,
+			 1.5
+			],
+			[
+			 14,
+			 2.6
+			],
+			[
+			 15,
+			 5.2
+			],
+			[
+			 16,
+			 6.7
+			],
+			[
+			 17,
+			 10.8
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier souterrain - filet interieur - route non classee restreint",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sou",
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "NON_CLASSEE_RESTREINT_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#F2F5FF",
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 2.3
+			],
+			[
+			 15,
+			 4.1
+			],
+			[
+			 16,
+			 6.3
+			],
+			[
+			 17,
+			 13.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier souterrain - filet interieur - route non classee",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sou",
+		 "maxzoom": 18,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "NON_CLASSEE_4_SOU",
+		  "NON_CLASSEE_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#DCDCDC",
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 2.3
+			],
+			[
+			 15,
+			 4.1
+			],
+			[
+			 16,
+			 6.3
+			],
+			[
+			 17,
+			 13.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier souterrain - filet interieur - route locale",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sou",
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BRET_LOCALE_SOU",
+		  "LOCALE_4_SOU",
+		  "LOCALE_3_SOU",
+		  "LOCALE_2_SOU",
+		  "LOCALE_1_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "rgba(255, 255, 255, 0.5)",
+		  "line-width": {
+		   "stops": [
+			[
+			 9,
+			 1.3
+			],
+			[
+			 14,
+			 2.3
+			],
+			[
+			 15,
+			 4.1
+			],
+			[
+			 16,
+			 6.1
+			],
+			[
+			 17,
+			 13.1
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier souterrain - filet interieur - route locale en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sou",
+		 "minzoom": 11,
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "LOCALE_CONSTR_SOU"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 12,
+			 "#FFFFFF"
+			],
+			[
+			 13,
+			 "#FCF4A8"
+			],
+			[
+			 17,
+			 "#FCF7C1"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 9,
+			 2
+			],
+			[
+			 14,
+			 3.5
+			],
+			[
+			 15,
+			 6
+			],
+			[
+			 16,
+			 8.4
+			],
+			[
+			 17,
+			 18.3
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   2,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "Routier souterrain - filet interieur - route regionale",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sou",
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BRET_REGIONALE_SOU",
+		  "REGIONALE_4_SOU",
+		  "REGIONALE_3_SOU",
+		  "REGIONALE_2_SOU",
+		  "REGIONALE_1_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "rgba(255, 255, 255, 0.5)",
+		  "line-width": {
+		   "stops": [
+			[
+			 6,
+			 1.4
+			],
+			[
+			 9,
+			 1.5
+			],
+			[
+			 14,
+			 3.2
+			],
+			[
+			 15,
+			 5.8
+			],
+			[
+			 16,
+			 8.3
+			],
+			[
+			 17,
+			 16.2
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier souterrain - filet interieur - route regionale en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sou",
+		 "minzoom": 10,
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "REGIONALE_CONSTR_SOU"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 9,
+			 "#FFFFFF"
+			],
+			[
+			 10,
+			 "#FDF28B"
+			],
+			[
+			 17,
+			 "#FCF6BD"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 4,
+			 0.4
+			],
+			[
+			 6,
+			 1.5
+			],
+			[
+			 9,
+			 2.3
+			],
+			[
+			 14,
+			 5
+			],
+			[
+			 15,
+			 8.1
+			],
+			[
+			 16,
+			 11.2
+			],
+			[
+			 17,
+			 22
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   2,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "Routier souterrain - filet interieur - route principale",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sou",
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BRET_PRINCIPALE_SOU",
+		  "PRINCIPALE_4_SOU",
+		  "PRINCIPALE_3_SOU",
+		  "PRINCIPALE_2_SOU",
+		  "PRINCIPALE_1_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "rgba(255, 255, 255, 0.5)",
+		  "line-width": {
+		   "stops": [
+			[
+			 4,
+			 0.5
+			],
+			[
+			 6,
+			 1.8
+			],
+			[
+			 9,
+			 2.1
+			],
+			[
+			 14,
+			 4.4
+			],
+			[
+			 15,
+			 7.3
+			],
+			[
+			 16,
+			 10
+			],
+			[
+			 17,
+			 18.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier souterrain - filet interieur - route principale en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sou",
+		 "minzoom": 10,
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "PRINCIPALE_CONSTR_SOU"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 9,
+			 "#F3C66D"
+			],
+			[
+			 17,
+			 "#F2DDB3"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 4,
+			 0.5
+			],
+			[
+			 6,
+			 1.8
+			],
+			[
+			 9,
+			 2.7
+			],
+			[
+			 14,
+			 5.9
+			],
+			[
+			 15,
+			 9
+			],
+			[
+			 16,
+			 12.2
+			],
+			[
+			 17,
+			 22.5
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   2,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "Routier souterrain - filet interieur - autoroute",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sou",
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "AUTOROU_PEAGE_SOU",
+		  "AUTOROU_LIBRE_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "rgba(255, 255, 255, 0.5)",
+		  "line-width": {
+		   "stops": [
+			[
+			 4,
+			 0.7
+			],
+			[
+			 6,
+			 2.5
+			],
+			[
+			 9,
+			 2.7
+			],
+			[
+			 14,
+			 5.8
+			],
+			[
+			 15,
+			 9
+			],
+			[
+			 16,
+			 12
+			],
+			[
+			 17,
+			 20.8
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier souterrain - axe central - autoroute",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sou",
+		 "minzoom": 13,
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "AUTOROU_PEAGE_SOU",
+		  "AUTOROU_LIBRE_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#FFFFFF",
+		  "line-width": {
+		   "stops": [
+			[
+			 9,
+			 0.6
+			],
+			[
+			 14,
+			 0.7
+			],
+			[
+			 15,
+			 1
+			],
+			[
+			 16,
+			 1.2
+			],
+			[
+			 17,
+			 2.1
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier souterrain - filet interieur - autoroute en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sou",
+		 "minzoom": 10,
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "AUTOROU_CONSTR_SOU"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 9,
+			 "#F2BA59"
+			],
+			[
+			 17,
+			 "#F2C261"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 4,
+			 0.7
+			],
+			[
+			 6,
+			 2.5
+			],
+			[
+			 9,
+			 3.5
+			],
+			[
+			 14,
+			 7.5
+			],
+			[
+			 15,
+			 11
+			],
+			[
+			 16,
+			 15
+			],
+			[
+			 17,
+			 26
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   2,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "Routier souterrain - axe central - autoroute en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sou",
+		 "minzoom": 13,
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "AUTOROU_CONSTR_SOU"
+		 ],
+		 "paint": {
+		  "line-color": "#808080",
+		  "line-width": {
+		   "stops": [
+			[
+			 9,
+			 0.6
+			],
+			[
+			 14,
+			 0.7
+			],
+			[
+			 15,
+			 1
+			],
+			[
+			 16,
+			 1.2
+			],
+			[
+			 17,
+			 2.1
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "réseau hydro - cours d'eau temporaire",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "hydro_reseau",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "COURS_D_EAU_TEMP",
+		  "COURS_D_EAU_TEMP_MOY"
+		 ],
+		 "paint": {
+		  "line-color": "#AAD5E9",
+		  "line-width": {
+		   "stops": [
+			[
+			 12,
+			 1.5
+			],
+			[
+			 17,
+			 4
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   6,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "réseau hydro - cours d'eau",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "hydro_reseau",
+		 "minzoom": 3,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "COURS_D_EAU"
+		 ],
+		 "paint": {
+		  "line-color": "#AAD5E9",
+		  "line-width": {
+		   "stops": [
+			[
+			 4,
+			 0.3
+			],
+			[
+			 7,
+			 1.5
+			],
+			[
+			 12,
+			 1.5
+			],
+			[
+			 17,
+			 6.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "réseau hydro - canal",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "hydro_reseau",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "CANAL"
+		 ],
+		 "paint": {
+		  "line-color": "#AAD5E9",
+		  "line-width": {
+		   "stops": [
+			[
+			 12,
+			 1.4
+			],
+			[
+			 17,
+			 5.9
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "réseau hydro - filet interieur - aqueduc",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "hydro_reseau",
+		 "minzoom": 12,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "AQUEDUC_AU_SOL"
+		 ],
+		 "paint": {
+		  "line-color": "#AAD5E9",
+		  "line-width": {
+		   "stops": [
+			[
+			 12,
+			 1.4
+			],
+			[
+			 16,
+			 3.5
+			],
+			[
+			 17,
+			 5.9
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "réseau hydro - carre - aqueduc",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "hydro_reseau",
+		 "minzoom": 12,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "AQUEDUC_AU_SOL"
+		 ],
+		 "paint": {
+		  "line-color": "#AAD5E9",
+		  "line-width": {
+		   "stops": [
+			[
+			 12,
+			 3.5
+			],
+			[
+			 16,
+			 8.7
+			],
+			[
+			 17,
+			 14.7
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   1,
+		   5
+		  ]
+		 }
+		},
+		{
+		 "id": "réseau hydro - cours d'eau moyen ",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "hydro_reseau",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "COURS_D_EAU_MOY"
+		 ],
+		 "paint": {
+		  "line-color": "#AAD5E9",
+		  "line-width": {
+		   "stops": [
+			[
+			 7,
+			 2
+			],
+			[
+			 12,
+			 2.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "réseau hydro - cours d'eau large ",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "hydro_reseau",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "COURS_D_EAU_LAR"
+		 ],
+		 "paint": {
+		  "line-color": "#AAD5E9",
+		  "line-width": {
+		   "stops": [
+			[
+			 7,
+			 3
+			],
+			[
+			 11,
+			 5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "parcellaire - parcelle surface",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "parcellaire_parcelle",
+		 "layout": {
+		  "visibility": "none"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "PARCELLE"
+		 ],
+		 "paint": {
+		  "fill-color": "#FFFFD1",
+		  "fill-opacity": 0.7
+		 }
+		},
+		{
+		 "id": "bati surfacique mairie - Zoom 14",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "maxzoom": 14,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "MAIRIE",
+		  "MAIRIE_ANNEXE"
+		 ],
+		 "paint": {
+		  "fill-color": "#FFA6A6"
+		 }
+		},
+		{
+		 "id": "bati surfacique mairie - Zoom 15,16,17,18",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "minzoom": 14,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "MAIRIE",
+		  "MAIRIE_ANNEXE"
+		 ],
+		 "paint": {
+		  "fill-color": {
+		   "stops": [
+			[
+			 14,
+			 "#FFA6A6"
+			],
+			[
+			 15,
+			 "#FFAEAE"
+			]
+		   ]
+		  },
+		  "fill-outline-color": "#FF7C7C"
+		 }
+		},
+		{
+		 "id": "bati surfacique fonctionnel industriel ou commercial - Zoom 14,15",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "maxzoom": 15,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BATI_COMMERCIAL",
+		  "BATI_INDUSTRIEL",
+		  "HANGAR",
+		  "HANGAR_COMMERCIAL",
+		  "HANGAR_INDUSTRIEL"
+		 ],
+		 "paint": {
+		  "fill-color": "#C8C8C8"
+		 }
+		},
+		{
+		 "id": "bati surfacique fonctionnel industriel ou commercial - Zoom 16,17,18",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "minzoom": 15,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BATI_COMMERCIAL",
+		  "BATI_INDUSTRIEL",
+		  "HANGAR",
+		  "HANGAR_COMMERCIAL",
+		  "HANGAR_INDUSTRIEL"
+		 ],
+		 "paint": {
+		  "fill-color": {
+		   "stops": [
+			[
+			 15,
+			 "#D1D1D1"
+			],
+			[
+			 16,
+			 "#E6E6E6"
+			]
+		   ]
+		  },
+		  "fill-outline-color": "#B8B8B8"
+		 }
+		},
+		{
+		 "id": "bati surfacique fonctionnel public - Zoom 14,15",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "maxzoom": 15,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BATI_PUBLIC",
+		  "HANGAR_PUBLIC"
+		 ],
+		 "paint": {
+		  "fill-color": "#B9B6D6"
+		 }
+		},
+		{
+		 "id": "bati surfacique fonctionnel public - Zoom 16,17,18",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "minzoom": 15,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BATI_PUBLIC",
+		  "HANGAR_PUBLIC"
+		 ],
+		 "paint": {
+		  "fill-color": {
+		   "stops": [
+			[
+			 15,
+			 "#CFC5DE"
+			],
+			[
+			 16,
+			 "#E4DAF3"
+			]
+		   ]
+		  },
+		  "fill-outline-color": "#A6A1D6"
+		 }
+		},
+		{
+		 "id": "bati surfacique fonctionnel sportif - bordure",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "minzoom": 15,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "BATI_SPORTIF"
+		 ],
+		 "paint": {
+		  "line-color": "#BCD9AB",
+		  "line-width": 4
+		 }
+		},
+		{
+		 "id": "bati surfacique fonctionnel sportif",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "minzoom": 13,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "BATI_SPORTIF"
+		 ],
+		 "paint": {
+		  "fill-color": {
+		   "stops": [
+			[
+			 14,
+			 "#C9E1DD"
+			],
+			[
+			 15,
+			 "#DCE6E4"
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "bati surfacique fonctionnel gare - Zoom 14,15",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "maxzoom": 15,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "BATI_GARE"
+		 ],
+		 "paint": {
+		  "fill-color": "#B3B5F5"
+		 }
+		},
+		{
+		 "id": "bati surfacique fonctionnel gare - Zoom 16,17,18",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "minzoom": 15,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "BATI_GARE"
+		 ],
+		 "paint": {
+		  "fill-color": {
+		   "stops": [
+			[
+			 15,
+			 "#BFC1F5"
+			],
+			[
+			 16,
+			 "#CBCDF5"
+			]
+		   ]
+		  },
+		  "fill-outline-color": "#9B9EF6"
+		 }
+		},
+		{
+		 "id": "bati surfacique quelconque - Zoom 15",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "minzoom": 14,
+		 "maxzoom": 15,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "BATI_QQUE"
+		 ],
+		 "paint": {
+		  "fill-color": "#D6C6B8"
+		 }
+		},
+		{
+		 "id": "bati surfacique quelconque - Zoom 16,17,18",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "minzoom": 15,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "BATI_QQUE"
+		 ],
+		 "paint": {
+		  "fill-color": {
+		   "stops": [
+			[
+			 15,
+			 "#E6E0CF"
+			],
+			[
+			 16,
+			 "#F1EBD9"
+			]
+		   ]
+		  },
+		  "fill-outline-color": "#C3AA8E"
+		 }
+		},
+		{
+		 "id": "cimetiere surfacique 1",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "CIMETIERE_SURF",
+		  "CIMETIERE_MILI_SURF",
+		  "NECROPOLE_NATIONALE"
+		 ],
+		 "paint": {
+		  "fill-color": "#F0F0F0",
+		  "fill-opacity": 0.5,
+		  "fill-outline-color": "#818181"
+		 }
+		},
+		{
+		 "id": "cimetiere surfacique 2",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "CIMETIERE_SURF",
+		  "CIMETIERE_MILI_SURF",
+		  "NECROPOLE_NATIONALE"
+		 ],
+		 "paint": {
+		  "fill-pattern": "Cimetiere"
+		 }
+		},
+		{
+		 "id": "bati hydro surfacique - Autre",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "ECLUSE_SURF",
+		  "RESERVOIR_EAU_SURF"
+		 ],
+		 "paint": {
+		  "fill-color": "#ADCCD9",
+		  "fill-outline-color": "#336699"
+		 }
+		},
+		{
+		 "id": "bati hydro surfacique - Pecherie",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "PECHERIE_SURF"
+		 ],
+		 "paint": {
+		  "fill-color": "#BFE2F0",
+		  "fill-outline-color": "#509FEF"
+		 }
+		},
+		{
+		 "id": "bati hydro surfacique - Barrage",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "BARRAGE_SURF"
+		 ],
+		 "paint": {
+		  "fill-color": "#FFFFFF",
+		  "fill-outline-color": "#464646"
+		 }
+		},
+		{
+		 "id": "bati hydro surfacique - Chateau d'eau",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "CHATEAU_EAU_SURF"
+		 ],
+		 "paint": {
+		  "fill-color": "#1466B2"
+		 }
+		},
+		{
+		 "id": "bati infra surfacique - Silo",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "minzoom": 15,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "SILO_SURF"
+		 ],
+		 "paint": {
+		  "fill-color": "#C7A9AA",
+		  "fill-outline-color": "#696969"
+		 }
+		},
+		{
+		 "id": "bati infra surfacique - Reservoir indus",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "minzoom": 14,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "RESERVOIR_INDUS_SURF"
+		 ],
+		 "paint": {
+		  "fill-color": "#8D9DAA",
+		  "fill-outline-color": "#464646"
+		 }
+		},
+		{
+		 "id": "bati infra surfacique - Serre",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "minzoom": 13,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "SERRE_SURF"
+		 ],
+		 "paint": {
+		  "fill-color": "#CAD6D9",
+		  "fill-outline-color": "#8C8C8C"
+		 }
+		},
+		{
+		 "id": "bati infra surfacique - poste electrique",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "POSTE_ELEC_SURF"
+		 ],
+		 "paint": {
+		  "fill-color": "#7993B6",
+		  "fill-opacity": 0.3
+		 }
+		},
+		{
+		 "id": "bati infra surfacique - poste electrique bord",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "POSTE_ELEC_SURF"
+		 ],
+		 "paint": {
+		  "line-color": "#000000",
+		  "line-width": {
+		   "stops": [
+			[
+			 12,
+			 0.3
+			],
+			[
+			 17,
+			 1.2
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "bati religieux surfacique - Zoom 14",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "maxzoom": 14,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "CHAPELLE_SURF",
+		  "EGLISE_SURF",
+		  "CHRETIEN_SURF",
+		  "SYNAGOGUE_SURF",
+		  "MOSQUEE_SURF",
+		  "AUTRE_CULTE_SURF"
+		 ],
+		 "paint": {
+		  "fill-color": "#F7CBCB"
+		 }
+		},
+		{
+		 "id": "bati religieux surfacique - Zoom 15,16,17,18",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "minzoom": 14,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "CHAPELLE_SURF",
+		  "EGLISE_SURF",
+		  "CHRETIEN_SURF",
+		  "SYNAGOGUE_SURF",
+		  "MOSQUEE_SURF",
+		  "AUTRE_CULTE_SURF"
+		 ],
+		 "paint": {
+		  "fill-color": {
+		   "stops": [
+			[
+			 14,
+			 "#F7CBCB"
+			],
+			[
+			 15,
+			 "#F7E1E1"
+			]
+		   ]
+		  },
+		  "fill-outline-color": {
+		   "stops": [
+			[
+			 14,
+			 "#F7A8A8"
+			],
+			[
+			 15,
+			 "#F7B7B7"
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "bati remarquable surfacique",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "minzoom": 13,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "FORTIF_SURF",
+		  "CHATEAU_SURF",
+		  "TOUR_MOULIN_SURF",
+		  "ARENE_THEATRE",
+		  "ARC_TRIOMPHE_SURF",
+		  "MONUMENT_SURF"
+		 ],
+		 "paint": {
+		  "fill-color": "#9B9B9B",
+		  "fill-outline-color": "#6E6E6E"
+		 }
+		},
+		{
+		 "id": "bati sportif surfacique fond",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "TENNIS_SURF",
+		  "SPORT_INDIF_SURF",
+		  "FOOT_SURF",
+		  "MULTI_SPORT_SURF",
+		  "PISTE_SPORT_SURF",
+		  "NATATION_SURF"
+		 ],
+		 "paint": {
+		  "fill-color": "#FFFFFF",
+		  "fill-outline-color": "#FFFFFF"
+		 }
+		},
+		{
+		 "id": "bati sportif surfacique",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "TENNIS_SURF",
+		  "SPORT_INDIF_SURF",
+		  "FOOT_SURF",
+		  "MULTI_SPORT_SURF",
+		  "PISTE_SPORT_SURF",
+		  "NATATION_SURF"
+		 ],
+		 "paint": {
+		  "line-color": "#BCD9AB",
+		  "line-width": 2
+		 }
+		},
+		{
+		 "id": "bati transport surfacique - piste",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "PISTE_DUR",
+		  "PISTE_HERBE"
+		 ],
+		 "paint": {
+		  "fill-color": "#DBDBDB",
+		  "fill-outline-color": "#808080"
+		 }
+		},
+		{
+		 "id": "bati ZAI - Autres",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_zai",
+		 "minzoom": 15,
+		 "maxzoom": 18,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "in",
+		  "nature",
+		  "Lycée",
+		  "Université",
+		  "Capitainerie",
+		  "Gendarmerie",
+		  "Siège d'EPCI",
+		  "Musée",
+		  "Collège",
+		  "Maison de retraite",
+		  "Etablissement thermal",
+		  "Autre service déconcentré de l'Etat",
+		  "Etablissement pénitentiaire",
+		  "Divers public ou administratif",
+		  "Autre établissement d'enseignement",
+		  "Maison du parc",
+		  "Palais de justice",
+		  "Enseignement primaire",
+		  "Office de tourisme",
+		  "Hôpital",
+		  "Police",
+		  "Piscine",
+		  "Enseignement supérieur",
+		  "Poste",
+		  "Caserne",
+		  "Etablissement hospitalier",
+		  "Etablissement extraterritorial",
+		  "Science",
+		  "Structure d'accueil pour personnes handicapées",
+		  "Administration centrale de l'Etat",
+		  "Caserne de pompiers"
+		 ],
+		 "paint": {
+		  "fill-color": "#E3BFE2",
+		  "fill-opacity": 0.5,
+		  "fill-outline-color": "#E39FE1"
+		 }
+		},
+		{
+		 "id": "bati ZAI - Commandement",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_zai",
+		 "minzoom": 15,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "in",
+		  "nature",
+		  "Hôtel de département",
+		  "Hôtel de région",
+		  "Préfecture de région",
+		  "Préfecture",
+		  "Sous-préfecture"
+		 ],
+		 "paint": {
+		  "fill-color": "#FF0000",
+		  "fill-opacity": 0.3,
+		  "fill-outline-color": "#B40000"
+		 }
+		},
+		{
+		 "id": "construction linéaire - mur",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "bati_lin",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "MUR"
+		 ],
+		 "paint": {
+		  "line-color": "#8C8C8C",
+		  "line-width": 0.3
+		 }
+		},
+		{
+		 "id": "construction linéaire - autre",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "bati_lin",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "RUINE_LIN",
+		  "MUR_SOUTENEMENT",
+		  "FORTIF_LIN"
+		 ],
+		 "paint": {
+		  "line-color": "#646464",
+		  "line-width": 0.5
+		 }
+		},
+		{
+		 "id": "construction hydrographique linéaire - Barrage",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "bati_lin",
+		 "minzoom": 13,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "BARRAGE_LIN"
+		 ],
+		 "paint": {
+		  "line-color": "#646464",
+		  "line-width": {
+		   "stops": [
+			[
+			 13,
+			 1.5
+			],
+			[
+			 17,
+			 5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "construction hydrographique linéaire - Quai",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "bati_lin",
+		 "minzoom": 12,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "QUAI",
+		  "DIGUE"
+		 ],
+		 "paint": {
+		  "line-color": "#828282",
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 1
+			],
+			[
+			 17,
+			 2.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "construction hydrographique linéaire - Pecherie",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "bati_lin",
+		 "minzoom": 12,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "PECHERIE_LIN"
+		 ],
+		 "paint": {
+		  "line-color": "#0066CC",
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 1
+			],
+			[
+			 17,
+			 2.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Chemin a niveau - piste cyclable",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_chemin",
+		 "minzoom": 13,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "PISTE_CYCLABLE"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 17,
+			 "#9B5CCC"
+			],
+			[
+			 18,
+			 "#FFFFFF"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 1.1
+			],
+			[
+			 15,
+			 1.7
+			],
+			[
+			 16,
+			 2
+			],
+			[
+			 17,
+			 3.5
+			],
+			[
+			 18,
+			 6
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   6,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "Chemin a niveau - filet exterieur - escalier",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_chemin",
+		 "minzoom": 14,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "ESCALIER"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 17,
+			 "#8C7274"
+			],
+			[
+			 18,
+			 "#C8C8C8"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 1.75
+			],
+			[
+			 15,
+			 3
+			],
+			[
+			 16,
+			 4.2
+			],
+			[
+			 17,
+			 9.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Chemin a niveau - filet interieur - escalier",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_chemin",
+		 "minzoom": 14,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "ESCALIER"
+		 ],
+		 "paint": {
+		  "line-color": "#FFFFFF",
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 1
+			],
+			[
+			 15,
+			 1.9
+			],
+			[
+			 16,
+			 2.7
+			],
+			[
+			 17,
+			 5.8
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   1,
+		   0.2
+		  ]
+		 }
+		},
+		{
+		 "id": "Chemin a niveau - Rue pietonne",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_chemin",
+		 "minzoom": 14,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "RUE_PIETONNE"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 17,
+			 "#8C7274"
+			],
+			[
+			 18,
+			 "#F8E5D5"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 1
+			],
+			[
+			 15,
+			 1.2
+			],
+			[
+			 16,
+			 1.4
+			],
+			[
+			 17,
+			 2
+			],
+			[
+			 18,
+			 5
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   1,
+		   3
+		  ]
+		 }
+		},
+		{
+		 "id": "Chemin a niveau - sentier",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_chemin",
+		 "minzoom": 13,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "SENTIER"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 17,
+			 "#8C7274"
+			],
+			[
+			 18,
+			 "#FFFFFF"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 1
+			],
+			[
+			 15,
+			 1.2
+			],
+			[
+			 16,
+			 1.4
+			],
+			[
+			 17,
+			 2
+			],
+			[
+			 18,
+			 6
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   4,
+		   3
+		  ]
+		 }
+		},
+		{
+		 "id": "Chemin a niveau - chemin",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_chemin",
+		 "minzoom": 12,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "CHEMIN"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 17,
+			 "#8C7274"
+			],
+			[
+			 18,
+			 "#FFFFFF"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 1
+			],
+			[
+			 15,
+			 1.2
+			],
+			[
+			 16,
+			 1.4
+			],
+			[
+			 17,
+			 2
+			],
+			[
+			 18,
+			 7
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier a niveau - filet extérieur - route non revetu carrosable",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route",
+		 "maxzoom": 18,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "NON_REVETUE_CARRO"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 12,
+			 "#646464"
+			],
+			[
+			 17,
+			 "#8C8C8C"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 3.2
+			],
+			[
+			 15,
+			 5.4
+			],
+			[
+			 16,
+			 7.7
+			],
+			[
+			 17,
+			 16.8
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   2,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "Routier a niveau - filet interieur - route non revetu carrosable",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "NON_REVETUE_CARRO"
+		 ],
+		 "paint": {
+		  "line-color": "#FFFFFF",
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 2.3
+			],
+			[
+			 15,
+			 4.1
+			],
+			[
+			 16,
+			 6.3
+			],
+			[
+			 17,
+			 13.5
+			],
+			[
+			 18,
+			 16.8
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier a niveau - filet extérieur - bretelle autoroute",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route",
+		 "minzoom": 12,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BRET_AUTO_PEAGE_3",
+		  "BRET_AUTO_PEAGE_2",
+		  "BRET_AUTO_PEAGE_1",
+		  "BRET_AUTO_LIBRE_3",
+		  "BRET_AUTO_LIBRE_2",
+		  "BRET_AUTO_LIBRE_1"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 9,
+			 "#DE460E"
+			],
+			[
+			 17,
+			 "#F18800"
+			],
+			[
+			 18,
+			 "#FFFFFF"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 12,
+			 2.5
+			],
+			[
+			 14,
+			 3.7
+			],
+			[
+			 15,
+			 6.8
+			],
+			[
+			 16,
+			 8.4
+			],
+			[
+			 17,
+			 14
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier a niveau - filet extérieur - route non classee restreint",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "NON_CLASSEE_RESTREINT"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 17,
+			 "#969696"
+			],
+			[
+			 18,
+			 "#FFFFFF"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 3.2
+			],
+			[
+			 15,
+			 5.4
+			],
+			[
+			 16,
+			 7.7
+			],
+			[
+			 17,
+			 16.8
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier a niveau - filet extérieur - route non classee",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "NON_CLASSEE_4",
+		  "NON_CLASSEE"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 17,
+			 "#969696"
+			],
+			[
+			 18,
+			 "#FFFFFF"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 3.2
+			],
+			[
+			 15,
+			 5.4
+			],
+			[
+			 16,
+			 7.7
+			],
+			[
+			 17,
+			 16.8
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier a niveau - filet extérieur - route locale",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route",
+		 "minzoom": 7,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BRET_LOCALE",
+		  "LOCALE_4",
+		  "LOCALE_3",
+		  "LOCALE_2",
+		  "LOCALE_1"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 12,
+			 "#8C8C8C"
+			],
+			[
+			 13,
+			 "#B4B4B4"
+			],
+			[
+			 17,
+			 "#B4B4B4"
+			],
+			[
+			 18,
+			 "#FFFFFF"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 9,
+			 2
+			],
+			[
+			 14,
+			 3.5
+			],
+			[
+			 15,
+			 6
+			],
+			[
+			 16,
+			 8.4
+			],
+			[
+			 17,
+			 18.3
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier a niveau - filet extérieur - route locale en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route",
+		 "minzoom": 11,
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "LOCALE_CONSTR"
+		 ],
+		 "paint": {
+		  "line-color": "#C8C8C8",
+		  "line-width": {
+		   "stops": [
+			[
+			 9,
+			 2
+			],
+			[
+			 14,
+			 3.5
+			],
+			[
+			 15,
+			 6
+			],
+			[
+			 16,
+			 8.4
+			],
+			[
+			 17,
+			 18.3
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier a niveau - filet extérieur - route regionale",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route",
+		 "minzoom": 8,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BRET_REGIONALE",
+		  "REGIONALE_4",
+		  "REGIONALE_3",
+		  "REGIONALE_2",
+		  "REGIONALE_1"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 9,
+			 "#828282"
+			],
+			[
+			 10,
+			 "#B4B4B4"
+			],
+			[
+			 17,
+			 "#B4B4B4"
+			],
+			[
+			 18,
+			 "#FFFFFF"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 6,
+			 1.5
+			],
+			[
+			 9,
+			 2.3
+			],
+			[
+			 14,
+			 5
+			],
+			[
+			 15,
+			 8.1
+			],
+			[
+			 16,
+			 11.2
+			],
+			[
+			 17,
+			 22
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier a niveau - filet extérieur - route regionale en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route",
+		 "minzoom": 10,
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "REGIONALE_CONSTR"
+		 ],
+		 "paint": {
+		  "line-color": "#C8C8C8",
+		  "line-width": {
+		   "stops": [
+			[
+			 6,
+			 1.5
+			],
+			[
+			 9,
+			 2.3
+			],
+			[
+			 14,
+			 5
+			],
+			[
+			 15,
+			 8.1
+			],
+			[
+			 16,
+			 11.2
+			],
+			[
+			 17,
+			 22
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier a niveau - filet extérieur - route principale",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route",
+		 "minzoom": 8,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BRET_PRINCIPALE",
+		  "PRINCIPALE_4",
+		  "PRINCIPALE_3",
+		  "PRINCIPALE_2",
+		  "PRINCIPALE_1"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 17,
+			 "#E2A52A"
+			],
+			[
+			 18,
+			 "#FFFFFF"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 6,
+			 1.8
+			],
+			[
+			 9,
+			 2.7
+			],
+			[
+			 14,
+			 5.9
+			],
+			[
+			 15,
+			 9
+			],
+			[
+			 16,
+			 12.2
+			],
+			[
+			 17,
+			 22.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier a niveau - filet extérieur - route principale en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route",
+		 "minzoom": 10,
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "PRINCIPALE_CONSTR"
+		 ],
+		 "paint": {
+		  "line-color": "#C8C8C8",
+		  "line-width": {
+		   "stops": [
+			[
+			 6,
+			 1.8
+			],
+			[
+			 9,
+			 2.7
+			],
+			[
+			 14,
+			 5.9
+			],
+			[
+			 15,
+			 9
+			],
+			[
+			 16,
+			 12.2
+			],
+			[
+			 17,
+			 22.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier a niveau - filet extérieur - autoroute",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route",
+		 "minzoom": 8,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "AUTOROU_PEAGE",
+		  "AUTOROU_LIBRE"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 9,
+			 "#DE460E"
+			],
+			[
+			 17,
+			 "#F18800"
+			],
+			[
+			 18,
+			 "#FFFFFF"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 6,
+			 2.5
+			],
+			[
+			 9,
+			 3.5
+			],
+			[
+			 14,
+			 7.5
+			],
+			[
+			 15,
+			 11
+			],
+			[
+			 16,
+			 15
+			],
+			[
+			 17,
+			 26
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier a niveau - filet extérieur - autoroute en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route",
+		 "minzoom": 8,
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "AUTOROU_CONSTR"
+		 ],
+		 "paint": {
+		  "line-color": "#C8C8C8",
+		  "line-width": {
+		   "stops": [
+			[
+			 6,
+			 2.5
+			],
+			[
+			 9,
+			 3.5
+			],
+			[
+			 14,
+			 7.5
+			],
+			[
+			 15,
+			 11
+			],
+			[
+			 16,
+			 15
+			],
+			[
+			 17,
+			 26
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier a niveau - filet interieur - bretelle autoroute",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route",
+		 "minzoom": 12,
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BRET_AUTO_PEAGE_3",
+		  "BRET_AUTO_PEAGE_2",
+		  "BRET_AUTO_PEAGE_1",
+		  "BRET_AUTO_LIBRE_3",
+		  "BRET_AUTO_LIBRE_2",
+		  "BRET_AUTO_LIBRE_1"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 9,
+			 "#F18800"
+			],
+			[
+			 17,
+			 "#F2B230"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 12,
+			 1.5
+			],
+			[
+			 14,
+			 2.6
+			],
+			[
+			 15,
+			 5.2
+			],
+			[
+			 16,
+			 6.7
+			],
+			[
+			 17,
+			 10.8
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier a niveau - filet interieur - route non classee restreint",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route",
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "NON_CLASSEE_RESTREINT"
+		 ],
+		 "paint": {
+		  "line-color": "#EDF1FF",
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 2.3
+			],
+			[
+			 15,
+			 4.1
+			],
+			[
+			 16,
+			 6.3
+			],
+			[
+			 17,
+			 13.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier a niveau - filet interieur - route non classee",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route",
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "NON_CLASSEE_4",
+		  "NON_CLASSEE"
+		 ],
+		 "paint": {
+		  "line-color": "#FFFFFF",
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 2.3
+			],
+			[
+			 15,
+			 4.1
+			],
+			[
+			 16,
+			 6.3
+			],
+			[
+			 17,
+			 13.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier a niveau - filet interieur - route locale",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route",
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BRET_LOCALE",
+		  "LOCALE_4",
+		  "LOCALE_3",
+		  "LOCALE_2",
+		  "LOCALE_1"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 6,
+			 "#F2B361"
+			],
+			[
+			 7,
+			 "#FFFFFF"
+			],
+			[
+			 12,
+			 "#FFFFFF"
+			],
+			[
+			 13,
+			 "#FCF4A8"
+			],
+			[
+			 17,
+			 "#FCF7C1"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 9,
+			 1.3
+			],
+			[
+			 14,
+			 2.3
+			],
+			[
+			 15,
+			 4.1
+			],
+			[
+			 16,
+			 6.1
+			],
+			[
+			 17,
+			 13.1
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier a niveau - filet interieur - route locale en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route",
+		 "minzoom": 11,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "LOCALE_CONSTR"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 12,
+			 "#FFFFFF"
+			],
+			[
+			 13,
+			 "#FCF4A8"
+			],
+			[
+			 17,
+			 "#FCF7C1"
+			],
+			[
+			 18,
+			 "#EDEDED"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 9,
+			 2
+			],
+			[
+			 14,
+			 3.5
+			],
+			[
+			 15,
+			 6
+			],
+			[
+			 16,
+			 8.4
+			],
+			[
+			 17,
+			 18.3
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   2,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "Routier a niveau - filet interieur - route regionale",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route",
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BRET_REGIONALE",
+		  "REGIONALE_4",
+		  "REGIONALE_3",
+		  "REGIONALE_2",
+		  "REGIONALE_1"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 6,
+			 "#F2A949"
+			],
+			[
+			 7,
+			 "#FFFFFF"
+			],
+			[
+			 9,
+			 "#FFFFFF"
+			],
+			[
+			 10,
+			 "#FDF28B"
+			],
+			[
+			 17,
+			 "#FCF6BD"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 4,
+			 1.1
+			],
+			[
+			 6,
+			 1.4
+			],
+			[
+			 9,
+			 1.5
+			],
+			[
+			 14,
+			 3.2
+			],
+			[
+			 15,
+			 5.8
+			],
+			[
+			 16,
+			 8.3
+			],
+			[
+			 17,
+			 16.2
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier a niveau - filet interieur - route regionale en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route",
+		 "minzoom": 10,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "REGIONALE_CONSTR"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 9,
+			 "#FFFFFF"
+			],
+			[
+			 10,
+			 "#FDF28B"
+			],
+			[
+			 17,
+			 "#FCF6BD"
+			],
+			[
+			 18,
+			 "#EDEDED"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 4,
+			 0.4
+			],
+			[
+			 6,
+			 1.5
+			],
+			[
+			 9,
+			 2.3
+			],
+			[
+			 14,
+			 5
+			],
+			[
+			 15,
+			 8.1
+			],
+			[
+			 16,
+			 11.2
+			],
+			[
+			 17,
+			 22
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   2,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "Routier a niveau - filet interieur - route principale",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route",
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BRET_PRINCIPALE",
+		  "PRINCIPALE_4",
+		  "PRINCIPALE_3",
+		  "PRINCIPALE_2",
+		  "PRINCIPALE_1"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 6,
+			 "#F29924"
+			],
+			[
+			 7,
+			 "#F3C66D"
+			],
+			[
+			 9,
+			 "#F3C66D"
+			],
+			[
+			 17,
+			 "#F2DDB3"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 4,
+			 0.6
+			],
+			[
+			 6,
+			 1.8
+			],
+			[
+			 9,
+			 2.1
+			],
+			[
+			 14,
+			 4.4
+			],
+			[
+			 15,
+			 7.3
+			],
+			[
+			 16,
+			 10
+			],
+			[
+			 17,
+			 18.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier a niveau - filet interieur - route principale en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route",
+		 "minzoom": 10,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "PRINCIPALE_CONSTR"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 9,
+			 "#F3C66D"
+			],
+			[
+			 17,
+			 "#F2DDB3"
+			],
+			[
+			 18,
+			 "#EDEDED"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 4,
+			 0.5
+			],
+			[
+			 6,
+			 1.8
+			],
+			[
+			 9,
+			 2.7
+			],
+			[
+			 14,
+			 5.9
+			],
+			[
+			 15,
+			 9
+			],
+			[
+			 16,
+			 12.2
+			],
+			[
+			 17,
+			 22.5
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   2,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "Routier a niveau - filet interieur - autoroute",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route",
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "AUTOROU_PEAGE",
+		  "AUTOROU_LIBRE"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 9,
+			 "#F18800"
+			],
+			[
+			 17,
+			 "#F2B230"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 4,
+			 0.7
+			],
+			[
+			 6,
+			 2.5
+			],
+			[
+			 9,
+			 2.7
+			],
+			[
+			 14,
+			 5.8
+			],
+			[
+			 15,
+			 9
+			],
+			[
+			 16,
+			 12
+			],
+			[
+			 17,
+			 20.8
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier a niveau - axe central - autoroute",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route",
+		 "minzoom": 13,
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "AUTOROU_PEAGE",
+		  "AUTOROU_LIBRE"
+		 ],
+		 "paint": {
+		  "line-color": "#FFFFFF",
+		  "line-width": {
+		   "stops": [
+			[
+			 9,
+			 0.6
+			],
+			[
+			 14,
+			 0.7
+			],
+			[
+			 15,
+			 1
+			],
+			[
+			 16,
+			 1.2
+			],
+			[
+			 17,
+			 2.1
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier a niveau - filet interieur - autoroute en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route",
+		 "minzoom": 8,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "AUTOROU_CONSTR"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 9,
+			 "#F18800"
+			],
+			[
+			 17,
+			 "#F2B230"
+			],
+			[
+			 18,
+			 "#EDEDED"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 4,
+			 0.7
+			],
+			[
+			 6,
+			 2.5
+			],
+			[
+			 9,
+			 3.5
+			],
+			[
+			 14,
+			 7.5
+			],
+			[
+			 15,
+			 11
+			],
+			[
+			 16,
+			 15
+			],
+			[
+			 17,
+			 26
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   2,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "Routier a niveau - axe centrale - autoroute en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route",
+		 "minzoom": 13,
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "AUTOROU_CONSTR"
+		 ],
+		 "paint": {
+		  "line-color": "#808080",
+		  "line-width": {
+		   "stops": [
+			[
+			 9,
+			 0.6
+			],
+			[
+			 14,
+			 0.7
+			],
+			[
+			 15,
+			 1
+			],
+			[
+			 16,
+			 1.2
+			],
+			[
+			 17,
+			 2.1
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Ferre a niveau - voie normale",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "ferre",
+		 "minzoom": 10,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "VF_1",
+		  "VF_2",
+		  "VF_3",
+		  "VF_4",
+		  "VF_ELEC_1",
+		  "VF_ELEC_2",
+		  "VF_ELEC_3",
+		  "VF_ELEC_4"
+		 ],
+		 "paint": {
+		  "line-color": "#787878",
+		  "line-width": {
+		   "stops": [
+			[
+			 10,
+			 0.8
+			],
+			[
+			 17,
+			 2.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Ferre a niveau - voie normale trait perpendic",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "ferre",
+		 "minzoom": 10,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "VF_1",
+		  "VF_2",
+		  "VF_3",
+		  "VF_4",
+		  "VF_ELEC_1",
+		  "VF_ELEC_2",
+		  "VF_ELEC_3",
+		  "VF_ELEC_4"
+		 ],
+		 "paint": {
+		  "line-color": "#787878",
+		  "line-width": {
+		   "stops": [
+			[
+			 10,
+			 3.5
+			],
+			[
+			 17,
+			 14.7
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   0.1,
+		   10
+		  ]
+		 }
+		},
+		{
+		 "id": "Ferre a niveau - voie etroite",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "ferre",
+		 "minzoom": 10,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "VF_ETROITE_1",
+		  "VF_ETROITE_2",
+		  "VF_ETROITE"
+		 ],
+		 "paint": {
+		  "line-color": "#787878",
+		  "line-width": {
+		   "stops": [
+			[
+			 10,
+			 0.3
+			],
+			[
+			 17,
+			 1.8
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Ferre a niveau - voie etroite trait perpendic",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "ferre",
+		 "minzoom": 10,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "VF_ETROITE_1",
+		  "VF_ETROITE_2",
+		  "VF_ETROITE"
+		 ],
+		 "paint": {
+		  "line-color": "#787878",
+		  "line-width": {
+		   "stops": [
+			[
+			 10,
+			 3.5
+			],
+			[
+			 17,
+			 14.7
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   0.1,
+		   10
+		  ]
+		 }
+		},
+		{
+		 "id": "Ferre a niveau - voie service",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "ferre",
+		 "minzoom": 14,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "VF_SERVICE",
+		  "VF_NON_EXPLOITEE"
+		 ],
+		 "paint": {
+		  "line-color": "#787878",
+		  "line-width": {
+		   "stops": [
+			[
+			 10,
+			 0.3
+			],
+			[
+			 17,
+			 1.8
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   5,
+		   2,
+		   1,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "Ferre a niveau - voie en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "ferre",
+		 "minzoom": 10,
+		 "maxzoom": 18,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "VF_EN_CONSTR"
+		 ],
+		 "paint": {
+		  "line-color": "#787878",
+		  "line-width": {
+		   "stops": [
+			[
+			 10,
+			 0.3
+			],
+			[
+			 17,
+			 1.8
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   2,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "Ferre a niveau - voie en construction trait perpendic",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "ferre",
+		 "minzoom": 10,
+		 "maxzoom": 18,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "VF_EN_CONSTR"
+		 ],
+		 "paint": {
+		  "line-color": "#787878",
+		  "line-width": {
+		   "stops": [
+			[
+			 10,
+			 3.5
+			],
+			[
+			 17,
+			 14.7
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   0.1,
+		   10
+		  ]
+		 }
+		},
+		{
+		 "id": "Ferre a niveau - funic/urbain",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "ferre",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "FUNI_CREMAILLERE",
+		  "TRANSPORT_URBAIN"
+		 ],
+		 "paint": {
+		  "line-color": "#787878",
+		  "line-width": {
+		   "stops": [
+			[
+			 10,
+			 0.3
+			],
+			[
+			 17,
+			 1.8
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Ferre a niveau - 2 trait perpendic - funic/urbain",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "ferre",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "FUNI_CREMAILLERE",
+		  "TRANSPORT_URBAIN"
+		 ],
+		 "paint": {
+		  "line-color": "#787878",
+		  "line-width": {
+		   "stops": [
+			[
+			 10,
+			 3.5
+			],
+			[
+			 17,
+			 17
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   0.1,
+		   0.2,
+		   0.1,
+		   10
+		  ]
+		 }
+		},
+		{
+		 "id": "liaison routiere - Bac Liaison Maritime",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_liaison",
+		 "minzoom": 8,
+		 "maxzoom": 18,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BAC_AUTO",
+		  "LIAISON_MARITIME",
+		  "BAC_LIAISON_MARITIME"
+		 ],
+		 "paint": {
+		  "line-color": "#5792C2",
+		  "line-width": {
+		   "stops": [
+			[
+			 8,
+			 1
+			],
+			[
+			 13,
+			 2.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "liaison routiere - Gue route",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_liaison",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "GUE_ROUTE"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 13,
+			 "#BEBEBE"
+			],
+			[
+			 17,
+			 "#646464"
+			],
+			[
+			 18,
+			 "#FFFFFF"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 2.3
+			],
+			[
+			 15,
+			 4.1
+			],
+			[
+			 16,
+			 6.3
+			],
+			[
+			 17,
+			 13.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "liaison routiere - Gue chemin",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_liaison",
+		 "maxzoom": 18,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "GUE_CHEMIN"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 13,
+			 "#BEBEBE"
+			],
+			[
+			 17,
+			 "#646464"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 1.6
+			],
+			[
+			 15,
+			 2.9
+			],
+			[
+			 16,
+			 4.4
+			],
+			[
+			 17,
+			 6.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "liaison routiere - filet extérieur - Pont passerelle",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_liaison",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "PONT_PASSERELLE",
+		  "PONT_LIN",
+		  "PONT_MOBILE_LIN"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 17,
+			 "#C8C8C8"
+			],
+			[
+			 18,
+			 "#FFFFFF"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 2.2
+			],
+			[
+			 15,
+			 3.8
+			],
+			[
+			 16,
+			 5.4
+			],
+			[
+			 17,
+			 11.8
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "liaison routiere - filet intérieur - Pont passerelle",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_liaison",
+		 "maxzoom": 18,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "PONT_PASSERELLE",
+		  "PONT_LIN",
+		  "PONT_MOBILE_LIN"
+		 ],
+		 "paint": {
+		  "line-color": "#FFFFFF",
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 0.7
+			],
+			[
+			 15,
+			 1.1
+			],
+			[
+			 16,
+			 1.7
+			],
+			[
+			 17,
+			 3.8
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier surfacique",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "routier_surf",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "SURF_ROUT_PRINC",
+		  "SURF_ROUT_REG",
+		  "SURF_ROUT_LOC",
+		  "SURF_ROUT_NON_CLA"
+		 ],
+		 "paint": {
+		  "fill-color": "#FFFFFF",
+		  "fill-outline-color": "#000000"
+		 }
+		},
+		{
+		 "id": "Routier surfacique - Dalle de protection",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "routier_surf",
+		 "maxzoom": 18,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "DALLE_DE_PROTECTION"
+		 ],
+		 "paint": {
+		  "fill-opacity": 0.5,
+		  "fill-color": "#FFFFFF",
+		  "fill-outline-color": "#000000"
+		 }
+		},
+		{
+		 "id": "Routier surfacique - Escalier surfacique",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "routier_surf",
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "ESCALIER_SURF"
+		 ],
+		 "paint": {
+		  "fill-opacity": 0.8,
+		  "fill-color": "#FFFFFF",
+		  "fill-outline-color": "#918091"
+		 }
+		},
+		{
+		 "id": "Routier surfacique - Péage surfacique",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "routier_surf",
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "SURF_PEAGE"
+		 ],
+		 "paint": {
+		  "fill-color": "#F2DAAA",
+		  "fill-outline-color": "#E2A52A"
+		 }
+		},
+		{
+		 "id": "bati transport surfacique - bati peage",
+		 "type": "fill",
+		 "source": "plan_ign",
+		 "source-layer": "bati_surf",
+		 "minzoom": 13,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "BATI_PEAGE"
+		 ],
+		 "paint": {
+		  "fill-color": "#DCDCDC",
+		  "fill-outline-color": "#808080"
+		 }
+		},
+		{
+		 "id": "réseau hydro  - cours d'eau superieur",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "hydro_reseau_sup",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "COURS_D_EAU_SUP",
+		  "COURS_D_EAU_MOY_SUP"
+		 ],
+		 "paint": {
+		  "line-color": "#AAD5E9",
+		  "line-width": {
+		   "stops": [
+			[
+			 12,
+			 1.5
+			],
+			[
+			 17,
+			 6.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "réseau hydro - canal superieur",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "hydro_reseau_sup",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "CANAL_SUP"
+		 ],
+		 "paint": {
+		  "line-color": "#AAD5E9",
+		  "line-width": {
+		   "stops": [
+			[
+			 12,
+			 1.4
+			],
+			[
+			 17,
+			 5.9
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "réseau hydro - filet interieur - aqueduc superieur",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "hydro_reseau_sup",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "AQUEDUC_SUP"
+		 ],
+		 "paint": {
+		  "line-color": "#AAD5E9",
+		  "line-width": {
+		   "stops": [
+			[
+			 12,
+			 1.4
+			],
+			[
+			 16,
+			 3.5
+			],
+			[
+			 17,
+			 5.9
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "réseau hydro - carre - aqueduc superieur",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "hydro_reseau_sup",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "AQUEDUC_SUP"
+		 ],
+		 "paint": {
+		  "line-color": "#AAD5E9",
+		  "line-width": {
+		   "stops": [
+			[
+			 12,
+			 3.5
+			],
+			[
+			 16,
+			 8.7
+			],
+			[
+			 17,
+			 14.7
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   1,
+		   5
+		  ]
+		 }
+		},
+		{
+		 "id": "Chemin superieur - piste cyclable",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_chemin_sup",
+		 "minzoom": 13,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "PISTE_CYCLABLE_SUP"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 17,
+			 "#9B5CCC"
+			],
+			[
+			 18,
+			 "#FFFFFF"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 1.1
+			],
+			[
+			 15,
+			 1.7
+			],
+			[
+			 16,
+			 2
+			],
+			[
+			 17,
+			 3.5
+			],
+			[
+			 18,
+			 6
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   6,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "Chemin superieur - filet exterieur - escalier",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_chemin_sup",
+		 "minzoom": 14,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "ESCALIER_SUP"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 17,
+			 "#8C7274"
+			],
+			[
+			 18,
+			 "#C8C8C8"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 1.75
+			],
+			[
+			 15,
+			 3
+			],
+			[
+			 16,
+			 4.2
+			],
+			[
+			 17,
+			 9.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Chemin superieur - filet interieur - escalier",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_chemin_sup",
+		 "minzoom": 14,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "ESCALIER_SUP"
+		 ],
+		 "paint": {
+		  "line-color": "#FFFFFF",
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 1
+			],
+			[
+			 15,
+			 1.9
+			],
+			[
+			 16,
+			 2.7
+			],
+			[
+			 17,
+			 5.8
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   1,
+		   0.2
+		  ]
+		 }
+		},
+		{
+		 "id": "Chemin superieur - Rue pietonne",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_chemin_sup",
+		 "minzoom": 14,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "RUE_PIETONNE_SUP"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 17,
+			 "#8C7274"
+			],
+			[
+			 18,
+			 "#EBEBEB"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 1
+			],
+			[
+			 15,
+			 1.2
+			],
+			[
+			 16,
+			 1.4
+			],
+			[
+			 17,
+			 2
+			],
+			[
+			 18,
+			 5
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   1,
+		   3
+		  ]
+		 }
+		},
+		{
+		 "id": "Chemin superieur - sentier",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_chemin_sup",
+		 "minzoom": 13,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "SENTIER_SUP"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 17,
+			 "#8C7274"
+			],
+			[
+			 18,
+			 "#FFFFFF"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 1
+			],
+			[
+			 15,
+			 1.2
+			],
+			[
+			 16,
+			 1.4
+			],
+			[
+			 17,
+			 2
+			],
+			[
+			 18,
+			 6
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   4,
+		   3
+		  ]
+		 }
+		},
+		{
+		 "id": "Chemin superieur - chemin",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_chemin_sup",
+		 "minzoom": 12,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "CHEMIN_SUP"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 17,
+			 "#8C7274"
+			],
+			[
+			 18,
+			 "#FFFFFF"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 1
+			],
+			[
+			 15,
+			 1.2
+			],
+			[
+			 16,
+			 1.4
+			],
+			[
+			 17,
+			 2
+			],
+			[
+			 18,
+			 7
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier superieur - filet extérieur - route non revetu carrosable",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sup",
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "NON_REVETUE_CARRO_SUP"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 12,
+			 "#646464"
+			],
+			[
+			 17,
+			 "#8C8C8C"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 3.2
+			],
+			[
+			 15,
+			 5.4
+			],
+			[
+			 16,
+			 7.7
+			],
+			[
+			 17,
+			 16.8
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   2,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "Routier superieur - filet extérieur - bretelle autoroute",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sup",
+		 "minzoom": 12,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BRET_AUTO_PEAGE_3_SUP",
+		  "BRET_AUTO_PEAGE_2_SUP",
+		  "BRET_AUTO_PEAGE_1_SUP",
+		  "BRET_AUTO_LIBRE_3_SUP",
+		  "BRET_AUTO_LIBRE_2_SUP",
+		  "BRET_AUTO_LIBRE_1_SUP"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 9,
+			 "#DE460E"
+			],
+			[
+			 17,
+			 "#F18800"
+			],
+			[
+			 18,
+			 "#FFFFFF"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 12,
+			 2.5
+			],
+			[
+			 14,
+			 3.7
+			],
+			[
+			 15,
+			 6.8
+			],
+			[
+			 16,
+			 8.4
+			],
+			[
+			 17,
+			 14
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier superieur - filet extérieur - route non classee restreint",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sup",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "NON_CLASSEE_RESTREINT_SUP"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 17,
+			 "#969696"
+			],
+			[
+			 18,
+			 "#FFFFFF"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 3.2
+			],
+			[
+			 15,
+			 5.4
+			],
+			[
+			 16,
+			 7.7
+			],
+			[
+			 17,
+			 16.8
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier superieur - filet extérieur - route non classee",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sup",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "NON_CLASSEE_4_SUP",
+		  "NON_CLASSEE_SUP"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 17,
+			 "#969696"
+			],
+			[
+			 18,
+			 "#FFFFFF"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 3.2
+			],
+			[
+			 15,
+			 5.4
+			],
+			[
+			 16,
+			 7.7
+			],
+			[
+			 17,
+			 16.8
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier superieur - filet extérieur - route locale",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sup",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BRET_LOCALE_SUP",
+		  "LOCALE_4_SUP",
+		  "LOCALE_3_SUP",
+		  "LOCALE_2_SUP",
+		  "LOCALE_1_SUP"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 12,
+			 "#8C8C8C"
+			],
+			[
+			 13,
+			 "#B4B4B4"
+			],
+			[
+			 17,
+			 "#B4B4B4"
+			],
+			[
+			 18,
+			 "#FFFFFF"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 9,
+			 2
+			],
+			[
+			 14,
+			 3.5
+			],
+			[
+			 15,
+			 6
+			],
+			[
+			 16,
+			 8.4
+			],
+			[
+			 17,
+			 18.3
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier superieur - filet extérieur - route locale en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sup",
+		 "minzoom": 11,
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "LOCALE_CONSTR_SUP"
+		 ],
+		 "paint": {
+		  "line-color": "#C8C8C8",
+		  "line-width": {
+		   "stops": [
+			[
+			 9,
+			 2
+			],
+			[
+			 14,
+			 3.5
+			],
+			[
+			 15,
+			 6
+			],
+			[
+			 16,
+			 8.4
+			],
+			[
+			 17,
+			 18.3
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier superieur - filet extérieur - route regionale",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sup",
+		 "minzoom": 8,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BRET_REGIONALE_SUP",
+		  "REGIONALE_4_SUP",
+		  "REGIONALE_3_SUP",
+		  "REGIONALE_2_SUP",
+		  "REGIONALE_1_SUP"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 9,
+			 "#828282"
+			],
+			[
+			 10,
+			 "#B4B4B4"
+			],
+			[
+			 17,
+			 "#B4B4B4"
+			],
+			[
+			 18,
+			 "#FFFFFF"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 6,
+			 1.5
+			],
+			[
+			 9,
+			 2.3
+			],
+			[
+			 14,
+			 5
+			],
+			[
+			 15,
+			 8.1
+			],
+			[
+			 16,
+			 11.2
+			],
+			[
+			 17,
+			 22
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier superieur - filet extérieur - route regionale en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sup",
+		 "minzoom": 10,
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "REGIONALE_CONSTR_SUP"
+		 ],
+		 "paint": {
+		  "line-color": "#C8C8C8",
+		  "line-width": {
+		   "stops": [
+			[
+			 6,
+			 1.5
+			],
+			[
+			 9,
+			 2.3
+			],
+			[
+			 14,
+			 5
+			],
+			[
+			 15,
+			 8.1
+			],
+			[
+			 16,
+			 11.2
+			],
+			[
+			 17,
+			 22
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier superieur - filet extérieur - route principale",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sup",
+		 "minzoom": 8,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BRET_PRINCIPALE_SUP",
+		  "PRINCIPALE_4_SUP",
+		  "PRINCIPALE_3_SUP",
+		  "PRINCIPALE_2_SUP",
+		  "PRINCIPALE_1_SUP"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 17,
+			 "#E2A52A"
+			],
+			[
+			 18,
+			 "#FFFFFF"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 6,
+			 1.8
+			],
+			[
+			 9,
+			 2.7
+			],
+			[
+			 14,
+			 5.9
+			],
+			[
+			 15,
+			 9
+			],
+			[
+			 16,
+			 12.2
+			],
+			[
+			 17,
+			 22.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier superieur - filet extérieur - route principale en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sup",
+		 "minzoom": 10,
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "PRINCIPALE_CONSTR_SUP"
+		 ],
+		 "paint": {
+		  "line-color": "#C8C8C8",
+		  "line-width": {
+		   "stops": [
+			[
+			 6,
+			 1.8
+			],
+			[
+			 9,
+			 2.7
+			],
+			[
+			 14,
+			 5.9
+			],
+			[
+			 15,
+			 9
+			],
+			[
+			 16,
+			 12.2
+			],
+			[
+			 17,
+			 22.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier superieur - filet extérieur - autoroute",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sup",
+		 "minzoom": 8,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "AUTOROU_PEAGE_SUP",
+		  "AUTOROU_LIBRE_SUP"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 9,
+			 "#DE460E"
+			],
+			[
+			 17,
+			 "#F18800"
+			],
+			[
+			 18,
+			 "#FFFFFF"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 6,
+			 2.5
+			],
+			[
+			 9,
+			 3.5
+			],
+			[
+			 14,
+			 7.5
+			],
+			[
+			 15,
+			 11
+			],
+			[
+			 16,
+			 15
+			],
+			[
+			 17,
+			 26
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier superieur - filet extérieur - autoroute en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sup",
+		 "minzoom": 10,
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "AUTOROU_CONSTR_SUP"
+		 ],
+		 "paint": {
+		  "line-color": "#C8C8C8",
+		  "line-width": {
+		   "stops": [
+			[
+			 6,
+			 2.5
+			],
+			[
+			 9,
+			 3.5
+			],
+			[
+			 14,
+			 7.5
+			],
+			[
+			 15,
+			 11
+			],
+			[
+			 16,
+			 15
+			],
+			[
+			 17,
+			 26
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier superieur - filet interieur - route non revetu carrosable",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sup",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "NON_REVETUE_CARRO_SUP"
+		 ],
+		 "paint": {
+		  "line-color": "#FFFFFF",
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 2.3
+			],
+			[
+			 15,
+			 4.1
+			],
+			[
+			 16,
+			 6.3
+			],
+			[
+			 17,
+			 13.5
+			],
+			[
+			 18,
+			 16.8
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier superieur - filet interieur - bretelle autoroute",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sup",
+		 "minzoom": 12,
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BRET_AUTO_PEAGE_3_SUP",
+		  "BRET_AUTO_PEAGE_2_SUP",
+		  "BRET_AUTO_PEAGE_1_SUP",
+		  "BRET_AUTO_LIBRE_3_SUP",
+		  "BRET_AUTO_LIBRE_2_SUP",
+		  "BRET_AUTO_LIBRE_1_SUP"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 9,
+			 "#F18800"
+			],
+			[
+			 17,
+			 "#F2B230"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 12,
+			 1.5
+			],
+			[
+			 14,
+			 2.6
+			],
+			[
+			 15,
+			 5.2
+			],
+			[
+			 16,
+			 6.7
+			],
+			[
+			 17,
+			 10.8
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier superieur - filet interieur - route non classee restreint",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sup",
+		 "maxzoom": 18,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "NON_CLASSEE_RESTREINT_SUP"
+		 ],
+		 "paint": {
+		  "line-color": "#EDF1FF",
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 2.3
+			],
+			[
+			 15,
+			 4.1
+			],
+			[
+			 16,
+			 6.3
+			],
+			[
+			 17,
+			 13.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier superieur - filet interieur - route non classee",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sup",
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "NON_CLASSEE_4_SUP",
+		  "NON_CLASSEE_SUP"
+		 ],
+		 "paint": {
+		  "line-color": "#FFFFFF",
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 2.3
+			],
+			[
+			 15,
+			 4.1
+			],
+			[
+			 16,
+			 6.3
+			],
+			[
+			 17,
+			 13.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier superieur - filet interieur - route locale",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sup",
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BRET_LOCALE_SUP",
+		  "LOCALE_4_SUP",
+		  "LOCALE_3_SUP",
+		  "LOCALE_2_SUP",
+		  "LOCALE_1_SUP"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 12,
+			 "#FFFFFF"
+			],
+			[
+			 13,
+			 "#FCF4A8"
+			],
+			[
+			 17,
+			 "#FCF7C1"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 9,
+			 1.3
+			],
+			[
+			 14,
+			 2.3
+			],
+			[
+			 15,
+			 4.1
+			],
+			[
+			 16,
+			 6.1
+			],
+			[
+			 17,
+			 13.1
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier superieur - filet interieur - route locale en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sup",
+		 "minzoom": 11,
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "LOCALE_CONSTR_SUP"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 12,
+			 "#FFFFFF"
+			],
+			[
+			 13,
+			 "#FCF4A8"
+			],
+			[
+			 17,
+			 "#FCF7C1"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 9,
+			 2
+			],
+			[
+			 14,
+			 3.5
+			],
+			[
+			 15,
+			 6
+			],
+			[
+			 16,
+			 8.4
+			],
+			[
+			 17,
+			 18.3
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   2,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "Routier superieur - filet interieur - route regionale",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sup",
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BRET_REGIONALE_SUP",
+		  "REGIONALE_4_SUP",
+		  "REGIONALE_3_SUP",
+		  "REGIONALE_2_SUP",
+		  "REGIONALE_1_SUP"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 9,
+			 "#FFFFFF"
+			],
+			[
+			 10,
+			 "#FDF28B"
+			],
+			[
+			 17,
+			 "#FCF6BD"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 6,
+			 1.4
+			],
+			[
+			 9,
+			 1.5
+			],
+			[
+			 14,
+			 3.2
+			],
+			[
+			 15,
+			 5.8
+			],
+			[
+			 16,
+			 8.3
+			],
+			[
+			 17,
+			 16.2
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier superieur - filet interieur - route regionale en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sup",
+		 "minzoom": 10,
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "REGIONALE_CONSTR_SUP"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 9,
+			 "#FFFFFF"
+			],
+			[
+			 10,
+			 "#FDF28B"
+			],
+			[
+			 17,
+			 "#FCF6BD"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 6,
+			 1.5
+			],
+			[
+			 9,
+			 2.3
+			],
+			[
+			 14,
+			 5
+			],
+			[
+			 15,
+			 8.1
+			],
+			[
+			 16,
+			 11.2
+			],
+			[
+			 17,
+			 22
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   2,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "Routier superieur - filet interieur - route principale",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sup",
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BRET_PRINCIPALE_SUP",
+		  "PRINCIPALE_4_SUP",
+		  "PRINCIPALE_3_SUP",
+		  "PRINCIPALE_2_SUP",
+		  "PRINCIPALE_1_SUP"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 9,
+			 "#F3C66D"
+			],
+			[
+			 17,
+			 "#F2DDB3"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 4,
+			 0.5
+			],
+			[
+			 6,
+			 1.8
+			],
+			[
+			 9,
+			 2.1
+			],
+			[
+			 14,
+			 4.4
+			],
+			[
+			 15,
+			 7.3
+			],
+			[
+			 16,
+			 10
+			],
+			[
+			 17,
+			 18.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier superieur - filet interieur - route principale en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sup",
+		 "minzoom": 10,
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "PRINCIPALE_CONSTR_SUP"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 9,
+			 "#F3C66D"
+			],
+			[
+			 17,
+			 "#F2DDB3"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 6,
+			 1.8
+			],
+			[
+			 9,
+			 2.7
+			],
+			[
+			 14,
+			 5.9
+			],
+			[
+			 15,
+			 9
+			],
+			[
+			 16,
+			 12.2
+			],
+			[
+			 17,
+			 22.5
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   2,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "Routier superieur - filet interieur - autoroute",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sup",
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "AUTOROU_PEAGE_SUP",
+		  "AUTOROU_LIBRE_SUP"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 9,
+			 "#F18800"
+			],
+			[
+			 17,
+			 "#F2B230"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 4,
+			 0.7
+			],
+			[
+			 6,
+			 2.5
+			],
+			[
+			 9,
+			 2.7
+			],
+			[
+			 14,
+			 5.8
+			],
+			[
+			 15,
+			 9
+			],
+			[
+			 16,
+			 12
+			],
+			[
+			 17,
+			 20.8
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier superieur - axe central - autoroute",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sup",
+		 "minzoom": 13,
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "AUTOROU_PEAGE_SUP",
+		  "AUTOROU_LIBRE_SUP"
+		 ],
+		 "paint": {
+		  "line-color": "#FFFFFF",
+		  "line-width": {
+		   "stops": [
+			[
+			 9,
+			 0.6
+			],
+			[
+			 14,
+			 0.7
+			],
+			[
+			 15,
+			 1
+			],
+			[
+			 16,
+			 1.2
+			],
+			[
+			 17,
+			 2.1
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Routier superieur - filet interieur - autoroute en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sup",
+		 "minzoom": 10,
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "AUTOROU_CONSTR_SUP"
+		 ],
+		 "paint": {
+		  "line-color": {
+		   "stops": [
+			[
+			 9,
+			 "#F18800"
+			],
+			[
+			 17,
+			 "#F2B230"
+			]
+		   ]
+		  },
+		  "line-width": {
+		   "stops": [
+			[
+			 4,
+			 0.7
+			],
+			[
+			 6,
+			 2.5
+			],
+			[
+			 9,
+			 3.5
+			],
+			[
+			 14,
+			 7.5
+			],
+			[
+			 15,
+			 11
+			],
+			[
+			 16,
+			 15
+			],
+			[
+			 17,
+			 26
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   2,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "Routier superieur - axe centrale - autoroute en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "routier_route_sup",
+		 "minzoom": 13,
+		 "maxzoom": 20,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "AUTOROU_CONSTR_SUP"
+		 ],
+		 "paint": {
+		  "line-color": "#808080",
+		  "line-width": {
+		   "stops": [
+			[
+			 9,
+			 0.6
+			],
+			[
+			 14,
+			 0.7
+			],
+			[
+			 15,
+			 1
+			],
+			[
+			 16,
+			 1.2
+			],
+			[
+			 17,
+			 2.1
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Ferre superieur - voie normale",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "ferre_sup",
+		 "minzoom": 10,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "VF_1_SUP",
+		  "VF_2_SUP",
+		  "VF_ELEC_1_SUP"
+		 ],
+		 "paint": {
+		  "line-color": "#787878",
+		  "line-width": {
+		   "stops": [
+			[
+			 10,
+			 0.8
+			],
+			[
+			 17,
+			 2.5
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Ferre superieur - voie normale trait perpendic",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "ferre_sup",
+		 "minzoom": 10,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "VF_1_SUP",
+		  "VF_2_SUP",
+		  "VF_ELEC_1_SUP"
+		 ],
+		 "paint": {
+		  "line-color": "#787878",
+		  "line-width": {
+		   "stops": [
+			[
+			 10,
+			 3.5
+			],
+			[
+			 17,
+			 14.7
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   0.1,
+		   10
+		  ]
+		 }
+		},
+		{
+		 "id": "Ferre superieur - voie etroite",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "ferre_sup",
+		 "minzoom": 10,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "VF_ETROITE_1_SUP",
+		  "VF_ETROITE_SUP"
+		 ],
+		 "paint": {
+		  "line-color": "#787878",
+		  "line-width": {
+		   "stops": [
+			[
+			 10,
+			 0.3
+			],
+			[
+			 17,
+			 1.8
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Ferre superieur - voie etroite trait perpendic",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "ferre_sup",
+		 "minzoom": 10,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "VF_ETROITE_1_SUP",
+		  "VF_ETROITE_SUP"
+		 ],
+		 "paint": {
+		  "line-color": "#787878",
+		  "line-width": {
+		   "stops": [
+			[
+			 10,
+			 3.5
+			],
+			[
+			 17,
+			 14.7
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   0.1,
+		   10
+		  ]
+		 }
+		},
+		{
+		 "id": "Ferre superieur - voie service",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "ferre_sup",
+		 "minzoom": 14,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "VF_SERVICE_SUP",
+		  "VF_NON_EXPLOITEE_SUP"
+		 ],
+		 "paint": {
+		  "line-color": "#787878",
+		  "line-width": {
+		   "stops": [
+			[
+			 10,
+			 0.3
+			],
+			[
+			 17,
+			 1.8
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   5,
+		   2,
+		   1,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "Ferre superieur - voie en construction",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "ferre_sup",
+		 "minzoom": 10,
+		 "maxzoom": 18,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "VF_EN_CONSTR_SUP"
+		 ],
+		 "paint": {
+		  "line-color": "#787878",
+		  "line-width": {
+		   "stops": [
+			[
+			 10,
+			 0.3
+			],
+			[
+			 17,
+			 1.8
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   2,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "Ferre superieur - voie en construction trait perpendic",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "ferre_sup",
+		 "minzoom": 10,
+		 "maxzoom": 18,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "VF_EN_CONSTR_SUP"
+		 ],
+		 "paint": {
+		  "line-color": "#787878",
+		  "line-width": {
+		   "stops": [
+			[
+			 10,
+			 3.5
+			],
+			[
+			 17,
+			 14.7
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   0.1,
+		   10
+		  ]
+		 }
+		},
+		{
+		 "id": "Ferre superieur - funic/urbain",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "ferre_sup",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "FUNI_CREMAILLERE_SUP",
+		  "TRANSPORT_URBAIN_SUP"
+		 ],
+		 "paint": {
+		  "line-color": "#787878",
+		  "line-width": {
+		   "stops": [
+			[
+			 10,
+			 0.3
+			],
+			[
+			 17,
+			 1.8
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "Ferre superieur - 2 trait perpendic - funic/urbain",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "ferre_sup",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "FUNI_CREMAILLERE_SUP",
+		  "TRANSPORT_URBAIN_SUP"
+		 ],
+		 "paint": {
+		  "line-color": "#787878",
+		  "line-width": {
+		   "stops": [
+			[
+			 10,
+			 3.5
+			],
+			[
+			 17,
+			 17
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   0.1,
+		   0.2,
+		   0.1,
+		   10
+		  ]
+		 }
+		},
+		{
+		 "id": "Limite - cloture",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "limite_lin",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "CLOTURE"
+		 ],
+		 "paint": {
+		  "line-color": "#000000",
+		  "line-width": {
+		   "stops": [
+			[
+			 13,
+			 0.6
+			],
+			[
+			 17,
+			 1
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   1.5,
+		   4
+		  ]
+		 }
+		},
+		{
+		 "id": "Limite - layon",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "limite_lin",
+		 "minzoom": 14,
+		 "maxzoom": 18,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "LAYON"
+		 ],
+		 "paint": {
+		  "line-color": "#B3989A",
+		  "line-width": {
+		   "stops": [
+			[
+			 14,
+			 1
+			],
+			[
+			 15,
+			 1.2
+			],
+			[
+			 16,
+			 1.4
+			],
+			[
+			 17,
+			 2
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   4,
+		   7
+		  ]
+		 }
+		},
+		{
+		 "id": "Zone Règlementee - Enceinte militaire",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "limite_lin",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "LIM_ZONE_REGLEMENTEE",
+		  "LIM_ENCEINTE_MILITAIRE",
+		  "LIM_ENCEINTE_MILI",
+		  "LIM_CHAMP_TIR"
+		 ],
+		 "paint": {
+		  "line-color": "rgba(226, 130, 92, 0.8)",
+		  "line-width": {
+		   "stops": [
+			[
+			 13,
+			 1.7
+			],
+			[
+			 17,
+			 3.1
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   4,
+		   1,
+		   2,
+		   5
+		  ]
+		 }
+		},
+		{
+		 "id": "limite zone naturelle",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "limite_lin",
+		 "maxzoom": 18,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "LIM_ZONE_NATURELLE",
+		  "LIM_ZONE_NATURELLE_ILE",
+		  "LIM_RESERVE_NATURELLE"
+		 ],
+		 "paint": {
+		  "line-color": "#FFC2CB",
+		  "line-width": {
+		   "stops": [
+			[
+			 13,
+			 2
+			],
+			[
+			 17,
+			 4
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   2,
+		   1
+		  ]
+		 }
+		},
+		{
+		 "id": "limite zone naturelle - Parc naturel 10",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "limite_lin",
+		 "maxzoom": 10,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "LIM_PARC_NATUREL",
+		  "LIM_PARC_NATUREL_ILE"
+		 ],
+		 "paint": {
+		  "line-color": "#42A266",
+		  "line-width": {
+		   "stops": [
+			[
+			 13,
+			 2
+			],
+			[
+			 17,
+			 4
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   2,
+		   1
+		  ]
+		 }
+		},
+		{
+		 "id": "limite zone naturelle - Parc naturel 11",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "limite_lin",
+		 "minzoom": 10,
+		 "maxzoom": 11,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "LIM_PARC_NATUREL",
+		  "LIM_PARC_NATUREL_ILE"
+		 ],
+		 "paint": {
+		  "line-color": "#42A266",
+		  "line-width": {
+		   "stops": [
+			[
+			 13,
+			 2
+			],
+			[
+			 17,
+			 4
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   2,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "limite zone naturelle - Parc naturel 12",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "limite_lin",
+		 "minzoom": 11,
+		 "maxzoom": 12,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "LIM_PARC_NATUREL",
+		  "LIM_PARC_NATUREL_ILE"
+		 ],
+		 "paint": {
+		  "line-color": "#42A266",
+		  "line-width": {
+		   "stops": [
+			[
+			 13,
+			 2
+			],
+			[
+			 17,
+			 4
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   2,
+		   3
+		  ]
+		 }
+		},
+		{
+		 "id": "limite zone naturelle - Parc naturel 13",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "limite_lin",
+		 "minzoom": 12,
+		 "maxzoom": 13,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "LIM_PARC_NATUREL",
+		  "LIM_PARC_NATUREL_ILE"
+		 ],
+		 "paint": {
+		  "line-color": "#42A266",
+		  "line-width": {
+		   "stops": [
+			[
+			 13,
+			 2
+			],
+			[
+			 17,
+			 4
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   2,
+		   4
+		  ]
+		 }
+		},
+		{
+		 "id": "limite zone naturelle - Parc naturel 14",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "limite_lin",
+		 "minzoom": 13,
+		 "maxzoom": 18,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "LIM_PARC_NATUREL",
+		  "LIM_PARC_NATUREL_ILE"
+		 ],
+		 "paint": {
+		  "line-color": "rgba(66, 162, 102, 0.7)",
+		  "line-width": {
+		   "stops": [
+			[
+			 13,
+			 2
+			],
+			[
+			 17,
+			 4
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   2,
+		   5
+		  ]
+		 }
+		},
+		{
+		 "id": "limite zone naturelle - Parc marin",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "limite_lin",
+		 "maxzoom": 18,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "LIM_PARC_NATUREL_MARIN"
+		 ],
+		 "paint": {
+		  "line-color": "#2A81A2",
+		  "line-width": {
+		   "stops": [
+			[
+			 13,
+			 2
+			],
+			[
+			 17,
+			 4
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   2,
+		   1
+		  ]
+		 }
+		},
+		{
+		 "id": "parcellaire - parcelle bordure",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "parcellaire_parcelle",
+		 "layout": {
+		  "visibility": "none",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "PARCELLE"
+		 ],
+		 "paint": {
+		  "line-color": "#9933FF",
+		  "line-width": 1
+		 }
+		},
+		{
+		 "id": "parcellaire - section",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "parcellaire_section",
+		 "layout": {
+		  "visibility": "none",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "SECTION"
+		 ],
+		 "paint": {
+		  "line-color": "#287B00",
+		  "line-width": 1.9,
+		  "line-dasharray": [
+		   2,
+		   4,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "toponyme - parcellaire - section",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_parcellaire_section",
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "SECTION"
+		 ],
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-offset": [
+		   0,
+		   0
+		  ],
+		  "text-field": "{texte}",
+		  "text-size": 15,
+		  "text-anchor": "center",
+		  "text-keep-upright": true,
+		  "text-max-angle": 45,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ],
+		  "visibility": "none"
+		 },
+		 "paint": {
+		  "text-color": "#287B00"
+		 }
+		},
+		{
+		 "id": "toponyme - parcellaire - parcelle",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_parcellaire_parcelle",
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "PARCELLE"
+		 ],
+		 "layout": {
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 11,
+		  "text-anchor": "center",
+		  "text-keep-upright": true,
+		  "text-max-angle": 45,
+		  "text-font": [
+		   "Source Sans Pro Bold"
+		  ],
+		  "visibility": "none"
+		 },
+		 "paint": {
+		  "text-color": "#9933FF",
+		  "text-halo-width": 1,
+		  "text-halo-color": "#FFFFFF"
+		 }
+		},
+		{
+		 "id": "toponyme - parcellaire - adresse",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_parcellaire_adresse_ponc",
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "ADRESSE"
+		 ],
+		 "layout": {
+		  "symbol-placement": "point",
+		  "text-field": [
+		   "concat",
+		   "{numero}",
+		   "{indice_de_repetition}"
+		  ],
+		  "text-size": 11,
+		  "text-anchor": "center",
+		  "text-keep-upright": true,
+		  "text-max-angle": 45,
+		  "text-font": [
+		   "Source Sans Pro Bold"
+		  ],
+		  "visibility": "none"
+		 },
+		 "paint": {
+		  "text-color": "#695744",
+		  "text-halo-width": 1,
+		  "text-halo-color": "#FFFFFF"
+		 }
+		},
+		{
+		 "id": "limite admin - limite de commune",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "limite_lin",
+		 "minzoom": 13,
+		 "maxzoom": 18,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "LIM_COMMUNE",
+		  "LIM_CANTON",
+		  "LIM_ARRONDISSEMENT"
+		 ],
+		 "paint": {
+		  "line-color": "rgba(126, 119, 184, 0.5)",
+		  "line-width": {
+		   "stops": [
+			[
+			 13,
+			 3
+			],
+			[
+			 17,
+			 5.5
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   4,
+		   2,
+		   1,
+		   1,
+		   1,
+		   1,
+		   1,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "limite admin - limite de département bandeau",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "limite_lin",
+		 "minzoom": 8,
+		 "maxzoom": 13,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "LIM_DEPARTEMENT"
+		 ],
+		 "paint": {
+		  "line-color": "rgba(178, 175, 219, 0.4)",
+		  "line-width": {
+		   "stops": [
+			[
+			 9,
+			 4.1
+			],
+			[
+			 12,
+			 6
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "limite admin - limite de département tiret",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "limite_lin",
+		 "minzoom": 13,
+		 "maxzoom": 18,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "LIM_DEPARTEMENT"
+		 ],
+		 "paint": {
+		  "line-color": "rgba(126, 119, 184, 0.5)",
+		  "line-width": {
+		   "stops": [
+			[
+			 13,
+			 3
+			],
+			[
+			 17,
+			 5.5
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   4,
+		   2,
+		   1,
+		   1,
+		   1,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "limite admin - limite de région bandeau",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "limite_lin",
+		 "minzoom": 7,
+		 "maxzoom": 13,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "LIM_REGION"
+		 ],
+		 "paint": {
+		  "line-color": "rgba(178, 175, 219, 0.5)",
+		  "line-width": {
+		   "stops": [
+			[
+			 9,
+			 4.5
+			],
+			[
+			 12,
+			 6.7
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "limite admin - limite de région tiret",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "limite_lin",
+		 "minzoom": 13,
+		 "maxzoom": 18,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "LIM_REGION"
+		 ],
+		 "paint": {
+		  "line-color": "rgba(126, 119, 184, 0.5)",
+		  "line-width": {
+		   "stops": [
+			[
+			 13,
+			 3
+			],
+			[
+			 17,
+			 5.5
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   4,
+		   2,
+		   1,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "limite etat 1",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "limite_lin",
+		 "minzoom": 2,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "LIM_ETAT",
+		  "LIM_ETAT_ETRANGER"
+		 ],
+		 "paint": {
+		  "line-color": "rgba(178, 175, 219, 0.6)",
+		  "line-width": {
+		   "stops": [
+			[
+			 2,
+			 2
+			],
+			[
+			 3,
+			 3.5
+			],
+			[
+			 9,
+			 5
+			],
+			[
+			 14,
+			 13
+			],
+			[
+			 15,
+			 20
+			],
+			[
+			 16,
+			 24
+			],
+			[
+			 17,
+			 42
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "limite etat 2",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "limite_lin",
+		 "minzoom": 7,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "LIM_ETAT",
+		  "LIM_ETAT_ETRANGER"
+		 ],
+		 "paint": {
+		  "line-color": "#9F9CB8",
+		  "line-width": {
+		   "stops": [
+			[
+			 9,
+			 1.5
+			],
+			[
+			 14,
+			 3.5
+			],
+			[
+			 15,
+			 5.5
+			],
+			[
+			 16,
+			 6.5
+			],
+			[
+			 17,
+			 11
+			]
+		   ]
+		  },
+		  "line-dasharray": [
+		   4,
+		   2
+		  ]
+		 }
+		},
+		{
+		 "id": "limite cote",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "limite_lin",
+		 "minzoom": 7,
+		 "maxzoom": 10,
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "LIM_COTE"
+		 ],
+		 "paint": {
+		  "line-color": "#82A3B2",
+		  "line-width": 1
+		 }
+		},
+		{
+		 "id": "ligne electrique",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "bati_lin",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "LIGNE_ELECTRIQUE"
+		 ],
+		 "paint": {
+		  "line-color": "#808080",
+		  "line-width": {
+		   "stops": [
+			[
+			 13,
+			 1
+			],
+			[
+			 17,
+			 2
+			]
+		   ]
+		  }
+		 }
+		},
+		{
+		 "id": "autre construction linéaire",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "bati_lin",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "round",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "CABLE",
+		  "REMONTEE_MEC",
+		  "HYDROCARBURES",
+		  "CONDUITE_MATIERES_P",
+		  "SPORT_MONTAGNE_LIN",
+		  "PISTE_BOBSLEIGH",
+		  "PISTE_LUGE",
+		  "PISTE_AERO_LIN"
+		 ],
+		 "paint": {
+		  "line-color": "#808080",
+		  "line-width": 1
+		 }
+		},
+		{
+		 "id": "autre construction linéaire - trait perpend cable",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "bati_lin",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "CABLE"
+		 ],
+		 "paint": {
+		  "line-color": "#808080",
+		  "line-width": 5,
+		  "line-dasharray": [
+		   0.5,
+		   10
+		  ]
+		 }
+		},
+		{
+		 "id": "autre construction linéaire - trait perpend 1 remont",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "bati_lin",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "REMONTEE_MEC"
+		 ],
+		 "paint": {
+		  "line-color": "#808080",
+		  "line-width": 6,
+		  "line-dasharray": [
+		   1,
+		   10
+		  ]
+		 }
+		},
+		{
+		 "id": "autre construction linéaire - trait perpend 2 remont",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "bati_lin",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "REMONTEE_MEC"
+		 ],
+		 "paint": {
+		  "line-color": "#BEBEBE",
+		  "line-width": 6,
+		  "line-dasharray": [
+		   0.3,
+		   0.4,
+		   0.3,
+		   10
+		  ]
+		 }
+		},
+		{
+		 "id": "autre construction linéaire - trait perpend carbur",
+		 "type": "line",
+		 "source": "plan_ign",
+		 "source-layer": "bati_lin",
+		 "layout": {
+		  "visibility": "visible",
+		  "line-cap": "butt",
+		  "line-join": "round"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "HYDROCARBURES",
+		  "CONDUITE_MATIERES_P"
+		 ],
+		 "paint": {
+		  "line-color": "#808080",
+		  "line-width": 5,
+		  "line-dasharray": [
+		   1,
+		   10
+		  ]
+		 }
+		},
+		{
+		 "id": "routier ponctuel - peage ponctuel",
+		 "type": "circle",
+		 "source": "plan_ign",
+		 "source-layer": "routier_ponc",
+		 "minzoom": 8,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "PEAGE_PONC"
+		 ],
+		 "paint": {
+		  "circle-radius": {
+		   "stops": [
+			[
+			 9,
+			 3.5
+			],
+			[
+			 12,
+			 6.5
+			]
+		   ]
+		  },
+		  "circle-color": "#E2A52A",
+		  "circle-stroke-width": 1,
+		  "circle-stroke-color": "#808080"
+		 }
+		},
+		{
+		 "id": "routier ponctuel - barriere",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "routier_ponc",
+		 "minzoom": 12,
+		 "layout": {
+		  "visibility": "visible",
+		  "icon-image": "Barriere",
+		  "icon-size": {
+		   "stops": [
+			[
+			 13,
+			 0.25
+			],
+			[
+			 16,
+			 0.45
+			],
+			[
+			 17,
+			 0.7
+			]
+		   ]
+		  },
+		  "icon-allow-overlap": true,
+		  "icon-rotate": [
+		   "get",
+		   "rotation"
+		  ]
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "BARRIERE"
+		 ],
+		 "paint": {
+		  "icon-color": "#969696"
+		 }
+		},
+		{
+		 "id": "hydro ponctuel",
+		 "type": "circle",
+		 "source": "plan_ign",
+		 "source-layer": "hydro_ponc",
+		 "minzoom": 13,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "FONTAINE",
+		  "POINT_D_EAU",
+		  "SOURCE",
+		  "SOURCE_CAPTEE",
+		  "PERTE",
+		  "RESURGENCE",
+		  "CASCADE",
+		  "AUTRE_HYDRO_PONC"
+		 ],
+		 "paint": {
+		  "circle-radius": {
+		   "stops": [
+			[
+			 14,
+			 3
+			],
+			[
+			 17,
+			 7
+			]
+		   ]
+		  },
+		  "circle-color": "#FFFFFF",
+		  "circle-opacity": 1,
+		  "circle-stroke-width": {
+		   "stops": [
+			[
+			 14,
+			 2
+			],
+			[
+			 17,
+			 5
+			]
+		   ]
+		  },
+		  "circle-stroke-color": "#1466B2"
+		 }
+		},
+		{
+		 "id": "point coté",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "oro_ponc",
+		 "minzoom": 11,
+		 "maxzoom": 16,
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "POINT_COTE",
+		  "POINT_COTE_TOPO",
+		  "POINT_COTE_RESEAU",
+		  "POINT_RBF"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "icon-image": "Localite",
+		  "icon-size": 0.1,
+		  "text-field": "{texte}",
+		  "text-size": 10,
+		  "text-allow-overlap": false,
+		  "text-anchor": "bottom-left",
+		  "text-offset": [
+		   0.2,
+		   0.4
+		  ],
+		  "text-padding": 2,
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#505050"
+		 }
+		},
+		{
+		 "id": "bati ponctuel : Hopital",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "bati_ponc",
+		 "layout": {
+		  "visibility": "visible",
+		  "icon-image": "Hopital",
+		  "icon-size": 0.33
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "HOPITAL_PONC"
+		 ],
+		 "paint": {
+		  "icon-color": "#646464"
+		 }
+		},
+		{
+		 "id": "bati ponctuel hydrographique",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "bati_ponc",
+		 "minzoom": 14,
+		 "layout": {
+		  "visibility": "visible",
+		  "icon-image": "Pompage",
+		  "icon-size": {
+		   "stops": [
+			[
+			 13,
+			 0.2
+			],
+			[
+			 17,
+			 0.6
+			]
+		   ]
+		  },
+		  "icon-allow-overlap": true
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "CITERNE",
+		  "LAVOIR",
+		  "STATION_EPURATION",
+		  "STATION_DE_POMPAGE",
+		  "USINE_PRODUCTION_EAU",
+		  "USINE_ELEVATRICE"
+		 ],
+		 "paint": {
+		  "icon-color": "#1C62A6"
+		 }
+		},
+		{
+		 "id": "bati ponctuel hydrographique - Puits-Abreuvoir",
+		 "type": "circle",
+		 "source": "plan_ign",
+		 "source-layer": "bati_ponc",
+		 "minzoom": 13,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "PUITS",
+		  "ABREUVOIR"
+		 ],
+		 "paint": {
+		  "circle-radius": {
+		   "stops": [
+			[
+			 14,
+			 3
+			],
+			[
+			 17,
+			 7
+			]
+		   ]
+		  },
+		  "circle-color": "#FFFFFF",
+		  "circle-opacity": 1,
+		  "circle-stroke-width": {
+		   "stops": [
+			[
+			 14,
+			 2
+			],
+			[
+			 17,
+			 5
+			]
+		   ]
+		  },
+		  "circle-stroke-color": "#1466B2"
+		 }
+		},
+		{
+		 "id": "bati ponctuel hydrographique - Phare",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "bati_ponc",
+		 "minzoom": 13,
+		 "layout": {
+		  "visibility": "visible",
+		  "icon-image": "Phare",
+		  "icon-size": {
+		   "stops": [
+			[
+			 13,
+			 0.7
+			],
+			[
+			 17,
+			 1.3
+			]
+		   ]
+		  }
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "PHARE"
+		 ],
+		 "paint": {
+		  "icon-color": "#646464"
+		 }
+		},
+		{
+		 "id": "bati ponctuel hydrographique - Amer-Feu",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "bati_ponc",
+		 "minzoom": 13,
+		 "layout": {
+		  "visibility": "visible",
+		  "icon-image": "Feu",
+		  "icon-size": {
+		   "stops": [
+			[
+			 13,
+			 0.7
+			],
+			[
+			 17,
+			 1.3
+			]
+		   ]
+		  }
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "AMER",
+		  "FEU",
+		  "FEU_PONC",
+		  "TOURELLE_LUMINEUSE"
+		 ],
+		 "paint": {
+		  "icon-color": "#646464"
+		 }
+		},
+		{
+		 "id": "bati ponctuel hydrographique - Balise",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "bati_ponc",
+		 "minzoom": 13,
+		 "layout": {
+		  "visibility": "visible",
+		  "icon-image": "Balise",
+		  "icon-size": {
+		   "stops": [
+			[
+			 13,
+			 0.7
+			],
+			[
+			 17,
+			 1.3
+			]
+		   ]
+		  }
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "BALISE",
+		  "TOURELLE"
+		 ],
+		 "paint": {
+		  "icon-color": "#646464"
+		 }
+		},
+		{
+		 "id": "bati ponctuel hydrographique - Ecluse",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "bati_ponc",
+		 "minzoom": 12,
+		 "maxzoom": 15,
+		 "layout": {
+		  "visibility": "visible",
+		  "icon-image": "Ecluse",
+		  "icon-size": 0.2
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "ECLUSE_PONC"
+		 ],
+		 "paint": {
+		  "icon-color": "#1C62A6"
+		 }
+		},
+		{
+		 "id": "bati ponctuel hydrographique - Barrage",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "bati_ponc",
+		 "minzoom": 12,
+		 "maxzoom": 14,
+		 "layout": {
+		  "visibility": "visible",
+		  "icon-image": "Barrage",
+		  "icon-size": 0.25
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "BARRAGE_PONC"
+		 ],
+		 "paint": {
+		  "icon-color": "#1C62A6"
+		 }
+		},
+		{
+		 "id": "bati ponctuel hydrographique - Chateau d'eau",
+		 "type": "circle",
+		 "source": "plan_ign",
+		 "source-layer": "bati_ponc",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "CHATEAU_EAU_PONC"
+		 ],
+		 "paint": {
+		  "circle-radius": {
+		   "stops": [
+			[
+			 14,
+			 3
+			],
+			[
+			 17,
+			 8
+			]
+		   ]
+		  },
+		  "circle-color": "#1466B2"
+		 }
+		},
+		{
+		 "id": "bati ponctuel hydrographique - Réservoir d'eau",
+		 "type": "circle",
+		 "source": "plan_ign",
+		 "source-layer": "bati_ponc",
+		 "maxzoom": 15,
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "RESERVOIR_EAU_PONC"
+		 ],
+		 "paint": {
+		  "circle-radius": {
+		   "stops": [
+			[
+			 14,
+			 3
+			],
+			[
+			 17,
+			 8
+			]
+		   ]
+		  },
+		  "circle-color": "#AAD5E9",
+		  "circle-opacity": 1,
+		  "circle-stroke-width": {
+		   "stops": [
+			[
+			 14,
+			 1
+			],
+			[
+			 17,
+			 2.5
+			]
+		   ]
+		  },
+		  "circle-stroke-color": "#1466B2"
+		 }
+		},
+		{
+		 "id": "bati ponctuel infrastructure - Constr spé",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "bati_ponc",
+		 "layout": {
+		  "visibility": "visible",
+		  "icon-image": "ConstrSpeciale",
+		  "icon-size": {
+		   "stops": [
+			[
+			 13,
+			 0.22
+			],
+			[
+			 17,
+			 0.5
+			]
+		   ]
+		  }
+		 },
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "ANTENNE",
+		  "CONSTR_SPE_TECHNIQUE",
+		  "CONSTR_INDIF_PONC",
+		  "CHEMINEE",
+		  "CHEVALEMENT",
+		  "PUITS_GAZ",
+		  "PUITS_PETROLE",
+		  "PYLONE_METEO",
+		  "TORCHERE",
+		  "TOUR_GUET",
+		  "TOUR_HERTZIENNE"
+		 ],
+		 "paint": {
+		  "icon-color": "#646464"
+		 }
+		},
+		{
+		 "id": "bati ponctuel infrastructure - Silo",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "bati_ponc",
+		 "maxzoom": 15,
+		 "layout": {
+		  "visibility": "visible",
+		  "icon-image": "Silo",
+		  "icon-size": {
+		   "stops": [
+			[
+			 13,
+			 0.22
+			],
+			[
+			 17,
+			 0.5
+			]
+		   ]
+		  }
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "SILO_PONC"
+		 ],
+		 "paint": {
+		  "icon-color": "#646464"
+		 }
+		},
+		{
+		 "id": "bati ponctuel infrastructure - Eolienne",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "bati_ponc",
+		 "layout": {
+		  "visibility": "visible",
+		  "icon-image": "Eolienne",
+		  "icon-size": {
+		   "stops": [
+			[
+			 13,
+			 0.4
+			],
+			[
+			 17,
+			 1
+			],
+			[
+			 18,
+			 0.8
+			]
+		   ]
+		  }
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "EOLIENNE"
+		 ],
+		 "paint": {
+		  "icon-color": "#646464"
+		 }
+		},
+		{
+		 "id": "bati ponctuel infrastructure - Reservoir",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "bati_ponc",
+		 "maxzoom": 15,
+		 "layout": {
+		  "visibility": "visible",
+		  "icon-image": "Reservoir",
+		  "icon-size": {
+		   "stops": [
+			[
+			 13,
+			 0.26
+			],
+			[
+			 17,
+			 0.5
+			]
+		   ]
+		  }
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "RESERVOIR_PONC"
+		 ],
+		 "paint": {
+		  "icon-color": "#646464"
+		 }
+		},
+		{
+		 "id": "bati ponctuel infrastructure - pylone électrique",
+		 "type": "circle",
+		 "source": "plan_ign",
+		 "source-layer": "bati_ponc",
+		 "layout": {
+		  "visibility": "visible"
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "PYLONE_ELEC"
+		 ],
+		 "paint": {
+		  "circle-radius": {
+		   "stops": [
+			[
+			 13,
+			 1
+			],
+			[
+			 17,
+			 2
+			]
+		   ]
+		  },
+		  "circle-color": "#000000"
+		 }
+		},
+		{
+		 "id": "bati ponctuel montagne - Abri",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "bati_ponc",
+		 "layout": {
+		  "visibility": "visible",
+		  "icon-image": "Abri",
+		  "icon-size": {
+		   "stops": [
+			[
+			 13,
+			 0.4
+			],
+			[
+			 15,
+			 0.6
+			],
+			[
+			 17,
+			 0.9
+			]
+		   ]
+		  }
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "ABRI"
+		 ],
+		 "paint": {
+		  "icon-color": "#246138"
+		 }
+		},
+		{
+		 "id": "bati ponctuel montagne - Refuge Garde",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "bati_ponc",
+		 "layout": {
+		  "visibility": "visible",
+		  "icon-image": "Refugegard",
+		  "icon-size": {
+		   "stops": [
+			[
+			 13,
+			 0.4
+			],
+			[
+			 15,
+			 0.6
+			],
+			[
+			 17,
+			 0.9
+			]
+		   ]
+		  }
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "REFUGE_GARDE"
+		 ],
+		 "paint": {
+		  "icon-color": "#246138"
+		 }
+		},
+		{
+		 "id": "bati ponctuel montagne - Refuge Non Garde",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "bati_ponc",
+		 "layout": {
+		  "visibility": "visible",
+		  "icon-image": "Refugenongard",
+		  "icon-size": {
+		   "stops": [
+			[
+			 13,
+			 0.4
+			],
+			[
+			 15,
+			 0.6
+			],
+			[
+			 17,
+			 0.9
+			]
+		   ]
+		  }
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "REFUGE"
+		 ],
+		 "paint": {
+		  "icon-color": "#246138"
+		 }
+		},
+		{
+		 "id": "bati ponctuel transport aerien - Aeroport FXX",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "bati_ponc",
+		 "layout": {
+		  "visibility": "visible",
+		  "icon-image": "Aeroport",
+		  "icon-size": 0.5
+		 },
+		 "filter": [
+		  "all",
+		  [
+		   "==",
+		   "symbo",
+		   "AEROPORT_PONC"
+		  ],
+		  [
+		   "==",
+		   "territoire",
+		   "FXX"
+		  ]
+		 ],
+		 "paint": {
+		  "icon-color": "#646464"
+		 }
+		},
+		{
+		 "id": "bati ponctuel transport aerien - Aerodrome FXX",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "bati_ponc",
+		 "layout": {
+		  "visibility": "visible",
+		  "icon-image": "Aerodrome",
+		  "icon-size": 0.4
+		 },
+		 "filter": [
+		  "all",
+		  [
+		   "==",
+		   "symbo",
+		   "AERODROME_PONC"
+		  ],
+		  [
+		   "==",
+		   "territoire",
+		   "FXX"
+		  ]
+		 ],
+		 "paint": {
+		  "icon-color": "#646464"
+		 }
+		},
+		{
+		 "id": "bati ponctuel transport aerien - Aeroport DOM",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "bati_ponc",
+		 "minzoom": 8,
+		 "layout": {
+		  "visibility": "visible",
+		  "icon-image": "Aeroport",
+		  "icon-size": 0.5
+		 },
+		 "filter": [
+		  "all",
+		  [
+		   "==",
+		   "symbo",
+		   "AEROPORT_PONC"
+		  ],
+		  [
+		   "!=",
+		   "territoire",
+		   "FXX"
+		  ]
+		 ],
+		 "paint": {
+		  "icon-color": "#646464"
+		 }
+		},
+		{
+		 "id": "bati ponctuel transport aerien - Aerodrome DOM",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "bati_ponc",
+		 "minzoom": 8,
+		 "layout": {
+		  "visibility": "visible",
+		  "icon-image": "Aerodrome",
+		  "icon-size": 0.4
+		 },
+		 "filter": [
+		  "all",
+		  [
+		   "==",
+		   "symbo",
+		   "AERODROME_PONC"
+		  ],
+		  [
+		   "!=",
+		   "territoire",
+		   "FXX"
+		  ]
+		 ],
+		 "paint": {
+		  "icon-color": "#646464"
+		 }
+		},
+		{
+		 "id": "bati ponctuel transport ferroviaire",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "bati_ponc",
+		 "layout": {
+		  "visibility": "visible",
+		  "icon-image": "Gare",
+		  "icon-size": 0.33
+		 },
+		 "filter": [
+		  "==",
+		  "symbo",
+		  "GARE_VOYAGEURS"
+		 ],
+		 "paint": {
+		  "icon-color": "#787878"
+		 }
+		},
+		{
+		 "id": "toponyme - bornes postales haute - chemins",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_routier_borne",
+		 "minzoom": 17,
+		 "maxzoom": 20,
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "CHEMIN",
+		  "CHEMIN_SOU",
+		  "CHEMIN_SUP",
+		  "PISTE_CYCLABLE",
+		  "PISTE_CYCLABLE_SOU",
+		  "PISTE_CYCLABLE_SUP",
+		  "RUE_PIETONNE",
+		  "RUE_PIETONNE_SOU",
+		  "RUE_PIETONNE_SUP",
+		  "SENTIER",
+		  "SENTIER_SOU",
+		  "SENTIER_SUP",
+		  "ESCALIER",
+		  "ESCALIER_SUP"
+		 ],
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{borne_sur}",
+		  "text-size": 11,
+		  "text-anchor": "center",
+		  "text-allow-overlap": true,
+		  "text-offset": [
+		   0,
+		   -1
+		  ],
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ],
+		  "visibility": "none"
+		 },
+		 "paint": {
+		  "text-color": "#79654F",
+		  "text-halo-width": 1,
+		  "text-halo-color": "#FFFFFF"
+		 }
+		},
+		{
+		 "id": "toponyme - bornes postales haute - non revetue, non classee",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_routier_borne",
+		 "minzoom": 17,
+		 "maxzoom": 20,
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "NON_CLASSEE",
+		  "NON_CLASSEE_4",
+		  "NON_CLASSEE_4_SUP",
+		  "NON_CLASSEE_RESTREINT",
+		  "NON_CLASSEE_RESTREINT_SUP",
+		  "NON_CLASSEE_SOU",
+		  "NON_CLASSEE_SUP",
+		  "NON_REVETUE_CARRO",
+		  "NON_REVETUE_CARRO_SUP"
+		 ],
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{borne_sur}",
+		  "text-size": 11,
+		  "text-anchor": "center",
+		  "text-allow-overlap": true,
+		  "text-offset": [
+		   0,
+		   -1.3
+		  ],
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ],
+		  "visibility": "none"
+		 },
+		 "paint": {
+		  "text-color": "#79654F",
+		  "text-halo-width": 1,
+		  "text-halo-color": "#FFFFFF"
+		 }
+		},
+		{
+		 "id": "toponyme - bornes postales haute - locales",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_routier_borne",
+		 "minzoom": 17,
+		 "maxzoom": 20,
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "LOCALE_1",
+		  "LOCALE_1_SOU",
+		  "LOCALE_1_SUP",
+		  "LOCALE_2",
+		  "LOCALE_2_SOU",
+		  "LOCALE_2_SUP",
+		  "LOCALE_3",
+		  "LOCALE_3_SOU",
+		  "LOCALE_3_SUP",
+		  "LOCALE_4",
+		  "LOCALE_4_SOU",
+		  "LOCALE_4_SUP",
+		  "LOCALE_CONSTR",
+		  "LOCALE_CONSTR_SUP"
+		 ],
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{borne_sur}",
+		  "text-size": 11,
+		  "text-anchor": "center",
+		  "text-allow-overlap": true,
+		  "text-offset": [
+		   0,
+		   -1.4
+		  ],
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ],
+		  "visibility": "none"
+		 },
+		 "paint": {
+		  "text-color": "#79654F",
+		  "text-halo-width": 1,
+		  "text-halo-color": "#FFFFFF"
+		 }
+		},
+		{
+		 "id": "toponyme - bornes postales haute - regionales",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_routier_borne",
+		 "minzoom": 17,
+		 "maxzoom": 20,
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "REGIONALE_1",
+		  "REGIONALE_1_SOU",
+		  "REGIONALE_1_SUP",
+		  "REGIONALE_2",
+		  "REGIONALE_2_SOU",
+		  "REGIONALE_2_SUP",
+		  "REGIONALE_3",
+		  "REGIONALE_3_SOU",
+		  "REGIONALE_3_SUP",
+		  "REGIONALE_4",
+		  "REGIONALE_4_SUP",
+		  "REGIONALE_CONSTR"
+		 ],
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{borne_sur}",
+		  "text-size": 11,
+		  "text-anchor": "center",
+		  "text-allow-overlap": true,
+		  "text-offset": [
+		   0,
+		   -1.5
+		  ],
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ],
+		  "visibility": "none"
+		 },
+		 "paint": {
+		  "text-color": "#79654F",
+		  "text-halo-width": 1,
+		  "text-halo-color": "#FFFFFF"
+		 }
+		},
+		{
+		 "id": "toponyme - bornes postales haute - principales",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_routier_borne",
+		 "minzoom": 17,
+		 "maxzoom": 20,
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "PRINCIPALE_1",
+		  "PRINCIPALE_1_SOU",
+		  "PRINCIPALE_1_SUP",
+		  "PRINCIPALE_2",
+		  "PRINCIPALE_2_SOU",
+		  "PRINCIPALE_2_SUP",
+		  "PRINCIPALE_3",
+		  "PRINCIPALE_3_SOU",
+		  "PRINCIPALE_3_SUP",
+		  "PRINCIPALE_4",
+		  "PRINCIPALE_4_SOU",
+		  "PRINCIPALE_4_SUP",
+		  "PRINCIPALE_CONSTR"
+		 ],
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{borne_sur}",
+		  "text-size": 11,
+		  "text-anchor": "center",
+		  "text-allow-overlap": true,
+		  "text-offset": [
+		   0,
+		   -1.6
+		  ],
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ],
+		  "visibility": "none"
+		 },
+		 "paint": {
+		  "text-color": "#79654F",
+		  "text-halo-width": 1,
+		  "text-halo-color": "#FFFFFF"
+		 }
+		},
+		{
+		 "id": "toponyme - bornes postales bas - chemins",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_routier_borne",
+		 "minzoom": 17,
+		 "maxzoom": 20,
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "CHEMIN",
+		  "CHEMIN_SOU",
+		  "CHEMIN_SUP",
+		  "PISTE_CYCLABLE",
+		  "PISTE_CYCLABLE_SOU",
+		  "PISTE_CYCLABLE_SUP",
+		  "RUE_PIETONNE",
+		  "RUE_PIETONNE_SOU",
+		  "RUE_PIETONNE_SUP",
+		  "SENTIER",
+		  "SENTIER_SOU",
+		  "SENTIER_SUP",
+		  "ESCALIER",
+		  "ESCALIER_SUP"
+		 ],
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{borne_sous}",
+		  "text-size": 11,
+		  "text-anchor": "center",
+		  "text-allow-overlap": true,
+		  "text-offset": [
+		   0,
+		   1
+		  ],
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ],
+		  "visibility": "none"
+		 },
+		 "paint": {
+		  "text-color": "#79654F",
+		  "text-halo-width": 1,
+		  "text-halo-color": "#FFFFFF"
+		 }
+		},
+		{
+		 "id": "toponyme - bornes postales bas - non revetue, non classee",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_routier_borne",
+		 "minzoom": 17,
+		 "maxzoom": 20,
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "NON_CLASSEE",
+		  "NON_CLASSEE_4",
+		  "NON_CLASSEE_4_SUP",
+		  "NON_CLASSEE_RESTREINT",
+		  "NON_CLASSEE_RESTREINT_SUP",
+		  "NON_CLASSEE_SOU",
+		  "NON_CLASSEE_SUP",
+		  "NON_REVETUE_CARRO",
+		  "NON_REVETUE_CARRO_SUP"
+		 ],
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{borne_sous}",
+		  "text-size": 11,
+		  "text-anchor": "center",
+		  "text-allow-overlap": true,
+		  "text-offset": [
+		   0,
+		   1.3
+		  ],
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ],
+		  "visibility": "none"
+		 },
+		 "paint": {
+		  "text-color": "#79654F",
+		  "text-halo-width": 1,
+		  "text-halo-color": "#FFFFFF"
+		 }
+		},
+		{
+		 "id": "toponyme - bornes postales bas - locales",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_routier_borne",
+		 "minzoom": 17,
+		 "maxzoom": 20,
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "LOCALE_1",
+		  "LOCALE_1_SOU",
+		  "LOCALE_1_SUP",
+		  "LOCALE_2",
+		  "LOCALE_2_SOU",
+		  "LOCALE_2_SUP",
+		  "LOCALE_3",
+		  "LOCALE_3_SOU",
+		  "LOCALE_3_SUP",
+		  "LOCALE_4",
+		  "LOCALE_4_SOU",
+		  "LOCALE_4_SUP",
+		  "LOCALE_CONSTR",
+		  "LOCALE_CONSTR_SUP"
+		 ],
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{borne_sous}",
+		  "text-size": 11,
+		  "text-anchor": "center",
+		  "text-allow-overlap": true,
+		  "text-offset": [
+		   0,
+		   1.4
+		  ],
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ],
+		  "visibility": "none"
+		 },
+		 "paint": {
+		  "text-color": "#79654F",
+		  "text-halo-width": 1,
+		  "text-halo-color": "#FFFFFF"
+		 }
+		},
+		{
+		 "id": "toponyme - bornes postales bas - regionales",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_routier_borne",
+		 "minzoom": 17,
+		 "maxzoom": 20,
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "REGIONALE_1",
+		  "REGIONALE_1_SOU",
+		  "REGIONALE_1_SUP",
+		  "REGIONALE_2",
+		  "REGIONALE_2_SOU",
+		  "REGIONALE_2_SUP",
+		  "REGIONALE_3",
+		  "REGIONALE_3_SOU",
+		  "REGIONALE_3_SUP",
+		  "REGIONALE_4",
+		  "REGIONALE_4_SUP",
+		  "REGIONALE_CONSTR"
+		 ],
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{borne_sous}",
+		  "text-size": 11,
+		  "text-anchor": "center",
+		  "text-allow-overlap": true,
+		  "text-offset": [
+		   0,
+		   1.5
+		  ],
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ],
+		  "visibility": "none"
+		 },
+		 "paint": {
+		  "text-color": "#79654F",
+		  "text-halo-width": 1,
+		  "text-halo-color": "#FFFFFF"
+		 }
+		},
+		{
+		 "id": "toponyme - bornes postales bas - principales",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_routier_borne",
+		 "minzoom": 17,
+		 "maxzoom": 20,
+		 "filter": [
+		  "in",
+		  "symbo",
+		  "PRINCIPALE_1",
+		  "PRINCIPALE_1_SOU",
+		  "PRINCIPALE_1_SUP",
+		  "PRINCIPALE_2",
+		  "PRINCIPALE_2_SOU",
+		  "PRINCIPALE_2_SUP",
+		  "PRINCIPALE_3",
+		  "PRINCIPALE_3_SOU",
+		  "PRINCIPALE_3_SUP",
+		  "PRINCIPALE_4",
+		  "PRINCIPALE_4_SOU",
+		  "PRINCIPALE_4_SUP",
+		  "PRINCIPALE_CONSTR"
+		 ],
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{borne_sous}",
+		  "text-size": 11,
+		  "text-anchor": "center",
+		  "text-allow-overlap": true,
+		  "text-offset": [
+		   0,
+		   1.6
+		  ],
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ],
+		  "visibility": "none"
+		 },
+		 "paint": {
+		  "text-color": "#79654F",
+		  "text-halo-width": 1,
+		  "text-halo-color": "#FFFFFF"
+		 }
+		},
+		{
+		 "id": "toponyme - courbe rocher maitresse",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_oro_ponc",
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "ORO_COURBE_ROCHER"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 10,
+		  "text-allow-overlap": false,
+		  "text-padding": 30,
+		  "text-rotate": {
+		   "type": "identity",
+		   "property": "rotation"
+		  },
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#333333",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 1
+		 }
+		},
+		{
+		 "id": "toponyme - courbe glacier maitresse",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_oro_ponc",
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "ORO_COURBE_GLACIER"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 10,
+		  "text-allow-overlap": false,
+		  "text-padding": 30,
+		  "text-rotate": {
+		   "type": "identity",
+		   "property": "rotation"
+		  },
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#629FD9",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 1
+		 }
+		},
+		{
+		 "id": "toponyme - courbe maitresse",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_oro_ponc",
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "ORO_COURBE"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 10,
+		  "text-allow-overlap": false,
+		  "text-padding": 30,
+		  "text-rotate": {
+		   "type": "identity",
+		   "property": "rotation"
+		  },
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#604A2F",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 1
+		 }
+		},
+		{
+		 "id": "toponyme - liaison maritime",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_routier_liaison_lin",
+		 "minzoom": 8,
+		 "maxzoom": 20,
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "LIAISON_MARITIME"
+		 ],
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{texte}",
+		  "text-size": 15,
+		  "text-anchor": "center",
+		  "text-keep-upright": true,
+		  "text-max-angle": 45,
+		  "text-padding": 10,
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ],
+		  "visibility": "visible"
+		 },
+		 "paint": {
+		  "text-color": "#5792C2",
+		  "text-halo-width": 5,
+		  "text-halo-color": "#AAD5E9"
+		 }
+		},
+		{
+		 "id": "toponyme bati station de métro + bati ponctuel metro",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_bati_ponc",
+		 "minzoom": 14,
+		 "filter": [
+		  "all",
+		  [
+		   "==",
+		   "txt_typo",
+		   "TYPO_E_1"
+		  ],
+		  [
+		   "==",
+		   "symbo",
+		   "STATION_METRO"
+		  ]
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 11,
+		  "text-allow-overlap": false,
+		  "text-offset": [
+		   0.3,
+		   -0.25
+		  ],
+		  "text-padding": 3,
+		  "text-anchor": "bottom-left",
+		  "text-font": [
+		   "Source Sans Pro"
+		  ],
+		  "icon-image": "Metro",
+		  "icon-size": {
+		   "stops": [
+			[
+			 15,
+			 0.33
+			],
+			[
+			 17,
+			 0.6
+			]
+		   ]
+		  }
+		 },
+		 "paint": {
+		  "text-color": "#3C3C3C",
+		  "icon-color": "#646464"
+		 }
+		},
+		{
+		 "id": "toponyme ferre lineaire",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_ferre_lin",
+		 "minzoom": 12,
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "FER_NOM",
+		  "FER_OUVRAGE"
+		 ],
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{texte}",
+		  "text-size": 10,
+		  "text-anchor": "center",
+		  "text-offset": [
+		   0,
+		   -1
+		  ],
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ],
+		  "visibility": "visible"
+		 },
+		 "paint": {
+		  "text-color": "#000000",
+		  "text-halo-width": 1,
+		  "text-halo-color": "rgba(255, 255, 255, 1)"
+		 }
+		},
+		{
+		 "id": "toponyme station epuration, de pompage, usine de production eau",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_bati_ponc",
+		 "minzoom": 14,
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "station"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{designation}",
+		  "text-anchor": "left",
+		  "text-offset": [
+		   0.8,
+		   0
+		  ],
+		  "text-size": 11,
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#447FB3"
+		 }
+		},
+		{
+		 "id": "toponyme bati ponc gare",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_bati_ponc",
+		 "minzoom": 15,
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "gore"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{designation}",
+		  "text-size": 11,
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#000000"
+		 }
+		},
+		{
+		 "id": "toponyme bati ponc barrage",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_bati_ponc",
+		 "minzoom": 12,
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "BARRAGE_PONC"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-anchor": "left",
+		  "text-offset": [
+		   0.8,
+		   0
+		  ],
+		  "text-size": 11,
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#447FB3"
+		 }
+		},
+		{
+		 "id": "toponyme bati ponc phare - niveau 13",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_bati_ponc",
+		 "maxzoom": 13,
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "PHARE"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-anchor": "right",
+		  "text-size": 11,
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#532A2A"
+		 }
+		},
+		{
+		 "id": "toponyme bati ponc phare - niveau 14à19",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_bati_ponc",
+		 "minzoom": 13,
+		 "filter": [
+		  "all",
+		  [
+		   "==",
+		   "symbo",
+		   "PHARE"
+		  ],
+		  [
+		   "in",
+		   "txt_typo",
+		   "TYPO_C_6",
+		   "TYPO_C_7",
+		   "TYPO_C_8",
+		   "TYPO_E_GE"
+		  ]
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-anchor": "right",
+		  "text-size": {
+		   "stops": [
+			[
+			 13,
+			 12
+			],
+			[
+			 18,
+			 18
+			]
+		   ]
+		  },
+		  "text-allow-overlap": false,
+		  "text-offset": [
+		   -2,
+		   0
+		  ],
+		  "text-padding": 3,
+		  "text-font": [
+		   "Source Sans Pro"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#532A2A"
+		 }
+		},
+		{
+		 "id": "toponyme bati ponc autre",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_bati_ponc",
+		 "minzoom": 12,
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "BAT_ACTIVITE",
+		  "BAT_FORTIF",
+		  "BAT_VILLAGE_DETRUIT"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-anchor": "center",
+		  "text-size": 11,
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#532A2A"
+		 }
+		},
+		{
+		 "id": "toponyme bati ponc aerogare",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_bati_ponc",
+		 "minzoom": 14,
+		 "maxzoom": 17,
+		 "filter": [
+		  "all",
+		  [
+		   "==",
+		   "txt_typo",
+		   "TYPO_E_GE"
+		  ],
+		  [
+		   "==",
+		   "symbo",
+		   "AEROGARE"
+		  ]
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-anchor": "center",
+		  "text-size": {
+		   "stops": [
+			[
+			 12,
+			 9
+			],
+			[
+			 16,
+			 11
+			]
+		   ]
+		  },
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#120049",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 1
+		 }
+		},
+		{
+		 "id": "toponyme bati ponc aeroport 12",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_bati_ponc",
+		 "minzoom": 11,
+		 "maxzoom": 12,
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "AEROPORT_PONC"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-anchor": "bottom",
+		  "text-offset": [
+		   0,
+		   -1.3
+		  ],
+		  "text-size": 10.5,
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#120049",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme bati ponc aeroport 13",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_bati_ponc",
+		 "minzoom": 12,
+		 "maxzoom": 13,
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "AEROPORT_PONC"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-anchor": "bottom",
+		  "text-offset": [
+		   0,
+		   -2
+		  ],
+		  "text-size": 11,
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#120049",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme bati ponc aeroport",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_bati_ponc",
+		 "minzoom": 13,
+		 "maxzoom": 17,
+		 "filter": [
+		  "all",
+		  [
+		   "==",
+		   "txt_typo",
+		   "TYPO_A_5"
+		  ],
+		  [
+		   "==",
+		   "symbo",
+		   "AEROPORT"
+		  ]
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-anchor": "center",
+		  "text-size": {
+		   "stops": [
+			[
+			 12,
+			 11
+			],
+			[
+			 16,
+			 13
+			]
+		   ]
+		  },
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#120049",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme bati ponc aerodrome 12",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_bati_ponc",
+		 "minzoom": 11,
+		 "maxzoom": 12,
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "AERODROME_PONC"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-anchor": "bottom",
+		  "text-offset": [
+		   0,
+		   -1.3
+		  ],
+		  "text-size": 9.5,
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#120049",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme bati ponc aerodrome 13",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_bati_ponc",
+		 "minzoom": 12,
+		 "maxzoom": 13,
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "AERODROME_PONC"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-anchor": "bottom",
+		  "text-offset": [
+		   0,
+		   -2
+		  ],
+		  "text-size": 10,
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#120049",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme bati ponc aerodrome",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_bati_ponc",
+		 "minzoom": 13,
+		 "maxzoom": 17,
+		 "filter": [
+		  "all",
+		  [
+		   "==",
+		   "txt_typo",
+		   "TYPO_A_7"
+		  ],
+		  [
+		   "==",
+		   "symbo",
+		   "AERODROME"
+		  ]
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-anchor": "center",
+		  "text-size": {
+		   "stops": [
+			[
+			 12,
+			 10
+			],
+			[
+			 16,
+			 12
+			]
+		   ]
+		  },
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#120049",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme - hydro ponc 5",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_hydro_ponc",
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "TYPO_D_9",
+		  "TYPO_D_10",
+		  "TYPO_E_1_cyan"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 15,
+			 11
+			],
+			[
+			 17,
+			 14
+			]
+		   ]
+		  },
+		  "text-allow-overlap": true,
+		  "text-padding": 5,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#447FB3",
+		  "text-halo-color": "#FFFFFF",
+		  "text-halo-width": 1
+		 }
+		},
+		{
+		 "id": "toponyme - hydro ponc glacier",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_hydro_ponc",
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "ORO_GLACIER_2"
+		 ],
+		 "layout": {
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 14,
+		  "text-anchor": "center",
+		  "text-allow-overlap": true,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ],
+		  "visibility": "visible"
+		 },
+		 "paint": {
+		  "text-color": "#447FB3",
+		  "text-halo-width": 2,
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)"
+		 }
+		},
+		{
+		 "id": "toponyme - limite militaire ponc 3 et 4",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_limite_ponc",
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "LIM_MILI_3",
+		  "LIM_MILI_4"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 12,
+		  "text-allow-overlap": false,
+		  "text-padding": 2,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#0D2000",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 1
+		 }
+		},
+		{
+		 "id": "toponyme - limite parc ponc 3 et 4",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_limite_ponc",
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "LIM_PARC_3",
+		  "LIM_PARC_4",
+		  "RESERVE_NATURELLE_PONC"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 13,
+		  "text-allow-overlap": false,
+		  "text-padding": 2,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#287B00",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 1
+		 }
+		},
+		{
+		 "id": "toponyme numéro de route - départementale",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_routier_numero_lin",
+		 "minzoom": 11,
+		 "maxzoom": 20,
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "Départementale"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "line",
+		  "text-field": "{texte}",
+		  "text-size": 10.5,
+		  "text-allow-overlap": false,
+		  "text-padding": 2,
+		  "text-anchor": "center",
+		  "text-font": [
+		   "Source Sans Pro Semibold"
+		  ],
+		  "text-rotation-alignment": "viewport"
+		 },
+		 "paint": {
+		  "text-color": "#4D4D4D",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 4
+		 }
+		},
+		{
+		 "id": "toponyme numéro de route - nationale",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_routier_numero_lin",
+		 "minzoom": 7,
+		 "maxzoom": 20,
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "Nationale"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "line",
+		  "text-field": "{texte}",
+		  "text-size": 12,
+		  "text-allow-overlap": false,
+		  "text-padding": 0,
+		  "text-anchor": "center",
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ],
+		  "icon-image": "Ecluse",
+		  "icon-rotation-alignment": "viewport",
+		  "text-rotation-alignment": "viewport",
+		  "icon-text-fit": "both",
+		  "icon-size": 0
+		 },
+		 "paint": {
+		  "text-color": "#F0F0F0",
+		  "icon-color": "#646464",
+		  "text-halo-color": "rgba(80, 80, 80, 0.5)",
+		  "text-halo-width": 4
+		 }
+		},
+		{
+		 "id": "toponyme numéro de route - autoroute",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_routier_numero_lin",
+		 "minzoom": 7,
+		 "maxzoom": 20,
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "Autoroute"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "line",
+		  "text-field": "{texte}",
+		  "text-size": 15,
+		  "text-allow-overlap": false,
+		  "text-padding": 0,
+		  "text-anchor": "center",
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ],
+		  "icon-image": "Ecluse",
+		  "icon-rotation-alignment": "viewport",
+		  "text-rotation-alignment": "viewport",
+		  "icon-text-fit": "both",
+		  "icon-size": 0
+		 },
+		 "paint": {
+		  "text-color": "#F0F0F0",
+		  "icon-color": "#646464",
+		  "text-halo-color": "rgba(80, 80, 80, 0.5)",
+		  "text-halo-width": 5
+		 }
+		},
+		{
+		 "id": "toponyme - odonyme abrégé",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_routier_odonyme_lin",
+		 "minzoom": 15,
+		 "maxzoom": 20,
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{nom_gauche}",
+		  "text-size": 10,
+		  "text-anchor": "center",
+		  "text-max-angle": 30,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ],
+		  "visibility": "none"
+		 },
+		 "paint": {
+		  "text-color": "#000000",
+		  "text-halo-width": 2,
+		  "text-halo-color": "rgba(255, 255, 255, 1)"
+		 }
+		},
+		{
+		 "id": "toponyme - odonyme desabrégé",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_routier_odonyme_lin",
+		 "minzoom": 17,
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{nom_desabrege}",
+		  "text-size": 11,
+		  "text-anchor": "center",
+		  "text-max-angle": 30,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ],
+		  "visibility": "none"
+		 },
+		 "paint": {
+		  "text-color": "#000000",
+		  "text-halo-width": 2,
+		  "text-halo-color": "rgba(255, 255, 255, 1)"
+		 }
+		},
+		{
+		 "id": "toponyme - lieu dit non habité 3",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_ocs_ponc",
+		 "filter": [
+		  "all",
+		  [
+		   "==",
+		   "symbo",
+		   "LIEU-DIT_NON_HABITE"
+		  ],
+		  [
+		   "in",
+		   "txt_typo",
+		   "TYPO_B_10",
+		   "TYPO_B_11"
+		  ]
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 11,
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#000000",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 1
+		 }
+		},
+		{
+		 "id": "toponyme - bois",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_ocs_ponc",
+		 "filter": [
+		  "all",
+		  [
+		   "==",
+		   "symbo",
+		   "BOIS"
+		  ],
+		  [
+		   "in",
+		   "txt_typo",
+		   "TYPO_F_10",
+		   "TYPO_F_11"
+		  ]
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 13,
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#287B00",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 1
+		 }
+		},
+		{
+		 "id": "toponyme - oro lineaire 4",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_oro_lin",
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "ORO_SOMMET_3",
+		  "ORO_GORGE_2"
+		 ],
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{texte}",
+		  "text-size": 11,
+		  "text-anchor": "center",
+		  "text-keep-upright": true,
+		  "text-max-angle": 45,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ],
+		  "visibility": "visible"
+		 },
+		 "paint": {
+		  "text-color": "#863831",
+		  "text-halo-width": 1.5,
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)"
+		 }
+		},
+		{
+		 "id": "toponyme - oro ponc 4",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_oro_ponc",
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "ORO_SOMMET_3",
+		  "ORO_GORGE_2",
+		  "GROTTE",
+		  "GORGE",
+		  "TYPO_G_9",
+		  "TYPO_G_10"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 13,
+			 11
+			],
+			[
+			 16,
+			 16
+			]
+		   ]
+		  },
+		  "text-allow-overlap": true,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#863831",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 1.5
+		 }
+		},
+		{
+		 "id": "toponyme - hydro ponc 4",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_hydro_ponc",
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "lac - étang - bassin",
+		  "HYD_SURF_4",
+		  "HYD_SURF_4_T",
+		  "HYD_SURF_5",
+		  "HYD_SURF_5_T",
+		  "TYPO_D_8",
+		  "SOURCE"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 14,
+			 13
+			],
+			[
+			 17,
+			 16
+			]
+		   ]
+		  },
+		  "text-allow-overlap": true,
+		  "text-padding": 5,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#447FB3",
+		  "text-halo-color": "#FFFFFF",
+		  "text-halo-width": 1
+		 }
+		},
+		{
+		 "id": "toponyme quartier ",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_localite_ponc",
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "BAT_QUARTIER",
+		  "BAT_QUARTIER_T"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 11,
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#000000",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme localite n0 typoA10",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_localite_ponc",
+		 "maxzoom": 18,
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "TYPO_A_10"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 15,
+			 11
+			],
+			[
+			 17,
+			 13.5
+			]
+		   ]
+		  },
+		  "text-allow-overlap": true,
+		  "text-anchor": "center",
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#000000",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme - lieu dit non habité",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_ocs_ponc",
+		 "filter": [
+		  "all",
+		  [
+		   "==",
+		   "symbo",
+		   "LIEU-DIT_NON_HABITE"
+		  ],
+		  [
+		   "in",
+		   "txt_typo",
+		   "TYPO_B_7",
+		   "TYPO_B_8",
+		   "TYPO_B_9"
+		  ]
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 12,
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#000000",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 1
+		 }
+		},
+		{
+		 "id": "toponyme - bois 2",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_ocs_ponc",
+		 "filter": [
+		  "all",
+		  [
+		   "==",
+		   "symbo",
+		   "BOIS"
+		  ],
+		  [
+		   "in",
+		   "txt_typo",
+		   "TYPO_F_7",
+		   "TYPO_F_8",
+		   "TYPO_F_9"
+		  ]
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 16,
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#287B00",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme localite hameau ",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_localite_ponc",
+		 "minzoom": 11,
+		 "maxzoom": 13,
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "BAT_HAMEAU",
+		  "BAT_HAMEAU_T"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "icon-image": "Localite",
+		  "icon-size": 0.17,
+		  "text-field": "{texte}",
+		  "text-size": 11,
+		  "text-allow-overlap": false,
+		  "text-anchor": "bottom-left",
+		  "text-offset": [
+		   0.3,
+		   0.1
+		  ],
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#000000",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme localite importance 5",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_localite_ponc",
+		 "minzoom": 9,
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "commune 5",
+		  "BAT_COMMUNE_5",
+		  "BAT_COMMUNE_5_T",
+		  "BAT_CHEF_LIEU_COM",
+		  "BAT_CHEF_LIEU_COM_T",
+		  "BAT_CHEF_LIEU_COM-T",
+		  "BAT_ANCIENNE_COM",
+		  "BAT_ANCIENNE_COM_T",
+		  "BAT_COMMUNE_ASSOCIEE",
+		  "BAT_COMMUNE_ASSOCIEE_T",
+		  "Commune très petite"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "icon-image": "Localite",
+		  "icon-size": 0.21,
+		  "text-field": "{texte}",
+		  "text-size": 11.5,
+		  "text-allow-overlap": false,
+		  "text-anchor": "bottom-left",
+		  "text-offset": [
+		   0.3,
+		   0.1
+		  ],
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#000000",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme - ocs lineaire 3",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_ocs_lin",
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "OCS_FORET_3"
+		 ],
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 10,
+			 12
+			],
+			[
+			 12,
+			 15
+			]
+		   ]
+		  },
+		  "text-anchor": "center",
+		  "text-keep-upright": true,
+		  "text-max-angle": 45,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ],
+		  "visibility": "visible"
+		 },
+		 "paint": {
+		  "text-color": "#287B00",
+		  "text-halo-width": 1,
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)"
+		 }
+		},
+		{
+		 "id": "toponyme - lieu dit non habité 1",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_ocs_ponc",
+		 "filter": [
+		  "all",
+		  [
+		   "==",
+		   "symbo",
+		   "LIEU-DIT_NON_HABITE"
+		  ],
+		  [
+		   "in",
+		   "txt_typo",
+		   "TYPO_B_5",
+		   "TYPO_B_4"
+		  ]
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 15,
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#000000",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 1
+		 }
+		},
+		{
+		 "id": "toponyme - bois 1",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_ocs_ponc",
+		 "filter": [
+		  "all",
+		  [
+		   "==",
+		   "symbo",
+		   "BOIS"
+		  ],
+		  [
+		   "in",
+		   "txt_typo",
+		   "TYPO_F_5",
+		   "TYPO_F_4"
+		  ]
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 19,
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#287B00",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme - bois 0",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_ocs_ponc",
+		 "filter": [
+		  "all",
+		  [
+		   "==",
+		   "symbo",
+		   "BOIS"
+		  ],
+		  [
+		   "in",
+		   "txt_typo",
+		   "TYPO_F_3",
+		   "TYPO_F_2"
+		  ]
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 22,
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#287B00",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme - ocs ponc 3",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_ocs_ponc",
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "OCS_FORET_3"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 10,
+			 12
+			],
+			[
+			 12,
+			 15
+			]
+		   ]
+		  },
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-anchor": "center",
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#287B00",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 1
+		 }
+		},
+		{
+		 "id": "toponyme - oro lineaire 3",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_oro_lin",
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "ORO_ILE_3",
+		  "ORO_RELIEF_3",
+		  "ORO_RELIEF_3_T",
+		  "ORO_RELIEF_4",
+		  "ORO_RELIEF_4_T",
+		  "ORO_CAP_2",
+		  "ORO_CAP_3",
+		  "ORO_SOMMET_2",
+		  "ORO_COL_2",
+		  "ORO_GORGE_1",
+		  "ORO_GORGE-1"
+		 ],
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{texte}",
+		  "text-size": 12,
+		  "text-anchor": "center",
+		  "text-keep-upright": true,
+		  "text-max-angle": 45,
+		  "text-padding": 10,
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ],
+		  "visibility": "visible"
+		 },
+		 "paint": {
+		  "text-color": "#863831",
+		  "text-halo-width": 1.5,
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)"
+		 }
+		},
+		{
+		 "id": "toponyme - oro ponc 3",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_oro_ponc",
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "ORO_ILE_3",
+		  "ORO_RELIEF_3",
+		  "ORO_RELIEF_3_T",
+		  "ORO_RELIEF_4",
+		  "ORO_RELIEF_4_T",
+		  "ORO_CAP_2",
+		  "ORO_CAP_3",
+		  "ORO_SOMMET_2",
+		  "ORO_COL_2",
+		  "ORO_GORGE_1",
+		  "ORO_GORGE-1",
+		  "TYPO_G_7",
+		  "TYPO_G_8"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 13,
+			 12
+			],
+			[
+			 16,
+			 17
+			]
+		   ]
+		  },
+		  "text-allow-overlap": true,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#863831",
+		  "text-halo-color": "#FFFFFF",
+		  "text-halo-width": 1.5
+		 }
+		},
+		{
+		 "id": "toponyme - hydro lineaire 3",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_hydro_lin",
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "HYD_LIN_3",
+		  "HYD_LIN_4",
+		  "HYD_LIN_5",
+		  "petite rivière",
+		  "canal",
+		  "HYD_SURF_3",
+		  "HYD_SURF_3_T",
+		  "HYD_SURF_4",
+		  "HYD_SURF_4_T",
+		  "HYD_SURF_5",
+		  "HYD_SURF_5_T",
+		  "TYPO_D_5"
+		 ],
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 14,
+			 12
+			],
+			[
+			 18,
+			 19
+			]
+		   ]
+		  },
+		  "text-anchor": "center",
+		  "text-keep-upright": true,
+		  "text-max-angle": 45,
+		  "text-padding": 10,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ],
+		  "visibility": "visible"
+		 },
+		 "paint": {
+		  "text-color": "#447FB3",
+		  "text-halo-width": 1.5,
+		  "text-halo-color": "rgba(255, 255, 255, 0.7)"
+		 }
+		},
+		{
+		 "id": "toponyme - hydro lineaire 4",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_hydro_lin",
+		 "minzoom": 14,
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "TYPO_D_6",
+		  "TYPO_D_8",
+		  "TYPO_D_9",
+		  "TYPO_D_10"
+		 ],
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 14,
+			 10
+			],
+			[
+			 18,
+			 16
+			]
+		   ]
+		  },
+		  "text-anchor": "center",
+		  "text-keep-upright": true,
+		  "text-max-angle": 45,
+		  "text-padding": 10,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ],
+		  "visibility": "visible"
+		 },
+		 "paint": {
+		  "text-color": "#447FB3",
+		  "text-halo-width": 1.5,
+		  "text-halo-color": "rgba(255, 255, 255, 0.7)"
+		 }
+		},
+		{
+		 "id": "toponyme - hydro ponc 3",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_hydro_ponc",
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "petit golfe",
+		  "grande baie",
+		  "baie",
+		  "HYD_SURF_3",
+		  "TYPO_D_5",
+		  "TYPO_D_6",
+		  "TYPO_D_7"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 15,
+			 15
+			],
+			[
+			 17,
+			 18
+			]
+		   ]
+		  },
+		  "text-allow-overlap": true,
+		  "text-padding": 10,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#447FB3",
+		  "text-halo-color": "#FFFFFF",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme bati ponc zai zoom 16",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_bati_ponc",
+		 "minzoom": 15,
+		 "maxzoom": 16,
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "zai"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{designation}",
+		  "text-size": 11,
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#000000"
+		 }
+		},
+		{
+		 "id": "toponyme bati ponc zai zoom 17 et 18",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_bati_ponc",
+		 "minzoom": 16,
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "zai"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 11,
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#000000"
+		 }
+		},
+		{
+		 "id": "toponyme localite importance 4",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_localite_ponc",
+		 "minzoom": 7,
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "commune 4",
+		  "BAT_COMMUNE_4",
+		  "BAT_COMMUNE_4_T"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "icon-image": "Localite",
+		  "icon-size": 0.21,
+		  "text-field": "{texte}",
+		  "text-size": 13,
+		  "text-allow-overlap": false,
+		  "text-anchor": "bottom-left",
+		  "text-offset": [
+		   0.3,
+		   0.1
+		  ],
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#000000",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme localite n0 typoA9",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_localite_ponc",
+		 "maxzoom": 18,
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "TYPO_A_9"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 15,
+			 11.5
+			],
+			[
+			 17,
+			 14
+			]
+		   ]
+		  },
+		  "text-allow-overlap": true,
+		  "text-anchor": "center",
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#000000",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme localite n0 typoA8",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_localite_ponc",
+		 "maxzoom": 18,
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "TYPO_A_8"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 15,
+			 12
+			],
+			[
+			 17,
+			 15
+			]
+		   ]
+		  },
+		  "text-allow-overlap": true,
+		  "text-anchor": "center",
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#000000",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme - limite militaire ponc 1 et 2",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_limite_ponc",
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "LIM_MILI_1",
+		  "LIM_MILI_2"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 15,
+		  "text-allow-overlap": false,
+		  "text-padding": 5,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#0D2000",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme - limite parc marin",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_limite_ponc",
+		 "minzoom": 8,
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "LIM_PARC_NATUREL_MARIN"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 15,
+		  "text-allow-overlap": false,
+		  "text-padding": 10,
+		  "text-transform": "uppercase",
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#2A81A2",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme - limite parc ponc 1 et 2",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_limite_ponc",
+		 "minzoom": 8,
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "LIM_PARC_1",
+		  "LIM_PARC_2",
+		  "LIM_PARC_NATUREL"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 15,
+		  "text-allow-overlap": false,
+		  "text-padding": 10,
+		  "text-transform": "uppercase",
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#287B00",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme - ocs lineaire 2",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_ocs_lin",
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "OCS_FORET_2"
+		 ],
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 10,
+			 15
+			],
+			[
+			 12,
+			 18
+			]
+		   ]
+		  },
+		  "text-anchor": "center",
+		  "text-keep-upright": true,
+		  "text-max-angle": 45,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ],
+		  "visibility": "visible"
+		 },
+		 "paint": {
+		  "text-color": "#287B00",
+		  "text-halo-width": 2,
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)"
+		 }
+		},
+		{
+		 "id": "toponyme - ocs ponc 2",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_ocs_ponc",
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "OCS_FORET_2"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 10,
+			 15
+			],
+			[
+			 12,
+			 18
+			]
+		   ]
+		  },
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-anchor": "center",
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#287B00",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme - oro lineaire 2",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_oro_lin",
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "ORO_ILE_2",
+		  "ORO_RELIEF_2",
+		  "ORO_RELIEF_2_T",
+		  "ORO_CAP_1",
+		  "ORO_SOMMET_1"
+		 ],
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{texte}",
+		  "text-size": 15,
+		  "text-anchor": "center",
+		  "text-keep-upright": true,
+		  "text-padding": 10,
+		  "text-max-angle": 45,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ],
+		  "visibility": "visible"
+		 },
+		 "paint": {
+		  "text-color": "#863831",
+		  "text-halo-width": 2,
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)"
+		 }
+		},
+		{
+		 "id": "toponyme - oro ponc 2",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_oro_ponc",
+		 "minzoom": 9,
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "ORO_ILE_2",
+		  "ORO_RELIEF_2",
+		  "ORO_RELIEF_2_T",
+		  "ORO_CAP_1",
+		  "ORO_COL_1",
+		  "sommet ou col",
+		  "ORO_SOMMET_1",
+		  "TYPO_G_4",
+		  "TYPO_G_6"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 9,
+			 13
+			],
+			[
+			 10,
+			 15
+			],
+			[
+			 13,
+			 15
+			],
+			[
+			 16,
+			 19
+			]
+		   ]
+		  },
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#863831",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme - oro ponc 2B",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_oro_ponc",
+		 "minzoom": 8,
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "île",
+		  "cap ou pointe"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 15,
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#863831",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme - hydro lineaire 2",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_hydro_lin",
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "HYD_LIN_2",
+		  "rivière moyenne",
+		  "HYD_SURF_2",
+		  "HYD_SURF_2_T",
+		  "TYPO_D_3"
+		 ],
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 14,
+			 15
+			],
+			[
+			 18,
+			 21
+			]
+		   ]
+		  },
+		  "text-anchor": "center",
+		  "text-keep-upright": true,
+		  "text-max-angle": 45,
+		  "text-padding": 10,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ],
+		  "visibility": "visible"
+		 },
+		 "paint": {
+		  "text-color": "#447FB3",
+		  "text-halo-width": 2,
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)"
+		 }
+		},
+		{
+		 "id": "toponyme - hydro ponc 2",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_hydro_ponc",
+		 "minzoom": 5,
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "moyen",
+		  "golfe moyen",
+		  "HYD_SURF_2",
+		  "TYPO_D_2",
+		  "TYPO_D_3",
+		  "TYPO_D_4"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 5,
+			 12
+			],
+			[
+			 6,
+			 18
+			],
+			[
+			 10,
+			 17
+			],
+			[
+			 18,
+			 21
+			]
+		   ]
+		  },
+		  "text-allow-overlap": false,
+		  "text-padding": 10,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#447FB3",
+		  "text-halo-color": "#FFFFFF",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme localite importance 3",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_localite_ponc",
+		 "minzoom": 5,
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "commune 3",
+		  "BAT_COMMUNE_3",
+		  "BAT_COMMUNE_3_T"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "icon-image": "Localite",
+		  "icon-size": 0.21,
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 5,
+			 10
+			],
+			[
+			 6,
+			 15
+			]
+		   ]
+		  },
+		  "text-allow-overlap": false,
+		  "text-anchor": "bottom-left",
+		  "text-offset": [
+		   0.3,
+		   0.1
+		  ],
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#000000",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme localite n0 typoA7 non commune",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_localite_ponc",
+		 "maxzoom": 18,
+		 "filter": [
+		  "all",
+		  [
+		   "!=",
+		   "symbo",
+		   "COMMUNE_FUSIONNEE"
+		  ],
+		  [
+		   "!=",
+		   "symbo",
+		   "COMMUNE_CHEF_LIEU"
+		  ],
+		  [
+		   "==",
+		   "txt_typo",
+		   "TYPO_A_7"
+		  ]
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 15,
+			 13
+			],
+			[
+			 17,
+			 16
+			]
+		   ]
+		  },
+		  "text-allow-overlap": true,
+		  "text-anchor": "center",
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#000000",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme localite n0 typoA6 non commune",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_localite_ponc",
+		 "maxzoom": 18,
+		 "filter": [
+		  "all",
+		  [
+		   "!=",
+		   "symbo",
+		   "COMMUNE_FUSIONNEE"
+		  ],
+		  [
+		   "!=",
+		   "symbo",
+		   "COMMUNE_CHEF_LIEU"
+		  ],
+		  [
+		   "==",
+		   "txt_typo",
+		   "TYPO_A_6"
+		  ]
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 15,
+			 15
+			],
+			[
+			 17,
+			 18
+			]
+		   ]
+		  },
+		  "text-allow-overlap": true,
+		  "text-anchor": "center",
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#000000",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme - oro lineaire 1",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_oro_lin",
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "ORO_ILE_1",
+		  "ORO_RELIEF_1",
+		  "ORO_RELIEF_1_T"
+		 ],
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{texte}",
+		  "text-size": 20,
+		  "text-anchor": "center",
+		  "text-keep-upright": true,
+		  "text-padding": 5,
+		  "text-max-angle": 45,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ],
+		  "visibility": "visible"
+		 },
+		 "paint": {
+		  "text-color": "#863831",
+		  "text-halo-width": 2,
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)"
+		 }
+		},
+		{
+		 "id": "toponyme - oro ponc monde",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_oro_ponc",
+		 "minzoom": 5,
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "Basin",
+		  "Depression",
+		  "Desert",
+		  "Geoarea",
+		  "Gorge",
+		  "Isthmus",
+		  "Lake",
+		  "Lowland",
+		  "Pen/cape",
+		  "Plain",
+		  "Plateau",
+		  "Range/mtn",
+		  "Tundra",
+		  "Valley",
+		  "Island",
+		  "Island group"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 11,
+		  "text-allow-overlap": false,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#863831",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme localite n0 typoA4 non commune",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_localite_ponc",
+		 "maxzoom": 16,
+		 "filter": [
+		  "all",
+		  [
+		   "!=",
+		   "symbo",
+		   "COMMUNE_FUSIONNEE"
+		  ],
+		  [
+		   "!=",
+		   "symbo",
+		   "COMMUNE_CHEF_LIEU"
+		  ],
+		  [
+		   "==",
+		   "txt_typo",
+		   "TYPO_A_4"
+		  ]
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 17,
+		  "text-allow-overlap": true,
+		  "text-anchor": "center",
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#000000",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 3
+		 }
+		},
+		{
+		 "id": "toponyme - ocs lineaire 1",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_ocs_lin",
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "OCS_FORET_1"
+		 ],
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 10,
+			 18
+			],
+			[
+			 12,
+			 22
+			]
+		   ]
+		  },
+		  "text-anchor": "center",
+		  "text-keep-upright": true,
+		  "text-padding": 1,
+		  "text-max-angle": 45,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ],
+		  "visibility": "visible"
+		 },
+		 "paint": {
+		  "text-color": "#287B00",
+		  "text-halo-width": 2,
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)"
+		 }
+		},
+		{
+		 "id": "toponyme - ocs ponc 1",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_ocs_ponc",
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "OCS_FORET_1"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 10,
+			 18
+			],
+			[
+			 12,
+			 22
+			]
+		   ]
+		  },
+		  "text-allow-overlap": true,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#287B00",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme - oro ponc 1",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_oro_ponc",
+		 "minzoom": 8,
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "grande île",
+		  "ORO_ILE_1",
+		  "ORO_RELIEF_1",
+		  "ORO_RELIEF_1_T",
+		  "TYPO_G_3",
+		  "TYPO_G_2",
+		  "TYPO_G_1"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 21,
+		  "text-allow-overlap": true,
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#863831",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme - hydro lineaire glacier",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_hydro_lin",
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "ORO_GLACIER_1",
+		  "ORO_GLACIER_2"
+		 ],
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{texte}",
+		  "text-size": 15,
+		  "text-anchor": "center",
+		  "text-keep-upright": true,
+		  "text-max-angle": 45,
+		  "text-font": [
+		   "Source Sans Pro Italic"
+		  ],
+		  "visibility": "visible"
+		 },
+		 "paint": {
+		  "text-color": "#447FB3",
+		  "text-halo-width": 2,
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)"
+		 }
+		},
+		{
+		 "id": "toponyme - hydro lineaire 1",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_hydro_lin",
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "HYD_LIN_1",
+		  "HYD-LIN-1",
+		  "grande rivière",
+		  "HYD_SURF_1",
+		  "HYD_SURF_1_T",
+		  "TYPO_D_1",
+		  "TYPO_D_2"
+		 ],
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{texte}",
+		  "text-size": 18,
+		  "text-anchor": "center",
+		  "text-keep-upright": true,
+		  "text-max-angle": 45,
+		  "text-padding": 10,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ],
+		  "visibility": "visible"
+		 },
+		 "paint": {
+		  "text-color": "#447FB3",
+		  "text-halo-width": 2,
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)"
+		 }
+		},
+		{
+		 "id": "toponyme - hydro lineaire ocean",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_hydro_lin",
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "mer et océan"
+		 ],
+		 "layout": {
+		  "symbol-placement": "line",
+		  "text-field": "{texte}",
+		  "text-size": 30,
+		  "text-anchor": "center",
+		  "text-keep-upright": true,
+		  "text-max-angle": 45,
+		  "text-padding": 10,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ],
+		  "visibility": "visible"
+		 },
+		 "paint": {
+		  "text-color": "#447FB3",
+		  "text-halo-width": 4,
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)"
+		 }
+		},
+		{
+		 "id": "toponyme - hydro ponc 1",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_hydro_ponc",
+		 "minzoom": 4,
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "mer",
+		  "grand",
+		  "grand golfe",
+		  "HYD_SURF_1",
+		  "TYPO_D_1"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 4,
+			 16
+			],
+			[
+			 6,
+			 30
+			],
+			[
+			 10,
+			 25
+			]
+		   ]
+		  },
+		  "text-allow-overlap": true,
+		  "text-padding": 10,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#447FB3",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 4
+		 }
+		},
+		{
+		 "id": "toponyme localite importance 2",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_localite_ponc",
+		 "minzoom": 4,
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "commune 2",
+		  "BAT_COMMUNE_2",
+		  "BAT_COMMUNE-2",
+		  "BAT_COMMUNE_2_T"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "icon-image": "Localite",
+		  "icon-size": 0.25,
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 4,
+			 10
+			],
+			[
+			 6,
+			 17
+			]
+		   ]
+		  },
+		  "text-allow-overlap": true,
+		  "text-anchor": "bottom-left",
+		  "text-offset": [
+		   0.3,
+		   0.2
+		  ],
+		  "text-padding": 1,
+		  "text-transform": "uppercase",
+		  "text-font": {
+		   "stops": [
+			[
+			 1,
+			 [
+			  "Source Sans Pro Regular"
+			 ]
+			],
+			[
+			 7,
+			 [
+			  "Source Sans Pro Bold"
+			 ]
+			],
+			[
+			 10,
+			 [
+			  "Source Sans Pro Regular"
+			 ]
+			]
+		   ]
+		  }
+		 },
+		 "paint": {
+		  "text-color": "#000000",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 3
+		 }
+		},
+		{
+		 "id": "toponyme localite n0 typoA3 non commune",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_localite_ponc",
+		 "maxzoom": 16,
+		 "filter": [
+		  "all",
+		  [
+		   "!=",
+		   "symbo",
+		   "COMMUNE_FUSIONNEE"
+		  ],
+		  [
+		   "!=",
+		   "symbo",
+		   "COMMUNE_CHEF_LIEU"
+		  ],
+		  [
+		   "==",
+		   "txt_typo",
+		   "TYPO_A_3"
+		  ]
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 19,
+		  "text-allow-overlap": true,
+		  "text-anchor": "center",
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#000000",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 3
+		 }
+		},
+		{
+		 "id": "toponyme localite n0 typoA2 non commune",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_localite_ponc",
+		 "maxzoom": 16,
+		 "filter": [
+		  "all",
+		  [
+		   "!=",
+		   "symbo",
+		   "COMMUNE_FUSIONNEE"
+		  ],
+		  [
+		   "!=",
+		   "symbo",
+		   "COMMUNE_CHEF_LIEU"
+		  ],
+		  [
+		   "==",
+		   "txt_typo",
+		   "TYPO_A_2"
+		  ]
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 21,
+		  "text-allow-overlap": true,
+		  "text-anchor": "center",
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#000000",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 4
+		 }
+		},
+		{
+		 "id": "toponyme localite n0 typoA7 commune",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_localite_ponc",
+		 "maxzoom": 18,
+		 "filter": [
+		  "all",
+		  [
+		   "in",
+		   "symbo",
+		   "COMMUNE_FUSIONNEE",
+		   "COMMUNE_CHEF_LIEU"
+		  ],
+		  [
+		   "==",
+		   "txt_typo",
+		   "TYPO_A_7"
+		  ]
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 15,
+			 13
+			],
+			[
+			 17,
+			 16
+			]
+		   ]
+		  },
+		  "text-allow-overlap": true,
+		  "text-anchor": "center",
+		  "text-padding": 1,
+		  "text-transform": "uppercase",
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#000000",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme localite n0 typoA6 commune",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_localite_ponc",
+		 "maxzoom": 18,
+		 "filter": [
+		  "all",
+		  [
+		   "in",
+		   "symbo",
+		   "COMMUNE_FUSIONNEE",
+		   "COMMUNE_CHEF_LIEU"
+		  ],
+		  [
+		   "==",
+		   "txt_typo",
+		   "TYPO_A_6"
+		  ]
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 15,
+			 15
+			],
+			[
+			 17,
+			 18
+			]
+		   ]
+		  },
+		  "text-allow-overlap": true,
+		  "text-anchor": "center",
+		  "text-padding": 1,
+		  "text-transform": "uppercase",
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#000000",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 2
+		 }
+		},
+		{
+		 "id": "toponyme localite n0 typoA1 non commune",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_localite_ponc",
+		 "maxzoom": 16,
+		 "filter": [
+		  "all",
+		  [
+		   "!=",
+		   "symbo",
+		   "COMMUNE_FUSIONNEE"
+		  ],
+		  [
+		   "!=",
+		   "symbo",
+		   "COMMUNE_CHEF_LIEU"
+		  ],
+		  [
+		   "==",
+		   "txt_typo",
+		   "TYPO_A_1"
+		  ]
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 23,
+		  "text-allow-overlap": true,
+		  "text-anchor": "center",
+		  "text-padding": 1,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#000000",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 4
+		 }
+		},
+		{
+		 "id": "toponyme localite n0 typoA4 commune",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_localite_ponc",
+		 "maxzoom": 16,
+		 "filter": [
+		  "all",
+		  [
+		   "in",
+		   "symbo",
+		   "COMMUNE_FUSIONNEE",
+		   "COMMUNE_CHEF_LIEU"
+		  ],
+		  [
+		   "==",
+		   "txt_typo",
+		   "TYPO_A_4"
+		  ]
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 17,
+		  "text-allow-overlap": true,
+		  "text-anchor": "center",
+		  "text-padding": 1,
+		  "text-transform": "uppercase",
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#000000",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 3
+		 }
+		},
+		{
+		 "id": "toponyme localite n0 typoA3 commune",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_localite_ponc",
+		 "maxzoom": 16,
+		 "filter": [
+		  "all",
+		  [
+		   "in",
+		   "symbo",
+		   "COMMUNE_FUSIONNEE",
+		   "COMMUNE_CHEF_LIEU"
+		  ],
+		  [
+		   "==",
+		   "txt_typo",
+		   "TYPO_A_3"
+		  ]
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 19,
+		  "text-allow-overlap": true,
+		  "text-anchor": "center",
+		  "text-padding": 1,
+		  "text-transform": "uppercase",
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#000000",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 3
+		 }
+		},
+		{
+		 "id": "toponyme localite n0 typoA2 commune",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_localite_ponc",
+		 "maxzoom": 16,
+		 "filter": [
+		  "all",
+		  [
+		   "in",
+		   "symbo",
+		   "COMMUNE_FUSIONNEE",
+		   "COMMUNE_CHEF_LIEU"
+		  ],
+		  [
+		   "==",
+		   "txt_typo",
+		   "TYPO_A_2"
+		  ]
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 21,
+		  "text-allow-overlap": true,
+		  "text-anchor": "center",
+		  "text-padding": 1,
+		  "text-transform": "uppercase",
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#000000",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 4
+		 }
+		},
+		{
+		 "id": "toponyme localite importance 1",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_localite_ponc",
+		 "minzoom": 3,
+		 "filter": [
+		  "in",
+		  "txt_typo",
+		  "commune 1",
+		  "BAT_COMMUNE_1",
+		  "BAT_COMMUNE_1_T"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "icon-image": "Localite",
+		  "icon-size": 0.3,
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 3,
+			 10
+			],
+			[
+			 6,
+			 20
+			]
+		   ]
+		  },
+		  "text-allow-overlap": false,
+		  "text-anchor": "bottom-left",
+		  "text-offset": [
+		   0.25,
+		   -0.1
+		  ],
+		  "text-padding": 1,
+		  "text-transform": "uppercase",
+		  "text-font": {
+		   "stops": [
+			[
+			 1,
+			 [
+			  "Source Sans Pro Regular"
+			 ]
+			],
+			[
+			 7,
+			 [
+			  "Source Sans Pro Bold"
+			 ]
+			],
+			[
+			 10,
+			 [
+			  "Source Sans Pro Regular"
+			 ]
+			]
+		   ]
+		  }
+		 },
+		 "paint": {
+		  "text-color": "#000000",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 4
+		 }
+		},
+		{
+		 "id": "toponyme localite n0 typoA1 commune",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_localite_ponc",
+		 "maxzoom": 16,
+		 "filter": [
+		  "all",
+		  [
+		   "in",
+		   "symbo",
+		   "COMMUNE_FUSIONNEE",
+		   "COMMUNE_CHEF_LIEU"
+		  ],
+		  [
+		   "==",
+		   "txt_typo",
+		   "TYPO_A_1"
+		  ]
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": 23,
+		  "text-allow-overlap": true,
+		  "text-anchor": "center",
+		  "text-padding": 1,
+		  "text-transform": "uppercase",
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#000000",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 4
+		 }
+		},
+		{
+		 "id": "toponyme - hydro ponc ocean",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_hydro_ponc",
+		 "minzoom": 1,
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "ocean"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "symbol-placement": "point",
+		  "text-field": "{texte}",
+		  "text-size": {
+		   "stops": [
+			[
+			 1,
+			 16
+			],
+			[
+			 6,
+			 30
+			]
+		   ]
+		  },
+		  "text-allow-overlap": true,
+		  "text-anchor": "center",
+		  "text-padding": 10,
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#447FB3",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 4
+		 }
+		},
+		{
+		 "id": "toponyme pays 3",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_localite_ponc",
+		 "minzoom": 4,
+		 "maxzoom": 5,
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "pays 3"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "text-field": "{texte}",
+		  "text-size": 9,
+		  "text-allow-overlap": true,
+		  "text-anchor": "center",
+		  "text-padding": 1,
+		  "text-transform": "uppercase",
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#787878",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 4
+		 }
+		},
+		{
+		 "id": "toponyme pays 2",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_localite_ponc",
+		 "minzoom": 2,
+		 "maxzoom": 5,
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "pays 2"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "text-field": "{texte}",
+		  "text-size": 13,
+		  "text-allow-overlap": true,
+		  "text-anchor": "center",
+		  "text-padding": 2,
+		  "text-transform": "uppercase",
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#787878",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 4
+		 }
+		},
+		{
+		 "id": "toponyme pays 1",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_localite_ponc",
+		 "minzoom": 2,
+		 "maxzoom": 5,
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "pays 1"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "text-field": "{texte}",
+		  "text-size": 13,
+		  "text-allow-overlap": true,
+		  "text-anchor": "center",
+		  "text-padding": 2,
+		  "text-transform": "uppercase",
+		  "text-font": [
+		   "Source Sans Pro Regular"
+		  ]
+		 },
+		 "paint": {
+		  "text-color": "#787878",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 4
+		 }
+		},
+		{
+		 "id": "toponyme continent",
+		 "type": "symbol",
+		 "source": "plan_ign",
+		 "source-layer": "toponyme_localite_ponc",
+		 "maxzoom": 3,
+		 "filter": [
+		  "==",
+		  "txt_typo",
+		  "continent"
+		 ],
+		 "layout": {
+		  "visibility": "visible",
+		  "text-field": "{texte}",
+		  "text-size": 15,
+		  "text-allow-overlap": true,
+		  "text-anchor": "center",
+		  "text-padding": 1,
+		  "text-transform": "uppercase",
+		  "text-font": [
 		   "Source Sans Pro Bold"
 		  ]
-		 ],
-		 [
-		  10,
-		  [
-		   "Source Sans Pro Regular"
-		  ]
-		 ]
-		]
-	   }
-	  },
-	  "paint": {
-	   "text-color": "#000000",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 3
+		 },
+		 "paint": {
+		  "text-color": "#787878",
+		  "text-halo-color": "rgba(255, 255, 255, 0.5)",
+		  "text-halo-width": 4
+		 }
+		}
+	   ]
 	  }
-	 },
-	 {
-	  "id": "toponyme localite n0 typoA3 non commune",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_localite_ponc",
-	  "maxzoom": 16,
-	  "filter": [
-	   "all",
-	   [
-		"!=",
-		"symbo",
-		"COMMUNE_FUSIONNEE"
-	   ],
-	   [
-		"!=",
-		"symbo",
-		"COMMUNE_CHEF_LIEU"
-	   ],
-	   [
-		"==",
-		"txt_typo",
-		"TYPO_A_3"
-	   ]
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-size": 19,
-	   "text-allow-overlap": true,
-	   "text-anchor": "center",
-	   "text-padding": 1,
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#000000",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 3
-	  }
-	 },
-	 {
-	  "id": "toponyme localite n0 typoA2 non commune",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_localite_ponc",
-	  "maxzoom": 16,
-	  "filter": [
-	   "all",
-	   [
-		"!=",
-		"symbo",
-		"COMMUNE_FUSIONNEE"
-	   ],
-	   [
-		"!=",
-		"symbo",
-		"COMMUNE_CHEF_LIEU"
-	   ],
-	   [
-		"==",
-		"txt_typo",
-		"TYPO_A_2"
-	   ]
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-size": 21,
-	   "text-allow-overlap": true,
-	   "text-anchor": "center",
-	   "text-padding": 1,
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#000000",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 4
-	  }
-	 },
-	 {
-	  "id": "toponyme localite n0 typoA7 commune",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_localite_ponc",
-	  "maxzoom": 18,
-	  "filter": [
-	   "all",
-	   [
-		"in",
-		"symbo",
-		"COMMUNE_FUSIONNEE",
-		"COMMUNE_CHEF_LIEU"
-	   ],
-	   [
-		"==",
-		"txt_typo",
-		"TYPO_A_7"
-	   ]
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-size": {
-		"stops": [
-		 [
-		  15,
-		  13
-		 ],
-		 [
-		  17,
-		  16
-		 ]
-		]
-	   },
-	   "text-allow-overlap": true,
-	   "text-anchor": "center",
-	   "text-padding": 1,
-	   "text-transform": "uppercase",
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#000000",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 2
-	  }
-	 },
-	 {
-	  "id": "toponyme localite n0 typoA6 commune",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_localite_ponc",
-	  "maxzoom": 18,
-	  "filter": [
-	   "all",
-	   [
-		"in",
-		"symbo",
-		"COMMUNE_FUSIONNEE",
-		"COMMUNE_CHEF_LIEU"
-	   ],
-	   [
-		"==",
-		"txt_typo",
-		"TYPO_A_6"
-	   ]
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-size": {
-		"stops": [
-		 [
-		  15,
-		  15
-		 ],
-		 [
-		  17,
-		  18
-		 ]
-		]
-	   },
-	   "text-allow-overlap": true,
-	   "text-anchor": "center",
-	   "text-padding": 1,
-	   "text-transform": "uppercase",
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#000000",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 2
-	  }
-	 },
-	 {
-	  "id": "toponyme localite n0 typoA1 non commune",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_localite_ponc",
-	  "maxzoom": 16,
-	  "filter": [
-	   "all",
-	   [
-		"!=",
-		"symbo",
-		"COMMUNE_FUSIONNEE"
-	   ],
-	   [
-		"!=",
-		"symbo",
-		"COMMUNE_CHEF_LIEU"
-	   ],
-	   [
-		"==",
-		"txt_typo",
-		"TYPO_A_1"
-	   ]
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-size": 23,
-	   "text-allow-overlap": true,
-	   "text-anchor": "center",
-	   "text-padding": 1,
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#000000",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 4
-	  }
-	 },
-	 {
-	  "id": "toponyme localite n0 typoA4 commune",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_localite_ponc",
-	  "maxzoom": 16,
-	  "filter": [
-	   "all",
-	   [
-		"in",
-		"symbo",
-		"COMMUNE_FUSIONNEE",
-		"COMMUNE_CHEF_LIEU"
-	   ],
-	   [
-		"==",
-		"txt_typo",
-		"TYPO_A_4"
-	   ]
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-size": 17,
-	   "text-allow-overlap": true,
-	   "text-anchor": "center",
-	   "text-padding": 1,
-	   "text-transform": "uppercase",
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#000000",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 3
-	  }
-	 },
-	 {
-	  "id": "toponyme localite n0 typoA3 commune",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_localite_ponc",
-	  "maxzoom": 16,
-	  "filter": [
-	   "all",
-	   [
-		"in",
-		"symbo",
-		"COMMUNE_FUSIONNEE",
-		"COMMUNE_CHEF_LIEU"
-	   ],
-	   [
-		"==",
-		"txt_typo",
-		"TYPO_A_3"
-	   ]
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-size": 19,
-	   "text-allow-overlap": true,
-	   "text-anchor": "center",
-	   "text-padding": 1,
-	   "text-transform": "uppercase",
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#000000",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 3
-	  }
-	 },
-	 {
-	  "id": "toponyme localite n0 typoA2 commune",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_localite_ponc",
-	  "maxzoom": 16,
-	  "filter": [
-	   "all",
-	   [
-		"in",
-		"symbo",
-		"COMMUNE_FUSIONNEE",
-		"COMMUNE_CHEF_LIEU"
-	   ],
-	   [
-		"==",
-		"txt_typo",
-		"TYPO_A_2"
-	   ]
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-size": 21,
-	   "text-allow-overlap": true,
-	   "text-anchor": "center",
-	   "text-padding": 1,
-	   "text-transform": "uppercase",
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#000000",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 4
-	  }
-	 },
-	 {
-	  "id": "toponyme localite importance 1",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_localite_ponc",
-	  "minzoom": 3,
-	  "filter": [
-	   "in",
-	   "txt_typo",
-	   "commune 1",
-	   "BAT_COMMUNE_1",
-	   "BAT_COMMUNE_1_T"
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "icon-image": "Localite",
-	   "icon-size": 0.3,
-	   "text-field": "{texte}",
-	   "text-size": {
-		"stops": [
-		 [
-		  3,
-		  10
-		 ],
-		 [
-		  6,
-		  20
-		 ]
-		]
-	   },
-	   "text-allow-overlap": false,
-	   "text-anchor": "bottom-left",
-	   "text-offset": [
-		0.25,
-		-0.1
-	   ],
-	   "text-padding": 1,
-	   "text-transform": "uppercase",
-	   "text-font": {
-		"stops": [
-		 [
-		  1,
-		  [
-		   "Source Sans Pro Regular"
-		  ]
-		 ],
-		 [
-		  7,
-		  [
-		   "Source Sans Pro Bold"
-		  ]
-		 ],
-		 [
-		  10,
-		  [
-		   "Source Sans Pro Regular"
-		  ]
-		 ]
-		]
-	   }
-	  },
-	  "paint": {
-	   "text-color": "#000000",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 4
-	  }
-	 },
-	 {
-	  "id": "toponyme localite n0 typoA1 commune",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_localite_ponc",
-	  "maxzoom": 16,
-	  "filter": [
-	   "all",
-	   [
-		"in",
-		"symbo",
-		"COMMUNE_FUSIONNEE",
-		"COMMUNE_CHEF_LIEU"
-	   ],
-	   [
-		"==",
-		"txt_typo",
-		"TYPO_A_1"
-	   ]
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-size": 23,
-	   "text-allow-overlap": true,
-	   "text-anchor": "center",
-	   "text-padding": 1,
-	   "text-transform": "uppercase",
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#000000",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 4
-	  }
-	 },
-	 {
-	  "id": "toponyme - hydro ponc ocean",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_hydro_ponc",
-	  "minzoom": 1,
-	  "filter": [
-	   "==",
-	   "txt_typo",
-	   "ocean"
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "symbol-placement": "point",
-	   "text-field": "{texte}",
-	   "text-size": {
-		"stops": [
-		 [
-		  1,
-		  16
-		 ],
-		 [
-		  6,
-		  30
-		 ]
-		]
-	   },
-	   "text-allow-overlap": true,
-	   "text-anchor": "center",
-	   "text-padding": 10,
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#447FB3",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 4
-	  }
-	 },
-	 {
-	  "id": "toponyme pays 3",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_localite_ponc",
-	  "minzoom": 4,
-	  "maxzoom": 5,
-	  "filter": [
-	   "==",
-	   "txt_typo",
-	   "pays 3"
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "text-field": "{texte}",
-	   "text-size": 9,
-	   "text-allow-overlap": true,
-	   "text-anchor": "center",
-	   "text-padding": 1,
-	   "text-transform": "uppercase",
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#787878",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 4
-	  }
-	 },
-	 {
-	  "id": "toponyme pays 2",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_localite_ponc",
-	  "minzoom": 2,
-	  "maxzoom": 5,
-	  "filter": [
-	   "==",
-	   "txt_typo",
-	   "pays 2"
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "text-field": "{texte}",
-	   "text-size": 13,
-	   "text-allow-overlap": true,
-	   "text-anchor": "center",
-	   "text-padding": 2,
-	   "text-transform": "uppercase",
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#787878",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 4
-	  }
-	 },
-	 {
-	  "id": "toponyme pays 1",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_localite_ponc",
-	  "minzoom": 2,
-	  "maxzoom": 5,
-	  "filter": [
-	   "==",
-	   "txt_typo",
-	   "pays 1"
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "text-field": "{texte}",
-	   "text-size": 13,
-	   "text-allow-overlap": true,
-	   "text-anchor": "center",
-	   "text-padding": 2,
-	   "text-transform": "uppercase",
-	   "text-font": [
-		"Source Sans Pro Regular"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#787878",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 4
-	  }
-	 },
-	 {
-	  "id": "toponyme continent",
-	  "type": "symbol",
-	  "source": "plan_ign",
-	  "source-layer": "toponyme_localite_ponc",
-	  "maxzoom": 3,
-	  "filter": [
-	   "==",
-	   "txt_typo",
-	   "continent"
-	  ],
-	  "layout": {
-	   "visibility": "visible",
-	   "text-field": "{texte}",
-	   "text-size": 15,
-	   "text-allow-overlap": true,
-	   "text-anchor": "center",
-	   "text-padding": 1,
-	   "text-transform": "uppercase",
-	   "text-font": [
-		"Source Sans Pro Bold"
-	   ]
-	  },
-	  "paint": {
-	   "text-color": "#787878",
-	   "text-halo-color": "rgba(255, 255, 255, 0.5)",
-	   "text-halo-width": 4
-	  }
-	 }
-	]
-   }


### PR DESCRIPTION
Utilisation des fonds de cartes vecteur tuilés IGN. Suppression du style toponyme pour les valeurs suivantes : routier_borne, routier_numeor_lin et routier_donyme_lin