### PR TITLE
Affichage des suffixes en minuscule dans la preview d'adresse

### DIFF
--- a/lib/utils/numero.js
+++ b/lib/utils/numero.js
@@ -1,7 +1,7 @@
 export const computeCompletNumero = (numero, suffixe) => {
   if (suffixe && Number.isNaN(suffixe)) {
-    return `${numero}${suffixe}`
+    return `${numero}${suffixe.toLowerCase()}`
   }
 
-  return `${numero}${suffixe ? ` ${suffixe}` : ''}`
+  return `${numero}${suffixe ? ` ${suffixe.toLowerCase()}` : ''}`
 }


### PR DESCRIPTION
Close #469 
La preview dynamique d'adresse permettait l'affichage du suffixe en majuscule.
Il est à présent automatiquement traité en minuscule.

<img width="501" alt="Capture d’écran 2022-01-17 à 12 35 08" src="https://user-images.githubusercontent.com/66621960/149763633-a8a338f1-7e3a-4753-83d0-d4f9c0f3fea0.png">
