### PR TITLE
Retire le bouton "Publier" en mode démonstration

### DIFF
--- a/components/sub-header/bal-status/index.js
+++ b/components/sub-header/bal-status/index.js
@@ -44,12 +44,14 @@ function BALStatus({baseLocale, commune, token, isRefrehSyncStat, handleChangeSt
             togglePause={baseLocale.sync.isPaused ? handleResumeSync : handlePause}
           />
         ) : (
-          <Publication
-            baseLocale={baseLocale}
-            status={baseLocale.status}
-            handleBackToDraft={() => handleChangeStatus('draft')}
-            onPublish={handleHabilitation}
-          />
+          baseLocale.status !== 'demo' && (
+            <Publication
+              baseLocale={baseLocale}
+              status={baseLocale.status}
+              handleBackToDraft={() => handleChangeStatus('draft')}
+              onPublish={handleHabilitation}
+            />
+          )
         )
       ) : (
         <Tooltip


### PR DESCRIPTION
## Description
Cette PR retire le bouton "Publier" lorsqu'une BAL est en mode démonstration (`status === "demo"`)

Fix #497 