### PR TITLE
Cache les identifiants des parcelles quand plus de 3 sont sélectionnées

### DIFF
--- a/components/bal/numero-editor/select-parcelles.js
+++ b/components/bal/numero-editor/select-parcelles.js
@@ -1,6 +1,8 @@
-import {useContext} from 'react'
+import {useState, useEffect, useContext} from 'react'
 import PropTypes from 'prop-types'
 import {Pane, Button, Badge, Alert, TrashIcon, ControlIcon, Text} from 'evergreen-ui'
+
+import SelectedParcellesDialog from './selected-parcelles-dialog'
 
 import ParcellesContext from '../../../contexts/parcelles'
 
@@ -8,9 +10,16 @@ import InputLabel from '../../input-label'
 import MapContext from '../../../contexts/map'
 
 function SelectParcelles({isToponyme}) {
+  const [isDialogOpen, setIsDialogOpen] = useState(false)
   const {isCadastreDisplayed, setIsCadastreDisplayed} = useContext(MapContext)
   const {selectedParcelles, hoveredParcelle, handleHoveredParcelle, handleParcelle} = useContext(ParcellesContext)
   const addressType = isToponyme ? 'toponyme' : 'numéro'
+
+  useEffect(() => {
+    if (isDialogOpen && selectedParcelles.length < 4) {
+      setIsDialogOpen(false)
+    }
+  }, [isDialogOpen, selectedParcelles])
 
   return (
     <Pane display='flex' flexDirection='column'>
@@ -20,7 +29,7 @@ function SelectParcelles({isToponyme}) {
       />
       <Pane>
         {selectedParcelles.length > 0 ?
-          selectedParcelles.map(parcelle => {
+          selectedParcelles.slice(0, 3).map(parcelle => {
             const isHovered = parcelle === hoveredParcelle?.id
 
             return (
@@ -44,6 +53,19 @@ function SelectParcelles({isToponyme}) {
             </Alert>
           )}
       </Pane>
+
+      <SelectedParcellesDialog
+        selectedParcelles={selectedParcelles}
+        hoveredParcelle={hoveredParcelle}
+        handleParcelle={handleParcelle}
+        handleHoveredParcelle={handleHoveredParcelle}
+        isShown={isDialogOpen}
+        setIsShown={setIsDialogOpen}
+      />
+
+      {selectedParcelles.length > 3 && (
+        <Button marginTop={8} type='button' onClick={() => setIsDialogOpen(true)}>Afficher les autres parcelles sélectionnées ({selectedParcelles.length - 3})</Button>
+      )}
 
       <Button
         type='button'

--- a/components/bal/numero-editor/selected-parcelles-dialog.js
+++ b/components/bal/numero-editor/selected-parcelles-dialog.js
@@ -1,0 +1,46 @@
+import PropTypes from 'prop-types'
+import {Badge, TrashIcon, Dialog} from 'evergreen-ui'
+
+function SelectedParcellesDialog({selectedParcelles, hoveredParcelle, handleParcelle, handleHoveredParcelle, isShown, setIsShown}) {
+  return (
+    <Dialog
+      hasFooter={false}
+      isShown={isShown}
+      title='Parcelles sélectionnées'
+      onCloseComplete={() => setIsShown(false)}
+    >
+      {selectedParcelles.slice(3).map(parcelle => {
+        const isHovered = parcelle === hoveredParcelle?.id
+
+        return (
+          <Badge
+            key={parcelle}
+            isInteractive
+            color={parcelle === hoveredParcelle?.id ? 'red' : 'green'}
+            margin={4}
+            onClick={() => handleParcelle(parcelle)}
+            onMouseEnter={() => handleHoveredParcelle({id: parcelle})}
+            onMouseLeave={() => handleHoveredParcelle(null)}
+          >
+            {parcelle}{isHovered && <TrashIcon marginLeft={4} size={14} color='danger' verticalAlign='text-bottom' />}
+          </Badge>
+        )
+      })}
+    </Dialog>
+  )
+}
+
+SelectedParcellesDialog.defaultProps = {
+  hoveredParcelle: null
+}
+
+SelectedParcellesDialog.propTypes = {
+  selectedParcelles: PropTypes.array.isRequired,
+  hoveredParcelle: PropTypes.object,
+  handleParcelle: PropTypes.func.isRequired,
+  handleHoveredParcelle: PropTypes.func.isRequired,
+  isShown: PropTypes.bool.isRequired,
+  setIsShown: PropTypes.func.isRequired
+}
+
+export default SelectedParcellesDialog


### PR DESCRIPTION
resolves #472 

- Lorsque plus de 3 parcelles sont sélectionnées, un bouton apparaît.
- Le bouton permet d'ouvrir un dialogue qui contient les identifiants des parcelles qui ont été cachées.

*capture vidéo*

https://user-images.githubusercontent.com/45098730/157879046-185616bf-1b15-4366-86b7-20df7aa51a80.mp4


