### PR TITLE
Refonte du chargement des pages et des contextes

### DIFF
--- a/components/bal/address-editor.js
+++ b/components/bal/address-editor.js
@@ -10,14 +10,14 @@ import BalDataContext from '@/contexts/bal-data'
 import NumeroEditor from '@/components/bal/numero-editor'
 import ToponymeEditor from '@/components/bal/toponyme-editor'
 
-function AddressEditor({commune, balId, codeCommune, closeForm}) {
+function AddressEditor({balId, commune, closeForm}) {
   const {token} = useContext(TokenContext)
   const {voie, reloadVoies, reloadNumeros, reloadToponymes, reloadGeojson, refreshBALSync} = useContext(BalDataContext)
 
   const [isToponyme, setIsToponyme] = useState(false)
 
   const onAddToponyme = async toponymeData => {
-    await addToponyme(balId, codeCommune, toponymeData, token)
+    await addToponyme(balId, commune.code, toponymeData, token)
     await reloadToponymes()
     await reloadGeojson()
     refreshBALSync()
@@ -30,7 +30,7 @@ function AddressEditor({commune, balId, codeCommune, closeForm}) {
     const isNewVoie = !editedVoie._id
 
     if (isNewVoie) {
-      editedVoie = await addVoie(balId, codeCommune, editedVoie, token)
+      editedVoie = await addVoie(balId, commune.code, editedVoie, token)
     }
 
     await addNumero(editedVoie._id, numero, token)
@@ -69,9 +69,8 @@ function AddressEditor({commune, balId, codeCommune, closeForm}) {
 }
 
 AddressEditor.propTypes = {
-  commune: PropTypes.object.isRequired,
   balId: PropTypes.string.isRequired,
-  codeCommune: PropTypes.string.isRequired,
+  commune: PropTypes.object.isRequired,
   closeForm: PropTypes.func.isRequired
 }
 

--- a/components/bal/address-editor.js
+++ b/components/bal/address-editor.js
@@ -34,7 +34,11 @@ function AddressEditor({balId, commune, closeForm}) {
     }
 
     await addNumero(editedVoie._id, numero, token)
-    await reloadNumeros()
+
+    if (voie?._id === editedVoie._id) {
+      await reloadNumeros()
+    }
+
     await reloadVoies()
     refreshBALSync()
 

--- a/components/bal/toponyme-editor.js
+++ b/components/bal/toponyme-editor.js
@@ -21,7 +21,7 @@ function ToponymeEditor({initialValue, onSubmit, onCancel}) {
   const {selectedParcelles, setSelectedParcelles, setIsParcelleSelectionEnabled} = useContext(ParcellesContext)
 
   const [isLoading, setIsLoading] = useState(false)
-  const [nom, onNomChange, resetNom] = useInput(initialValue ? initialValue.nom : '')
+  const [nom, onNomChange, resetNom] = useInput(initialValue?.nom || '')
   const [error, setError] = useState()
 
   const onFormSubmit = useCallback(async e => {

--- a/components/bal/toponymes-list.js
+++ b/components/bal/toponymes-list.js
@@ -12,12 +12,8 @@ import useFuse from '@/hooks/fuse'
 import TableRow from '@/components/table-row'
 import ToponymeEditor from '@/components/bal/toponyme-editor'
 
-function ToponymesList({isAdding, onAdd, onEdit, onCancel, onSelect, onEnableEditing, isPopulating, setToRemove}) {
-  const {
-    isEditing,
-    editingId,
-    toponymes
-  } = useContext(BalDataContext)
+function ToponymesList({toponymes, isAdding, onAdd, onEdit, onCancel, onSelect, onEnableEditing, isPopulating, setToRemove}) {
+  const {isEditing, editingId} = useContext(BalDataContext)
 
   const [filtered, setFilter] = useFuse(toponymes, 200, {
     keys: [
@@ -80,6 +76,7 @@ function ToponymesList({isAdding, onAdd, onEdit, onCancel, onSelect, onEnableEdi
 }
 
 ToponymesList.propTypes = {
+  toponymes: PropTypes.array.isRequired,
   isPopulating: PropTypes.bool,
   isAdding: PropTypes.bool.isRequired,
   setToRemove: PropTypes.func.isRequired,

--- a/components/bal/voies-list.js
+++ b/components/bal/voies-list.js
@@ -12,14 +12,10 @@ import useFuse from '@/hooks/fuse'
 import TableRow from '@/components/table-row'
 import VoieEditor from '@/components/bal/voie-editor'
 
-function VoiesList({defaultVoies, onEnableEditing, isAdding, onSelect, isPopulating, onAdd, onEdit, onCancel, setToRemove}) {
-  const {
-    isEditing,
-    editingId,
-    voies
-  } = useContext(BalDataContext)
+function VoiesList({voies, onEnableEditing, isAdding, onSelect, isPopulating, onAdd, onEdit, onCancel, setToRemove}) {
+  const {isEditing, editingId} = useContext(BalDataContext)
 
-  const [filtered, setFilter] = useFuse(voies || defaultVoies, 200, {
+  const [filtered, setFilter] = useFuse(voies, 200, {
     keys: [
       'nom'
     ]
@@ -79,7 +75,7 @@ function VoiesList({defaultVoies, onEnableEditing, isAdding, onSelect, isPopulat
 }
 
 VoiesList.propTypes = {
-  defaultVoies: PropTypes.array,
+  voies: PropTypes.array,
   isPopulating: PropTypes.bool,
   isAdding: PropTypes.bool.isRequired,
   setToRemove: PropTypes.func.isRequired,
@@ -91,7 +87,7 @@ VoiesList.propTypes = {
 }
 
 VoiesList.defaultProps = {
-  defaultVoies: null,
+  voies: null,
   isPopulating: false
 }
 

--- a/components/bases-locales-list/index.js
+++ b/components/bases-locales-list/index.js
@@ -115,11 +115,8 @@ function BasesLocalesList({basesLocales, sortBal}) {
 }
 
 BasesLocalesList.getInitialProps = async () => {
-  const basesLocales = await listBasesLocales()
-
   return {
-    basesLocales,
-    layout: 'fullscreen'
+    basesLocales: await listBasesLocales()
   }
 }
 

--- a/components/bases-locales-list/public-bases-locales-list.js
+++ b/components/bases-locales-list/public-bases-locales-list.js
@@ -78,11 +78,8 @@ function PublicBasesLocalesList({basesLocales, sortBal}) {
 }
 
 PublicBasesLocalesList.getInitialProps = async () => {
-  const basesLocales = await listBasesLocales()
-
   return {
-    basesLocales,
-    layout: 'fullscreen'
+    basesLocales: await listBasesLocales()
   }
 }
 

--- a/components/help/tuto/sidebar.js
+++ b/components/help/tuto/sidebar.js
@@ -1,6 +1,6 @@
 import {Paragraph, IconButton, ChevronRightIcon} from 'evergreen-ui'
 
-import Tuto from '.'
+import Tuto from '@/components/help/tuto'
 
 function Sidebar() {
   return (

--- a/components/help/tuto/unauthorized.js
+++ b/components/help/tuto/unauthorized.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import {Paragraph, Button, EditIcon} from 'evergreen-ui'
 
-import Tuto from '.'
+import Tuto from '@/components/help/tuto'
 
 function Unauthorized({title}) {
   return (

--- a/components/map/hooks/layers.js
+++ b/components/map/hooks/layers.js
@@ -7,7 +7,7 @@ import {getNumerosPointLayer, getNumerosLabelLayer} from '@/components/map/layer
 import {cadastreLayers} from '@/components/map/layers/cadastre'
 
 function useLayers(voie, sources, isCadastreDisplayed, style) {
-  const {parcelles, codeCommune} = useContext(BalDataContext)
+  const {parcelles, commune} = useContext(BalDataContext)
 
   return useMemo(() => {
     const hasNumeros = sources.find(({name}) => name === 'positions')
@@ -15,7 +15,7 @@ function useLayers(voie, sources, isCadastreDisplayed, style) {
     let layers = []
 
     if (isCadastreDisplayed) {
-      layers = [...cadastreLayers(parcelles, codeCommune)]
+      layers = [...cadastreLayers(parcelles, commune.code)]
     }
 
     if (hasVoies) {
@@ -36,7 +36,7 @@ function useLayers(voie, sources, isCadastreDisplayed, style) {
     }
 
     return layers
-  }, [voie, sources, isCadastreDisplayed, parcelles, style, codeCommune])
+  }, [voie, sources, isCadastreDisplayed, parcelles, style, commune.code])
 }
 
 export default useLayers

--- a/components/map/map.js
+++ b/components/map/map.js
@@ -1,5 +1,4 @@
 import {useState, useMemo, useEffect, useCallback, useContext} from 'react'
-import PropTypes from 'prop-types'
 import {useRouter} from 'next/router'
 import MapGl from 'react-map-gl'
 import {fromJS} from 'immutable'
@@ -67,7 +66,7 @@ function generateNewStyle(style, sources, layers) {
   return baseStyle.updateIn(['layers'], arr => arr.push(...layers))
 }
 
-function Map({toponyme}) {
+function Map() {
   const router = useRouter()
   const {map, setMap, style, setStyle, defaultStyle, viewport, setViewport, isCadastreDisplayed, setIsCadastreDisplayed} = useContext(MapContext)
   const {isParcelleSelectionEnabled, handleParcelle} = useContext(ParcellesContext)
@@ -83,6 +82,7 @@ function Map({toponyme}) {
   const {
     commune,
     voie,
+    toponyme,
     numeros,
     toponymes,
     editingId,
@@ -313,14 +313,6 @@ function Map({toponyme}) {
       )}
     </Pane>
   )
-}
-
-Map.propTypes = {
-  toponyme: PropTypes.object
-}
-
-Map.defaultProps = {
-  toponyme: null
 }
 
 export default Map

--- a/components/map/map.js
+++ b/components/map/map.js
@@ -67,7 +67,7 @@ function generateNewStyle(style, sources, layers) {
   return baseStyle.updateIn(['layers'], arr => arr.push(...layers))
 }
 
-function Map({voie, toponyme}) {
+function Map({toponyme}) {
   const router = useRouter()
   const {map, setMap, style, setStyle, defaultStyle, viewport, setViewport, isCadastreDisplayed, setIsCadastreDisplayed} = useContext(MapContext)
   const {isParcelleSelectionEnabled, handleParcelle} = useContext(ParcellesContext)
@@ -82,6 +82,7 @@ function Map({voie, toponyme}) {
 
   const {
     commune,
+    voie,
     numeros,
     toponymes,
     editingId,
@@ -291,7 +292,7 @@ function Map({voie, toponyme}) {
           {isEditing && (
             <EditableMarker
               style={style || defaultStyle}
-              idVoie={voie ? voie._id : null}
+              idVoie={voie?._id}
               isToponyme={Boolean(toponyme)}
               viewport={viewport}
             />
@@ -315,12 +316,10 @@ function Map({voie, toponyme}) {
 }
 
 Map.propTypes = {
-  voie: PropTypes.object,
   toponyme: PropTypes.object
 }
 
 Map.defaultProps = {
-  voie: null,
   toponyme: null
 }
 

--- a/components/map/map.js
+++ b/components/map/map.js
@@ -67,7 +67,7 @@ function generateNewStyle(style, sources, layers) {
   return baseStyle.updateIn(['layers'], arr => arr.push(...layers))
 }
 
-function Map({commune, voie, toponyme}) {
+function Map({voie, toponyme}) {
   const router = useRouter()
   const {map, setMap, style, setStyle, defaultStyle, viewport, setViewport, isCadastreDisplayed, setIsCadastreDisplayed} = useContext(MapContext)
   const {isParcelleSelectionEnabled, handleParcelle} = useContext(ParcellesContext)
@@ -78,9 +78,10 @@ function Map({commune, voie, toponyme}) {
   const [editPrevStyle, setEditPrevSyle] = useState(defaultStyle)
   const [mapStyle, setMapStyle] = useState(getBaseStyle(defaultStyle))
 
-  const {balId, codeCommune} = router.query
+  const {balId} = router.query
 
   const {
+    commune,
     numeros,
     toponymes,
     editingId,
@@ -137,14 +138,14 @@ function Map({commune, voie, toponyme}) {
         setEditingId(voie._id)
       } else {
         router.push(
-          `/bal/voie?balId=${balId}&codeCommune=${codeCommune}&idVoie=${idVoie}`,
-          `/bal/${balId}/communes/${codeCommune}/voies/${idVoie}`
+          `/bal/voie?balId=${balId}&codeCommune=${commune.code}&idVoie=${idVoie}`,
+          `/bal/${balId}/communes/${commune.code}/voies/${idVoie}`
         )
       }
     }
 
     setIsContextMenuDisplayed(null)
-  }, [router, balId, codeCommune, setEditingId, isEditing, voie, handleParcelle])
+  }, [router, balId, commune, setEditingId, isEditing, voie, handleParcelle])
 
   const handleCursor = useCallback(({isHovering}) => {
     if (modeId === 'drawLineString') {
@@ -303,9 +304,8 @@ function Map({commune, voie, toponyme}) {
       {commune && openForm && (
         <Pane background='white' height={400} overflowY='auto'>
           <AddressEditor
-            commune={commune}
             balId={balId}
-            codeCommune={codeCommune}
+            commune={commune}
             closeForm={() => setOpenForm(false)}
           />
         </Pane>
@@ -315,13 +315,11 @@ function Map({commune, voie, toponyme}) {
 }
 
 Map.propTypes = {
-  commune: PropTypes.object,
   voie: PropTypes.object,
   toponyme: PropTypes.object
 }
 
 Map.defaultProps = {
-  commune: null,
   voie: null,
   toponyme: null
 }

--- a/components/map/numeros-markers.js
+++ b/components/map/numeros-markers.js
@@ -16,7 +16,7 @@ function NumerosMarkers({numeros, voie, isLabelDisplayed, isContextMenuDisplayed
   const [setError] = useError()
 
   const {token} = useContext(TokenContext)
-  const {setEditingId, isEditing, reloadNumeros, reloadNumerosToponyme} = useContext(BalDataContext)
+  const {setEditingId, isEditing, reloadNumeros} = useContext(BalDataContext)
 
   const onEnableEditing = useCallback((e, numeroId) => {
     e.stopPropagation()
@@ -69,13 +69,13 @@ function NumerosMarkers({numeros, voie, isLabelDisplayed, isContextMenuDisplayed
   const removeAddress = useCallback(async numeroId => {
     try {
       await removeNumero(numeroId, token)
-      await (voie ? reloadNumeros() : reloadNumerosToponyme())
+      await reloadNumeros()
     } catch (error) {
       setError(error.message)
     }
 
     setIsContextMenuDisplayed(null)
-  }, [token, voie, reloadNumeros, reloadNumerosToponyme, setError, setIsContextMenuDisplayed])
+  }, [token, reloadNumeros, setError, setIsContextMenuDisplayed])
 
   return (
     numeros.map(numero => (

--- a/components/new/create-form.js
+++ b/components/new/create-form.js
@@ -24,13 +24,13 @@ function CreateForm({defaultCommune}) {
   )
   const [email, onEmailChange] = useInput('')
   const [populate, onPopulateChange] = useCheckboxInput(true)
-  const [commune, setCommune] = useState(defaultCommune ? defaultCommune.code : null)
+  const [codeCommune, setCodeCommune] = useState(defaultCommune ? defaultCommune.code : null)
   const [isShown, setIsShown] = useState(false)
   const [userBALs, setUserBALs] = useState([])
   const [focusRef] = useFocus()
 
   const onSelect = useCallback(commune => {
-    setCommune(commune.code)
+    setCodeCommune(commune.code)
   }, [])
 
   const createNewBal = useCallback(async () => {
@@ -41,26 +41,26 @@ function CreateForm({defaultCommune}) {
       ]
     })
 
-    if (commune) {
+    if (codeCommune) {
       addBalAccess(bal._id, bal.token)
-      await addCommune(bal._id, commune, bal.token)
+      await addCommune(bal._id, codeCommune, bal.token)
 
       if (populate) {
-        await populateCommune(bal._id, commune, bal.token)
+        await populateCommune(bal._id, codeCommune, bal.token)
       }
 
       Router.push(
-        `/bal/commune?balId=${bal._id}&codeCommune=${commune}`,
-        `/bal/${bal._id}/communes/${commune}`
+        `/bal/commune?balId=${bal._id}&codeCommune=${codeCommune}`,
+        `/bal/${bal._id}/communes/${codeCommune}`
       )
     }
-  }, [email, nom, populate, commune, addBalAccess])
+  }, [email, nom, populate, codeCommune, addBalAccess])
 
   const onSubmit = async e => {
     e.preventDefault()
     setIsLoading(true)
 
-    checkUserBALs(commune, email)
+    checkUserBALs(codeCommune, email)
   }
 
   const onCancel = () => {
@@ -69,7 +69,7 @@ function CreateForm({defaultCommune}) {
   }
 
   const checkUserBALs = async () => {
-    const userBALs = await searchBAL(commune, email)
+    const userBALs = await searchBAL(codeCommune, email)
 
     if (userBALs.length > 0) {
       setUserBALs(userBALs)
@@ -88,7 +88,7 @@ function CreateForm({defaultCommune}) {
             isShown={isShown}
             userEmail={email}
             basesLocales={userBALs}
-            updateBAL={() => checkUserBALs(commune, email)}
+            updateBAL={() => checkUserBALs(codeCommune, email)}
             onConfirm={createNewBal}
             onClose={() => onCancel()}
           />
@@ -158,7 +158,10 @@ function CreateForm({defaultCommune}) {
 }
 
 CreateForm.propTypes = {
-  defaultCommune: PropTypes.object
+  defaultCommune: PropTypes.shape({
+    nom: PropTypes.string.isRequired,
+    code: PropTypes.string.isRequired
+  }),
 }
 
 CreateForm.defaultProps = {

--- a/components/new/demo-form.js
+++ b/components/new/demo-form.js
@@ -20,11 +20,11 @@ function DemoForm({defaultCommune}) {
   const [isLoading, setIsLoading] = useState(false)
 
   const [populate, onPopulateChange] = useCheckboxInput(true)
-  const [commune, setCommune] = useState(defaultCommune ? defaultCommune.code : null)
+  const [codeCommune, setCodeCommune] = useState(defaultCommune ? defaultCommune.code : null)
   const [focusRef] = useFocus()
 
   const onSelect = useCallback(commune => {
-    setCommune(commune.code)
+    setCodeCommune(commune.code)
   }, [])
 
   const onSubmit = useCallback(async e => {
@@ -32,15 +32,15 @@ function DemoForm({defaultCommune}) {
 
     setIsLoading(true)
 
-    const bal = await createBaseLocaleDemo({commune, populate})
+    const bal = await createBaseLocaleDemo({codeCommune, populate})
 
     addBalAccess(bal._id, bal.token)
 
     Router.push(
-      `/bal/commune?balId=${bal._id}&codeCommune=${commune}`,
-      `/bal/${bal._id}/communes/${commune}`
+      `/bal/commune?balId=${bal._id}&codeCommune=${codeCommune}`,
+      `/bal/${bal._id}/communes/${codeCommune}`
     )
-  }, [commune, populate, addBalAccess])
+  }, [codeCommune, populate, addBalAccess])
 
   return (
 
@@ -86,7 +86,10 @@ function DemoForm({defaultCommune}) {
 }
 
 DemoForm.propTypes = {
-  defaultCommune: PropTypes.object
+  defaultCommune: PropTypes.shape({
+    nom: PropTypes.string.isRequired,
+    code: PropTypes.string.isRequired
+  }),
 }
 
 DemoForm.defaultProps = {

--- a/components/new/demo-form.js
+++ b/components/new/demo-form.js
@@ -32,7 +32,7 @@ function DemoForm({defaultCommune}) {
 
     setIsLoading(true)
 
-    const bal = await createBaseLocaleDemo({codeCommune, populate})
+    const bal = await createBaseLocaleDemo({commune: codeCommune, populate})
 
     addBalAccess(bal._id, bal.token)
 

--- a/components/settings.js
+++ b/components/settings.js
@@ -1,8 +1,5 @@
-import React, {useState, useContext, useEffect, useCallback} from 'react'
-import PropTypes from 'prop-types'
+import React, {useContext, useEffect} from 'react'
 import {SideSheet, Pane, Alert} from 'evergreen-ui'
-
-import {getCommune} from '@/lib/bal-api'
 
 import SettingsContext from '@/contexts/settings'
 import BalDataContext from '@/contexts/bal-data'
@@ -10,22 +7,15 @@ import BalDataContext from '@/contexts/bal-data'
 import Certification from '@/components/settings/certification'
 import SettingsForm from '@/components/settings/settings-form'
 
-const Settings = React.memo(({codeCommune}) => {
+const Settings = React.memo(() => {
   const {isSettingsDisplayed, setIsSettingsDisplayed} = useContext(SettingsContext)
-  const {baseLocale} = useContext(BalDataContext)
-
-  const [commune, setCommune] = useState()
-
-  const fetchCommune = useCallback(async () => {
-    const commune = await getCommune(baseLocale._id, codeCommune)
-    setCommune(commune)
-  }, [baseLocale._id, codeCommune])
+  const {baseLocale, commune, reloadCommune} = useContext(BalDataContext)
 
   useEffect(() => { // Update number of certified numeros when setting is open
-    if (codeCommune) {
-      fetchCommune()
+    if (isSettingsDisplayed) {
+      reloadCommune()
     }
-  }, [baseLocale._id, codeCommune, isSettingsDisplayed, fetchCommune])
+  }, [isSettingsDisplayed, reloadCommune])
 
   return (
     <SideSheet
@@ -39,7 +29,7 @@ const Settings = React.memo(({codeCommune}) => {
       <Pane padding={16}>
         {commune && (
           <Pane display='flex' justifyContent='center'>
-            <Certification nbNumeros={commune.nbNumeros} nbNumerosCertifies={commune.nbNumerosCertifies} onSubmit={fetchCommune} />
+            <Certification nbNumeros={commune.nbNumeros} nbNumerosCertifies={commune.nbNumerosCertifies} onSubmit={() => reloadCommune()} />
           </Pane>
         )}
       </Pane>
@@ -58,13 +48,5 @@ const Settings = React.memo(({codeCommune}) => {
     </SideSheet>
   )
 })
-
-Settings.defaultProps = {
-  codeCommune: null
-}
-
-Settings.propTypes = {
-  codeCommune: PropTypes.string
-}
 
 export default Settings

--- a/components/settings.js
+++ b/components/settings.js
@@ -10,31 +10,29 @@ import BalDataContext from '@/contexts/bal-data'
 import Certification from '@/components/settings/certification'
 import SettingsForm from '@/components/settings/settings-form'
 
-const Settings = React.memo(({initialBaseLocale, codeCommune}) => {
+const Settings = React.memo(({codeCommune}) => {
   const {isSettingsDisplayed, setIsSettingsDisplayed} = useContext(SettingsContext)
-  const balDataContext = useContext(BalDataContext)
-
-  const baseLocale = balDataContext.baseLocale || initialBaseLocale
+  const {baseLocale} = useContext(BalDataContext)
 
   const [commune, setCommune] = useState()
 
   const fetchCommune = useCallback(async () => {
-    const commune = await getCommune(initialBaseLocale._id, codeCommune)
+    const commune = await getCommune(baseLocale._id, codeCommune)
     setCommune(commune)
-  }, [initialBaseLocale._id, codeCommune])
+  }, [baseLocale._id, codeCommune])
 
   useEffect(() => { // Update number of certified numeros when setting is open
     if (codeCommune) {
       fetchCommune()
     }
-  }, [initialBaseLocale._id, codeCommune, isSettingsDisplayed, fetchCommune])
+  }, [baseLocale._id, codeCommune, isSettingsDisplayed, fetchCommune])
 
   return (
     <SideSheet
       isShown={isSettingsDisplayed}
       onCloseComplete={() => setIsSettingsDisplayed(false)}
     >
-      <SettingsForm initialBaseLocale={initialBaseLocale} />
+      <SettingsForm baseLocale={baseLocale} />
 
       <Pane borderBottom='1px solid #d8dae5' width='80%' marginY={16} marginX='auto' />
 
@@ -66,11 +64,6 @@ Settings.defaultProps = {
 }
 
 Settings.propTypes = {
-  initialBaseLocale: PropTypes.shape({
-    _id: PropTypes.string.isRequired,
-    status: PropTypes.string.isRequired,
-    nom: PropTypes.string.isRequired
-  }).isRequired,
   codeCommune: PropTypes.string
 }
 

--- a/components/settings/settings-form.js
+++ b/components/settings/settings-form.js
@@ -31,11 +31,9 @@ const mailHasChanged = (listA, listB) => {
   return !isEqual([...listA].sort(), [...listB].sort())
 }
 
-const Settings = React.memo(({initialBaseLocale}) => {
+const Settings = React.memo(({baseLocale}) => {
   const {token, emails, reloadEmails} = useContext(TokenContext)
-  const balDataContext = useContext(BalDataContext)
-
-  const baseLocale = balDataContext.baseLocale || initialBaseLocale
+  const {reloadBaseLocale} = useContext(BalDataContext)
 
   const [isLoading, setIsLoading] = useState(false)
   const [balEmails, setBalEmails] = useState([])
@@ -76,13 +74,13 @@ const Settings = React.memo(({initialBaseLocale}) => {
     setIsLoading(true)
 
     try {
-      await updateBaseLocale(initialBaseLocale._id, {
+      await updateBaseLocale(baseLocale._id, {
         nom: nomInput.trim(),
         emails: balEmails
       }, token)
 
       await reloadEmails()
-      await balDataContext.reloadBaseLocale()
+      await reloadBaseLocale()
 
       if (mailHasChanged(emails || [], balEmails) && difference(emails, balEmails).length > 0) {
         setIsRenewTokenWarningShown(true)
@@ -94,7 +92,7 @@ const Settings = React.memo(({initialBaseLocale}) => {
     }
 
     setIsLoading(false)
-  }, [initialBaseLocale._id, nomInput, balEmails, token, reloadEmails, balDataContext, emails])
+  }, [baseLocale._id, nomInput, balEmails, token, reloadEmails, reloadBaseLocale, emails])
 
   useEffect(() => {
     if (error) {
@@ -212,7 +210,7 @@ const Settings = React.memo(({initialBaseLocale}) => {
             <RenewTokenDialog
               token={token}
               emails={emails}
-              baseLocaleId={initialBaseLocale._id}
+              baseLocaleId={baseLocale._id}
               isShown={isRenewTokenWarningShown}
               setIsShown={setIsRenewTokenWarningShown}
               setError={setError}
@@ -230,7 +228,7 @@ const Settings = React.memo(({initialBaseLocale}) => {
 })
 
 Settings.propTypes = {
-  initialBaseLocale: PropTypes.shape({
+  baseLocale: PropTypes.shape({
     _id: PropTypes.string.isRequired,
     status: PropTypes.string.isRequired,
     nom: PropTypes.string.isRequired

--- a/components/sub-header/index.js
+++ b/components/sub-header/index.js
@@ -1,5 +1,4 @@
 import React, {useState, useContext} from 'react'
-import PropTypes from 'prop-types'
 import {useRouter} from 'next/router'
 import {Pane} from 'evergreen-ui'
 

--- a/components/sub-header/index.js
+++ b/components/sub-header/index.js
@@ -17,7 +17,7 @@ import SettingsMenu from '@/components/sub-header/settings-menu'
 import DemoWarning from '@/components/sub-header/demo-warning'
 import BALStatus from '@/components/sub-header/bal-status'
 
-const SubHeader = React.memo(({commune, initialeVoie, initialToponyme}) => {
+const SubHeader = React.memo(({initialeVoie, initialToponyme}) => {
   const {query} = useRouter()
   const [isHabilitationDisplayed, setIsHabilitationDisplayed] = useState(query['france-connect'] === '1')
 
@@ -26,6 +26,7 @@ const SubHeader = React.memo(({commune, initialeVoie, initialToponyme}) => {
     habilitation,
     reloadBaseLocale,
     reloadHabilitation,
+    commune,
     voie,
     toponyme,
     isRefrehSyncStat
@@ -130,13 +131,11 @@ const SubHeader = React.memo(({commune, initialeVoie, initialToponyme}) => {
 })
 
 SubHeader.propTypes = {
-  commune: PropTypes.object,
   initialeVoie: PropTypes.object,
   initialToponyme: PropTypes.object
 }
 
 SubHeader.defaultProps = {
-  commune: null,
   initialeVoie: null,
   initialToponyme: null
 }

--- a/components/sub-header/index.js
+++ b/components/sub-header/index.js
@@ -17,7 +17,7 @@ import SettingsMenu from '@/components/sub-header/settings-menu'
 import DemoWarning from '@/components/sub-header/demo-warning'
 import BALStatus from '@/components/sub-header/bal-status'
 
-const SubHeader = React.memo(({initialToponyme}) => {
+const SubHeader = React.memo(() => {
   const {query} = useRouter()
   const [isHabilitationDisplayed, setIsHabilitationDisplayed] = useState(query['france-connect'] === '1')
 
@@ -90,7 +90,7 @@ const SubHeader = React.memo(({initialToponyme}) => {
           baseLocale={baseLocale}
           commune={commune}
           voie={voie}
-          toponyme={toponyme || initialToponyme}
+          toponyme={toponyme}
           marginLeft={8}
         />
 
@@ -129,13 +129,5 @@ const SubHeader = React.memo(({initialToponyme}) => {
     </>
   )
 })
-
-SubHeader.propTypes = {
-  initialToponyme: PropTypes.object
-}
-
-SubHeader.defaultProps = {
-  initialToponyme: null
-}
 
 export default SubHeader

--- a/components/sub-header/index.js
+++ b/components/sub-header/index.js
@@ -17,7 +17,7 @@ import SettingsMenu from '@/components/sub-header/settings-menu'
 import DemoWarning from '@/components/sub-header/demo-warning'
 import BALStatus from '@/components/sub-header/bal-status'
 
-const SubHeader = React.memo(({initialeVoie, initialToponyme}) => {
+const SubHeader = React.memo(({initialToponyme}) => {
   const {query} = useRouter()
   const [isHabilitationDisplayed, setIsHabilitationDisplayed] = useState(query['france-connect'] === '1')
 
@@ -89,7 +89,7 @@ const SubHeader = React.memo(({initialeVoie, initialToponyme}) => {
         <Breadcrumbs
           baseLocale={baseLocale}
           commune={commune}
-          voie={voie || initialeVoie}
+          voie={voie}
           toponyme={toponyme || initialToponyme}
           marginLeft={8}
         />
@@ -131,12 +131,10 @@ const SubHeader = React.memo(({initialeVoie, initialToponyme}) => {
 })
 
 SubHeader.propTypes = {
-  initialeVoie: PropTypes.object,
   initialToponyme: PropTypes.object
 }
 
 SubHeader.defaultProps = {
-  initialeVoie: null,
   initialToponyme: null
 }
 

--- a/components/sub-header/index.js
+++ b/components/sub-header/index.js
@@ -17,25 +17,32 @@ import SettingsMenu from '@/components/sub-header/settings-menu'
 import DemoWarning from '@/components/sub-header/demo-warning'
 import BALStatus from '@/components/sub-header/bal-status'
 
-const SubHeader = React.memo(({initialBaseLocale, commune, voie, toponyme}) => {
+const SubHeader = React.memo(({commune, initialeVoie, initialToponyme}) => {
   const {query} = useRouter()
   const [isHabilitationDisplayed, setIsHabilitationDisplayed] = useState(query['france-connect'] === '1')
 
-  const balDataContext = useContext(BalDataContext)
+  const {
+    baseLocale,
+    habilitation,
+    reloadBaseLocale,
+    reloadHabilitation,
+    voie,
+    toponyme,
+    isRefrehSyncStat
+  } = useContext(BalDataContext)
   const {token} = useContext(TokenContext)
 
   const [setError] = useError(null)
 
-  const csvUrl = getBaseLocaleCsvUrl(initialBaseLocale._id)
-  const baseLocale = balDataContext.baseLocale || initialBaseLocale
-  const isEntitled = balDataContext.habilitation && balDataContext.habilitation.status === 'accepted'
+  const csvUrl = getBaseLocaleCsvUrl(baseLocale._id)
+  const isEntitled = habilitation && habilitation.status === 'accepted'
   const isAdmin = Boolean(token)
 
   const handleChangeStatus = async status => {
     try {
-      await updateBaseLocale(initialBaseLocale._id, {status}, token)
+      await updateBaseLocale(baseLocale._id, {status}, token)
 
-      await balDataContext.reloadBaseLocale()
+      await reloadBaseLocale()
     } catch (error) {
       setError(error.message)
     }
@@ -44,9 +51,9 @@ const SubHeader = React.memo(({initialBaseLocale, commune, voie, toponyme}) => {
   const handleHabilitation = async () => {
     await handleChangeStatus('ready-to-publish')
 
-    if (!balDataContext.habilitation || balDataContext.habilitation.status === 'rejected') {
-      await createHabilitation(token, initialBaseLocale._id)
-      await balDataContext.reloadHabilitation()
+    if (!habilitation || habilitation.status === 'rejected') {
+      await createHabilitation(token, baseLocale._id)
+      await reloadHabilitation()
     }
 
     setIsHabilitationDisplayed(true)
@@ -58,7 +65,7 @@ const SubHeader = React.memo(({initialBaseLocale, commune, voie, toponyme}) => {
 
   const handleSync = async () => {
     await sync(baseLocale._id, token)
-    await balDataContext.reloadBaseLocale()
+    await reloadBaseLocale()
   }
 
   return (
@@ -81,8 +88,8 @@ const SubHeader = React.memo(({initialBaseLocale, commune, voie, toponyme}) => {
         <Breadcrumbs
           baseLocale={baseLocale}
           commune={commune}
-          voie={balDataContext.voie || voie}
-          toponyme={balDataContext.toponyme || toponyme}
+          voie={voie || initialeVoie}
+          toponyme={toponyme || initialToponyme}
           marginLeft={8}
         />
 
@@ -93,10 +100,10 @@ const SubHeader = React.memo(({initialBaseLocale, commune, voie, toponyme}) => {
               baseLocale={baseLocale}
               commune={commune}
               token={token}
-              isRefrehSyncStat={balDataContext.isRefrehSyncStat}
+              isRefrehSyncStat={isRefrehSyncStat}
               handleChangeStatus={handleChangeStatus}
               handleHabilitation={handleHabilitation}
-              reloadBaseLocale={async () => balDataContext.reloadBaseLocale()}
+              reloadBaseLocale={async () => reloadBaseLocale()}
             />
           )}
         </Pane>
@@ -106,13 +113,13 @@ const SubHeader = React.memo(({initialBaseLocale, commune, voie, toponyme}) => {
         <DemoWarning baseLocale={baseLocale} token={token} />
       )}
 
-      {isAdmin && commune && balDataContext.habilitation && (
+      {isAdmin && commune && habilitation && (
         <HabilitationProcess
           token={token}
           isShown={isHabilitationDisplayed}
           baseLocale={baseLocale}
           commune={commune}
-          habilitation={balDataContext.habilitation}
+          habilitation={habilitation}
           resetHabilitationProcess={handleHabilitation}
           handleClose={handleCloseHabilitation}
           handleSync={handleSync}
@@ -123,19 +130,15 @@ const SubHeader = React.memo(({initialBaseLocale, commune, voie, toponyme}) => {
 })
 
 SubHeader.propTypes = {
-  initialBaseLocale: PropTypes.shape({
-    _id: PropTypes.string.isRequired,
-    status: PropTypes.oneOf(['demo', 'replaced', 'draft', 'ready-to-publish', 'published'])
-  }).isRequired,
   commune: PropTypes.object,
-  voie: PropTypes.object,
-  toponyme: PropTypes.object
+  initialeVoie: PropTypes.object,
+  initialToponyme: PropTypes.object
 }
 
 SubHeader.defaultProps = {
   commune: null,
-  voie: null,
-  toponyme: null
+  initialeVoie: null,
+  initialToponyme: null
 }
 
 export default SubHeader

--- a/components/sub-header/index.js
+++ b/components/sub-header/index.js
@@ -1,5 +1,6 @@
 import React, {useState, useContext} from 'react'
 import PropTypes from 'prop-types'
+import {useRouter} from 'next/router'
 import {Pane} from 'evergreen-ui'
 
 import {createHabilitation, getBaseLocaleCsvUrl, sync, updateBaseLocale} from '@/lib/bal-api'
@@ -16,8 +17,9 @@ import SettingsMenu from '@/components/sub-header/settings-menu'
 import DemoWarning from '@/components/sub-header/demo-warning'
 import BALStatus from '@/components/sub-header/bal-status'
 
-const SubHeader = React.memo(({initialBaseLocale, commune, voie, toponyme, isFranceConnectAuthentication}) => {
-  const [isHabilitationDisplayed, setIsHabilitationDisplayed] = useState(isFranceConnectAuthentication)
+const SubHeader = React.memo(({initialBaseLocale, commune, voie, toponyme}) => {
+  const {query} = useRouter()
+  const [isHabilitationDisplayed, setIsHabilitationDisplayed] = useState(query['france-connect'] === '1')
 
   const balDataContext = useContext(BalDataContext)
   const {token} = useContext(TokenContext)
@@ -127,15 +129,13 @@ SubHeader.propTypes = {
   }).isRequired,
   commune: PropTypes.object,
   voie: PropTypes.object,
-  toponyme: PropTypes.object,
-  isFranceConnectAuthentication: PropTypes.bool
+  toponyme: PropTypes.object
 }
 
 SubHeader.defaultProps = {
   commune: null,
   voie: null,
-  toponyme: null,
-  isFranceConnectAuthentication: false
+  toponyme: null
 }
 
 export default SubHeader

--- a/components/toponyme/toponyme-heading.js
+++ b/components/toponyme/toponyme-heading.js
@@ -1,4 +1,4 @@
-import {useState, useCallback, useContext, useEffect} from 'react'
+import {useState, useContext} from 'react'
 import PropTypes from 'prop-types'
 import {Pane, Heading, EditIcon, Text} from 'evergreen-ui'
 
@@ -9,20 +9,19 @@ import BalDataContext from '@/contexts/bal-data'
 
 import ToponymeEditor from '@/components/bal/toponyme-editor'
 
-function ToponymeHeading({defaultToponyme}) {
-  const [toponyme, setToponyme] = useState(defaultToponyme)
+function ToponymeHeading({toponyme}) {
   const [hovered, setHovered] = useState(false)
   const {token} = useContext(TokenContext)
-  const {editingId, setEditingId, isEditing, refreshBALSync, reloadToponymes, numeros} = useContext(BalDataContext)
+  const {editingId, setEditingId, isEditing, setToponyme, refreshBALSync, reloadToponymes, numeros} = useContext(BalDataContext)
 
-  const onEnableToponymeEditing = useCallback(() => {
+  const onEnableToponymeEditing = () => {
     if (!isEditing) {
       setEditingId(toponyme._id)
       setHovered(false)
     }
-  }, [setEditingId, isEditing, toponyme._id])
+  }
 
-  const onEditToponyme = useCallback(async ({nom, positions, parcelles}) => {
+  const onEditToponyme = async ({nom, positions, parcelles}) => {
     const editedToponyme = await editToponyme(toponyme._id, {
       nom,
       positions,
@@ -30,15 +29,12 @@ function ToponymeHeading({defaultToponyme}) {
     }, token)
 
     setEditingId(null)
+
     await reloadToponymes()
     refreshBALSync()
 
     setToponyme(editedToponyme)
-  }, [reloadToponymes, refreshBALSync, setEditingId, token, toponyme])
-
-  useEffect(() => {
-    setToponyme(defaultToponyme)
-  }, [defaultToponyme])
+  }
 
   return (
     <Pane
@@ -79,7 +75,7 @@ function ToponymeHeading({defaultToponyme}) {
 }
 
 ToponymeHeading.propTypes = {
-  defaultToponyme: PropTypes.shape({
+  toponyme: PropTypes.shape({
     _id: PropTypes.string.isRequired,
     nom: PropTypes.string.isRequired,
     positions: PropTypes.array.isRequired

--- a/components/voie/numeros-list.js
+++ b/components/voie/numeros-list.js
@@ -12,14 +12,14 @@ import TableRow from '@/components/table-row'
 import DeleteWarning from '@/components/delete-warning'
 import GroupedActions from '@/components/grouped-actions'
 
-function NumerosList({token, voieId, defaultNumeros, isEditionDisabled, handleEditing}) {
+function NumerosList({token, voieId, numeros, isEditionDisabled, handleEditing}) {
   const [isRemoveWarningShown, setIsRemoveWarningShown] = useState(false)
   const [selectedNumerosIds, setSelectedNumerosIds] = useState([])
   const [error, setError] = useState(null)
 
-  const {numeros, reloadNumeros, refreshBALSync} = useContext(BalDataContext)
+  const {reloadNumeros, refreshBALSync} = useContext(BalDataContext)
 
-  const [filtered, setFilter] = useFuse(numeros || defaultNumeros, 200, {
+  const [filtered, setFilter] = useFuse(numeros, 200, {
     keys: [
       'numeroComplet'
     ]
@@ -221,7 +221,7 @@ NumerosList.defaultProps = {
 NumerosList.propTypes = {
   token: PropTypes.string,
   voieId: PropTypes.string.isRequired,
-  defaultNumeros: PropTypes.array.isRequired,
+  numeros: PropTypes.array.isRequired,
   isEditionDisabled: PropTypes.bool.isRequired,
   handleEditing: PropTypes.func.isRequired
 }

--- a/components/voie/voie-heading.js
+++ b/components/voie/voie-heading.js
@@ -1,4 +1,4 @@
-import {useState, useContext, useEffect} from 'react'
+import {useState, useContext} from 'react'
 import PropTypes from 'prop-types'
 import {Pane, Heading, EditIcon, Text} from 'evergreen-ui'
 
@@ -9,8 +9,7 @@ import BalDataContext from '@/contexts/bal-data'
 
 import VoieEditor from '@/components/bal/voie-editor'
 
-function VoieHeading({defaultVoie}) {
-  const [editedVoie, setEditedVoie] = useState(defaultVoie)
+function VoieHeading({voie}) {
   const [hovered, setHovered] = useState(false)
 
   const {token} = useContext(TokenContext)
@@ -18,13 +17,13 @@ function VoieHeading({defaultVoie}) {
 
   const onEnableVoieEditing = () => {
     if (!isEditing) {
-      setEditingId(editedVoie._id)
+      setEditingId(voie._id)
       setHovered(false)
     }
   }
 
   const onEditVoie = async ({nom, typeNumerotation, trace}) => {
-    const voie = await editVoie(editedVoie._id, {
+    const updatedVoie = await editVoie(voie._id, {
       nom,
       typeNumerotation,
       trace
@@ -36,28 +35,19 @@ function VoieHeading({defaultVoie}) {
     await reloadGeojson()
     refreshBALSync()
 
-    setEditedVoie(voie)
-
-    // Update voie name in breadcrum
-    if (editingId === editedVoie._id) {
-      setVoie(voie)
-    }
+    setVoie(updatedVoie)
   }
-
-  useEffect(() => {
-    setEditedVoie(defaultVoie)
-  }, [defaultVoie])
 
   return (
     <Pane
       display='flex'
       flexDirection='column'
       background='tint1'
-      padding={editingId === editedVoie._id ? 0 : 16}
+      padding={editingId === voie._id ? 0 : 16}
     >
-      {editingId === editedVoie._id ? (
+      {editingId === voie._id ? (
         <VoieEditor
-          initialValue={editedVoie}
+          initialValue={voie}
           onSubmit={onEditVoie}
           onCancel={() => setEditingId(null)}
         />
@@ -68,7 +58,7 @@ function VoieHeading({defaultVoie}) {
           onMouseEnter={() => setHovered(true)}
           onMouseLeave={() => setHovered(false)}
         >
-          {editedVoie.nom}
+          {voie.nom}
           {!isEditing && token && (
             <EditIcon
               marginBottom={-2}
@@ -79,14 +69,14 @@ function VoieHeading({defaultVoie}) {
         </Heading>
       )}
       {numeros && (
-        <Text padding={editingId === editedVoie._id ? 16 : 0}>{numeros.length} numéro{numeros.length > 1 ? 's' : ''}</Text>
+        <Text padding={editingId === voie._id ? 16 : 0}>{numeros.length} numéro{numeros.length > 1 ? 's' : ''}</Text>
       )}
     </Pane>
   )
 }
 
 VoieHeading.propTypes = {
-  defaultVoie: PropTypes.shape({
+  voie: PropTypes.shape({
     _id: PropTypes.string.isRequired,
     nom: PropTypes.string.isRequired
   }).isRequired

--- a/contexts/bal-data.js
+++ b/contexts/bal-data.js
@@ -13,7 +13,7 @@ import {
   getToponymes,
   getNumerosToponyme,
   certifyBAL
-} from '../lib/bal-api'
+} from '@/lib/bal-api'
 
 import TokenContext from '@/contexts/token'
 

--- a/contexts/bal-data.js
+++ b/contexts/bal-data.js
@@ -70,16 +70,18 @@ export const BalDataContextProvider = React.memo(({
   }, [baseLocale._id, commune])
 
   const reloadNumeros = useCallback(async () => {
-    const numeros = await getNumeros(initialVoie._id, token)
-    await reloadParcelles()
-    setNumeros(numeros)
-  }, [initialVoie, token, reloadParcelles])
+    let numeros
+    if (voie) {
+      numeros = await getNumeros(voie._id, token)
+    } else if (toponyme) {
+      numeros = await getNumerosToponyme(toponyme._id, token)
+    }
 
-  const reloadNumerosToponyme = useCallback(async () => {
-    const numeros = await getNumerosToponyme(initialToponyme._id, token)
-    await reloadParcelles()
-    setNumeros(numeros)
-  }, [initialToponyme, token, reloadParcelles])
+    if (numeros) {
+      await reloadParcelles()
+      setNumeros(numeros)
+    }
+  }, [voie, toponyme, token, reloadParcelles])
 
   const reloadCommune = useCallback(async () => {
     const baseLocaleCommune = await getCommune(baseLocale._id, initialCommune.code)
@@ -191,7 +193,6 @@ export const BalDataContextProvider = React.memo(({
     reloadToponymes,
     reloadCommune,
     reloadBaseLocale,
-    reloadNumerosToponyme,
     setVoie,
     setToponyme,
     certifyAllNumeros
@@ -221,7 +222,6 @@ export const BalDataContextProvider = React.memo(({
     reloadNumeros,
     reloadVoies,
     reloadToponymes,
-    reloadNumerosToponyme,
     toponyme,
     certifyAllNumeros,
     isRefrehSyncStat,

--- a/layouts/dashboard.js
+++ b/layouts/dashboard.js
@@ -4,7 +4,7 @@ import Link from 'next/link'
 import {Heading, Pane, Icon} from 'evergreen-ui'
 
 import Map from '@/components/dashboard/map'
-import Header from '@/components/header'
+import Fullscreen from '@/layouts/fullscreen'
 
 const MOBILE_WIDTH = '820'
 
@@ -46,8 +46,6 @@ function BackButton() {
 function Mobile({title, backButton, mapData, children}) {
   return (
     <Pane display='flex' backgroundColor='#fff' flexDirection='column' width='100%'>
-      <Header />
-
       {backButton && (
         <BackButton />
       )}
@@ -67,9 +65,7 @@ Mobile.propTypes = propTypes
 
 function Desktop({title, mapData, backButton, children}) {
   return (
-    <Pane height='100vh' display='flex' backgroundColor='#fff' flexDirection='column'>
-      <Header />
-
+    <Fullscreen>
       <Pane display='flex' width='100%' height='calc(100vh - 77px)'>
         <Pane display='flex' flexDirection='column' width={600} overflowY='auto'>
           {backButton && (
@@ -85,11 +81,7 @@ function Desktop({title, mapData, backButton, children}) {
           <Map {...mapData} />
         </Pane>
       </Pane>
-      <style jsx>{`
-
-
-      `}</style>
-    </Pane>
+    </Fullscreen>
   )
 }
 

--- a/layouts/editor.js
+++ b/layouts/editor.js
@@ -28,7 +28,7 @@ function Editor({baseLocale, commune, voie, toponyme, children}) {
   }, [baseLocale])
 
   return (
-    <BalDataContextProvider initialBaseLocale={baseLocale} initialCommune={commune} initialVoie={voie} idToponyme={toponyme?._id}>
+    <BalDataContextProvider initialBaseLocale={baseLocale} initialCommune={commune} initialVoie={voie} initialToponyme={toponyme}>
       <MapContextProvider>
         <DrawContextProvider>
           <MarkersContextProvider>
@@ -36,10 +36,10 @@ function Editor({baseLocale, commune, voie, toponyme, children}) {
 
               <SettingsContextProvider>
                 <Settings />
-                <SubHeader initialToponyme={toponyme} />
+                <SubHeader />
               </SettingsContextProvider>
 
-              <Map top={116} left={leftOffset} toponyme={toponyme} />
+              <Map top={116} left={leftOffset} />
 
               <Sidebar
                 top={topOffset}

--- a/layouts/editor.js
+++ b/layouts/editor.js
@@ -28,25 +28,20 @@ function Editor({baseLocale, commune, voie, toponyme, children}) {
   }, [baseLocale])
 
   return (
-    <BalDataContextProvider initialBaseLocale={baseLocale} codeCommune={commune?.code} idVoie={voie?._id} idToponyme={toponyme?._id}>
+    <BalDataContextProvider initialBaseLocale={baseLocale} initialCommune={commune} idVoie={voie?._id} idToponyme={toponyme?._id}>
       <MapContextProvider>
         <DrawContextProvider>
           <MarkersContextProvider>
             <ParcellesContextProvider>
 
               <SettingsContextProvider>
-                <Settings codeCommune={commune?.code} />
-                <SubHeader
-                  commune={commune}
-                  initialeVoie={voie}
-                  initialToponyme={toponyme}
-                />
+                <Settings />
+                <SubHeader initialeVoie={voie} initialToponyme={toponyme} />
               </SettingsContextProvider>
 
               <Map
                 top={116}
                 left={leftOffset}
-                commune={commune}
                 voie={voie}
                 toponyme={toponyme}
               />

--- a/layouts/editor.js
+++ b/layouts/editor.js
@@ -16,7 +16,7 @@ import WelcomeMessage from '@/components/welcome-message'
 import CertificationMessage from '@/components/certification-message'
 import Settings from '@/components/settings'
 
-function Editor({baseLocale, commune, voie, toponyme, children}) {
+function Editor({baseLocale, commune, voie, toponyme, voies, toponymes, numeros, children}) {
   const [isHidden, setIsHidden] = useState(false)
 
   const leftOffset = useMemo(() => {
@@ -28,7 +28,15 @@ function Editor({baseLocale, commune, voie, toponyme, children}) {
   }, [baseLocale])
 
   return (
-    <BalDataContextProvider initialBaseLocale={baseLocale} initialCommune={commune} initialVoie={voie} initialToponyme={toponyme}>
+    <BalDataContextProvider
+      initialBaseLocale={baseLocale}
+      initialCommune={commune}
+      initialVoie={voie}
+      initialToponyme={toponyme}
+      initialVoies={voies}
+      initialToponymes={toponymes}
+      initialNumeros={numeros}
+    >
       <MapContextProvider>
         <DrawContextProvider>
           <MarkersContextProvider>
@@ -78,6 +86,9 @@ Editor.propTypes = {
   }),
   voie: PropTypes.object,
   toponyme: PropTypes.object,
+  voies: PropTypes.array,
+  toponymes: PropTypes.array,
+  numeros: PropTypes.array,
   children: PropTypes.node.isRequired
 }
 

--- a/layouts/editor.js
+++ b/layouts/editor.js
@@ -28,7 +28,7 @@ function Editor({baseLocale, commune, voie, toponyme, children}) {
   }, [baseLocale])
 
   return (
-    <BalDataContextProvider initialBaseLocale={baseLocale} initialCommune={commune} idVoie={voie?._id} idToponyme={toponyme?._id}>
+    <BalDataContextProvider initialBaseLocale={baseLocale} initialCommune={commune} initialVoie={voie} idToponyme={toponyme?._id}>
       <MapContextProvider>
         <DrawContextProvider>
           <MarkersContextProvider>
@@ -36,15 +36,10 @@ function Editor({baseLocale, commune, voie, toponyme, children}) {
 
               <SettingsContextProvider>
                 <Settings />
-                <SubHeader initialeVoie={voie} initialToponyme={toponyme} />
+                <SubHeader initialToponyme={toponyme} />
               </SettingsContextProvider>
 
-              <Map
-                top={116}
-                left={leftOffset}
-                voie={voie}
-                toponyme={toponyme}
-              />
+              <Map top={116} left={leftOffset} toponyme={toponyme} />
 
               <Sidebar
                 top={topOffset}

--- a/layouts/editor.js
+++ b/layouts/editor.js
@@ -28,33 +28,28 @@ function Editor({baseLocale, commune, voie, toponyme, children}) {
   }, [baseLocale])
 
   return (
-    <BalDataContextProvider balId={baseLocale._id} codeCommune={commune?.code} idVoie={voie?._id} idToponyme={toponyme?._id}>
+    <BalDataContextProvider initialBaseLocale={baseLocale} codeCommune={commune?.code} idVoie={voie?._id} idToponyme={toponyme?._id}>
       <MapContextProvider>
         <DrawContextProvider>
           <MarkersContextProvider>
             <ParcellesContextProvider>
 
-              {baseLocale && (
-                <SettingsContextProvider>
-                  <Settings initialBaseLocale={baseLocale} codeCommune={commune?.code} />
-                  <SubHeader
-                    commune={commune}
-                    voie={voie}
-                    toponyme={toponyme}
-                    initialBaseLocale={baseLocale}
-                  />
-                </SettingsContextProvider>
-              )}
-
-              {baseLocale && (
-                <Map
-                  top={116}
-                  left={leftOffset}
+              <SettingsContextProvider>
+                <Settings codeCommune={commune?.code} />
+                <SubHeader
                   commune={commune}
-                  voie={voie}
-                  toponyme={toponyme}
+                  initialeVoie={voie}
+                  initialToponyme={toponyme}
                 />
-              )}
+              </SettingsContextProvider>
+
+              <Map
+                top={116}
+                left={leftOffset}
+                commune={commune}
+                voie={voie}
+                toponyme={toponyme}
+              />
 
               <Sidebar
                 top={topOffset}

--- a/layouts/editor.js
+++ b/layouts/editor.js
@@ -1,0 +1,99 @@
+import {useState, useMemo} from 'react'
+import PropTypes from 'prop-types'
+
+import {SettingsContextProvider} from '@/contexts/settings'
+import {DrawContextProvider} from '@/contexts/draw'
+import {MarkersContextProvider} from '@/contexts/markers'
+import {MapContextProvider} from '@/contexts/map'
+import {BalDataContextProvider} from '@/contexts/bal-data'
+import {ParcellesContextProvider} from '@/contexts/parcelles'
+
+import Sidebar from '@/layouts/sidebar'
+
+import SubHeader from '@/components/sub-header'
+import Map from '@/components/map'
+import WelcomeMessage from '@/components/welcome-message'
+import CertificationMessage from '@/components/certification-message'
+import Settings from '@/components/settings'
+
+function Editor({baseLocale, commune, voie, toponyme, children}) {
+  const [isHidden, setIsHidden] = useState(false)
+
+  const leftOffset = useMemo(() => {
+    return isHidden ? 0 : 500
+  }, [isHidden])
+
+  const topOffset = useMemo(() => {
+    return baseLocale.status === 'demo' ? 166 : 116
+  }, [baseLocale])
+
+  return (
+    <BalDataContextProvider balId={baseLocale._id} codeCommune={commune?.code} idVoie={voie?._id} idToponyme={toponyme?._id}>
+      <MapContextProvider>
+        <DrawContextProvider>
+          <MarkersContextProvider>
+            <ParcellesContextProvider>
+
+              {baseLocale && (
+                <SettingsContextProvider>
+                  <Settings initialBaseLocale={baseLocale} codeCommune={commune?.code} />
+                  <SubHeader
+                    commune={commune}
+                    voie={voie}
+                    toponyme={toponyme}
+                    initialBaseLocale={baseLocale}
+                  />
+                </SettingsContextProvider>
+              )}
+
+              {baseLocale && (
+                <Map
+                  top={116}
+                  left={leftOffset}
+                  commune={commune}
+                  voie={voie}
+                  toponyme={toponyme}
+                />
+              )}
+
+              <Sidebar
+                top={topOffset}
+                isHidden={isHidden}
+                size={500}
+                elevation={2}
+                background='tint2'
+                display='flex'
+                flexDirection='column'
+                onToggle={setIsHidden}
+              >
+                <>
+                  <WelcomeMessage />
+                  {baseLocale.status === 'published' && (
+                    <CertificationMessage balId={baseLocale._id} codeCommune={commune?.code} />
+                  )}
+
+                  {children}
+                </>
+              </Sidebar>
+            </ParcellesContextProvider>
+          </MarkersContextProvider>
+        </DrawContextProvider>
+      </MapContextProvider>
+    </BalDataContextProvider>
+  )
+}
+
+Editor.propTypes = {
+  baseLocale: PropTypes.shape({
+    _id: PropTypes.string.isRequired,
+    status: PropTypes.string.isRequired
+  }).isRequired,
+  commune: PropTypes.shape({
+    code: PropTypes.string.isRequired,
+  }),
+  voie: PropTypes.object,
+  toponyme: PropTypes.object,
+  children: PropTypes.node.isRequired
+}
+
+export default Editor

--- a/layouts/editor.js
+++ b/layouts/editor.js
@@ -62,7 +62,7 @@ function Editor({baseLocale, commune, voie, toponyme, voies, toponymes, numeros,
                 <>
                   <WelcomeMessage />
                   {baseLocale.status === 'published' && (
-                    <CertificationMessage balId={baseLocale._id} codeCommune={commune?.code} />
+                    <CertificationMessage balId={baseLocale._id} codeCommune={commune.code} />
                   )}
 
                   {children}

--- a/layouts/fullscreen.js
+++ b/layouts/fullscreen.js
@@ -1,31 +1,16 @@
-import PropTypes from 'prop-types'
 import {Pane} from 'evergreen-ui'
 
-function Fullscreen({isOpen, isHidden, size, top, onToggle, ...props}) {
+function Fullscreen({...props}) {
   return (
     <Pane
       display='flex'
       width='100%'
-      height='100%'
+      height='100hv'
       flex={1}
+      flexDirection='column'
       {...props}
     />
   )
-}
-
-Fullscreen.propTypes = {
-  children: PropTypes.node.isRequired,
-
-  // Ignored props
-  isOpen: PropTypes.bool,
-  isHidden: PropTypes.bool.isRequired,
-  size: PropTypes.number.isRequired,
-  top: PropTypes.number.isRequired,
-  onToggle: PropTypes.func.isRequired
-}
-
-Fullscreen.defaultProps = {
-  isOpen: false
 }
 
 export default Fullscreen

--- a/layouts/main.js
+++ b/layouts/main.js
@@ -1,0 +1,20 @@
+import PropTypes from 'prop-types'
+
+import Fullscreen from '@/layouts/fullscreen'
+
+import Footer from '@/components/footer'
+
+function Main({children}) {
+  return (
+    <Fullscreen>
+      {children}
+      <Footer />
+    </Fullscreen>
+  )
+}
+
+Main.propTypes = {
+  children: PropTypes.node.isRequired
+}
+
+export default Main

--- a/lib/bal-api/index.js
+++ b/lib/bal-api/index.js
@@ -186,7 +186,7 @@ export function createBaseLocaleDemo(body) {
 }
 
 export async function updateBaseLocale(balId, body, token) {
-  const baseLocale = await request(`/bases-locales/${balId}`, {
+  return request(`/bases-locales/${balId}`, {
     method: 'PUT',
     headers: {
       authorization: `Token ${token}`,
@@ -194,12 +194,10 @@ export async function updateBaseLocale(balId, body, token) {
     },
     body: JSON.stringify(body)
   })
-
-  return baseLocale
 }
 
 export async function transformToDraft(balId, body, token) {
-  const baseLocale = await request(`/bases-locales/${balId}/transform-to-draft`, {
+  return request(`/bases-locales/${balId}/transform-to-draft`, {
     method: 'POST',
     headers: {
       authorization: `Token ${token}`,
@@ -207,8 +205,6 @@ export async function transformToDraft(balId, body, token) {
     },
     body: JSON.stringify(body)
   })
-
-  return baseLocale
 }
 
 export async function removeBaseLocale(balId, token) {

--- a/pages/404.js
+++ b/pages/404.js
@@ -3,12 +3,9 @@ import {Pane, Heading, Button, Icon, ArrowLeftIcon, RouteIcon} from 'evergreen-u
 
 import Main from '@/layouts/main'
 
-import Header from '@/components/header'
-
 function Custom404() {
   return (
     <Main>
-      <Header />
       <Pane
         display='flex'
         flex={1}

--- a/pages/404.js
+++ b/pages/404.js
@@ -1,14 +1,17 @@
 import Link from 'next/link'
 import {Pane, Heading, Button, Icon, ArrowLeftIcon, RouteIcon} from 'evergreen-ui'
 
+import Main from '@/layouts/main'
+
 import Header from '@/components/header'
 
 function Custom404() {
   return (
-    <Pane display='flex' backgroundColor='#fff' flexDirection='column' width='100%' height='100%'>
+    <Main>
       <Header />
       <Pane
         display='flex'
+        flex={1}
         alignItems='center'
         flexDirection='column'
         justifyContent='center'
@@ -22,7 +25,7 @@ function Custom404() {
           </Button>
         </Link>
       </Pane>
-    </Pane>
+    </Main>
   )
 }
 

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -5,8 +5,8 @@ import {Pane, Dialog, Paragraph} from 'evergreen-ui'
 
 import 'mapbox-gl/dist/mapbox-gl.css'
 
-import {getBaseLocale, getVoie, getToponyme} from '@/lib/bal-api'
-import {getCommune} from '@/lib/geo-api'
+import {getCommune as getGeoCommune} from '@/lib/geo-api'
+import {getBaseLocale, getCommune, getVoie, getToponyme} from '@/lib/bal-api'
 
 import {LocalStorageContextProvider} from '@/contexts/local-storage'
 import {HelpContextProvider} from '@/contexts/help'
@@ -102,9 +102,12 @@ App.getInitialProps = async ({Component, ctx}) => {
 
     if (query.codeCommune) {
       if (baseLocale.communes.includes(query.codeCommune)) {
-        commune = await getCommune(query.codeCommune, {
+        const baseLocaleCommune = await getCommune(query.balId, query.codeCommune)
+        const geoCommune = await getGeoCommune(query.codeCommune, {
           fields: 'contour'
         })
+
+        commune = {...baseLocaleCommune, ...geoCommune}
       } else {
         throw new Error('La commune demandée ne fais pas partie de la Base Adresse Locale')
       }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -6,7 +6,7 @@ import {Pane, Dialog, Paragraph} from 'evergreen-ui'
 import 'mapbox-gl/dist/mapbox-gl.css'
 
 import {getCommune as getGeoCommune} from '@/lib/geo-api'
-import {getBaseLocale, getCommune, getVoie, getToponyme} from '@/lib/bal-api'
+import {getBaseLocale, getCommune, getVoies, getToponymes} from '@/lib/bal-api'
 
 import {LocalStorageContextProvider} from '@/contexts/local-storage'
 import {HelpContextProvider} from '@/contexts/help'
@@ -92,8 +92,8 @@ App.getInitialProps = async ({Component, ctx}) => {
 
   let baseLocale
   let commune
-  let voie
-  let toponyme
+  let voies
+  let toponymes
 
   try {
     if (query.balId) {
@@ -110,14 +110,8 @@ App.getInitialProps = async ({Component, ctx}) => {
       })
 
       commune = {...baseLocaleCommune, ...geoCommune}
-    }
-
-    if (query.idVoie) {
-      voie = await getVoie(query.idVoie)
-    }
-
-    if (query.idToponyme) {
-      toponyme = await getToponyme(query.idToponyme)
+      voies = await getVoies(query.balId, codeCommune)
+      toponymes = await getToponymes(query.balId, codeCommune)
     }
 
     if (Component.getInitialProps) {
@@ -125,8 +119,8 @@ App.getInitialProps = async ({Component, ctx}) => {
         ...ctx,
         baseLocale,
         commune,
-        voie,
-        toponyme
+        voies,
+        toponymes
       })
     }
   } catch {
@@ -142,8 +136,8 @@ App.getInitialProps = async ({Component, ctx}) => {
     pageProps: {
       baseLocale,
       commune,
-      voie,
-      toponyme,
+      voies,
+      toponymes,
       ...pageProps
     },
     query

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,4 +1,4 @@
-import {useState, useMemo, useEffect} from 'react'
+import {useState} from 'react'
 import PropTypes from 'prop-types'
 import Head from 'next/head'
 import {Pane, Dialog, Paragraph} from 'evergreen-ui'
@@ -10,63 +10,18 @@ import {getCommune} from '@/lib/geo-api'
 
 import {LocalStorageContextProvider} from '@/contexts/local-storage'
 import {HelpContextProvider} from '@/contexts/help'
-import {SettingsContextProvider} from '@/contexts/settings'
-import {DrawContextProvider} from '@/contexts/draw'
-import {MarkersContextProvider} from '@/contexts/markers'
-import {MapContextProvider} from '@/contexts/map'
 import {TokenContextProvider} from '@/contexts/token'
-import {BalDataContextProvider} from '@/contexts/bal-data'
-import {ParcellesContextProvider} from '@/contexts/parcelles'
-
-import useWindowSize from '@/hooks/window-size'
 
 import ErrorPage from '@/pages/_error'
 
-import Fullscreen from '@/layouts/fullscreen'
-import Sidebar from '@/layouts/sidebar'
+import Editor from '@/layouts/editor'
 
-import Settings from '@/components/settings'
 import Header from '@/components/header'
-import SubHeader from '@/components/sub-header'
 import IEWarning from '@/components/ie-warning'
-import WelcomeMessage from '@/components/welcome-message'
-import CertificationMessage from '@/components/certification-message'
-import Map from '@/components/map'
 import Help from '@/components/help'
 
-const layoutMap = {
-  fullscreen: Fullscreen,
-  sidebar: Sidebar
-}
-
 function App({error, Component, pageProps, query}) {
-  const {innerWidth} = useWindowSize()
-  const [isShown, setIsShown] = useState(false)
-  const [isHidden, setIsHidden] = useState(false)
-  const {layout, ...otherPageProps} = pageProps
-  const Wrapper = layoutMap[layout] || Fullscreen
-
-  const leftOffset = useMemo(() => {
-    if (layout === 'sidebar' && !isHidden) {
-      return 500
-    }
-
-    return 0
-  }, [layout, isHidden])
-
-  const topOffset = useMemo(() => {
-    if (pageProps.baseLocale && pageProps.baseLocale.status === 'demo') {
-      return 166 // Adding space for demo-warning component
-    }
-
-    return pageProps.baseLocale ? 116 : 0
-  }, [pageProps.baseLocale])
-
-  useEffect(() => {
-    if (innerWidth && innerWidth < 700 && !/(\/dashboard)/.test(location.pathname)) {
-      setIsShown(true)
-    }
-  }, [innerWidth])
+  const [isMobileWarningDisplayed, setIsMobileWarningDisplayed] = useState(false)
 
   return (
     <>
@@ -77,11 +32,11 @@ function App({error, Component, pageProps, query}) {
 
       <Pane>
         <Dialog
-          isShown={isShown}
+          isShown={isMobileWarningDisplayed}
           title='Attention'
           confirmLabel='Continuer'
           hasCancel={false}
-          onCloseComplete={() => setIsShown(false)}
+          onCloseComplete={() => setIsMobileWarningDisplayed(false)}
         >
           <Paragraph marginTop='default'>
             Afin de profiter d’une meilleure expérience, il est recommandé d’utiliser cet outil sur un écran plus grand 🖥
@@ -97,66 +52,26 @@ function App({error, Component, pageProps, query}) {
 
       <LocalStorageContextProvider>
         <TokenContextProvider balId={query.balId} _token={query.token}>
-          <BalDataContextProvider balId={query.balId} codeCommune={query.codeCommune} idVoie={query.idVoie} idToponyme={query.idToponyme}>
-            <MapContextProvider>
-              <DrawContextProvider>
-                <MarkersContextProvider>
-                  <ParcellesContextProvider>
-                    <HelpContextProvider>
+          <HelpContextProvider>
 
-                      <Help />
+            <Help />
 
-                      {pageProps.baseLocale && (
-                        <SettingsContextProvider>
-                          <Settings initialBaseLocale={pageProps.baseLocale} codeCommune={pageProps.commune?.code} />
-                          <Header />
-                          <SubHeader
-                            {...pageProps}
-                            initialBaseLocale={pageProps.baseLocale}
-                            isFranceConnectAuthentication={query['france-connect'] === '1'}
-                          />
-                        </SettingsContextProvider>
-                      )}
-
-                      {pageProps.baseLocale && (
-                        <Map
-                          top={topOffset}
-                          left={leftOffset}
-                          commune={pageProps.commune}
-                          voie={pageProps.voie}
-                          toponyme={pageProps.toponyme}
-                        />
-                      )}
-
-                      <Wrapper
-                        top={topOffset}
-                        isHidden={isHidden}
-                        size={500}
-                        elevation={2}
-                        background='tint2'
-                        display='flex'
-                        flexDirection='column'
-                        onToggle={setIsHidden}
-                      >
-                        {error ? (
-                          <ErrorPage statusCode={error.statusCode} />
-                        ) : (
-                          <>
-                            <IEWarning />
-                            {pageProps.baseLocale && <WelcomeMessage />}
-                            {pageProps.baseLocale && pageProps.baseLocale.status === 'published' && (
-                              <CertificationMessage balId={query.balId} codeCommune={query.codeCommune} />
-                            )}
-                            <Component {...otherPageProps} />
-                          </>
-                        )}
-                      </Wrapper>
-                    </HelpContextProvider>
-                  </ParcellesContextProvider>
-                </MarkersContextProvider>
-              </DrawContextProvider>
-            </MapContextProvider>
-          </BalDataContextProvider>
+            {error ? (
+              <ErrorPage statusCode={error.statusCode} />
+            ) : (
+              <Pane height='100%' width='100%' display='flex' flexDirection='column'>
+                <Header />
+                <IEWarning />
+                {query.balId ? (
+                  <Editor {...pageProps}>
+                    <Component {...pageProps} />
+                  </Editor>
+                ) : (
+                  <Component {...pageProps} />
+                )}
+              </Pane>
+            )}
+          </HelpContextProvider>
         </TokenContextProvider>
       </LocalStorageContextProvider>
       {/* ⚠️ This is needed to expand Evergreen’Tootip width
@@ -173,9 +88,7 @@ function App({error, Component, pageProps, query}) {
 App.getInitialProps = async ({Component, ctx}) => {
   const {query} = ctx
 
-  let pageProps = {
-    layout: 'fullscreen'
-  }
+  let pageProps = {}
 
   let baseLocale
   let commune

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -56,21 +56,23 @@ function App({error, Component, pageProps, query}) {
 
             <Help />
 
-            {error ? (
-              <ErrorPage statusCode={error.statusCode} />
-            ) : (
-              <Pane height='100%' width='100%' display='flex' flexDirection='column'>
-                <Header />
-                <IEWarning />
-                {query.balId ? (
-                  <Editor {...pageProps}>
+            <Pane height='100%' width='100%' display='flex' flexDirection='column'>
+              <Header />
+              {error ? (
+                <ErrorPage statusCode={error.statusCode} />
+              ) : (
+                <>
+                  <IEWarning />
+                  {query.balId ? (
+                    <Editor {...pageProps}>
+                      <Component {...pageProps} />
+                    </Editor>
+                  ) : (
                     <Component {...pageProps} />
-                  </Editor>
-                ) : (
-                  <Component {...pageProps} />
-                )}
-              </Pane>
-            )}
+                  )}
+                </>
+              )}
+            </Pane>
           </HelpContextProvider>
         </TokenContextProvider>
       </LocalStorageContextProvider>

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -98,19 +98,18 @@ App.getInitialProps = async ({Component, ctx}) => {
   try {
     if (query.balId) {
       baseLocale = await getBaseLocale(query.balId)
-    }
 
-    if (query.codeCommune) {
-      if (baseLocale.communes.includes(query.codeCommune)) {
-        const baseLocaleCommune = await getCommune(query.balId, query.codeCommune)
-        const geoCommune = await getGeoCommune(query.codeCommune, {
-          fields: 'contour'
-        })
-
-        commune = {...baseLocaleCommune, ...geoCommune}
-      } else {
+      const [codeCommune] = baseLocale.communes
+      if (query.codeCommune && query.codeCommune !== codeCommune) {
         throw new Error('La commune demandée ne fais pas partie de la Base Adresse Locale')
       }
+
+      const baseLocaleCommune = await getCommune(query.balId, codeCommune)
+      const geoCommune = await getGeoCommune(codeCommune, {
+        fields: 'contour'
+      })
+
+      commune = {...baseLocaleCommune, ...geoCommune}
     }
 
     if (query.idVoie) {
@@ -140,7 +139,13 @@ App.getInitialProps = async ({Component, ctx}) => {
   }
 
   return {
-    pageProps,
+    pageProps: {
+      baseLocale,
+      commune,
+      voie,
+      toponyme,
+      ...pageProps
+    },
     query
   }
 }

--- a/pages/_error.js
+++ b/pages/_error.js
@@ -2,6 +2,8 @@ import PropTypes from 'prop-types'
 import Link from 'next/link'
 import {Pane, Heading, Button, Icon, ArrowLeftIcon, ErrorIcon, Alert, Text} from 'evergreen-ui'
 
+import Main from '@/layouts/main'
+
 import Custom404 from '@/pages/404'
 
 import Header from '@/components/header'
@@ -12,10 +14,11 @@ function CustomError({statusCode}) {
   }
 
   return (
-    <Pane display='flex' backgroundColor='#fff' flexDirection='column' width='100%' height='100%'>
+    <Main>
       <Header />
       <Pane
         display='flex'
+        flex={1}
         alignItems='center'
         flexDirection='column'
         justifyContent='center'
@@ -34,7 +37,7 @@ function CustomError({statusCode}) {
           </Button>
         </Link>
       </Pane>
-    </Pane>
+    </Main>
   )
 }
 

--- a/pages/_error.js
+++ b/pages/_error.js
@@ -6,8 +6,6 @@ import Main from '@/layouts/main'
 
 import Custom404 from '@/pages/404'
 
-import Header from '@/components/header'
-
 function CustomError({statusCode}) {
   if (statusCode === 404) {
     return <Custom404 />
@@ -15,7 +13,6 @@ function CustomError({statusCode}) {
 
   return (
     <Main>
-      <Header />
       <Pane
         display='flex'
         flex={1}

--- a/pages/all.js
+++ b/pages/all.js
@@ -17,7 +17,7 @@ const PublicBasesLocalesList = dynamic(() => import('@/components/bases-locales-
 
 function All({basesLocales}) {
   return (
-    <>
+    <Main>
       <Pane padding={16} backgroundColor='white'>
         <Heading size={600} marginBottom={8}>Rechercher une Base Adresse Locale</Heading>
         <Paragraph>
@@ -39,16 +39,13 @@ function All({basesLocales}) {
           </Button>
         </Link>
       </Pane>
-    </>
+    </Main>
   )
 }
 
 All.getInitialProps = async () => {
-  const basesLocales = await listBasesLocales()
-
   return {
-    basesLocales,
-    layout: 'fullscreen'
+    basesLocales: await listBasesLocales()
   }
 }
 

--- a/pages/all.js
+++ b/pages/all.js
@@ -6,6 +6,8 @@ import {Pane, Heading, Paragraph, Spinner, Button} from 'evergreen-ui'
 import {listBasesLocales} from '@/lib/bal-api'
 import {sortBalByUpdate} from '@/lib/sort-bal'
 
+import Main from '@/layouts/main'
+
 const PublicBasesLocalesList = dynamic(() => import('@/components/bases-locales-list/public-bases-locales-list'), { // eslint-disable-line node/no-unsupported-features/es-syntax
   ssr: false,
   loading: () => (

--- a/pages/bal.js
+++ b/pages/bal.js
@@ -37,7 +37,6 @@ const Index = React.memo(({baseLocale}) => {
 
 Index.getInitialProps = async ({baseLocale}) => {
   return {
-    layout: 'sidebar',
     baseLocale
   }
 }

--- a/pages/bal/commune.js
+++ b/pages/bal/commune.js
@@ -291,7 +291,6 @@ Commune.getInitialProps = async ({baseLocale, commune}) => {
   const defaultVoies = await getVoies(baseLocale._id, commune.code)
 
   return {
-    layout: 'sidebar',
     baseLocale,
     commune,
     defaultVoies

--- a/pages/bal/commune.js
+++ b/pages/bal/commune.js
@@ -1,9 +1,9 @@
 import React, {useState, useCallback, useContext, useEffect} from 'react'
 import PropTypes from 'prop-types'
-import Router from 'next/router'
+import {useRouter} from 'next/router'
 import {Pane, Heading, Text, Paragraph, Button, AddIcon} from 'evergreen-ui'
 
-import {getVoies, addVoie, populateCommune, editVoie, removeVoie, addToponyme, editToponyme, removeToponyme} from '@/lib/bal-api'
+import {addVoie, populateCommune, editVoie, removeVoie, addToponyme, editToponyme, removeToponyme} from '@/lib/bal-api'
 
 import TokenContext from '@/contexts/token'
 import BalDataContext from '@/contexts/bal-data'
@@ -14,13 +14,14 @@ import DeleteWarning from '@/components/delete-warning'
 import VoiesList from '@/components/bal/voies-list'
 import ToponymesList from '@/components/bal/toponymes-list'
 
-const Commune = React.memo(({baseLocale, commune, defaultVoies}) => {
+const Commune = React.memo(({baseLocale, commune}) => {
   const [isAdding, setIsAdding] = useState(false)
   const [isPopulating, setIsPopulating] = useState(false)
   const [toRemove, setToRemove] = useState(null)
   const [selectedTab, setSelectedTab] = useState('voie')
 
   const {token} = useContext(TokenContext)
+  const router = useRouter()
 
   const {
     voies,
@@ -128,17 +129,17 @@ const Commune = React.memo(({baseLocale, commune, defaultVoies}) => {
     }
 
     if (selectedTab === 'voie') {
-      Router.push(
+      router.replace(
         `/bal/voie?balId=${baseLocale._id}&codeCommune=${commune.code}&idVoie=${id}`,
         `/bal/${baseLocale._id}/communes/${commune.code}/voies/${id}`
       )
     } else {
-      Router.push(
+      router.replace(
         `/bal/toponyme?balId=${baseLocale._id}&codeCommune=${commune.code}&idToponyme=${id}`,
         `/bal/${baseLocale._id}/communes/${commune.code}/toponymes/${id}`
       )
     }
-  }, [baseLocale._id, editingId, isAdding, commune, selectedTab, onCancel])
+  }, [baseLocale._id, router, editingId, isAdding, commune, selectedTab, onCancel])
 
   useEffect(() => {
     if (isAdding) {
@@ -226,7 +227,7 @@ const Commune = React.memo(({baseLocale, commune, defaultVoies}) => {
 
       {selectedTab === 'voie' ? (
         <VoiesList
-          defaultVoies={defaultVoies}
+          voies={voies}
           isPopulating={isPopulating}
           isAdding={isAdding}
           setToRemove={setToRemove}
@@ -238,6 +239,7 @@ const Commune = React.memo(({baseLocale, commune, defaultVoies}) => {
         />
       ) : (
         <ToponymesList
+          toponymes={toponymes}
           isPopulating={isPopulating}
           isAdding={isAdding}
           setToRemove={setToRemove}
@@ -287,16 +289,6 @@ const Commune = React.memo(({baseLocale, commune, defaultVoies}) => {
   )
 })
 
-Commune.getInitialProps = async ({baseLocale, commune}) => {
-  const defaultVoies = await getVoies(baseLocale._id, commune.code)
-
-  return {
-    baseLocale,
-    commune,
-    defaultVoies
-  }
-}
-
 Commune.propTypes = {
   baseLocale: PropTypes.shape({
     _id: PropTypes.string.isRequired
@@ -304,12 +296,7 @@ Commune.propTypes = {
   commune: PropTypes.shape({
     code: PropTypes.string.isRequired,
     nom: PropTypes.string.isRequired
-  }).isRequired,
-  defaultVoies: PropTypes.array
-}
-
-Commune.defaultProps = {
-  defaultVoies: null
+  }).isRequired
 }
 
 export default Commune

--- a/pages/bal/toponyme.js
+++ b/pages/bal/toponyme.js
@@ -26,7 +26,7 @@ function Toponyme({baseLocale, commune}) {
   const {
     toponyme,
     numeros,
-    reloadNumerosToponyme,
+    reloadNumeros,
     editingId,
     setEditingId,
     isEditing,
@@ -53,7 +53,7 @@ function Toponyme({baseLocale, commune}) {
         }, token, true)
       }))
 
-      await reloadNumerosToponyme()
+      await reloadNumeros()
 
       if (isMultiNumeros) {
         toaster.success('Les numéros ont bien été ajoutés')
@@ -83,13 +83,13 @@ function Toponyme({baseLocale, commune}) {
       }
 
       await editNumero(editingId, {...body, voie: editedVoie._id}, token)
-      await reloadNumerosToponyme()
+      await reloadNumeros()
     } catch (error) {
       setError(error.message)
     }
 
     setEditingId(null)
-  }, [editingId, setEditingId, baseLocale, commune.code, reloadNumerosToponyme, token])
+  }, [editingId, setEditingId, baseLocale, commune.code, reloadNumeros, token])
 
   const handleSelection = useCallback(id => {
     if (!isEditing) {

--- a/pages/bal/toponyme.js
+++ b/pages/bal/toponyme.js
@@ -2,7 +2,7 @@ import {useState, useCallback, useEffect, useContext} from 'react'
 import PropTypes from 'prop-types'
 import {Pane, Heading, Table, Button, Alert, AddIcon, toaster} from 'evergreen-ui'
 
-import {addVoie, editNumero, getNumerosToponyme, getToponyme} from '@/lib/bal-api'
+import {addVoie, editNumero, getNumerosToponyme} from '@/lib/bal-api'
 
 import TokenContext from '@/contexts/token'
 import BalDataContext from '@/contexts/bal-data'
@@ -15,10 +15,9 @@ import ToponymeNumeros from '@/components/toponyme/toponyme-numeros'
 import AddNumeros from '@/components/toponyme/add-numeros'
 import ToponymeHeading from '@/components/toponyme/toponyme-heading'
 
-function Toponyme({commune, toponyme, defaultNumeros}) {
+function Toponyme({commune, defaultNumeros, ...props}) {
   const [isEdited, setEdited] = useState(false)
   const [isAdding, setIsAdding] = useState(false)
-  const [updatedToponyme, setUpdatedToponyme] = useState(toponyme)
   const [error, setError] = useState()
   const [isLoading, setIsLoading] = useState(false)
 
@@ -26,6 +25,7 @@ function Toponyme({commune, toponyme, defaultNumeros}) {
 
   const {
     baseLocale,
+    toponyme,
     numeros,
     reloadNumerosToponyme,
     editingId,
@@ -50,7 +50,7 @@ function Toponyme({commune, toponyme, defaultNumeros}) {
     try {
       await Promise.all(numeros.map(id => {
         return editNumero(id, {
-          toponyme: toponyme._id
+          toponyme: props.toponyme._id
         }, token, true)
       }))
 
@@ -83,17 +83,14 @@ function Toponyme({commune, toponyme, defaultNumeros}) {
         editedVoie = await addVoie(baseLocale._id, commune.code, editedVoie, token)
       }
 
-      const {toponyme} = body
       await editNumero(editingId, {...body, voie: editedVoie._id}, token)
-
-      await reloadNumerosToponyme(updatedToponyme._id || toponyme)
-      setUpdatedToponyme(toponyme ? await getToponyme(toponyme) : updatedToponyme)
+      await reloadNumerosToponyme()
     } catch (error) {
       setError(error.message)
     }
 
     setEditingId(null)
-  }, [editingId, setEditingId, baseLocale, commune.code, reloadNumerosToponyme, token, updatedToponyme])
+  }, [editingId, setEditingId, baseLocale, commune.code, reloadNumerosToponyme, token])
 
   const handleSelection = useCallback(id => {
     if (!isEditing) {
@@ -128,7 +125,7 @@ function Toponyme({commune, toponyme, defaultNumeros}) {
 
   return (
     <>
-      <ToponymeHeading defaultToponyme={toponyme} />
+      <ToponymeHeading toponyme={toponyme || props.toponyme} />
       <Pane
         flexShrink={0}
         elevation={0}
@@ -189,7 +186,7 @@ function Toponyme({commune, toponyme, defaultNumeros}) {
             </Table.Row>
           )}
 
-          {editingId && editingId !== toponyme._id ? (
+          {editingId && editingId !== props.toponyme._id ? (
             <Table.Row height='auto'>
               <Table.Cell display='block' padding={0} background='tint1'>
                 <NumeroEditor

--- a/pages/bal/toponyme.js
+++ b/pages/bal/toponyme.js
@@ -214,7 +214,6 @@ Toponyme.getInitialProps = async ({baseLocale, commune, toponyme}) => {
   const defaultNumeros = await getNumerosToponyme(toponyme._id)
 
   return {
-    layout: 'sidebar',
     toponyme,
     baseLocale,
     commune,

--- a/pages/bal/voie.js
+++ b/pages/bal/voie.js
@@ -13,7 +13,7 @@ import NumeroEditor from '@/components/bal/numero-editor'
 import VoieHeading from '@/components/voie/voie-heading'
 import NumerosList from '@/components/voie/numeros-list'
 
-const Voie = React.memo(({baseLocale, commune, voie, defaultNumeros}) => {
+const Voie = React.memo(({baseLocale, commune, defaultNumeros, ...props}) => {
   const [isFormOpen, setIsFormOpen] = useState(false)
 
   useHelp(3)
@@ -21,6 +21,7 @@ const Voie = React.memo(({baseLocale, commune, voie, defaultNumeros}) => {
   const {token} = useContext(TokenContext)
 
   const {
+    voie,
     numeros,
     reloadNumeros,
     reloadVoies,
@@ -62,7 +63,7 @@ const Voie = React.memo(({baseLocale, commune, voie, defaultNumeros}) => {
     await reloadNumeros()
     refreshBALSync()
 
-    if (editedVoie._id !== voie._id || isNewVoie) {
+    if (editedVoie._id !== props.voie._id || isNewVoie) {
       await reloadGeojson()
     }
 
@@ -100,7 +101,7 @@ const Voie = React.memo(({baseLocale, commune, voie, defaultNumeros}) => {
 
   return (
     <>
-      <VoieHeading defaultVoie={voie} />
+      <VoieHeading voie={voie || props.voie} />
 
       {isFormOpen ? (
         <Pane flex={1} overflowY='scroll'>
@@ -108,7 +109,7 @@ const Voie = React.memo(({baseLocale, commune, voie, defaultNumeros}) => {
             <Table.Cell display='block' padding={0} background='tint1'>
               <NumeroEditor
                 hasPreview
-                initialVoieId={voie._id}
+                initialVoieId={props.voie._id}
                 initialValue={editedNumero}
                 commune={commune}
                 onSubmit={editedNumero ? onEdit : onAdd}
@@ -120,7 +121,7 @@ const Voie = React.memo(({baseLocale, commune, voie, defaultNumeros}) => {
       ) : (
         <NumerosList
           token={token}
-          voieId={voie._id}
+          voieId={props.voie._id}
           defaultNumeros={defaultNumeros}
           isEditionDisabled={isEditing}
           handleEditing={handleEditing}

--- a/pages/bal/voie.js
+++ b/pages/bal/voie.js
@@ -2,7 +2,7 @@ import React, {useState, useCallback, useEffect, useMemo, useContext} from 'reac
 import PropTypes from 'prop-types'
 import {Pane, Table} from 'evergreen-ui'
 
-import {editNumero, getNumeros, addVoie, addNumero} from '@/lib/bal-api'
+import {editNumero, getNumeros, getVoie, addVoie, addNumero} from '@/lib/bal-api'
 
 import TokenContext from '@/contexts/token'
 import BalDataContext from '@/contexts/bal-data'
@@ -13,7 +13,7 @@ import NumeroEditor from '@/components/bal/numero-editor'
 import VoieHeading from '@/components/voie/voie-heading'
 import NumerosList from '@/components/voie/numeros-list'
 
-const Voie = React.memo(({baseLocale, commune, defaultNumeros, ...props}) => {
+const Voie = React.memo(({baseLocale, commune}) => {
   const [isFormOpen, setIsFormOpen] = useState(false)
 
   useHelp(3)
@@ -63,7 +63,7 @@ const Voie = React.memo(({baseLocale, commune, defaultNumeros, ...props}) => {
     await reloadNumeros()
     refreshBALSync()
 
-    if (editedVoie._id !== props.voie._id || isNewVoie) {
+    if (editedVoie._id !== voie._id || isNewVoie) {
       await reloadGeojson()
     }
 
@@ -101,7 +101,7 @@ const Voie = React.memo(({baseLocale, commune, defaultNumeros, ...props}) => {
 
   return (
     <>
-      <VoieHeading voie={voie || props.voie} />
+      <VoieHeading voie={voie} />
 
       {isFormOpen ? (
         <Pane flex={1} overflowY='scroll'>
@@ -109,7 +109,7 @@ const Voie = React.memo(({baseLocale, commune, defaultNumeros, ...props}) => {
             <Table.Cell display='block' padding={0} background='tint1'>
               <NumeroEditor
                 hasPreview
-                initialVoieId={props.voie._id}
+                initialVoieId={voie._id}
                 initialValue={editedNumero}
                 commune={commune}
                 onSubmit={editedNumero ? onEdit : onAdd}
@@ -121,8 +121,8 @@ const Voie = React.memo(({baseLocale, commune, defaultNumeros, ...props}) => {
       ) : (
         <NumerosList
           token={token}
-          voieId={props.voie._id}
-          defaultNumeros={defaultNumeros}
+          voieId={voie._id}
+          numeros={numeros}
           isEditionDisabled={isEditing}
           handleEditing={handleEditing}
         />
@@ -131,14 +131,13 @@ const Voie = React.memo(({baseLocale, commune, defaultNumeros, ...props}) => {
   )
 })
 
-Voie.getInitialProps = async ({baseLocale, commune, voie}) => {
-  const defaultNumeros = await getNumeros(voie._id)
+Voie.getInitialProps = async ({query}) => {
+  const voie = await getVoie(query.idVoie)
+  const numeros = await getNumeros(voie._id)
 
   return {
     voie,
-    baseLocale,
-    commune,
-    defaultNumeros
+    numeros
   }
 }
 
@@ -148,16 +147,7 @@ Voie.propTypes = {
   }).isRequired,
   commune: PropTypes.shape({
     code: PropTypes.string.isRequired
-  }).isRequired,
-  voie: PropTypes.shape({
-    _id: PropTypes.string.isRequired,
-    nom: PropTypes.string.isRequired
-  }).isRequired,
-  defaultNumeros: PropTypes.array
-}
-
-Voie.defaultProps = {
-  defaultNumeros: null
+  }).isRequired
 }
 
 export default Voie

--- a/pages/bal/voie.js
+++ b/pages/bal/voie.js
@@ -134,7 +134,6 @@ Voie.getInitialProps = async ({baseLocale, commune, voie}) => {
   const defaultNumeros = await getNumeros(voie._id)
 
   return {
-    layout: 'sidebar',
     voie,
     baseLocale,
     commune,

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -46,8 +46,7 @@ Index.getInitialProps = async () => {
 
   return {
     basesLocales: basesLocalesWithoutDemo,
-    basesLoclesStats,
-    layout: 'fullscreen'
+    basesLoclesStats
   }
 }
 

--- a/pages/dashboard/departement.js
+++ b/pages/dashboard/departement.js
@@ -95,7 +95,6 @@ Departement.getInitialProps = async ({query}) => {
     basesLocalesDepartementWithoutDemo,
     BALGroupedByCommune,
     stats: basesLocalesDepartement.stats,
-    layout: 'fullscreen'
   }
 }
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -2,8 +2,8 @@ import dynamic from 'next/dynamic'
 import {Pane, Button, Spinner, Heading, PlusIcon} from 'evergreen-ui'
 import Link from 'next/link'
 
-import Header from '@/components/header'
-import Footer from '@/components/footer'
+import Main from '@/layouts/main'
+
 import BALRecovery from '@/components/bal-recovery/bal-recovery'
 
 const UserBasesLocales = dynamic(() => import('@/components/user-bases-locales'), { // eslint-disable-line node/no-unsupported-features/es-syntax
@@ -17,8 +17,7 @@ const UserBasesLocales = dynamic(() => import('@/components/user-bases-locales')
 
 function Index() {
   return (
-    <Pane height='100vh' display='flex' flexDirection='column'>
-      <Header />
+    <Main>
       <Heading padding={16} size={400} color='snow' display='flex' justifyContent='space-between' alignItems='center' backgroundColor='#0053b3' flexShrink='0'>
         Mes Bases Adresse Locales
         <Link href='/new' passHref>
@@ -33,15 +32,8 @@ function Index() {
       <Pane padding={22}>
         <BALRecovery />
       </Pane>
-      <Footer />
-    </Pane>
+    </Main>
   )
-}
-
-Index.getInitialProps = async () => {
-  return {
-    layout: 'fullscreen'
-  }
 }
 
 export default Index

--- a/pages/new.js
+++ b/pages/new.js
@@ -88,7 +88,7 @@ Index.getInitialProps = async ({query}) => {
 }
 
 Index.propTypes = {
-  defaultCommune: PropTypes.string,
+  defaultCommune: PropTypes.object,
   isDemo: PropTypes.bool
 }
 

--- a/pages/new.js
+++ b/pages/new.js
@@ -7,8 +7,8 @@ import {getCommune} from '@/lib/geo-api'
 
 import LocalStorageContext from '@/contexts/local-storage'
 
-import Header from '@/components/header'
-import Footer from '@/components/footer'
+import Main from '@/layouts/main'
+
 import BackButton from '@/components/back-button'
 import CreateForm from '@/components/new/create-form'
 import UploadForm from '@/components/new/upload-form'
@@ -20,8 +20,7 @@ function Index({defaultCommune, isDemo}) {
   const [index, setIndex] = useState(0)
 
   return (
-    <Pane height='100%' display='flex' flexDirection='column'>
-      <Header />
+    <Main>
       <Pane padding={12}>
         <Heading size={600} marginBottom={8}>{`Nouvelle Base Adresse Locale ${isDemo ? 'de démonstration' : ''}`}</Heading>
         <Paragraph>
@@ -70,8 +69,7 @@ function Index({defaultCommune, isDemo}) {
           </Pane>
         </Pane>
       )}
-      <Footer />
-    </Pane>
+    </Main>
   )
 }
 
@@ -85,8 +83,7 @@ Index.getInitialProps = async ({query}) => {
 
   return {
     defaultCommune,
-    isDemo: query.demo === '1',
-    layout: 'fullscreen'
+    isDemo: query.demo === '1'
   }
 }
 


### PR DESCRIPTION
## Description
L'outil comporte de nombreux contextes de données et de lourds composants qui ne sont nécessaires que pour l'outil d'édition. Hors ceux-ci sont actuellement chargés même en dehors de l'outil d'édition.

Cet agencement pose deux problèmes importants : 
- Un problème de performances, car leur chargement relativement important affecte inutilement les autres pages
- De conditions, puisqu'en étant présent sans pouvoir recevoir les données nécessaires à leur bon fonctionnement, il est nécessaire de vérifier la présence de chaque variable afin d'assurer un comportement viable.

De plus, l'arrivée de l'API de dépôt et la migration des bases locales a mis un terme définitif au mode multi-communal. Cette PR supprime donc la page `/bal`, retire les messages d'avertissement liés à ces BAL et met à jour la documentation.

## Résumé
- Suppression du système de layout `fullscreen/sidebar` désormais devenu optionnel. Le layout `sidebar` n'étant utilisé que pour l'outil décision, celui-ci utilise le layout directement.
- Un nouveau composant/layout `<Editor />`  qui s'occupe d'embarquer tout ce qui est nécessaire à l'outil d'édition (les contextes, composants du menu latéral ainsi que la carte)
- Les variables comme `baseLocale` et `commune` ne peuvent plus être optionnelles et leur gestion à travers l'application a été simplifiée.
- Dorénavant seul le contexte `BalDataContext` manipule et fourni les variables `baseLocale`, `commune`, `voie` et `toponyme`. Si celle-ci sont modifiée alors l'intégralité de l'application est mise à jour automatiquement.
- `_app.getInitialProps` se charge de récupérer toutes les de la BAL (`baseLocale`, `commune`, `voies` et `toponymes`), et les pages complète avec leur propre données.
----

## To do
Afin de ne plus considérer cette PR comme un brouillon, il est nécessaire de : 

- [x] Merger Intégration de l'API de dépôt côté front #471
- [x] Merger Intégration de l'API de dépôt côté back [#303](https://github.com/BaseAdresseNationale/api-bal/pull/303)
- [x] S'assurer qu'il n'existe plus de BAL multi-communale 