### PR TITLE
Ajout d'une redirection sur la page /bal

### DIFF
--- a/pages/bal.js
+++ b/pages/bal.js
@@ -1,189 +1,43 @@
-import React, {useState, useCallback, useContext} from 'react'
+import React, {useEffect} from 'react'
 import PropTypes from 'prop-types'
-import Router from 'next/router'
-import {sortBy} from 'lodash'
-import {Pane, Heading, Paragraph, Button, Table, Text, AddIcon, Alert} from 'evergreen-ui'
+import {useRouter} from 'next/router'
+import {Pane, Heading, Text, Spinner} from 'evergreen-ui'
 
-import {addCommune, removeCommune, populateCommune} from '@/lib/bal-api'
-import {getCommune} from '@/lib/geo-api'
-import {normalizeSort} from '@/lib/normalize'
+const Index = React.memo(({baseLocale}) => {
+  const router = useRouter()
 
-import TokenContext from '@/contexts/token'
-import BalDataContext from '@/contexts/bal-data'
+  useEffect(() => {
+    const [codeCommume] = baseLocale.communes
 
-import useFuse from '@/hooks/fuse'
-
-import DeleteWarning from '@/components/delete-warning'
-import TableRow from '@/components/table-row'
-import CommuneEditor from '@/components/bal/commune-editor'
-
-const Index = React.memo(({baseLocale, defaultCommunes}) => {
-  const [communes, setCommunes] = useState(defaultCommunes)
-  const [isAdding, setIsAdding] = useState(false)
-  const [toRemove, setToRemove] = useState(null)
-
-  const {token} = useContext(TokenContext)
-  const balDataContext = useContext(BalDataContext)
-
-  const [filtered, onFilter] = useFuse(communes, 200, {
-    keys: [
-      'nom'
-    ]
-  })
-
-  const onAdd = useCallback(async ({commune, populate}) => {
-    const updated = await addCommune(baseLocale._id, commune, token)
-
-    if (populate) {
-      await populateCommune(baseLocale._id, commune, token)
-    }
-
-    const updatedCommunes = await Promise.all(
-      updated.communes.map(commune => getCommune(commune))
+    router.push(
+      `/bal/commune?balId=${baseLocale._id}&codeCommune=${codeCommume}`,
+      `/bal/${baseLocale._id}/communes/${codeCommume}`
     )
-
-    setIsAdding(false)
-    setCommunes(updatedCommunes)
-  }, [baseLocale._id, token])
-
-  const onRemove = useCallback(async () => {
-    const updated = await removeCommune(baseLocale._id, toRemove, token)
-
-    const updatedCommunes = await Promise.all(
-      updated.communes.map(commune => getCommune(commune))
-    )
-
-    setCommunes(updatedCommunes)
-    setToRemove(null)
-  }, [baseLocale._id, toRemove, token])
-
-  const onSelect = useCallback(codeCommune => {
-    Router.push(
-      `/bal/commune?balId=${baseLocale._id}&codeCommune=${codeCommune}`,
-      `/bal/${baseLocale._id}/communes/${codeCommune}`
-    )
-  }, [baseLocale._id])
+  }, [router, baseLocale])
 
   return (
     <>
-      <DeleteWarning
-        isShown={Boolean(toRemove)}
-        content={(
-          <Paragraph>
-            Êtes vous bien sûr de vouloir supprimer cette commune ainsi que toutes ses voies et numéros ?
-          </Paragraph>
-        )}
-        onCancel={() => setToRemove(null)}
-        onConfirm={onRemove}
-      />
-
       <Pane
         display='flex'
         flexDirection='column'
         background='tint1'
         padding={16}
       >
-        <Heading>{balDataContext.baseLocale?.nom || baseLocale.nom}</Heading>
-        <Text>{communes.length} commune{communes.length > 1 ? 's' : ''}</Text>
+        <Heading>{baseLocale.nom}</Heading>
       </Pane>
-      <Pane
-        flexShrink={0}
-        elevation={0}
-        backgroundColor='white'
-        padding={16}
-        display='flex'
-        alignItems='center'
-        minHeight={64}
-      >
-        <Pane>
-          <Heading>Liste des communes</Heading>
+      <Pane display='flex' flex={1} alignItems='center' justifyContent='center'>
+        <Pane display='flex' flexDirection='column' alignItems='center'>
+          <Spinner size={80} marginBottom={16} />
+          <Text>Chargement de la commune…</Text>
         </Pane>
-        {token && communes.length === 0 && (
-          <Pane marginLeft='auto'>
-            <Button
-              iconBefore={AddIcon}
-              appearance='primary'
-              intent='success'
-              disabled={isAdding}
-              onClick={() => setIsAdding(true)}
-            >
-              Ajouter une commune
-            </Button>
-          </Pane>
-        )}
-      </Pane>
-
-      {communes.length > 1 && (
-        <Pane padding={16}>
-          <Alert
-            intent='warning'
-            title='Gestion de plusieurs communes'
-          >
-            L’éditeur « Mes Adresses » permet la gestion d’une Base Adresse Locale à l’échelle communale. Pour gérer plusieurs communes, vous devez créer plusieurs Bases Adresses Locales.
-          </Alert>
-        </Pane>
-      )}
-
-      <Pane flex={1} overflowY='scroll'>
-        <Table>
-          <Table.Head>
-            <Table.SearchHeaderCell
-              disabled={isAdding}
-              placeholder='Rechercher une commune…'
-              onChange={onFilter}
-            />
-          </Table.Head>
-          {isAdding && (
-            <Table.Row height='auto'>
-              <Table.Cell borderBottom display='block' paddingY={12} background='tint1'>
-                <CommuneEditor
-                  exclude={communes.map(c => c.code)}
-                  onSubmit={onAdd}
-                  onCancel={() => setIsAdding(false)}
-                />
-              </Table.Cell>
-            </Table.Row>
-          )}
-          {filtered.length === 0 && (
-            <Table.Row>
-              <Table.TextCell color='muted' fontStyle='italic'>
-                Aucun résultat
-              </Table.TextCell>
-            </Table.Row>
-          )}
-          {sortBy(filtered, v => normalizeSort(v.nom))
-            .map(commune => (
-              <TableRow
-                key={commune.code}
-                id={commune.code}
-                code={commune.code}
-                label={commune.nom}
-                onSelect={onSelect}
-                onRemove={id => setToRemove(id)}
-              />
-            ))}
-        </Table>
       </Pane>
     </>
   )
 })
 
 Index.getInitialProps = async ({baseLocale}) => {
-  const communes = await Promise.all(
-    baseLocale.communes.map(async codeCommune => {
-      try {
-        return await getCommune(codeCommune)
-      } catch {
-        return {
-          code: codeCommune
-        }
-      }
-    })
-  )
-
   return {
     layout: 'sidebar',
-    defaultCommunes: communes,
     baseLocale
   }
 }
@@ -191,13 +45,9 @@ Index.getInitialProps = async ({baseLocale}) => {
 Index.propTypes = {
   baseLocale: PropTypes.shape({
     _id: PropTypes.string.isRequired,
-    nom: PropTypes.string.isRequired
-  }).isRequired,
-  defaultCommunes: PropTypes.array
-}
-
-Index.defaultProps = {
-  defaultCommunes: null
+    nom: PropTypes.string.isRequired,
+    communes: PropTypes.array.isRequired
+  }).isRequired
 }
 
 export default Index


### PR DESCRIPTION
## Contexte
La page `/bal` était auparavant utilisée pour afficher la liste des communes d'une Base Adresses Locale et permettre les actions de base d'édition, d'ajout et de suppression sur cette liste.

Cependant depuis l'intégration de l'API de dépôt #471, toutes les Bases Adresses Locales sont devenu mono-communale. Cette page est donc devenu obsolète. 

## Évolutions
Cette PR propose d'ajouter une redirection vers la page `/commune` de la Base Adresse Locale. Cette redirection est temporaire en attendant le développement de #522 par exemple

![Capture d’écran 2022-03-15 à 11 32 58](https://user-images.githubusercontent.com/7040549/158362043-610ca69b-3ba8-4854-9a54-410c2cc213e1.png)
.