### PR TITLE
Ajout du nombre de numéros certifiés

### DIFF
--- a/components/dashboard/counter.js
+++ b/components/dashboard/counter.js
@@ -1,11 +1,13 @@
 import PropTypes from 'prop-types'
 import {Pane, Heading} from 'evergreen-ui'
 
+import {spaceThousands} from '../../lib/utils/numbers'
+
 function Counter({label, value, color}) {
   return (
     <Pane marginY={16} marginX='auto' textAlign='center'>
       <Heading size={700} color={color}>
-        {value}
+        {spaceThousands(value)}
       </Heading>
       <Heading size={500} fontWeight={300} color='muted'>
         {label}

--- a/lib/bal-api/index.js
+++ b/lib/bal-api/index.js
@@ -31,6 +31,10 @@ export async function listBasesLocales() {
   return request('/bases-locales')
 }
 
+export async function countNumerosCertifies() {
+  return request('/stats/numeros-certifies')
+}
+
 export async function listBALByCodeDepartement(codeDepartement) {
   return request(`/stats/departements/${codeDepartement}`)
 }

--- a/lib/utils/numbers.js
+++ b/lib/utils/numbers.js
@@ -1,0 +1,3 @@
+export function spaceThousands(number) {
+  return number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ' ')
+}

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types'
 import {Pane} from 'evergreen-ui'
 import {uniq, flattenDeep} from 'lodash'
 
-import {getContoursCommunes, listBasesLocales} from '../lib/bal-api'
+import {getContoursCommunes, listBasesLocales, countNumerosCertifies} from '../lib/bal-api'
 
 import DashboardLayout from '../components/layout/dashboard'
 
@@ -11,7 +11,7 @@ import BALCounterChart from '../components/dashboard/bal-counter-chart'
 import Counter from '../components/dashboard/counter'
 import Redirection from './dashboard/redirection'
 
-function Index({basesLocales, contoursCommunes}) {
+function Index({basesLocales, contoursCommunes, nbNumerosCertifies}) {
   const communeCount = uniq(flattenDeep(
     basesLocales
       .filter(({communes}) => communes.length > 0)
@@ -22,6 +22,7 @@ function Index({basesLocales, contoursCommunes}) {
     <DashboardLayout title='Tableau de bord de l&apos;éditeur Mes Adresses' mapData={{basesLocales, contours: contoursCommunes}}>
       <Pane display='grid' gridGap='2em' padding={5}>
         <Counter label='Communes couvertes par une Base Adresse Locale' value={communeCount} />
+        <Counter label='Numéros certifiés' value={nbNumerosCertifies} />
         <BALCounterChart basesLocales={basesLocales} />
         <BALCreationChart basesLocales={basesLocales} />
         <Redirection />
@@ -33,18 +34,21 @@ function Index({basesLocales, contoursCommunes}) {
 Index.getInitialProps = async () => {
   const basesLocales = await listBasesLocales()
   const contoursCommunes = await getContoursCommunes()
+  const {nbNumerosCertifies} = await countNumerosCertifies()
   const basesLocalesWithoutDemo = basesLocales.filter((b => b.status !== 'demo'))
 
   return {
     basesLocales: basesLocalesWithoutDemo,
     contoursCommunes,
+    nbNumerosCertifies,
     layout: 'fullscreen'
   }
 }
 
 Index.propTypes = {
   basesLocales: PropTypes.array.isRequired,
-  contoursCommunes: PropTypes.object.isRequired
+  contoursCommunes: PropTypes.object.isRequired,
+  nbNumerosCertifies: PropTypes.number.isRequired
 }
 
 export default Index

--- a/pages/dashboard/departement.js
+++ b/pages/dashboard/departement.js
@@ -13,12 +13,16 @@ import DashboardLayout from '../../components/layout/dashboard'
 
 function Departement({departement, filteredCommunesInBAL, basesLocalesDepartementWithoutDemo, BALGroupedByCommune, contoursCommunes}) {
   const {nom, code} = departement
+  let nbNumerosCertifies = 0
 
   const codesCommunes = new Set(filteredCommunesInBAL.map(({code}) => code))
   const communesWithoutTest = uniq(flatten(basesLocalesDepartementWithoutDemo.map(({communes}) => communes)))
   const countCommunesActuelles = communesWithoutTest.filter(c => codesCommunes.has(c)).length
 
   const BALByStatus = getBALByStatus(basesLocalesDepartementWithoutDemo)
+  basesLocalesDepartementWithoutDemo.forEach(bal => {
+    nbNumerosCertifies += bal.nbNumerosCertifies
+  })
 
   const mapData = {
     departement: code,
@@ -34,6 +38,12 @@ function Departement({departement, filteredCommunesInBAL, basesLocalesDepartemen
             <Counter
               label={`${countCommunesActuelles > 1 ? 'Communes couvertes' : 'Commune couverte'} par une Base Adresse Locale`}
               value={countCommunesActuelles}
+            />
+          )}
+          {nbNumerosCertifies > 0 && (
+            <Counter
+              label={`${nbNumerosCertifies > 1 ? 'Numéros certifiés' : 'Numéro certifié'}`}
+              value={nbNumerosCertifies}
             />
           )}
 


### PR DESCRIPTION
resolves #391 

- Ajout du nombre de numéros certifiés sur la page regroupant les statistiques de toutes les BAL, ainsi que sur la page des BAL par département.

Liée à la PR [api-bal #304](https://github.com/BaseAdresseNationale/api-bal/pull/304)

Capture  :
![dashboard-numeros-certifies](https://user-images.githubusercontent.com/45098730/149792990-7531a089-0b15-4ddc-8960-4a7e5f857867.png)
