### PR TITLE
Corrige le bug de fermeture de la modale "Modifications Multiples"

### DIFF
--- a/components/grouped-actions.js
+++ b/components/grouped-actions.js
@@ -59,8 +59,7 @@ function GroupedActions({idVoie, numeros, selectedNumerosIds, resetSelectedNumer
     resetPositionType()
   }
 
-  const onFormCancel = event => {
-    event.preventDefault()
+  const onFormCancel = () => {
     resetSelectedNumerosIds()
     setIsShown(false)
   }
@@ -137,6 +136,7 @@ function GroupedActions({idVoie, numeros, selectedNumerosIds, resetSelectedNumer
           title='Modification multiple'
           isConfirmLoading={isLoading}
           hasFooter={false}
+          onCloseComplete={() => onFormCancel()}
         >
           <Pane marginX='-32px' marginBottom='-8px'>
             <Paragraph marginBottom={8} marginLeft={32} color='muted'>{`${selectedNumerosIds.length} numéros sélectionnés`}</Paragraph>


### PR DESCRIPTION
Cette PR corrige le bug qui empêche la modale "Modifications Multiples" de se rouvrir après sa fermeture.

- Ajout de la propriété `onCloseComplete` sur la boite de dialogue Evergreen.

Fix #517 