### PR TITLE
Ajout de métriques pour le tableau de bord

### DIFF
--- a/components/dashboard/counter.js
+++ b/components/dashboard/counter.js
@@ -1,11 +1,13 @@
 import PropTypes from 'prop-types'
 import {Pane, Heading} from 'evergreen-ui'
 
+import {spaceThousands} from '../../lib/utils/numbers'
+
 function Counter({label, value, color}) {
   return (
     <Pane marginY={16} marginX='auto' textAlign='center'>
       <Heading size={700} color={color}>
-        {value}
+        {spaceThousands(value)}
       </Heading>
       <Heading size={500} fontWeight={300} color='muted'>
         {label}

--- a/components/dashboard/published-bal-stats.js
+++ b/components/dashboard/published-bal-stats.js
@@ -4,12 +4,13 @@ import {Heading, Pane} from 'evergreen-ui'
 import Counter from './counter'
 
 function PublishedBalStats({stats}) {
-  const {nbVoies, nbLieuxDits, nbNumeros, nbNumerosCertifies} = stats
+  const {nbCommunes, nbVoies, nbLieuxDits, nbNumeros, nbNumerosCertifies} = stats
 
   return (
-    <Pane>
+    <Pane marginTop={16}>
       <Heading size={500} color='muted' fontWeight={300} textAlign='center'>Chiffres des Bases Adresses Locales publiées</Heading>
-      <Pane display='grid' gridTemplateColumns='repeat(4, 1fr)'>
+      <Pane display='grid' gridTemplateColumns='repeat(3, 1fr)'>
+        <Counter label={nbCommunes > 1 ? 'Communes' : 'Commune'} value={nbCommunes} />
         <Counter label={nbVoies > 1 ? 'Voies' : 'Voie'} value={nbVoies} />
         <Counter label={nbLieuxDits > 1 ? 'Lieux-dits' : 'Lieu-dit'} value={nbLieuxDits} />
         <Counter label={nbNumeros > 1 ? 'Adresses' : 'Adresse'} value={nbNumeros} />

--- a/components/dashboard/published-bal-stats.js
+++ b/components/dashboard/published-bal-stats.js
@@ -1,0 +1,26 @@
+import PropTypes from 'prop-types'
+import {Heading, Pane} from 'evergreen-ui'
+
+import Counter from './counter'
+
+function PublishedBalStats({stats}) {
+  const {nbVoies, nbLieuxDits, nbNumerosCertifies} = stats
+
+  return (
+    <Pane>
+      <Heading size={500} color='muted' fontWeight={300} textAlign='center'>Chiffres des Bases Adresses Locales publiées</Heading>
+      <Pane display='grid' gridTemplateColumns='repeat(3, 1fr)'>
+        <Counter label={nbVoies > 1 ? 'Voies' : 'Voie'} value={nbVoies} />
+        <Counter label={nbLieuxDits > 1 ? 'Lieux-dits' : 'Lieu-dit'} value={nbLieuxDits} />
+        <Counter label={nbNumerosCertifies > 1 ? 'Adresses certifiées' : 'Adresse certifiée'} value={nbNumerosCertifies} />
+      </Pane>
+    </Pane>
+
+  )
+}
+
+PublishedBalStats.propTypes = {
+  stats: PropTypes.object.isRequired
+}
+
+export default PublishedBalStats

--- a/components/dashboard/published-bal-stats.js
+++ b/components/dashboard/published-bal-stats.js
@@ -12,7 +12,7 @@ function PublishedBalStats({stats}) {
       <Pane display='grid' gridTemplateColumns='repeat(4, 1fr)'>
         <Counter label={nbVoies > 1 ? 'Voies' : 'Voie'} value={nbVoies} />
         <Counter label={nbLieuxDits > 1 ? 'Lieux-dits' : 'Lieu-dit'} value={nbLieuxDits} />
-        <Counter label={nbNumeros > 1 ? 'Adresses' : 'Adresse'} value={nbNumerosCertifies} />
+        <Counter label={nbNumeros > 1 ? 'Adresses' : 'Adresse'} value={nbNumeros} />
         <Counter label={nbNumerosCertifies > 1 ? 'Adresses certifiées' : 'Adresse certifiée'} value={nbNumerosCertifies} />
       </Pane>
     </Pane>

--- a/components/dashboard/published-bal-stats.js
+++ b/components/dashboard/published-bal-stats.js
@@ -4,14 +4,15 @@ import {Heading, Pane} from 'evergreen-ui'
 import Counter from './counter'
 
 function PublishedBalStats({stats}) {
-  const {nbVoies, nbLieuxDits, nbNumerosCertifies} = stats
+  const {nbVoies, nbLieuxDits, nbNumeros, nbNumerosCertifies} = stats
 
   return (
     <Pane>
       <Heading size={500} color='muted' fontWeight={300} textAlign='center'>Chiffres des Bases Adresses Locales publiées</Heading>
-      <Pane display='grid' gridTemplateColumns='repeat(3, 1fr)'>
+      <Pane display='grid' gridTemplateColumns='repeat(4, 1fr)'>
         <Counter label={nbVoies > 1 ? 'Voies' : 'Voie'} value={nbVoies} />
         <Counter label={nbLieuxDits > 1 ? 'Lieux-dits' : 'Lieu-dit'} value={nbLieuxDits} />
+        <Counter label={nbNumeros > 1 ? 'Adresses' : 'Adresse'} value={nbNumerosCertifies} />
         <Counter label={nbNumerosCertifies > 1 ? 'Adresses certifiées' : 'Adresse certifiée'} value={nbNumerosCertifies} />
       </Pane>
     </Pane>

--- a/lib/bal-api/index.js
+++ b/lib/bal-api/index.js
@@ -35,6 +35,10 @@ export async function listBALByCodeDepartement(codeDepartement) {
   return request(`/stats/departements/${codeDepartement}`)
 }
 
+export async function getBasesLocalesStats() {
+  return request('/stats/bases-locales')
+}
+
 export async function getBaseLocale(balId, token) {
   const headers = token ? {
     authorization: `Token ${token}`

--- a/lib/bal-api/index.js
+++ b/lib/bal-api/index.js
@@ -36,7 +36,7 @@ export async function listBALByCodeDepartement(codeDepartement) {
 }
 
 export async function getBasesLocalesStats() {
-  return request('/stats/bases-locales')
+  return request('/stats')
 }
 
 export async function getBaseLocale(balId, token) {

--- a/lib/utils/numbers.js
+++ b/lib/utils/numbers.js
@@ -1,0 +1,3 @@
+export function spaceThousands(number) {
+  return number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ' ')
+}

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -22,9 +22,9 @@ function Index({basesLocales, basesLoclesStats, contoursCommunes}) {
   return (
     <DashboardLayout title='Tableau de bord de l&apos;éditeur Mes Adresses' mapData={{basesLocales, contours: contoursCommunes}}>
       <Pane display='grid' gridGap='2em' padding={5}>
-        <Counter label='Communes couvertes par une Base Adresse Locale' value={communeCount} />
-
         <PublishedBalStats stats={basesLoclesStats} />
+
+        <Counter label='Communes couvertes par une Base Adresse Locale' value={communeCount} />
 
         <BALCounterChart basesLocales={basesLocales} />
         <BALCreationChart basesLocales={basesLocales} />

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import {Pane, Heading} from 'evergreen-ui'
+import {Pane} from 'evergreen-ui'
 import {uniq, flattenDeep} from 'lodash'
 
 import {getBasesLocalesStats, getContoursCommunes, listBasesLocales} from '../lib/bal-api'
@@ -10,6 +10,7 @@ import BALCreationChart from '../components/dashboard/bal-creation-chart'
 import BALCounterChart from '../components/dashboard/bal-counter-chart'
 import Counter from '../components/dashboard/counter'
 import Redirection from './dashboard/redirection'
+import PublishedBalStats from '../components/dashboard/published-bal-stats'
 
 function Index({basesLocales, basesLoclesStats, contoursCommunes}) {
   const communeCount = uniq(flattenDeep(
@@ -22,14 +23,9 @@ function Index({basesLocales, basesLoclesStats, contoursCommunes}) {
     <DashboardLayout title='Tableau de bord de l&apos;éditeur Mes Adresses' mapData={{basesLocales, contours: contoursCommunes}}>
       <Pane display='grid' gridGap='2em' padding={5}>
         <Counter label='Communes couvertes par une Base Adresse Locale' value={communeCount} />
-        <Pane>
-          <Heading size={500} color='muted' fontWeight={300} textAlign='center'>Chiffres des Bases Adresses Locales publiées</Heading>
-          <Pane display='grid' gridTemplateColumns='repeat(3, 1fr)'>
-            <Counter label='Voies' value={basesLoclesStats.nbVoies} />
-            <Counter label='Lieux-dits' value={basesLoclesStats.nbLieuxDits} />
-            <Counter label='Adresses certifiées' value={basesLoclesStats.nbNumerosCertifies} />
-          </Pane>
-        </Pane>
+
+        <PublishedBalStats stats={basesLoclesStats} />
+
         <BALCounterChart basesLocales={basesLocales} />
         <BALCreationChart basesLocales={basesLocales} />
         <Redirection />

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types'
-import {Pane} from 'evergreen-ui'
+import {Pane, Heading} from 'evergreen-ui'
 import {uniq, flattenDeep} from 'lodash'
 
-import {getContoursCommunes, listBasesLocales} from '../lib/bal-api'
+import {getBasesLocalesStats, getContoursCommunes, listBasesLocales} from '../lib/bal-api'
 
 import DashboardLayout from '../components/layout/dashboard'
 
@@ -11,7 +11,7 @@ import BALCounterChart from '../components/dashboard/bal-counter-chart'
 import Counter from '../components/dashboard/counter'
 import Redirection from './dashboard/redirection'
 
-function Index({basesLocales, contoursCommunes}) {
+function Index({basesLocales, basesLoclesStats, contoursCommunes}) {
   const communeCount = uniq(flattenDeep(
     basesLocales
       .filter(({communes}) => communes.length > 0)
@@ -22,6 +22,14 @@ function Index({basesLocales, contoursCommunes}) {
     <DashboardLayout title='Tableau de bord de l&apos;éditeur Mes Adresses' mapData={{basesLocales, contours: contoursCommunes}}>
       <Pane display='grid' gridGap='2em' padding={5}>
         <Counter label='Communes couvertes par une Base Adresse Locale' value={communeCount} />
+        <Pane>
+          <Heading size={500} color='muted' fontWeight={300} textAlign='center'>Chiffres des Bases Adresses Locales publiées</Heading>
+          <Pane display='grid' gridTemplateColumns='repeat(3, 1fr)'>
+            <Counter label='Voies' value={basesLoclesStats.nbVoies} />
+            <Counter label='Lieux-dits' value={basesLoclesStats.nbLieuxDits} />
+            <Counter label='Adresses certifiées' value={basesLoclesStats.nbNumerosCertifies} />
+          </Pane>
+        </Pane>
         <BALCounterChart basesLocales={basesLocales} />
         <BALCreationChart basesLocales={basesLocales} />
         <Redirection />
@@ -32,11 +40,13 @@ function Index({basesLocales, contoursCommunes}) {
 
 Index.getInitialProps = async () => {
   const basesLocales = await listBasesLocales()
+  const basesLoclesStats = await getBasesLocalesStats()
   const contoursCommunes = await getContoursCommunes()
   const basesLocalesWithoutDemo = basesLocales.filter((b => b.status !== 'demo'))
 
   return {
     basesLocales: basesLocalesWithoutDemo,
+    basesLoclesStats,
     contoursCommunes,
     layout: 'fullscreen'
   }
@@ -44,6 +54,7 @@ Index.getInitialProps = async () => {
 
 Index.propTypes = {
   basesLocales: PropTypes.array.isRequired,
+  basesLoclesStats: PropTypes.object.isRequired,
   contoursCommunes: PropTypes.object.isRequired
 }
 

--- a/pages/dashboard/departement.js
+++ b/pages/dashboard/departement.js
@@ -14,7 +14,7 @@ import PublishedBalStats from '../../components/dashboard/published-bal-stats'
 
 function Departement({departement, filteredCommunesInBAL, basesLocalesDepartementWithoutDemo, BALGroupedByCommune, stats, contoursCommunes}) {
   const {nom, code} = departement
-  const {nbVoies, nbLieuxDits, nbNumeros, nbNumerosCertifies} = stats
+  const {nbCommunes, nbVoies, nbLieuxDits, nbNumeros, nbNumerosCertifies} = stats
   const codesCommunes = new Set(filteredCommunesInBAL.map(({code}) => code))
   const communesWithoutTest = uniq(flatten(basesLocalesDepartementWithoutDemo.map(({communes}) => communes)))
   const countCommunesActuelles = communesWithoutTest.filter(c => codesCommunes.has(c)).length

--- a/pages/dashboard/departement.js
+++ b/pages/dashboard/departement.js
@@ -10,10 +10,13 @@ import Counter from '../../components/dashboard/counter'
 import PieChart from '../../components/dashboard/charts/pie-chart'
 import CommuneBALList from '../../components/dashboard/commune-bal-list'
 import DashboardLayout from '../../components/layout/dashboard'
+import PublishedBalStats from '../../components/dashboard/published-bal-stats'
 
 function Departement({departement, filteredCommunesInBAL, basesLocalesDepartementWithoutDemo, BALGroupedByCommune, contoursCommunes}) {
   const {nom, code} = departement
-
+  let nbVoies = 0
+  let nbLieuxDits = 0
+  let nbNumerosCertifies = 0
   const codesCommunes = new Set(filteredCommunesInBAL.map(({code}) => code))
   const communesWithoutTest = uniq(flatten(basesLocalesDepartementWithoutDemo.map(({communes}) => communes)))
   const countCommunesActuelles = communesWithoutTest.filter(c => codesCommunes.has(c)).length
@@ -26,6 +29,12 @@ function Departement({departement, filteredCommunesInBAL, basesLocalesDepartemen
     contours: contoursCommunes
   }
 
+  basesLocalesDepartementWithoutDemo.forEach(bal => {
+    nbVoies += bal.nbVoies
+    nbLieuxDits += bal.nbLieuxDits
+    nbNumerosCertifies += bal.nbNumerosCertifies
+  })
+
   return (
     <DashboardLayout backButton title={`Tableau de bord de l'éditeur Mes Adresses - ${nom} (${code})`} mapData={mapData}>
       {basesLocalesDepartementWithoutDemo.length > 0 ? (
@@ -36,6 +45,8 @@ function Departement({departement, filteredCommunesInBAL, basesLocalesDepartemen
               value={countCommunesActuelles}
             />
           )}
+
+          <PublishedBalStats stats={{nbVoies, nbLieuxDits, nbNumerosCertifies}} />
 
           <Pane display='flex' flexDirection='column' alignItems='center' >
             <Counter

--- a/pages/dashboard/departement.js
+++ b/pages/dashboard/departement.js
@@ -31,10 +31,10 @@ function Departement({departement, filteredCommunesInBAL, basesLocalesDepartemen
   }
 
   basesLocalesDepartementWithoutDemo.forEach(bal => {
-    nbVoies += bal.nbVoies
-    nbLieuxDits += bal.nbLieuxDits
-    nbNumeros += bal.nbNumeros
-    nbNumerosCertifies += bal.nbNumerosCertifies
+    nbVoies += bal.nbVoies || 0
+    nbLieuxDits += bal.nbLieuxDits || 0
+    nbNumeros += bal.nbNumeros || 0
+    nbNumerosCertifies += bal.nbNumerosCertifies || 0
   })
 
   return (

--- a/pages/dashboard/departement.js
+++ b/pages/dashboard/departement.js
@@ -23,6 +23,7 @@ function Departement({departement, filteredCommunesInBAL, basesLocalesDepartemen
   const countCommunesActuelles = communesWithoutTest.filter(c => codesCommunes.has(c)).length
 
   const BALByStatus = getBALByStatus(basesLocalesDepartementWithoutDemo)
+  const countPublishedBAL = BALByStatus.find(({label}) => label === 'Publiée').values
 
   const mapData = {
     departement: code,
@@ -48,7 +49,9 @@ function Departement({departement, filteredCommunesInBAL, basesLocalesDepartemen
             />
           )}
 
-          <PublishedBalStats stats={{nbVoies, nbLieuxDits, nbNumeros, nbNumerosCertifies}} />
+          {countPublishedBAL > 0 && (
+            <PublishedBalStats stats={{nbVoies, nbLieuxDits, nbNumeros, nbNumerosCertifies}} />
+          )}
 
           <Pane display='flex' flexDirection='column' alignItems='center' >
             <Counter

--- a/pages/dashboard/departement.js
+++ b/pages/dashboard/departement.js
@@ -12,12 +12,9 @@ import CommuneBALList from '../../components/dashboard/commune-bal-list'
 import DashboardLayout from '../../components/layout/dashboard'
 import PublishedBalStats from '../../components/dashboard/published-bal-stats'
 
-function Departement({departement, filteredCommunesInBAL, basesLocalesDepartementWithoutDemo, BALGroupedByCommune, contoursCommunes}) {
+function Departement({departement, filteredCommunesInBAL, basesLocalesDepartementWithoutDemo, BALGroupedByCommune, stats, contoursCommunes}) {
   const {nom, code} = departement
-  let nbVoies = 0
-  let nbLieuxDits = 0
-  let nbNumeros = 0
-  let nbNumerosCertifies = 0
+  const {nbVoies, nbLieuxDits, nbNumeros, nbNumerosCertifies} = stats
   const codesCommunes = new Set(filteredCommunesInBAL.map(({code}) => code))
   const communesWithoutTest = uniq(flatten(basesLocalesDepartementWithoutDemo.map(({communes}) => communes)))
   const countCommunesActuelles = communesWithoutTest.filter(c => codesCommunes.has(c)).length
@@ -30,13 +27,6 @@ function Departement({departement, filteredCommunesInBAL, basesLocalesDepartemen
     basesLocales: basesLocalesDepartementWithoutDemo,
     contours: contoursCommunes
   }
-
-  basesLocalesDepartementWithoutDemo.forEach(bal => {
-    nbVoies += bal.nbVoies || 0
-    nbLieuxDits += bal.nbLieuxDits || 0
-    nbNumeros += bal.nbNumeros || 0
-    nbNumerosCertifies += bal.nbNumerosCertifies || 0
-  })
 
   return (
     <DashboardLayout backButton title={`Tableau de bord de l'éditeur Mes Adresses - ${nom} (${code})`} mapData={mapData}>
@@ -87,7 +77,7 @@ Departement.getInitialProps = async ({query}) => {
   const contoursCommunes = await getContoursCommunes()
   const departement = await getDepartement(codeDepartement)
   const basesLocalesDepartement = await listBALByCodeDepartement(codeDepartement)
-  const basesLocalesDepartementWithoutDemo = basesLocalesDepartement.filter(b => b.status !== 'demo')
+  const basesLocalesDepartementWithoutDemo = basesLocalesDepartement.basesLocales.filter(b => b.status !== 'demo')
 
   const BALAddedOneCodeCommune = flatten(basesLocalesDepartementWithoutDemo.map(b => b.communes.map(c => ({...b, commune: c}))))
   const BALGroupedByCommune = groupBy(BALAddedOneCodeCommune, 'commune')
@@ -105,6 +95,7 @@ Departement.getInitialProps = async ({query}) => {
     contoursCommunes,
     basesLocalesDepartementWithoutDemo,
     BALGroupedByCommune,
+    stats: basesLocalesDepartement.stats,
     layout: 'fullscreen'
   }
 }
@@ -114,6 +105,7 @@ Departement.propTypes = {
   filteredCommunesInBAL: PropTypes.array.isRequired,
   basesLocalesDepartementWithoutDemo: PropTypes.array.isRequired,
   BALGroupedByCommune: PropTypes.object.isRequired,
+  stats: PropTypes.object.isRequired,
   contoursCommunes: PropTypes.object.isRequired
 }
 

--- a/pages/dashboard/departement.js
+++ b/pages/dashboard/departement.js
@@ -16,6 +16,7 @@ function Departement({departement, filteredCommunesInBAL, basesLocalesDepartemen
   const {nom, code} = departement
   let nbVoies = 0
   let nbLieuxDits = 0
+  let nbNumeros = 0
   let nbNumerosCertifies = 0
   const codesCommunes = new Set(filteredCommunesInBAL.map(({code}) => code))
   const communesWithoutTest = uniq(flatten(basesLocalesDepartementWithoutDemo.map(({communes}) => communes)))
@@ -32,6 +33,7 @@ function Departement({departement, filteredCommunesInBAL, basesLocalesDepartemen
   basesLocalesDepartementWithoutDemo.forEach(bal => {
     nbVoies += bal.nbVoies
     nbLieuxDits += bal.nbLieuxDits
+    nbNumeros += bal.nbNumeros
     nbNumerosCertifies += bal.nbNumerosCertifies
   })
 
@@ -46,7 +48,7 @@ function Departement({departement, filteredCommunesInBAL, basesLocalesDepartemen
             />
           )}
 
-          <PublishedBalStats stats={{nbVoies, nbLieuxDits, nbNumerosCertifies}} />
+          <PublishedBalStats stats={{nbVoies, nbLieuxDits, nbNumeros, nbNumerosCertifies}} />
 
           <Pane display='flex' flexDirection='column' alignItems='center' >
             <Counter

--- a/pages/dashboard/departement.js
+++ b/pages/dashboard/departement.js
@@ -23,7 +23,7 @@ function Departement({departement, filteredCommunesInBAL, basesLocalesDepartemen
   const countCommunesActuelles = communesWithoutTest.filter(c => codesCommunes.has(c)).length
 
   const BALByStatus = getBALByStatus(basesLocalesDepartementWithoutDemo)
-  const countPublishedBAL = BALByStatus.find(({label}) => label === 'Publiée').values
+  const countPublishedBAL = BALByStatus.find(({label}) => label === 'Publiée' || label === 'Publiées')
 
   const mapData = {
     departement: code,
@@ -49,7 +49,7 @@ function Departement({departement, filteredCommunesInBAL, basesLocalesDepartemen
             />
           )}
 
-          {countPublishedBAL > 0 && (
+          {countPublishedBAL?.values > 0 && (
             <PublishedBalStats stats={{nbVoies, nbLieuxDits, nbNumeros, nbNumerosCertifies}} />
           )}
 

--- a/pages/dashboard/departement.js
+++ b/pages/dashboard/departement.js
@@ -32,15 +32,16 @@ function Departement({departement, filteredCommunesInBAL, basesLocalesDepartemen
     <DashboardLayout backButton title={`Tableau de bord de l'éditeur Mes Adresses - ${nom} (${code})`} mapData={mapData}>
       {basesLocalesDepartementWithoutDemo.length > 0 ? (
         <Pane display='grid' gridGap='2em' padding={8}>
+
+          {countPublishedBAL?.values > 0 && (
+            <PublishedBalStats stats={{nbCommunes, nbVoies, nbLieuxDits, nbNumeros, nbNumerosCertifies}} />
+          )}
+
           {countCommunesActuelles > 0 && (
             <Counter
               label={`${countCommunesActuelles > 1 ? 'Communes couvertes' : 'Commune couverte'} par une Base Adresse Locale`}
               value={countCommunesActuelles}
             />
-          )}
-
-          {countPublishedBAL?.values > 0 && (
-            <PublishedBalStats stats={{nbVoies, nbLieuxDits, nbNumeros, nbNumerosCertifies}} />
           )}
 
           <Pane display='flex' flexDirection='column' alignItems='center' >


### PR DESCRIPTION
Remplace la PR #479
resolves #391

Ajout de 3 métriques concernant les bases adresses locales publiées

## ⚠️ Liée à la PR [api-bal #307](https://github.com/BaseAdresseNationale/api-bal/pull/307)

Capture
![dashboard-mes-adresses-](https://user-images.githubusercontent.com/45098730/150799647-63db2ae5-63ad-4f42-9c8c-28801eb2b1c3.png)

## *edit 25/01*
- Modification de la route pour l'appel à l'API : `/stats/bases-locales` devient `/stats`
- Ajout de `nbNumeros`
- Sur la page `departement`, les nouvelles métriques s'affichent uniquement s'il y a au moins une base adresse locale publiée

## *edit 02/02*
Capture

![dashboard-metrics](https://user-images.githubusercontent.com/45098730/152126369-aee2112d-b995-4994-a32b-dea73dccd279.png)

