### PR TITLE
Correction de l'historique de publication

### DIFF
--- a/components/sub-header/bal-status/ban-sync/ban-history/revision.js
+++ b/components/sub-header/bal-status/ban-sync/ban-history/revision.js
@@ -14,7 +14,7 @@ function getIndicatorColor(isCurrent, isUserBAL) {
 }
 
 function Revision({baseLocaleId, commune, revision}) {
-  const isUserBAL = revision.context.extras.balId === baseLocaleId
+  const isUserBAL = revision.context.extras?.balId === baseLocaleId
   const indicatorColor = getIndicatorColor(revision.current, isUserBAL)
 
   return (


### PR DESCRIPTION
Fix #511 
## Contexte
Lorsqu'une BAL de l'historique de provient pas de Mes Adresses sa révisions ne possède pas de `extras.balId` ce qui provoque une erreur.

Cette correction rend `extras` optionnelle.