### PR TITLE
Utilisation de tuiles vectorielle pour la cartographie du dashboard

### DIFF
--- a/components/dashboard/bal-creation-chart.js
+++ b/components/dashboard/bal-creation-chart.js
@@ -38,6 +38,11 @@ function BALCreationChart({basesLocales}) {
       backgroundColor: colors.green
     },
     {
+      label: 'Remplacée',
+      data: sumByStatus('replaced'),
+      backgroundColor: colors.red
+    },
+    {
       label: 'Prêtes à être publiées',
       data: sumByStatus('ready-to-publish'),
       backgroundColor: colors.blue

--- a/components/dashboard/bal-creation-chart.js
+++ b/components/dashboard/bal-creation-chart.js
@@ -38,7 +38,7 @@ function BALCreationChart({basesLocales}) {
       backgroundColor: colors.green
     },
     {
-      label: 'Remplacée',
+      label: 'Remplacées',
       data: sumByStatus('replaced'),
       backgroundColor: colors.red
     },

--- a/components/dashboard/map.js
+++ b/components/dashboard/map.js
@@ -200,6 +200,8 @@ function Map({departement, basesLocales}) {
         dragPan={!isTouchScreenDevice || isDragPanEnabled}
         width='100%'
         height='100%'
+        minZoom={4}
+        maxZoom={14}
         doubleClickZoom={false}
         scrollZoom={isZoomActivated}
         mapStyle='https://etalab-tiles.fr/styles/osm-bright/style.json'
@@ -237,8 +239,6 @@ function Map({departement, basesLocales}) {
           type='vector'
           format='pbf'
           tiles={['http://localhost:5000/v1/stats/couverture-tiles/{z}/{x}/{y}.pbf']}
-          minzoom={6}
-          maxzoom={14}
         >
           <Layer id='bal-fill' {...balLayer} />
         </Source>

--- a/components/dashboard/map.js
+++ b/components/dashboard/map.js
@@ -221,7 +221,6 @@ function Map({departement, basesLocales}) {
             />
           </div>
         )}
-
         <Source
           id='decoupage-administratif'
           type='vector'
@@ -240,7 +239,7 @@ function Map({departement, basesLocales}) {
           format='pbf'
           tiles={['http://localhost:5000/v1/stats/couverture-tiles/{z}/{x}/{y}.pbf']}
         >
-          <Layer id='bal-fill' {...balLayer} />
+          <Layer id='bal-fill' {...balLayer} beforeId='departements-fill' />
         </Source>
 
         {hovered && hovered.feature.properties.maxStatus && viewport.zoom > 5 && (

--- a/components/dashboard/map.js
+++ b/components/dashboard/map.js
@@ -4,8 +4,6 @@ import PropTypes from 'prop-types'
 import MapGL, {Source, Layer, Popup, WebMercatorViewport} from 'react-map-gl'
 import {Paragraph, Heading, Alert} from 'evergreen-ui'
 
-import {colors} from '../../lib/colors'
-
 const defaultViewport = {
   latitude: 46.9,
   longitude: 1.7,
@@ -16,7 +14,7 @@ const defaultGeoData = {
   bbox: [-5.317, 41.277, 9.689, 51.234]
 }
 
-function Map({departement, basesLocales, contours}) {
+function Map({departement, basesLocales}) {
   const [viewport, setViewport] = useState(defaultViewport)
   const [hovered, setHovered] = useState(null)
   const [hoveredId, setHoveredId] = useState(null)
@@ -30,27 +28,11 @@ function Map({departement, basesLocales, contours}) {
   const mapRef = useRef()
 
   const balLayer = {
-    id: 'balLayer',
-    type: 'fill',
+    type: 'line',
+    'source-layer': 'contours-bal',
     paint: {
-      'fill-color': [
-        'match',
-        ['get', 'maxStatus'],
-        'draft',
-        colors.neutral,
-        'ready-to-publish',
-        colors.blue,
-        'published',
-        colors.green,
-        'white'
-      ],
-      'fill-opacity': [
-        'case',
-        ['==', ['get', 'code'], hoveredId ? hoveredId : null],
-        0.8,
-        1
-      ],
-      'fill-outline-color': '#ffffff'
+      'line-color': '#877b59',
+      'line-opacity': 1,
     }
   }
 
@@ -249,10 +231,17 @@ function Map({departement, basesLocales, contours}) {
           />
         </Source>
 
-        <Source id='contours-bal' type='geojson' data={contours}>
+        <Source
+          id='contours-bal'
+          type='vector'
+          format='pbf'
+          tiles={['http://localhost:5000/v1/stats/tiles/{z}/{x}/{y}.pbf']}
+          minzoom={6}
+          maxzoom={14}
+        >
           <Layer
             {...balLayer}
-            id='contours-bal-fills'
+            id='contours-bal-lines'
             source='contours-bal'
             beforeId='place-town'
           />

--- a/components/dashboard/map.js
+++ b/components/dashboard/map.js
@@ -235,7 +235,7 @@ function Map({departement, basesLocales}) {
           id='contours-bal'
           type='vector'
           format='pbf'
-          tiles={['http://localhost:5000/v1/stats/tiles/{z}/{x}/{y}.pbf']}
+          tiles={['http://localhost:5000/v1/stats/couverture-tiles/{z}/{x}/{y}.pbf']}
           minzoom={6}
           maxzoom={14}
         >

--- a/lib/bases-locales.js
+++ b/lib/bases-locales.js
@@ -9,6 +9,7 @@ export function filterByStatus(basesLocales, status) {
 export function getBALByStatus(basesLocales) {
   const sortedBalByStatus = {
     published: basesLocales.filter(bal => bal.status === 'published'),
+    replaced: basesLocales.filter(({status}) => status === 'replaced'),
     readyToPublish: basesLocales.filter(({status}) => status === 'ready-to-publish'),
     draft: basesLocales.filter(({status}) => status === 'draft')
   }
@@ -18,6 +19,11 @@ export function getBALByStatus(basesLocales) {
       label: sortedBalByStatus.published.length > 1 ? 'Publiées' : 'Publiée',
       values: sortedBalByStatus.published.length,
       color: colors.green
+    },
+    {
+      label: sortedBalByStatus.replaced.length > 1 ? 'Remplacées' : 'Remplacée',
+      values: sortedBalByStatus.replaced.length,
+      color: colors.red
     },
     {
       label: sortedBalByStatus.readyToPublish.length > 1 ? 'Prêtes à être publiées' : 'Prête à être publiée',

--- a/lib/colors.js
+++ b/lib/colors.js
@@ -1,5 +1,6 @@
 export const colors = {
   green: '#52BD95',
   blue: '#3366FF',
+  red: '#D14343',
   neutral: '#696f8c'
 }

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types'
 import {Pane} from 'evergreen-ui'
 import {uniq, flattenDeep} from 'lodash'
 
-import {getBasesLocalesStats, getContoursCommunes, listBasesLocales} from '../lib/bal-api'
+import {getBasesLocalesStats, listBasesLocales} from '../lib/bal-api'
 
 import DashboardLayout from '../components/layout/dashboard'
 
@@ -12,7 +12,7 @@ import Counter from '../components/dashboard/counter'
 import Redirection from './dashboard/redirection'
 import PublishedBalStats from '../components/dashboard/published-bal-stats'
 
-function Index({basesLocales, basesLoclesStats, contoursCommunes}) {
+function Index({basesLocales, basesLoclesStats}) {
   const communeCount = uniq(flattenDeep(
     basesLocales
       .filter(({communes}) => communes.length > 0)
@@ -20,7 +20,7 @@ function Index({basesLocales, basesLoclesStats, contoursCommunes}) {
   )).length
 
   return (
-    <DashboardLayout title='Tableau de bord de l&apos;éditeur Mes Adresses' mapData={{basesLocales, contours: contoursCommunes}}>
+    <DashboardLayout title='Tableau de bord de l&apos;éditeur Mes Adresses' mapData={{basesLocales}}>
       <Pane display='grid' gridGap='2em' padding={5}>
         <PublishedBalStats stats={basesLoclesStats} />
 
@@ -37,21 +37,18 @@ function Index({basesLocales, basesLoclesStats, contoursCommunes}) {
 Index.getInitialProps = async () => {
   const basesLocales = await listBasesLocales()
   const basesLoclesStats = await getBasesLocalesStats()
-  const contoursCommunes = await getContoursCommunes()
   const basesLocalesWithoutDemo = basesLocales.filter((b => b.status !== 'demo'))
 
   return {
     basesLocales: basesLocalesWithoutDemo,
     basesLoclesStats,
-    contoursCommunes,
     layout: 'fullscreen'
   }
 }
 
 Index.propTypes = {
   basesLocales: PropTypes.array.isRequired,
-  basesLoclesStats: PropTypes.object.isRequired,
-  contoursCommunes: PropTypes.object.isRequired
+  basesLoclesStats: PropTypes.object.isRequired
 }
 
 export default Index

--- a/pages/dashboard/departement.js
+++ b/pages/dashboard/departement.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types'
 import {Heading, Pane} from 'evergreen-ui'
 import {flatten, groupBy, uniq} from 'lodash'
 
-import {getContoursCommunes, listBALByCodeDepartement} from '../../lib/bal-api'
+import {listBALByCodeDepartement} from '../../lib/bal-api'
 import {getDepartement, searchCommunesByCode} from '../../lib/geo-api'
 import {getBALByStatus} from '../../lib/bases-locales'
 
@@ -12,7 +12,7 @@ import CommuneBALList from '../../components/dashboard/commune-bal-list'
 import DashboardLayout from '../../components/layout/dashboard'
 import PublishedBalStats from '../../components/dashboard/published-bal-stats'
 
-function Departement({departement, filteredCommunesInBAL, basesLocalesDepartementWithoutDemo, BALGroupedByCommune, stats, contoursCommunes}) {
+function Departement({departement, filteredCommunesInBAL, basesLocalesDepartementWithoutDemo, BALGroupedByCommune, stats}) {
   const {nom, code} = departement
   const {nbCommunes, nbVoies, nbLieuxDits, nbNumeros, nbNumerosCertifies} = stats
   const codesCommunes = new Set(filteredCommunesInBAL.map(({code}) => code))
@@ -24,8 +24,7 @@ function Departement({departement, filteredCommunesInBAL, basesLocalesDepartemen
 
   const mapData = {
     departement: code,
-    basesLocales: basesLocalesDepartementWithoutDemo,
-    contours: contoursCommunes
+    basesLocales: basesLocalesDepartementWithoutDemo
   }
 
   return (
@@ -75,7 +74,6 @@ function Departement({departement, filteredCommunesInBAL, basesLocalesDepartemen
 Departement.getInitialProps = async ({query}) => {
   const {codeDepartement} = query
 
-  const contoursCommunes = await getContoursCommunes()
   const departement = await getDepartement(codeDepartement)
   const basesLocalesDepartement = await listBALByCodeDepartement(codeDepartement)
   const basesLocalesDepartementWithoutDemo = basesLocalesDepartement.basesLocales.filter(b => b.status !== 'demo')
@@ -93,7 +91,6 @@ Departement.getInitialProps = async ({query}) => {
   return {
     departement,
     filteredCommunesInBAL,
-    contoursCommunes,
     basesLocalesDepartementWithoutDemo,
     BALGroupedByCommune,
     stats: basesLocalesDepartement.stats,
@@ -106,8 +103,7 @@ Departement.propTypes = {
   filteredCommunesInBAL: PropTypes.array.isRequired,
   basesLocalesDepartementWithoutDemo: PropTypes.array.isRequired,
   BALGroupedByCommune: PropTypes.object.isRequired,
-  stats: PropTypes.object.isRequired,
-  contoursCommunes: PropTypes.object.isRequired
+  stats: PropTypes.object.isRequired
 }
 
 export default Departement


### PR DESCRIPTION
## Contexte
Actuellement la coloration des BAL sur la carte du dashboard se fait à l'aide d'un `geojson` des contours de toutes les communes de France sur lequel on vient appliquer une couche en fonction des données des BAL existantes.
Ce processus est lourd et dégrade les performances de l'outil.

## Évolutions
Cette PR met en place les tuiles vectorielles pour les BAL. Cette fonctionnalité est apportée par [#309](#https://github.com/BaseAdresseNationale/mes-adresses-api/pull/309/files) et permet d'améliorer les performances globale du dashbord.

### Autres évolutions mineurs
- Ajout des BAL `remplacées` indiqué par la couleur rouge
- Amélioration du code du composant carte du dashboard