### PR TITLE
Permet de choisir une commune lors du téléversement d'un fichier csv

### DIFF
--- a/components/select-commune.js
+++ b/components/select-commune.js
@@ -1,0 +1,22 @@
+import PropTypes from 'prop-types'
+import {Pane, Select} from 'evergreen-ui'
+
+function SelectCommune({communes, selectedCodeCommune, setSelectedCodeCommune}) {
+  return (
+    <Pane marginTop={8}>
+      <Select value={selectedCodeCommune} onChange={event => setSelectedCodeCommune(event.target.value)}>
+        {communes.map(({code, nom}) => (
+          <option key={code} value={code}>{nom} ({code})</option>
+        ))}
+      </Select>
+    </Pane>
+  )
+}
+
+SelectCommune.propTypes = {
+  communes: PropTypes.array.isRequired,
+  selectedCodeCommune: PropTypes.string.isRequired,
+  setSelectedCodeCommune: PropTypes.func.isRequired
+}
+
+export default SelectCommune

--- a/lib/bal-api/index.js
+++ b/lib/bal-api/index.js
@@ -108,8 +108,8 @@ export async function removeBaseLocale(balId, token) {
   }
 }
 
-export function uploadBaseLocaleCsv(balId, file, token) {
-  return request(`/bases-locales/${balId}/upload`, {
+export function uploadBaseLocaleCsv(balId, codeCommune, file, token) {
+  return request(`/bases-locales/${balId}/communes/${codeCommune}/upload`, {
     method: 'POST',
     headers: {
       authorization: `Token ${token}`,

--- a/pages/new/upload-form.js
+++ b/pages/new/upload-form.js
@@ -14,6 +14,7 @@ import {useInput} from '../../hooks/input'
 import Form from '../../components/form'
 import FormInput from '../../components/form-input'
 import Uploader from '../../components/uploader'
+import SelectCommune from '../../components/select-commune'
 
 import AlertPublishedBAL from './alert-published-bal'
 
@@ -39,12 +40,15 @@ function UploadForm() {
   const [bal, setBal] = useState(null)
   const [file, setFile] = useState(null)
   const [error, setError] = useState(null)
+  const [warning, setWarning] = useState(null)
   const [isLoading, setIsLoading] = useState(false)
   const [nom, onNomChange] = useInput('')
   const [email, onEmailChange] = useInput('')
   const [focusRef] = useFocus()
   const [userBALs, setUserBALs] = useState([])
   const [isShown, setIsShown] = useState(false)
+  const [communesList, setCommunesList] = useState(null)
+  const [selectedCodeCommune, setSelectedCodeCommune] = useState(null)
 
   const {addBalAccess} = useContext(LocalStorageContext)
 
@@ -52,6 +56,16 @@ function UploadForm() {
     setFile(null)
     setIsLoading(false)
     setError(error)
+  }
+
+  const onWarning = (warning, communes = null) => {
+    setIsLoading(false)
+    setWarning(warning)
+
+    if (communes) {
+      setCommunesList(communes)
+      setSelectedCodeCommune(communes[0].code)
+    }
   }
 
   const onDrop = useCallback(async ([file]) => {
@@ -226,9 +240,18 @@ function UploadForm() {
             </Pane>
           </Pane>
 
-          {error && (
-            <Alert marginBottom={16} intent='danger' title='Erreur'>
-              {error}
+          {(error || warning) && (
+            <Alert marginBottom={16} intent={error ? 'danger' : 'warning'} title={error ? 'Erreur' : 'Attention'}>
+              <Text>
+                {error || warning}
+              </Text>
+              {warning && communesList && selectedCodeCommune && (
+                <SelectCommune
+                  communes={communesList}
+                  selectedCodeCommune={selectedCodeCommune}
+                  setSelectedCodeCommune={setSelectedCodeCommune}
+                />
+              )}
             </Alert>
           )}
 

--- a/pages/new/upload-form.js
+++ b/pages/new/upload-form.js
@@ -132,7 +132,9 @@ function UploadForm() {
     if (validateResponse) {
       const communes = extractCommuneFromCSV(validateResponse)
 
-      if (communes.length > 1 && !selectedCodeCommune) {
+      if (communes.length === 1) {
+        setSelectedCodeCommune(communes[0].code)
+      } else if (communes.length > 1 && !selectedCodeCommune) {
         onWarning(
           'Le fichier comporte plusieurs communes. Pour gérer plusieurs communes, vous devez créer plusieurs Bases Adresses Locales. Veuillez choisir une commune, puis validez à nouveau le formulaire.',
           communes
@@ -142,7 +144,7 @@ function UploadForm() {
 
       const userBALs = []
 
-      const basesLocales = await searchBAL(selectedCodeCommune, email)
+      const basesLocales = await searchBAL(selectedCodeCommune || communes[0].code, email)
       if (basesLocales.length > 0) {
         userBALs.push(...basesLocales)
       }

--- a/pages/new/upload-form.js
+++ b/pages/new/upload-form.js
@@ -81,6 +81,8 @@ function UploadForm() {
 
       setFile(file)
       setError(null)
+      setWarning(null)
+      setSelectedCodeCommune(null)
     }
   }, [])
 
@@ -113,6 +115,8 @@ function UploadForm() {
   const onCancel = () => {
     setIsShown(false)
     setIsLoading(false)
+    setWarning(null)
+    setSelectedCodeCommune(null)
   }
 
   const onSubmit = async e => {

--- a/pages/new/upload-form.js
+++ b/pages/new/upload-form.js
@@ -153,7 +153,6 @@ function UploadForm() {
         setUserBALs(uniqUserBALs)
         setIsShown(true)
       } else {
-        setSelectedCodeCommune(communes[0].code)
         createNewBal()
       }
     }

--- a/pages/new/upload-form.js
+++ b/pages/new/upload-form.js
@@ -138,12 +138,10 @@ function UploadForm() {
 
       const userBALs = []
 
-      await Promise.all(codes.map(async code => {
-        const basesLocales = await searchBAL(code, email)
-        if (basesLocales.length > 0) {
-          userBALs.push(...basesLocales)
-        }
-      }))
+      const basesLocales = await searchBAL(selectedCodeCommune, email)
+      if (basesLocales.length > 0) {
+        userBALs.push(...basesLocales)
+      }
 
       if (userBALs.length > 0) {
         const uniqUserBALs = uniqBy(userBALs, '_id')
@@ -151,15 +149,16 @@ function UploadForm() {
         setUserBALs(uniqUserBALs)
         setIsShown(true)
       } else {
+        setSelectedCodeCommune(communes[0].code)
         createNewBal()
       }
     }
-  }, [createNewBal, file, email])
+  }, [createNewBal, file, email, selectedCodeCommune])
 
   useEffect(() => {
     async function upload() {
       try {
-        const response = await uploadBaseLocaleCsv(bal._id, file, bal.token)
+        const response = await uploadBaseLocaleCsv(bal._id, selectedCodeCommune, file, bal.token)
         if (!response.isValid) {
           throw new Error('Fichier invalide')
         }
@@ -170,11 +169,11 @@ function UploadForm() {
       }
     }
 
-    if (file && bal) {
+    if (file && bal && selectedCodeCommune) {
       setIsLoading(true)
       upload()
     }
-  }, [bal, file])
+  }, [bal, selectedCodeCommune, file])
 
   useEffect(() => {
     if (file || error) {

--- a/pages/new/upload-form.js
+++ b/pages/new/upload-form.js
@@ -168,7 +168,10 @@ function UploadForm() {
           throw new Error('Fichier invalide')
         }
 
-        Router.push(`/bal?balId=${bal._id}`, `/bal/${bal._id}`)
+        Router.push(
+          `/bal/commune?balId=${bal._id}&codeCommune=${selectedCodeCommune}`,
+          `/bal/${bal._id}/communes/${selectedCodeCommune}`
+        )
       } catch (error) {
         setError(error.message)
       }


### PR DESCRIPTION
resolves #380 

Cette PR permet de choisir une commune lors du téléversement d'un fichier csv.

- Ajout du composant `SelectCommune`
- Ajout d'un warning si un csv comporte plusieurs communes (remplace l'alerte danger)
- La route vers l'api pour l'upload devient `/bases-locales/${balId}/communes/${codeCommune}/upload`

Capture warning :
![warning-mes-adresses](https://user-images.githubusercontent.com/45098730/150092455-0cd6766a-79b1-4cfe-96b4-95dd55d25e7e.png)

Capture vidéo :

https://user-images.githubusercontent.com/45098730/150108069-771b7d70-b2de-471d-b385-828fa3c0ea21.mp4





## Liée à la PR [api-bal #305](https://github.com/BaseAdresseNationale/api-bal/pull/305)