### PR TITLE
Permet d'enlever une base adresse locale de la liste sans la supprimer

### DIFF
--- a/components/base-locale-card/base-locale-card-content.js
+++ b/components/base-locale-card/base-locale-card-content.js
@@ -65,7 +65,7 @@ function BaseLocaleCardContent({isAdmin, baseLocale, userEmail, onSelect, onRemo
                 <Tooltip content={tooltipContent}>
                   {/* Button disabled props prevents pointer-events. Button is wrap in <Pane> to allow tooltip content to display => https://evergreen.segment.com/components/buttons#disabled_state */}
                   <Pane>
-                    <Button disabled iconAfter={TrashIcon}>Supprimer</Button>
+                    <Button disabled iconAfter={TrashIcon}>Supprimer définitivement</Button>
                   </Pane>
                 </Tooltip>
               )

--- a/components/base-locale-card/base-locale-card-content.js
+++ b/components/base-locale-card/base-locale-card-content.js
@@ -2,13 +2,13 @@ import {useState, useMemo, useContext} from 'react'
 import PropTypes from 'prop-types'
 import {format} from 'date-fns'
 import {fr} from 'date-fns/locale'
-import {Pane, Button, Tooltip, Text, UserIcon, InfoSignIcon, TrashIcon, EditIcon, KeyIcon} from 'evergreen-ui'
+import {Pane, Button, Tooltip, Text, UserIcon, InfoSignIcon, TrashIcon, EditIcon, KeyIcon, MinusIcon} from 'evergreen-ui'
 
 import LocalStorageContext from '../../contexts/local-storage'
 
 import RecoverBALAlert from '../bal-recovery/recover-bal-alert'
 
-function BaseLocaleCardContent({isAdmin, baseLocale, userEmail, onSelect, onRemove}) {
+function BaseLocaleCardContent({isAdmin, baseLocale, userEmail, onSelect, onRemove, onHide}) {
   const {status, _created, emails} = baseLocale
   const [isBALRecoveryShown, setIsBALRecoveryShown] = useState(false)
 
@@ -70,6 +70,8 @@ function BaseLocaleCardContent({isAdmin, baseLocale, userEmail, onSelect, onRemo
             )
           )}
 
+          <Button iconAfter={MinusIcon} onClick={onHide}>Retirer de la liste</Button>
+
           {hasToken ? (
             <Button appearance='primary' iconAfter={EditIcon} marginRight='8px' onClick={onSelect}>Gérer les adresses</Button>
           ) : (
@@ -95,7 +97,8 @@ function BaseLocaleCardContent({isAdmin, baseLocale, userEmail, onSelect, onRemo
 BaseLocaleCardContent.defaultProps = {
   isAdmin: false,
   userEmail: null,
-  onRemove: null
+  onRemove: null,
+  onHide: null
 }
 
 BaseLocaleCardContent.propTypes = {
@@ -110,6 +113,7 @@ BaseLocaleCardContent.propTypes = {
   isAdmin: PropTypes.bool,
   userEmail: PropTypes.string,
   onSelect: PropTypes.func.isRequired,
+  onHide: PropTypes.func,
   onRemove: PropTypes.func
 }
 

--- a/components/base-locale-card/base-locale-card-content.js
+++ b/components/base-locale-card/base-locale-card-content.js
@@ -75,7 +75,15 @@ function BaseLocaleCardContent({isAdmin, baseLocale, userEmail, onSelect, onRemo
           </Pane>
 
           {hasToken ? (
-            <Button appearance='primary' iconAfter={EditIcon} marginRight='8px' onClick={onSelect}>Gérer les adresses</Button>
+            <Button
+              appearance='primary'
+              iconAfter={EditIcon}
+              marginRight='8px'
+              onClick={onSelect}
+              disabled={!onSelect}
+            >
+              Gérer les adresses
+            </Button>
           ) : (
             <>
               <RecoverBALAlert
@@ -100,7 +108,8 @@ BaseLocaleCardContent.defaultProps = {
   isAdmin: false,
   userEmail: null,
   onRemove: null,
-  onHide: null
+  onHide: null,
+  onSelect: null
 }
 
 BaseLocaleCardContent.propTypes = {
@@ -114,7 +123,7 @@ BaseLocaleCardContent.propTypes = {
   }).isRequired,
   isAdmin: PropTypes.bool,
   userEmail: PropTypes.string,
-  onSelect: PropTypes.func.isRequired,
+  onSelect: PropTypes.func,
   onHide: PropTypes.func,
   onRemove: PropTypes.func
 }

--- a/components/base-locale-card/base-locale-card-content.js
+++ b/components/base-locale-card/base-locale-card-content.js
@@ -59,7 +59,7 @@ function BaseLocaleCardContent({isAdmin, baseLocale, userEmail, onSelect, onRemo
         <Pane borderTop display='flex' justifyContent='space-between' paddingTop='1em' marginTop='1em'>
           {hasToken && (
             isDeletable ? (
-              <Button iconAfter={TrashIcon} intent='danger' disabled={!onRemove} onClick={onRemove}>Supprimer</Button>
+              <Button iconAfter={TrashIcon} intent='danger' disabled={!onRemove} onClick={onRemove}>Supprimer définitivement</Button>
             ) : (
               <Tooltip content={tooltipContent}>
                 {/* Button disabled props prevents pointer-events. Button is wrap in <Pane> to allow tooltip content to display => https://evergreen.segment.com/components/buttons#disabled_state */}

--- a/components/base-locale-card/base-locale-card-content.js
+++ b/components/base-locale-card/base-locale-card-content.js
@@ -2,7 +2,7 @@ import {useState, useMemo, useContext} from 'react'
 import PropTypes from 'prop-types'
 import {format} from 'date-fns'
 import {fr} from 'date-fns/locale'
-import {Pane, Button, Tooltip, Text, UserIcon, InfoSignIcon, TrashIcon, EditIcon, KeyIcon, MinusIcon} from 'evergreen-ui'
+import {Pane, Button, Tooltip, Text, UserIcon, InfoSignIcon, TrashIcon, EditIcon, KeyIcon, EyeOffIcon} from 'evergreen-ui'
 
 import LocalStorageContext from '../../contexts/local-storage'
 
@@ -57,20 +57,22 @@ function BaseLocaleCardContent({isAdmin, baseLocale, userEmail, onSelect, onRemo
 
       {isAdmin ? (
         <Pane borderTop display='flex' justifyContent='space-between' paddingTop='1em' marginTop='1em'>
-          {hasToken && (
-            isDeletable ? (
-              <Button iconAfter={TrashIcon} intent='danger' disabled={!onRemove} onClick={onRemove}>Supprimer définitivement</Button>
-            ) : (
-              <Tooltip content={tooltipContent}>
-                {/* Button disabled props prevents pointer-events. Button is wrap in <Pane> to allow tooltip content to display => https://evergreen.segment.com/components/buttons#disabled_state */}
-                <Pane>
-                  <Button disabled iconAfter={TrashIcon}>Supprimer</Button>
-                </Pane>
-              </Tooltip>
-            )
-          )}
+          <Pane display='flex' flexFlow='wrap' gap={8}>
+            {hasToken && (
+              isDeletable ? (
+                <Button iconAfter={TrashIcon} intent='danger' disabled={!onRemove} onClick={onRemove}>Supprimer définitivement</Button>
+              ) : (
+                <Tooltip content={tooltipContent}>
+                  {/* Button disabled props prevents pointer-events. Button is wrap in <Pane> to allow tooltip content to display => https://evergreen.segment.com/components/buttons#disabled_state */}
+                  <Pane>
+                    <Button disabled iconAfter={TrashIcon}>Supprimer</Button>
+                  </Pane>
+                </Tooltip>
+              )
+            )}
 
-          <Button iconAfter={MinusIcon} onClick={onHide}>Retirer de la liste</Button>
+            {onHide && <Button iconAfter={EyeOffIcon} onClick={onHide}>Masquer de la liste</Button>}
+          </Pane>
 
           {hasToken ? (
             <Button appearance='primary' iconAfter={EditIcon} marginRight='8px' onClick={onSelect}>Gérer les adresses</Button>

--- a/components/base-locale-card/index.js
+++ b/components/base-locale-card/index.js
@@ -116,6 +116,7 @@ BaseLocaleCard.defaultProps = {
   userEmail: null,
   onRemove: null,
   onHide: null,
+  onSelect: null,
   isDefaultOpen: false
 }
 
@@ -133,7 +134,7 @@ BaseLocaleCard.propTypes = {
   isDefaultOpen: PropTypes.bool,
   isAdmin: PropTypes.bool,
   userEmail: PropTypes.string,
-  onSelect: PropTypes.func.isRequired,
+  onSelect: PropTypes.func,
   onHide: PropTypes.func,
   onRemove: PropTypes.func
 }

--- a/components/base-locale-card/index.js
+++ b/components/base-locale-card/index.js
@@ -12,7 +12,7 @@ import StatusBadge from '../status-badge'
 
 import BaseLocaleCardContent from './base-locale-card-content'
 
-function BaseLocaleCard({baseLocale, isAdmin, userEmail, isDefaultOpen, onSelect, onRemove}) {
+function BaseLocaleCard({baseLocale, isAdmin, userEmail, isDefaultOpen, onSelect, onRemove, onHide}) {
   const {nom, communes, _updated} = baseLocale
   const [commune, setCommune] = useState()
   const [isOpen, setIsOpen] = useState(isAdmin ? isDefaultOpen : false)
@@ -104,6 +104,7 @@ function BaseLocaleCard({baseLocale, isAdmin, userEmail, isDefaultOpen, onSelect
           baseLocale={baseLocale}
           onSelect={onSelect}
           onRemove={onRemove}
+          onHide={onHide}
         />
       )}
     </Card>
@@ -114,6 +115,7 @@ BaseLocaleCard.defaultProps = {
   isAdmin: false,
   userEmail: null,
   onRemove: null,
+  onHide: null,
   isDefaultOpen: false
 }
 
@@ -132,6 +134,7 @@ BaseLocaleCard.propTypes = {
   isAdmin: PropTypes.bool,
   userEmail: PropTypes.string,
   onSelect: PropTypes.func.isRequired,
+  onHide: PropTypes.func,
   onRemove: PropTypes.func
 }
 

--- a/components/bases-locales-list/index.js
+++ b/components/bases-locales-list/index.js
@@ -16,11 +16,15 @@ import DeleteWarning from '../delete-warning'
 import BaseLocaleCard from '../base-locale-card'
 
 function BasesLocalesList({basesLocales, sortBal}) {
-  const {removeBAL} = useContext(LocalStorageContext)
+  const {removeBAL, getHiddenBal, addHiddenBal} = useContext(LocalStorageContext)
 
   const [toRemove, setToRemove] = useState(null)
 
   const [setError] = useError(null)
+
+  const isHidden = useCallback(balId => {
+    return getHiddenBal(balId)
+  }, [getHiddenBal])
 
   const onBalSelect = useCallback(bal => {
     if (bal.communes.length === 1) {
@@ -57,6 +61,12 @@ function BasesLocalesList({basesLocales, sortBal}) {
     setToRemove(balId)
   }, [])
 
+  const handleHide = useCallback((e, balId) => {
+    e.stopPropagation()
+
+    addHiddenBal(balId, true)
+  }, [addHiddenBal])
+
   return (
     basesLocales.length > 0 && (
       <Pane borderTop>
@@ -87,7 +97,7 @@ function BasesLocalesList({basesLocales, sortBal}) {
             </Table.Row>
           )}
           <Table.Body background='tint1'>
-            {sortBal(filtered).map(bal => (
+            {sortBal(filtered).filter(({_id}) => Boolean(!isHidden(_id))).map(bal => (
               <BaseLocaleCard
                 key={bal._id}
                 isAdmin
@@ -95,6 +105,7 @@ function BasesLocalesList({basesLocales, sortBal}) {
                 isDefaultOpen={basesLocales.length === 1}
                 onSelect={() => onBalSelect(bal)}
                 onRemove={e => handleRemove(e, bal._id)}
+                onHide={e => handleHide(e, bal._id)}
               />
             ))}
           </Table.Body>

--- a/components/hidden-bal.js
+++ b/components/hidden-bal.js
@@ -1,34 +1,21 @@
-import {useContext, useState, useEffect} from 'react'
+import {useContext} from 'react'
 import {Alert, Button, Text} from 'evergreen-ui'
 
 import LocalStorageContext from '../contexts/local-storage'
 
 function HiddenBal() {
   const {setHiddenBal, hiddenBal} = useContext(LocalStorageContext)
-  const [hiddenBalList, setHiddenBalList] = useState([])
-
-  useEffect(() => {
-    if (hiddenBal) {
-      setHiddenBalList(Object.keys(hiddenBal))
-    } else {
-      setHiddenBalList([])
-    }
-  }, [hiddenBal])
-
-  const showAllBal = () => {
-    setHiddenBal(null)
-    setHiddenBalList([])
-  }
+  const isPlural = hiddenBal ? Object.keys(hiddenBal).length > 1 : false
 
   return (
     <div>
-      {hiddenBalList.length > 0 && (
+      {hiddenBal && Object.keys(hiddenBal).length > 0 && (
         <Alert intent='warning'>
           <Text>
-            Il y a {hiddenBalList.length} base{hiddenBalList.length > 1 ? 's' : ''} adresse{hiddenBalList.length > 1 ? 's' : ''} locale{hiddenBalList.length > 1 ? 's' : ''} non listée{hiddenBalList.length > 1 ? 's' : ''}.
-            Pour l{hiddenBalList.length > 1 ? 'es ' : '’'}afficher
+            Il y a {Object.keys(hiddenBal).length} base{isPlural ? 's' : ''} adresse{isPlural ? 's' : ''} locale{isPlural ? 's' : ''} non listée{isPlural ? 's' : ''}.
+            Pour l{isPlural ? 'es ' : '’'}afficher
           </Text>
-          <Button appearance='primary' marginLeft='1em' onClick={() => showAllBal()}>Cliquez ici</Button>
+          <Button appearance='primary' marginLeft='1em' onClick={() => setHiddenBal(null)}>Cliquez ici</Button>
         </Alert>
       )}
     </div>

--- a/components/hidden-bal.js
+++ b/components/hidden-bal.js
@@ -1,25 +1,67 @@
-import {useContext} from 'react'
-import {Alert, Button, Text} from 'evergreen-ui'
+import {useState, useContext} from 'react'
+import PropTypes from 'prop-types'
+import {Pane, Text, PlusIcon, MinusIcon, UndoIcon} from 'evergreen-ui'
 
 import LocalStorageContext from '../contexts/local-storage'
 
-function HiddenBal() {
-  const {setHiddenBal, hiddenBal} = useContext(LocalStorageContext)
-  const isPlural = hiddenBal ? Object.keys(hiddenBal).length > 1 : false
+import BaseLocaleCard from './base-locale-card'
+
+function HiddenBal({basesLocales}) {
+  const [isWrapped, setIsWrapped] = useState(true)
+  const {removeHiddenBal} = useContext(LocalStorageContext)
 
   return (
-    <div>
-      {hiddenBal && Object.keys(hiddenBal).length > 0 && (
-        <Alert intent='warning'>
-          <Text>
-            Il y a {Object.keys(hiddenBal).length} base{isPlural ? 's' : ''} adresse{isPlural ? 's' : ''} locale{isPlural ? 's' : ''} non listée{isPlural ? 's' : ''}.
-            Pour l{isPlural ? 'es ' : '’'}afficher
-          </Text>
-          <Button appearance='primary' marginLeft='1em' onClick={() => setHiddenBal(null)}>Cliquez ici</Button>
-        </Alert>
+    <Pane display='flex' flexDirection='column' justifyContent='center'>
+      <Pane
+        display='flex'
+        justifyContent='center'
+        alignItem='center'
+        cursor='pointer'
+        textAlign='center'
+        textDecoration='underline'
+        marginY={16}
+        onClick={() => setIsWrapped(!isWrapped)}
+      >
+        <Text marginRight={8}>{isWrapped ? 'Afficher' : 'Cacher'} vos Bases Adresses Locales masquées</Text>
+        <Pane>{isWrapped ? (
+          <PlusIcon style={{verticalAlign: 'middle'}} />
+        ) : (
+          <MinusIcon style={{verticalAlign: 'middle'}} />
+        )}</Pane>
+
+      </Pane>
+      {!isWrapped && (
+        <Pane background='#E4E7EB'>
+          {basesLocales.map(bal => (
+            <Pane key={bal._id} display='flex' alignItems='center'>
+              <Pane flex={1}>
+                <BaseLocaleCard
+                  isAdmin
+                  baseLocale={bal}
+                  isDefaultOpen={false}
+                />
+              </Pane>
+              <Pane
+                display='flex'
+                flexDirection='column'
+                alignItems='center'
+                cursor='pointer'
+                margin={16}
+                onClick={() => removeHiddenBal(bal._id)}
+              >
+                <UndoIcon size={24} />
+                <Text size={300}>Ne plus masquer</Text>
+              </Pane>
+            </Pane>
+          ))}
+        </Pane>
       )}
-    </div>
+    </Pane>
   )
+}
+
+HiddenBal.propTypes = {
+  basesLocales: PropTypes.array.isRequired
 }
 
 export default HiddenBal

--- a/components/hidden-bal.js
+++ b/components/hidden-bal.js
@@ -1,0 +1,38 @@
+import {useContext, useState, useEffect} from 'react'
+import {Alert, Button, Text} from 'evergreen-ui'
+
+import LocalStorageContext from '../contexts/local-storage'
+
+function HiddenBal() {
+  const {setHiddenBal, hiddenBal} = useContext(LocalStorageContext)
+  const [hiddenBalList, setHiddenBalList] = useState([])
+
+  useEffect(() => {
+    if (hiddenBal) {
+      setHiddenBalList(Object.keys(hiddenBal))
+    } else {
+      setHiddenBalList([])
+    }
+  }, [hiddenBal])
+
+  const showAllBal = () => {
+    setHiddenBal(null)
+    setHiddenBalList([])
+  }
+
+  return (
+    <div>
+      {hiddenBalList.length > 0 && (
+        <Alert intent='warning'>
+          <Text>
+            Il y a {hiddenBalList.length} base{hiddenBalList.length > 1 ? 's' : ''} adresse{hiddenBalList.length > 1 ? 's' : ''} locale{hiddenBalList.length > 1 ? 's' : ''} non listée{hiddenBalList.length > 1 ? 's' : ''}.
+            Pour l{hiddenBalList.length > 1 ? 'es ' : '’'}afficher
+          </Text>
+          <Button appearance='primary' marginLeft='1em' onClick={() => showAllBal()}>Cliquez ici</Button>
+        </Alert>
+      )}
+    </div>
+  )
+}
+
+export default HiddenBal

--- a/components/user-bases-locales.js
+++ b/components/user-bases-locales.js
@@ -7,10 +7,11 @@ import {getBaseLocale} from '../lib/bal-api'
 
 import LocalStorageContext from '../contexts/local-storage'
 
+import HiddenBal from '../components/hidden-bal'
 import BasesLocalesList from './bases-locales-list'
 
 function UserBasesLocales() {
-  const {balAccess} = useContext(LocalStorageContext)
+  const {balAccess, hiddenBal} = useContext(LocalStorageContext)
 
   const [isLoading, setIsLoading] = useState(true)
   const [basesLocales, setBasesLocales] = useState([])
@@ -49,7 +50,11 @@ function UserBasesLocales() {
       <>
         <BasesLocalesList basesLocales={basesLocales} />
 
-        <Pane margin='auto' textAlign='center'>
+        {hiddenBal && Object.keys(hiddenBal).length > 0 && (
+          <HiddenBal basesLocales={basesLocales.filter(({_id}) => Boolean(hiddenBal[_id]))} />
+        )}
+
+        <Pane margin='auto' textAlign='center' marginTop={16}>
           <Heading marginBottom={8}>Vous voulez simplement essayer l’éditeur sans créer de Base Adresse Locale ?</Heading>
           <Button onClick={() => Router.push('/new?demo=1')}>Essayer l’outil</Button>
         </Pane>

--- a/components/user-bases-locales.js
+++ b/components/user-bases-locales.js
@@ -18,24 +18,30 @@ function UserBasesLocales() {
 
   const getUserBals = useCallback(async () => {
     setIsLoading(true)
-    const balsToLoad = filter(Object.keys(balAccess), id => !getHiddenBal(id))
-    const basesLocales = await Promise.all(
-      map(balsToLoad, async id => {
-        try {
-          return await getBaseLocale(id, balAccess[id])
-        } catch {
-          console.log(`Impossible de récupérer la bal ${id}`)
-        }
-      }))
 
-    const findedBasesLocales = basesLocales.filter(bal => Boolean(bal))
+    if (balAccess) {
+      const balsToLoad = filter(Object.keys(balAccess), id => !getHiddenBal(id))
+      const basesLocales = await Promise.all(
+        map(balsToLoad, async id => {
+          const token = balAccess[id]
+          try {
+            return await getBaseLocale(id, token)
+          } catch {
+            console.log(`Impossible de récupérer la bal ${id}`)
+          }
+        }))
 
-    setBasesLocales(findedBasesLocales)
+      const findedBasesLocales = basesLocales.filter(bal => Boolean(bal))
+      setBasesLocales(findedBasesLocales)
+    }
+
     setIsLoading(false)
   }, [balAccess, getHiddenBal])
 
   useEffect(() => {
-    getUserBals()
+    if (balAccess !== undefined) {
+      getUserBals()
+    }
   }, [balAccess, getUserBals])
 
   if (balAccess === undefined || isLoading) {

--- a/components/user-bases-locales.js
+++ b/components/user-bases-locales.js
@@ -47,7 +47,7 @@ function UserBasesLocales() {
   }
 
   return (
-    basesLocales.length > 0 ? (
+    basesLocales.length > 0 || hiddenBal ? (
       <>
         <BasesLocalesList basesLocales={basesLocales} />
 

--- a/components/user-bases-locales.js
+++ b/components/user-bases-locales.js
@@ -53,23 +53,12 @@ function UserBasesLocales() {
   }
 
   return (
-    basesLocales.length > 0 || hiddenBal ? (
-      <>
+    <Pane display='flex' flexDirection='column' flex={1} justifyContent='center'>
+      {basesLocales.length > 0 ? (
         <BasesLocalesList basesLocales={basesLocales} />
-
-        {hiddenBal && Object.keys(hiddenBal).length > 0 && (
-          <HiddenBal />
-        )}
-
-        <Pane margin='auto' textAlign='center' marginTop={16}>
-          <Heading marginBottom={8}>Vous voulez simplement essayer l’éditeur sans créer de Base Adresse Locale ?</Heading>
-          <Button onClick={() => Router.push('/new?demo=1')}>Essayer l’outil</Button>
-        </Pane>
-      </>
-    ) : (
-      <Pane display='flex' flexDirection='column' justifyContent='center' alignItems='center' margin='auto'>
+      ) : (
         <Button
-          marginBottom={12}
+          margin='auto'
           height={40}
           appearance='primary'
           iconBefore={PlusIcon}
@@ -77,10 +66,17 @@ function UserBasesLocales() {
         >
           Créer une Base Adresse Locale
         </Button>
+      )}
+
+      {hiddenBal && Object.keys(hiddenBal).length > 0 && (
+        <HiddenBal />
+      )}
+
+      <Pane margin='auto' textAlign='center' marginTop={16}>
         <Heading marginBottom={8}>Vous voulez simplement essayer l’éditeur sans créer de Base Adresse Locale ?</Heading>
         <Button onClick={() => Router.push('/new?demo=1')}>Essayer l’outil</Button>
       </Pane>
-    )
+    </Pane>
   )
 }
 

--- a/contexts/local-storage.js
+++ b/contexts/local-storage.js
@@ -13,7 +13,7 @@ const CERTIFICATION_AUTO_KEY = 'certificationAutoAlert'
 const VISIBILITY_KEY = 'hidden-bal'
 
 export function LocalStorageContextProvider(props) {
-  const [balAccess, , getBalToken, addBalAccess, removeBalAccess] = useLocalStorage(STORAGE_KEY, {})
+  const [balAccess, , getBalToken, addBalAccess, removeBalAccess] = useLocalStorage(STORAGE_KEY) // Do not assign a default value
   const [wasWelcomed, setWasWelcomed] = useLocalStorage(WELCOMED_KEY)
   const [recoveryEmailSent, setRecoveryEmailSent] = useLocalStorage(RECOVERY_EMAIL)
   const [informedAboutCertification, , getInformedAboutCertification, addInformedAboutCertification] = useLocalStorage(CERTIFICATION_AUTO_KEY)

--- a/contexts/local-storage.js
+++ b/contexts/local-storage.js
@@ -10,12 +10,14 @@ const STORAGE_KEY = 'bal-access'
 const WELCOMED_KEY = 'was-welcomed'
 const RECOVERY_EMAIL = 'recovery-email-sent'
 const CERTIFICATION_AUTO_KEY = 'certificationAutoAlert'
+const VISIBILITY_KEY = 'hidden-bal'
 
 export function LocalStorageContextProvider(props) {
   const [balAccess, , getBalToken, addBalAccess, removeBalAccess] = useLocalStorage(STORAGE_KEY)
   const [wasWelcomed, setWasWelcomed] = useLocalStorage(WELCOMED_KEY)
   const [recoveryEmailSent, setRecoveryEmailSent] = useLocalStorage(RECOVERY_EMAIL)
   const [informedAboutCertification, , getInformedAboutCertification, addInformedAboutCertification] = useLocalStorage(CERTIFICATION_AUTO_KEY)
+  const [hiddenBal, setHiddenBal, getHiddenBal, addHiddenBal] = useLocalStorage(VISIBILITY_KEY)
 
   const removeBAL = useCallback(async balId => {
     const token = getBalToken(balId)
@@ -27,7 +29,8 @@ export function LocalStorageContextProvider(props) {
     balAccess, getBalToken, addBalAccess, removeBAL,
     wasWelcomed, setWasWelcomed,
     recoveryEmailSent, setRecoveryEmailSent,
-    informedAboutCertification, getInformedAboutCertification, addInformedAboutCertification
+    informedAboutCertification, getInformedAboutCertification, addInformedAboutCertification,
+    hiddenBal, setHiddenBal, getHiddenBal, addHiddenBal
   }), [
     balAccess,
     getBalToken,
@@ -39,7 +42,11 @@ export function LocalStorageContextProvider(props) {
     setRecoveryEmailSent,
     informedAboutCertification,
     getInformedAboutCertification,
-    addInformedAboutCertification
+    addInformedAboutCertification,
+    hiddenBal,
+    setHiddenBal,
+    getHiddenBal,
+    addHiddenBal
   ])
 
   return (

--- a/contexts/local-storage.js
+++ b/contexts/local-storage.js
@@ -13,7 +13,7 @@ const CERTIFICATION_AUTO_KEY = 'certificationAutoAlert'
 const VISIBILITY_KEY = 'hidden-bal'
 
 export function LocalStorageContextProvider(props) {
-  const [balAccess, , getBalToken, addBalAccess, removeBalAccess] = useLocalStorage(STORAGE_KEY)
+  const [balAccess, , getBalToken, addBalAccess, removeBalAccess] = useLocalStorage(STORAGE_KEY, {})
   const [wasWelcomed, setWasWelcomed] = useLocalStorage(WELCOMED_KEY)
   const [recoveryEmailSent, setRecoveryEmailSent] = useLocalStorage(RECOVERY_EMAIL)
   const [informedAboutCertification, , getInformedAboutCertification, addInformedAboutCertification] = useLocalStorage(CERTIFICATION_AUTO_KEY)

--- a/contexts/local-storage.js
+++ b/contexts/local-storage.js
@@ -17,7 +17,7 @@ export function LocalStorageContextProvider(props) {
   const [wasWelcomed, setWasWelcomed] = useLocalStorage(WELCOMED_KEY)
   const [recoveryEmailSent, setRecoveryEmailSent] = useLocalStorage(RECOVERY_EMAIL)
   const [informedAboutCertification, , getInformedAboutCertification, addInformedAboutCertification] = useLocalStorage(CERTIFICATION_AUTO_KEY)
-  const [hiddenBal, setHiddenBal, getHiddenBal, addHiddenBal] = useLocalStorage(VISIBILITY_KEY)
+  const [hiddenBal, setHiddenBal, getHiddenBal, addHiddenBal, removeHiddenBal] = useLocalStorage(VISIBILITY_KEY)
 
   const removeBAL = useCallback(async balId => {
     const token = getBalToken(balId)
@@ -30,7 +30,7 @@ export function LocalStorageContextProvider(props) {
     wasWelcomed, setWasWelcomed,
     recoveryEmailSent, setRecoveryEmailSent,
     informedAboutCertification, getInformedAboutCertification, addInformedAboutCertification,
-    hiddenBal, setHiddenBal, getHiddenBal, addHiddenBal
+    hiddenBal, setHiddenBal, getHiddenBal, addHiddenBal, removeHiddenBal
   }), [
     balAccess,
     getBalToken,
@@ -46,7 +46,8 @@ export function LocalStorageContextProvider(props) {
     hiddenBal,
     setHiddenBal,
     getHiddenBal,
-    addHiddenBal
+    addHiddenBal,
+    removeHiddenBal
   ])
 
   return (

--- a/pages/index.js
+++ b/pages/index.js
@@ -6,8 +6,6 @@ import Header from '../components/header'
 import Footer from '../components/footer'
 import BALRecovery from '../components/bal-recovery/bal-recovery'
 
-import HiddenBal from '../components/hidden-bal'
-
 const UserBasesLocales = dynamic(() => import('../components/user-bases-locales'), { // eslint-disable-line node/no-unsupported-features/es-syntax
   ssr: false,
   loading: () => (
@@ -27,10 +25,6 @@ function Index() {
       </Heading>
 
       <UserBasesLocales />
-
-      <Pane paddingX={22} paddingTop={22}>
-        <HiddenBal />
-      </Pane>
 
       <Pane padding={22}>
         <BALRecovery />

--- a/pages/index.js
+++ b/pages/index.js
@@ -6,6 +6,8 @@ import Header from '../components/header'
 import Footer from '../components/footer'
 import BALRecovery from '../components/bal-recovery/bal-recovery'
 
+import HiddenBal from '../components/hidden-bal'
+
 const UserBasesLocales = dynamic(() => import('../components/user-bases-locales'), { // eslint-disable-line node/no-unsupported-features/es-syntax
   ssr: false,
   loading: () => (
@@ -25,6 +27,10 @@ function Index() {
       </Heading>
 
       <UserBasesLocales />
+
+      <Pane paddingX={22} paddingTop={22}>
+        <HiddenBal />
+      </Pane>
 
       <Pane padding={22}>
         <BALRecovery />


### PR DESCRIPTION
resolves #487 

- Ajout du localstorage `hidden-bal` dans le context
- Ajout d'un bouton permettant de "cacher" la base adresse locale
- Ajout d'une alerte permettant de restaurer les bases adresses locales cachées

Capture vidéo :

https://user-images.githubusercontent.com/45098730/153556379-d15f4993-8117-4c32-992a-627e7b1aefc6.mp4


