### PR TITLE
Ajout d’une icône dans le fil d’Ariane

### DIFF
--- a/components/breadcrumbs.js
+++ b/components/breadcrumbs.js
@@ -1,21 +1,39 @@
 import React, {useMemo} from 'react'
 import PropTypes from 'prop-types'
 import NextLink from 'next/link'
-import {Pane, Link, Text} from 'evergreen-ui'
+import {Pane, Link, Text, HomeIcon} from 'evergreen-ui'
 
 function BaseLocalLink({baseLocale}) {
   return useMemo(() => {
     if (baseLocale.communes.length > 1) {
       return (
-        <NextLink href={`/bal?balId=${baseLocale._id}`} as={`/bal/${baseLocale._id}`}>
-          <Link href={`/bal/${baseLocale._id}`}>
-            {baseLocale.nom || 'Base Adresse Locale'}
-          </Link>
-        </NextLink>
+        <>
+          <NextLink href='/'>
+            <Link href='/'>
+              <HomeIcon style={{verticalAlign: 'middle', color: '#000'}} />
+            </Link>
+          </NextLink>
+          <Text color='muted'>{' > '}</Text>
+          <NextLink href={`/bal?balId=${baseLocale._id}`} as={`/bal/${baseLocale._id}`}>
+            <Link href={`/bal/${baseLocale._id}`}>
+              {baseLocale.nom || 'Base Adresse Locale'}
+            </Link>
+          </NextLink>
+        </>
       )
     }
 
-    return <Text>{baseLocale.nom || 'Base Adresse Locale'}</Text>
+    return (
+      <>
+        <NextLink href='/'>
+          <Link href='/'>
+            <HomeIcon style={{verticalAlign: 'middle', color: '#000'}} />
+          </Link>
+        </NextLink>
+        <Text color='muted'>{' > '}</Text>
+        <Text>{baseLocale.nom || 'Base Adresse Locale'}</Text>
+      </>
+    )
   }, [baseLocale])
 }
 


### PR DESCRIPTION
Des utilisateurs ont remonté le besoin d’avoir la possibilité de retourner à la liste des Bases Adresses Locales.
Il est actuellement possible de cliquer sur le logo du site, mais cette utilisation n’est pas évidente pour tout le monde.

Cette PR propose donc d'ajouter une icône de maison dans le fil d’Ariane qui permet de retourner sur la page d’accueil du site.

Capture : 

![image](https://user-images.githubusercontent.com/56537238/149357411-dc625a2b-9026-4cbc-9e3a-25ae27671425.png)


Fix #474 


