### PR TITLE
Corrige les adresses mails tronquées sur la page d’accueil

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -160,7 +160,8 @@ function App({error, Component, pageProps, query}) {
           </BalDataContextProvider>
         </TokenContextProvider>
       </LocalStorageContextProvider>
-      {/* ⚠️ This is needed to expand Evergreen’Tootip width */}
+      {/* ⚠️ This is needed to expand Evergreen’Tootip width
+      It select all Tooltip components with 'appearance: card' propertie */}
       <style jsx global>{`
         div[id^="evergreen-tooltip"].ub-max-w_240px.ub-bg-clr_white.ub-box-szg_border-box {
           max-width: fit-content;

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -160,6 +160,12 @@ function App({error, Component, pageProps, query}) {
           </BalDataContextProvider>
         </TokenContextProvider>
       </LocalStorageContextProvider>
+      {/*⚠️ This is needed to expand Evergreen’Tootip width*/}
+      <style jsx global>{`
+        div[id^="evergreen-tooltip"].ub-max-w_240px.ub-bg-clr_white.ub-box-szg_border-box {
+          max-width: fit-content;
+        }
+      `}</style>
     </>
   )
 }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -160,7 +160,7 @@ function App({error, Component, pageProps, query}) {
           </BalDataContextProvider>
         </TokenContextProvider>
       </LocalStorageContextProvider>
-      {/*⚠️ This is needed to expand Evergreen’Tootip width*/}
+      {/* ⚠️ This is needed to expand Evergreen’Tootip width */}
       <style jsx global>{`
         div[id^="evergreen-tooltip"].ub-max-w_240px.ub-bg-clr_white.ub-box-szg_border-box {
           max-width: fit-content;


### PR DESCRIPTION
Actuellement, les adresses mails des administrateurs sont tronquées lorsqu'elles sont trop longues.
Ce problème est dû à l’utilisation du Tooltip Evergreen dont la taille ne peux pas dépasser 240px.

Cette PR propose d’ajouter un style global à la racine du site pour modifier la classe qui empêche la `<div />` de s’agrandir.
J'ai ajouté un commentaire pour préciser le but de ce style global.

Avant : 

![image](https://user-images.githubusercontent.com/56537238/156391221-a95b39f0-ff70-455f-b492-7059f65b07a7.png)

Après : 

![image](https://user-images.githubusercontent.com/56537238/156391585-0713674a-a0b6-4742-9708-f76d3da36e3a.png)
