### PR TITLE
Refonte du composant <TableRow />

### DIFF
--- a/components/bal/toponymes-list.js
+++ b/components/bal/toponymes-list.js
@@ -65,9 +65,8 @@ function ToponymesList({toponymes, isAdding, onAdd, onEdit, onCancel, onSelect, 
               key={toponyme._id}
               id={toponyme._id}
               warning={toponyme.positions.length === 0 ? 'Ce toponyme n’a pas de position' : null}
-              isSelectable={!isEditing && !isPopulating}
               label={toponyme.nom}
-              isEditingEnabled={Boolean(!isEditing && token)}
+              isEditingEnabled={Boolean(!isEditing && !isPopulating && token)}
               actions={{
                 onSelect,
                 onEdit: onEnableEditing,

--- a/components/bal/toponymes-list.js
+++ b/components/bal/toponymes-list.js
@@ -6,6 +6,7 @@ import {Pane, Table} from 'evergreen-ui'
 import {normalizeSort} from '@/lib/normalize'
 
 import BalDataContext from '@/contexts/bal-data'
+import TokenContext from '@/contexts/token'
 
 import useFuse from '@/hooks/fuse'
 
@@ -13,6 +14,7 @@ import TableRow from '@/components/table-row'
 import ToponymeEditor from '@/components/bal/toponyme-editor'
 
 function ToponymesList({toponymes, isAdding, onAdd, onEdit, onCancel, onSelect, onEnableEditing, isPopulating, setToRemove}) {
+  const {token} = useContext(TokenContext)
   const {isEditing, editingId} = useContext(BalDataContext)
 
   const [filtered, setFilter] = useFuse(toponymes, 200, {
@@ -65,6 +67,7 @@ function ToponymesList({toponymes, isAdding, onAdd, onEdit, onCancel, onSelect, 
               warning={toponyme.positions.length === 0 ? 'Ce toponyme n’a pas de position' : null}
               isSelectable={!isEditing && !isPopulating}
               label={toponyme.nom}
+              isEditingEnabled={Boolean(!isEditing && token)}
               actions={{
                 onSelect,
                 onEdit: onEnableEditing,

--- a/components/bal/toponymes-list.js
+++ b/components/bal/toponymes-list.js
@@ -65,9 +65,11 @@ function ToponymesList({toponymes, isAdding, onAdd, onEdit, onCancel, onSelect, 
               warning={toponyme.positions.length === 0 ? 'Ce toponyme n’a pas de position' : null}
               isSelectable={!isEditing && !isPopulating}
               label={toponyme.nom}
-              onSelect={onSelect}
-              onEdit={onEnableEditing}
-              onRemove={id => setToRemove(id)}
+              actions={{
+                onSelect,
+                onEdit: onEnableEditing,
+                onRemove: () => setToRemove(toponyme._id)
+              }}
             />
           ))}
       </Table>

--- a/components/bal/toponymes-list.js
+++ b/components/bal/toponymes-list.js
@@ -63,15 +63,14 @@ function ToponymesList({toponymes, isAdding, onAdd, onEdit, onCancel, onSelect, 
           ) : (
             <TableRow
               key={toponyme._id}
-              id={toponyme._id}
               label={toponyme.nom}
               isEditingEnabled={Boolean(!isEditing && token)}
               notifications={{
                 warning: toponyme.positions.length === 0 ? 'Ce toponyme n’a pas de position' : null
               }}
               actions={{
-                onSelect,
-                onEdit: onEnableEditing,
+                onSelect: () => onSelect(toponyme._id),
+                onEdit: () => onEnableEditing(toponyme._id),
                 onRemove: () => setToRemove(toponyme._id)
               }}
             />

--- a/components/bal/toponymes-list.js
+++ b/components/bal/toponymes-list.js
@@ -64,9 +64,11 @@ function ToponymesList({toponymes, isAdding, onAdd, onEdit, onCancel, onSelect, 
             <TableRow
               key={toponyme._id}
               id={toponyme._id}
-              warning={toponyme.positions.length === 0 ? 'Ce toponyme n’a pas de position' : null}
               label={toponyme.nom}
               isEditingEnabled={Boolean(!isEditing && !isPopulating && token)}
+              notifications={{
+                warning: toponyme.positions.length === 0 ? 'Ce toponyme n’a pas de position' : null
+              }}
               actions={{
                 onSelect,
                 onEdit: onEnableEditing,

--- a/components/bal/toponymes-list.js
+++ b/components/bal/toponymes-list.js
@@ -13,7 +13,7 @@ import useFuse from '@/hooks/fuse'
 import TableRow from '@/components/table-row'
 import ToponymeEditor from '@/components/bal/toponyme-editor'
 
-function ToponymesList({toponymes, isAdding, onAdd, onEdit, onCancel, onSelect, onEnableEditing, isPopulating, setToRemove}) {
+function ToponymesList({toponymes, isAdding, onAdd, onEdit, onCancel, onSelect, onEnableEditing, setToRemove}) {
   const {token} = useContext(TokenContext)
   const {isEditing, editingId} = useContext(BalDataContext)
 
@@ -65,7 +65,7 @@ function ToponymesList({toponymes, isAdding, onAdd, onEdit, onCancel, onSelect, 
               key={toponyme._id}
               id={toponyme._id}
               label={toponyme.nom}
-              isEditingEnabled={Boolean(!isEditing && !isPopulating && token)}
+              isEditingEnabled={Boolean(!isEditing && token)}
               notifications={{
                 warning: toponyme.positions.length === 0 ? 'Ce toponyme n’a pas de position' : null
               }}
@@ -83,7 +83,6 @@ function ToponymesList({toponymes, isAdding, onAdd, onEdit, onCancel, onSelect, 
 
 ToponymesList.propTypes = {
   toponymes: PropTypes.array.isRequired,
-  isPopulating: PropTypes.bool,
   isAdding: PropTypes.bool.isRequired,
   setToRemove: PropTypes.func.isRequired,
   onEnableEditing: PropTypes.func.isRequired,
@@ -91,10 +90,6 @@ ToponymesList.propTypes = {
   onCancel: PropTypes.func.isRequired,
   onAdd: PropTypes.func.isRequired,
   onEdit: PropTypes.func.isRequired
-}
-
-ToponymesList.defaultProps = {
-  isPopulating: false
 }
 
 export default ToponymesList

--- a/components/bal/voies-list.js
+++ b/components/bal/voies-list.js
@@ -64,9 +64,11 @@ function VoiesList({voies, onEnableEditing, isAdding, onSelect, isPopulating, on
               id={voie._id}
               isSelectable={!isEditing && !isPopulating}
               label={voie.nom}
-              onSelect={onSelect}
-              onEdit={onEnableEditing}
-              onRemove={id => setToRemove(id)}
+              actions={{
+                onSelect,
+                onEdit: onEnableEditing,
+                onRemove: () => setToRemove(voie._id)
+              }}
             />
           ))}
       </Table>

--- a/components/bal/voies-list.js
+++ b/components/bal/voies-list.js
@@ -13,7 +13,7 @@ import useFuse from '@/hooks/fuse'
 import TableRow from '@/components/table-row'
 import VoieEditor from '@/components/bal/voie-editor'
 
-function VoiesList({voies, onEnableEditing, isAdding, onSelect, isPopulating, onAdd, onEdit, onCancel, setToRemove}) {
+function VoiesList({voies, onEnableEditing, isAdding, onSelect, onAdd, onEdit, onCancel, setToRemove}) {
   const {token} = useContext(TokenContext)
   const {isEditing, editingId} = useContext(BalDataContext)
 
@@ -65,7 +65,7 @@ function VoiesList({voies, onEnableEditing, isAdding, onSelect, isPopulating, on
               key={voie._id}
               id={voie._id}
               label={voie.nom}
-              isEditingEnabled={Boolean(!isEditing && !isPopulating && token)}
+              isEditingEnabled={Boolean(!isEditing && token)}
               actions={{
                 onSelect,
                 onEdit: onEnableEditing,
@@ -80,7 +80,6 @@ function VoiesList({voies, onEnableEditing, isAdding, onSelect, isPopulating, on
 
 VoiesList.propTypes = {
   voies: PropTypes.array,
-  isPopulating: PropTypes.bool,
   isAdding: PropTypes.bool.isRequired,
   setToRemove: PropTypes.func.isRequired,
   onEnableEditing: PropTypes.func.isRequired,
@@ -91,8 +90,7 @@ VoiesList.propTypes = {
 }
 
 VoiesList.defaultProps = {
-  voies: null,
-  isPopulating: false
+  voies: null
 }
 
 export default VoiesList

--- a/components/bal/voies-list.js
+++ b/components/bal/voies-list.js
@@ -64,9 +64,8 @@ function VoiesList({voies, onEnableEditing, isAdding, onSelect, isPopulating, on
             <TableRow
               key={voie._id}
               id={voie._id}
-              isSelectable={!isEditing && !isPopulating}
               label={voie.nom}
-              isEditingEnabled={Boolean(!isEditing && token)}
+              isEditingEnabled={Boolean(!isEditing && !isPopulating && token)}
               actions={{
                 onSelect,
                 onEdit: onEnableEditing,

--- a/components/bal/voies-list.js
+++ b/components/bal/voies-list.js
@@ -6,6 +6,7 @@ import {Pane, Table} from 'evergreen-ui'
 import {normalizeSort} from '@/lib/normalize'
 
 import BalDataContext from '@/contexts/bal-data'
+import TokenContext from '@/contexts/token'
 
 import useFuse from '@/hooks/fuse'
 
@@ -13,6 +14,7 @@ import TableRow from '@/components/table-row'
 import VoieEditor from '@/components/bal/voie-editor'
 
 function VoiesList({voies, onEnableEditing, isAdding, onSelect, isPopulating, onAdd, onEdit, onCancel, setToRemove}) {
+  const {token} = useContext(TokenContext)
   const {isEditing, editingId} = useContext(BalDataContext)
 
   const [filtered, setFilter] = useFuse(voies, 200, {
@@ -64,6 +66,7 @@ function VoiesList({voies, onEnableEditing, isAdding, onSelect, isPopulating, on
               id={voie._id}
               isSelectable={!isEditing && !isPopulating}
               label={voie.nom}
+              isEditingEnabled={Boolean(!isEditing && token)}
               actions={{
                 onSelect,
                 onEdit: onEnableEditing,

--- a/components/bal/voies-list.js
+++ b/components/bal/voies-list.js
@@ -63,12 +63,11 @@ function VoiesList({voies, onEnableEditing, isAdding, onSelect, onAdd, onEdit, o
           ) : (
             <TableRow
               key={voie._id}
-              id={voie._id}
               label={voie.nom}
               isEditingEnabled={Boolean(!isEditing && token)}
               actions={{
-                onSelect,
-                onEdit: onEnableEditing,
+                onSelect: () => onSelect(voie._id),
+                onEdit: () => onEnableEditing(voie._id),
                 onRemove: () => setToRemove(voie._id)
               }}
             />

--- a/components/table-row.js
+++ b/components/table-row.js
@@ -1,24 +1,12 @@
-import React, {useContext, useCallback, useMemo} from 'react'
+import React, {useCallback} from 'react'
 import PropTypes from 'prop-types'
 import {Table, Position, Tooltip, EndorsedIcon, WarningSignIcon, CommentIcon, Checkbox} from 'evergreen-ui'
-
-import BalDataContext from '@/contexts/bal-data'
 
 import TableRowActions from '@/components/table-row/table-row-actions'
 import TableRowEditShortcut from './table-row/table-row-edit-shortcut'
 
-const TableRow = React.memo(({id, label, warning, comment, secondary, isSelectable, isSelected, toponymeId, isEditingEnabled, isCertified, handleSelect, actions}) => {
-  const {numeros, toponymes} = useContext(BalDataContext)
-  const hasNumero = numeros && numeros.length > 1
-
+const TableRow = React.memo(({id, label, complement, warning, comment, secondary, isSelectable, isSelected, isEditingEnabled, isCertified, handleSelect, actions}) => {
   const {onSelect, onEdit, onRemove} = actions
-
-  const toponymeName = useMemo(() => {
-    if (toponymeId && toponymes) {
-      const toponyme = toponymes.find(({_id}) => _id === toponymeId)
-      return toponyme?.nom
-    }
-  }, [toponymeId, toponymes])
 
   const onClick = useCallback(e => {
     if (e.target.closest('[data-editable]') && isEditingEnabled) {
@@ -30,7 +18,7 @@ const TableRow = React.memo(({id, label, warning, comment, secondary, isSelectab
 
   return (
     <Table.Row onClick={onClick}>
-      {isEditingEnabled && hasNumero && isSelectable && (
+      {isEditingEnabled && isSelectable && (
         <Table.Cell flex='0 1 1'>
           <Checkbox
             checked={isSelected}
@@ -41,7 +29,7 @@ const TableRow = React.memo(({id, label, warning, comment, secondary, isSelectab
 
       <TableRowEditShortcut
         label={label}
-        complement={toponymeName}
+        complement={complement}
         isEditingEnabled={isEditingEnabled}
         isSelectable={Boolean(onSelect)}
       />
@@ -94,8 +82,8 @@ TableRow.propTypes = {
   id: PropTypes.string.isRequired,
   warning: PropTypes.string,
   label: PropTypes.string.isRequired,
+  complement: PropTypes.string,
   comment: PropTypes.string,
-  toponymeId: PropTypes.string,
   secondary: PropTypes.string,
   isSelectable: PropTypes.bool,
   handleSelect: PropTypes.func,
@@ -110,9 +98,9 @@ TableRow.propTypes = {
 }
 
 TableRow.defaultProps = {
+  complement: null,
   warning: null,
   comment: null,
-  toponymeId: null,
   secondary: null,
   isSelectable: false,
   handleSelect: null,

--- a/components/table-row.js
+++ b/components/table-row.js
@@ -1,15 +1,18 @@
 import React, {useState, useContext, useCallback, useMemo} from 'react'
 import PropTypes from 'prop-types'
-import {Pane, Table, Popover, Menu, Position, IconButton, toaster, Tooltip, EditIcon, EndorsedIcon, WarningSignIcon, CommentIcon, Checkbox, MoreIcon, SendToMapIcon, TrashIcon} from 'evergreen-ui'
+import {Pane, Table, Position, Tooltip, EditIcon, EndorsedIcon, WarningSignIcon, CommentIcon, Checkbox} from 'evergreen-ui'
 
 import TokenContext from '@/contexts/token'
 import BalDataContext from '@/contexts/bal-data'
+import TableRowActions from './table-row/table-row-actions'
 
-const TableRow = React.memo(({id, label, warning, comment, secondary, isSelectable, onSelect, onEdit, onRemove, handleSelect, isSelected, toponymeId, isCertified}) => {
+const TableRow = React.memo(({id, label, warning, comment, secondary, isSelectable, isSelected, toponymeId, isCertified, handleSelect, actions}) => {
   const [hovered, setHovered] = useState(false)
   const {token} = useContext(TokenContext)
   const {numeros, isEditing, toponymes} = useContext(BalDataContext)
   const hasNumero = numeros && numeros.length > 1
+
+  const {onSelect, onEdit, onRemove} = actions
 
   const toponymeName = useMemo(() => {
     if (toponymeId && toponymes) {
@@ -25,18 +28,6 @@ const TableRow = React.memo(({id, label, warning, comment, secondary, isSelectab
       onSelect(id)
     }
   }, [id, isEditing, token, onEdit, onSelect])
-
-  const _onEdit = useCallback(() => {
-    onEdit(id)
-  }, [onEdit, id])
-
-  const _onRemove = useCallback(async () => {
-    try {
-      await onRemove(id)
-    } catch (error) {
-      toaster.danger(`Erreur : ${error.message}`)
-    }
-  }, [onRemove, id])
 
   const _onMouseEnter = useCallback(() => {
     if (onEdit) {
@@ -87,6 +78,7 @@ const TableRow = React.memo(({id, label, warning, comment, secondary, isSelectab
           {secondary}
         </Table.TextCell>
       )}
+
       {comment && (
         <Table.Cell flex='0 1 1'>
           <Tooltip
@@ -97,6 +89,7 @@ const TableRow = React.memo(({id, label, warning, comment, secondary, isSelectab
           </Tooltip>
         </Table.Cell>
       )}
+
       {isCertified && (
         <Table.TextCell flex='0 1 1'>
           <Tooltip content='Cette adresse est certifiée par la commune' position={Position.BOTTOM}>
@@ -104,6 +97,7 @@ const TableRow = React.memo(({id, label, warning, comment, secondary, isSelectab
           </Tooltip>
         </Table.TextCell>
       )}
+
       {warning && (
         <Table.TextCell flex='0 1 1'>
           <Tooltip content={warning} position={Position.BOTTOM}>
@@ -111,35 +105,13 @@ const TableRow = React.memo(({id, label, warning, comment, secondary, isSelectab
           </Tooltip>
         </Table.TextCell>
       )}
-      {token && (onEdit || onRemove) && (
-        <Table.TextCell flex='0 1 1'>
-          <Popover
-            position={Position.BOTTOM_LEFT}
-            content={
-              <Menu>
-                <Menu.Group>
-                  {onSelect && (
-                    <Menu.Item icon={SendToMapIcon} onSelect={() => onSelect(id)}>
-                      Consulter
-                    </Menu.Item>
-                  )}
-                  {onEdit && !isEditing && (
-                    <Menu.Item icon={EditIcon} onSelect={_onEdit}>
-                      Modifier
-                    </Menu.Item>
-                  )}
-                  {onRemove && (
-                    <Menu.Item icon={TrashIcon} intent='danger' onSelect={_onRemove}>
-                      Supprimer…
-                    </Menu.Item>
-                  )}
-                </Menu.Group>
-              </Menu>
-            }
-          >
-            <IconButton type='button' height={24} icon={MoreIcon} appearance='minimal' />
-          </Popover>
-        </Table.TextCell>
+
+      {token && actions && (
+        <TableRowActions
+          onSelect={() => onSelect(id)}
+          onEdit={() => onEdit(id)}
+          onRemove={() => onRemove(id)}
+        />
       )}
 
       <style global jsx>{`
@@ -163,12 +135,14 @@ TableRow.propTypes = {
   toponymeId: PropTypes.string,
   secondary: PropTypes.string,
   isSelectable: PropTypes.bool,
-  onSelect: PropTypes.func,
-  onEdit: PropTypes.func,
-  onRemove: PropTypes.func.isRequired,
   handleSelect: PropTypes.func,
   isSelected: PropTypes.bool,
-  isCertified: PropTypes.bool
+  isCertified: PropTypes.bool,
+  actions: PropTypes.shape({
+    onSelect: PropTypes.func,
+    onEdit: PropTypes.func,
+    onRemove: PropTypes.func
+  }).isRequired
 }
 
 TableRow.defaultProps = {
@@ -177,9 +151,7 @@ TableRow.defaultProps = {
   toponymeId: null,
   secondary: null,
   isSelectable: false,
-  onEdit: null,
   handleSelect: null,
-  onSelect: null,
   isSelected: false,
   isCertified: false
 }

--- a/components/table-row.js
+++ b/components/table-row.js
@@ -6,7 +6,7 @@ import TableRowActions from '@/components/table-row/table-row-actions'
 import TableRowEditShortcut from './table-row/table-row-edit-shortcut'
 import TableRowNotifications from './table-row/table-row-notifications'
 
-const TableRow = React.memo(({id, label, complement, secondary, notifications, isSelectable, isSelected, isEditingEnabled, handleSelect, actions}) => {
+const TableRow = React.memo(({id, label, complement, secondary, notifications, isSelected, isEditingEnabled, handleSelect, actions}) => {
   const {onSelect, onEdit, onRemove} = actions
 
   const onClick = useCallback(e => {
@@ -19,7 +19,7 @@ const TableRow = React.memo(({id, label, complement, secondary, notifications, i
 
   return (
     <Table.Row onClick={onClick}>
-      {isEditingEnabled && isSelectable && (
+      {isEditingEnabled && handleSelect && (
         <Table.Cell flex='0 1 1'>
           <Checkbox
             checked={isSelected}
@@ -41,7 +41,9 @@ const TableRow = React.memo(({id, label, complement, secondary, notifications, i
         </Table.TextCell>
       )}
 
-      {notifications && <TableRowNotifications {...notifications} />}
+      {notifications && (
+        <TableRowNotifications {...notifications} />
+      )}
 
       {isEditingEnabled && actions && (
         <TableRowActions
@@ -59,7 +61,6 @@ TableRow.propTypes = {
   label: PropTypes.string.isRequired,
   complement: PropTypes.string,
   secondary: PropTypes.string,
-  isSelectable: PropTypes.bool,
   handleSelect: PropTypes.func,
   isSelected: PropTypes.bool,
   isEditingEnabled: PropTypes.bool,
@@ -75,7 +76,6 @@ TableRow.defaultProps = {
   complement: null,
   secondary: null,
   notifications: null,
-  isSelectable: false,
   handleSelect: null,
   isSelected: false,
   isEditingEnabled: false

--- a/components/table-row.js
+++ b/components/table-row.js
@@ -2,14 +2,13 @@ import React, {useState, useContext, useCallback, useMemo} from 'react'
 import PropTypes from 'prop-types'
 import {Pane, Table, Position, Tooltip, EditIcon, EndorsedIcon, WarningSignIcon, CommentIcon, Checkbox} from 'evergreen-ui'
 
-import TokenContext from '@/contexts/token'
 import BalDataContext from '@/contexts/bal-data'
-import TableRowActions from './table-row/table-row-actions'
 
-const TableRow = React.memo(({id, label, warning, comment, secondary, isSelectable, isSelected, toponymeId, isCertified, handleSelect, actions}) => {
+import TableRowActions from '@/components/table-row/table-row-actions'
+
+const TableRow = React.memo(({id, label, warning, comment, secondary, isSelectable, isSelected, toponymeId, isEditingEnabled, isCertified, handleSelect, actions}) => {
   const [hovered, setHovered] = useState(false)
-  const {token} = useContext(TokenContext)
-  const {numeros, isEditing, toponymes} = useContext(BalDataContext)
+  const {numeros, toponymes} = useContext(BalDataContext)
   const hasNumero = numeros && numeros.length > 1
 
   const {onSelect, onEdit, onRemove} = actions
@@ -22,12 +21,12 @@ const TableRow = React.memo(({id, label, warning, comment, secondary, isSelectab
   }, [toponymeId, toponymes])
 
   const onClick = useCallback(e => {
-    if (e.target.closest('[data-editable]') && !isEditing && token) {
+    if (e.target.closest('[data-editable]') && isEditingEnabled) {
       onEdit(id)
     } else if (onSelect && e.target.closest('[data-browsable]')) {
       onSelect(id)
     }
-  }, [id, isEditing, token, onEdit, onSelect])
+  }, [id, isEditingEnabled, onEdit, onSelect])
 
   const _onMouseEnter = useCallback(() => {
     if (onEdit) {
@@ -41,7 +40,7 @@ const TableRow = React.memo(({id, label, warning, comment, secondary, isSelectab
 
   return (
     <Table.Row onClick={onClick}>
-      {token && !isEditing && hasNumero && isSelectable && (
+      {isEditingEnabled && hasNumero && isSelectable && (
         <Table.Cell flex='0 1 1'>
           <Checkbox
             checked={isSelected}
@@ -59,20 +58,20 @@ const TableRow = React.memo(({id, label, warning, comment, secondary, isSelectab
         <Table.TextCell
           data-editable
           flex='0 1 1'
-          style={{cursor: onEdit && !isEditing ? 'text' : 'default'}}
+          style={{cursor: isEditingEnabled && onEdit ? 'text' : 'default'}}
           className='edit-cell'
         >
           <Pane padding={1}>
             {label} <i>{toponymeName && ` - ${toponymeName}`}</i>
-            {!isEditing && onEdit && token && (
+            {isEditingEnabled && onEdit && (
               <span className='pencil-icon'>
                 <EditIcon marginBottom={-4} marginLeft={8} />
               </span>
-
             )}
           </Pane>
         </Table.TextCell>
       </Table.Cell>
+
       {secondary && (
         <Table.TextCell flex='0 1 1'>
           {secondary}
@@ -106,7 +105,7 @@ const TableRow = React.memo(({id, label, warning, comment, secondary, isSelectab
         </Table.TextCell>
       )}
 
-      {token && actions && (
+      {isEditingEnabled && actions && (
         <TableRowActions
           onSelect={() => onSelect(id)}
           onEdit={() => onEdit(id)}
@@ -138,6 +137,7 @@ TableRow.propTypes = {
   handleSelect: PropTypes.func,
   isSelected: PropTypes.bool,
   isCertified: PropTypes.bool,
+  isEditingEnabled: PropTypes.bool,
   actions: PropTypes.shape({
     onSelect: PropTypes.func,
     onEdit: PropTypes.func,
@@ -153,7 +153,8 @@ TableRow.defaultProps = {
   isSelectable: false,
   handleSelect: null,
   isSelected: false,
-  isCertified: false
+  isCertified: false,
+  isEditingEnabled: false
 }
 
 export default TableRow

--- a/components/table-row.js
+++ b/components/table-row.js
@@ -5,7 +5,7 @@ import {Pane, Table, Popover, Menu, Position, IconButton, toaster, Tooltip, Edit
 import TokenContext from '@/contexts/token'
 import BalDataContext from '@/contexts/bal-data'
 
-const TableRow = React.memo(({id, code, label, warning, comment, secondary, isSelectable, onSelect, onEdit, onRemove, handleSelect, isSelected, toponymeId, isCertified}) => {
+const TableRow = React.memo(({id, label, warning, comment, secondary, isSelectable, onSelect, onEdit, onRemove, handleSelect, isSelected, toponymeId, isCertified}) => {
   const [hovered, setHovered] = useState(false)
   const {token} = useContext(TokenContext)
   const {numeros, isEditing, toponymes} = useContext(BalDataContext)
@@ -19,12 +19,12 @@ const TableRow = React.memo(({id, code, label, warning, comment, secondary, isSe
   }, [toponymeId, toponymes])
 
   const onClick = useCallback(e => {
-    if (e.target.closest('[data-editable]') && !isEditing && !code && token) { // Not a commune
+    if (e.target.closest('[data-editable]') && !isEditing && token) {
       onEdit(id)
     } else if (onSelect && e.target.closest('[data-browsable]')) {
       onSelect(id)
     }
-  }, [code, id, isEditing, token, onEdit, onSelect])
+  }, [id, isEditing, token, onEdit, onSelect])
 
   const _onEdit = useCallback(() => {
     onEdit(id)
@@ -58,9 +58,7 @@ const TableRow = React.memo(({id, code, label, warning, comment, secondary, isSe
           />
         </Table.Cell>
       )}
-      {code && (
-        <Table.TextCell data-browsable isNumber flex='0 1 1'>{code}</Table.TextCell>
-      )}
+
       <Table.Cell
         data-browsable
         style={onSelect ? {cursor: 'pointer', backgroundColor: hovered ? '#E4E7EB' : '#f5f6f7'} : null}
@@ -159,7 +157,6 @@ const TableRow = React.memo(({id, code, label, warning, comment, secondary, isSe
 
 TableRow.propTypes = {
   id: PropTypes.string.isRequired,
-  code: PropTypes.string,
   warning: PropTypes.string,
   label: PropTypes.string.isRequired,
   comment: PropTypes.string,
@@ -175,7 +172,6 @@ TableRow.propTypes = {
 }
 
 TableRow.defaultProps = {
-  code: null,
   warning: null,
   comment: null,
   toponymeId: null,

--- a/components/table-row.js
+++ b/components/table-row.js
@@ -1,11 +1,12 @@
 import React, {useCallback} from 'react'
 import PropTypes from 'prop-types'
-import {Table, Position, Tooltip, EndorsedIcon, WarningSignIcon, CommentIcon, Checkbox} from 'evergreen-ui'
+import {Table, Checkbox} from 'evergreen-ui'
 
 import TableRowActions from '@/components/table-row/table-row-actions'
 import TableRowEditShortcut from './table-row/table-row-edit-shortcut'
+import TableRowNotifications from './table-row/table-row-notifications'
 
-const TableRow = React.memo(({id, label, complement, warning, comment, secondary, isSelectable, isSelected, isEditingEnabled, isCertified, handleSelect, actions}) => {
+const TableRow = React.memo(({id, label, complement, secondary, notifications, isSelectable, isSelected, isEditingEnabled, handleSelect, actions}) => {
   const {onSelect, onEdit, onRemove} = actions
 
   const onClick = useCallback(e => {
@@ -40,32 +41,7 @@ const TableRow = React.memo(({id, label, complement, warning, comment, secondary
         </Table.TextCell>
       )}
 
-      {comment && (
-        <Table.Cell flex='0 1 1'>
-          <Tooltip
-            content={comment}
-            position={Position.BOTTOM_RIGHT}
-          >
-            <CommentIcon color='muted' />
-          </Tooltip>
-        </Table.Cell>
-      )}
-
-      {isCertified && (
-        <Table.TextCell flex='0 1 1'>
-          <Tooltip content='Cette adresse est certifiée par la commune' position={Position.BOTTOM}>
-            <EndorsedIcon color='success' style={{verticalAlign: 'bottom'}} />
-          </Tooltip>
-        </Table.TextCell>
-      )}
-
-      {warning && (
-        <Table.TextCell flex='0 1 1'>
-          <Tooltip content={warning} position={Position.BOTTOM}>
-            <WarningSignIcon color='warning' style={{verticalAlign: 'bottom'}} />
-          </Tooltip>
-        </Table.TextCell>
-      )}
+      {notifications && <TableRowNotifications {...notifications} />}
 
       {isEditingEnabled && actions && (
         <TableRowActions
@@ -80,16 +56,14 @@ const TableRow = React.memo(({id, label, complement, warning, comment, secondary
 
 TableRow.propTypes = {
   id: PropTypes.string.isRequired,
-  warning: PropTypes.string,
   label: PropTypes.string.isRequired,
   complement: PropTypes.string,
-  comment: PropTypes.string,
   secondary: PropTypes.string,
   isSelectable: PropTypes.bool,
   handleSelect: PropTypes.func,
   isSelected: PropTypes.bool,
-  isCertified: PropTypes.bool,
   isEditingEnabled: PropTypes.bool,
+  notifications: PropTypes.object,
   actions: PropTypes.shape({
     onSelect: PropTypes.func,
     onEdit: PropTypes.func,
@@ -99,13 +73,11 @@ TableRow.propTypes = {
 
 TableRow.defaultProps = {
   complement: null,
-  warning: null,
-  comment: null,
   secondary: null,
+  notifications: null,
   isSelectable: false,
   handleSelect: null,
   isSelected: false,
-  isCertified: false,
   isEditingEnabled: false
 }
 

--- a/components/table-row.js
+++ b/components/table-row.js
@@ -1,13 +1,13 @@
-import React, {useState, useContext, useCallback, useMemo} from 'react'
+import React, {useContext, useCallback, useMemo} from 'react'
 import PropTypes from 'prop-types'
-import {Pane, Table, Position, Tooltip, EditIcon, EndorsedIcon, WarningSignIcon, CommentIcon, Checkbox} from 'evergreen-ui'
+import {Table, Position, Tooltip, EndorsedIcon, WarningSignIcon, CommentIcon, Checkbox} from 'evergreen-ui'
 
 import BalDataContext from '@/contexts/bal-data'
 
 import TableRowActions from '@/components/table-row/table-row-actions'
+import TableRowEditShortcut from './table-row/table-row-edit-shortcut'
 
 const TableRow = React.memo(({id, label, warning, comment, secondary, isSelectable, isSelected, toponymeId, isEditingEnabled, isCertified, handleSelect, actions}) => {
-  const [hovered, setHovered] = useState(false)
   const {numeros, toponymes} = useContext(BalDataContext)
   const hasNumero = numeros && numeros.length > 1
 
@@ -28,16 +28,6 @@ const TableRow = React.memo(({id, label, warning, comment, secondary, isSelectab
     }
   }, [id, isEditingEnabled, onEdit, onSelect])
 
-  const _onMouseEnter = useCallback(() => {
-    if (onEdit) {
-      setHovered(true)
-    }
-  }, [onEdit])
-
-  const _onMouseLeave = useCallback(() => {
-    setHovered(false)
-  }, [])
-
   return (
     <Table.Row onClick={onClick}>
       {isEditingEnabled && hasNumero && isSelectable && (
@@ -49,28 +39,12 @@ const TableRow = React.memo(({id, label, warning, comment, secondary, isSelectab
         </Table.Cell>
       )}
 
-      <Table.Cell
-        data-browsable
-        style={onSelect ? {cursor: 'pointer', backgroundColor: hovered ? '#E4E7EB' : '#f5f6f7'} : null}
-        onMouseEnter={() => _onMouseEnter(id)}
-        onMouseLeave={_onMouseLeave}
-      >
-        <Table.TextCell
-          data-editable
-          flex='0 1 1'
-          style={{cursor: isEditingEnabled && onEdit ? 'text' : 'default'}}
-          className='edit-cell'
-        >
-          <Pane padding={1}>
-            {label} <i>{toponymeName && ` - ${toponymeName}`}</i>
-            {isEditingEnabled && onEdit && (
-              <span className='pencil-icon'>
-                <EditIcon marginBottom={-4} marginLeft={8} />
-              </span>
-            )}
-          </Pane>
-        </Table.TextCell>
-      </Table.Cell>
+      <TableRowEditShortcut
+        label={label}
+        complement={toponymeName}
+        isEditingEnabled={isEditingEnabled}
+        isSelectable={Boolean(onSelect)}
+      />
 
       {secondary && (
         <Table.TextCell flex='0 1 1'>
@@ -112,16 +86,6 @@ const TableRow = React.memo(({id, label, warning, comment, secondary, isSelectab
           onRemove={() => onRemove(id)}
         />
       )}
-
-      <style global jsx>{`
-        .edit-cell .pencil-icon {
-          display: none;
-        }
-
-        .edit-cell:hover .pencil-icon {
-          display: inline-block;
-        }
-        `}</style>
     </Table.Row>
   )
 })

--- a/components/table-row/index.js
+++ b/components/table-row/index.js
@@ -18,7 +18,7 @@ const TableRow = React.memo(({id, label, complement, secondary, notifications, i
   }, [id, isEditingEnabled, onEdit, onSelect])
 
   return (
-    <Table.Row onClick={onClick}>
+    <Table.Row onClick={onClick} paddingRight={8}>
       {isEditingEnabled && handleSelect && (
         <Table.Cell flex='0 1 1'>
           <Checkbox

--- a/components/table-row/index.js
+++ b/components/table-row/index.js
@@ -6,16 +6,16 @@ import TableRowActions from '@/components/table-row/table-row-actions'
 import TableRowEditShortcut from '@/components/table-row/table-row-edit-shortcut'
 import TableRowNotifications from '@/components/table-row/table-row-notifications'
 
-const TableRow = React.memo(({id, label, complement, secondary, notifications, isSelected, isEditingEnabled, handleSelect, actions}) => {
-  const {onSelect, onEdit, onRemove} = actions
+const TableRow = React.memo(({label, complement, secondary, notifications, isSelected, isEditingEnabled, handleSelect, actions}) => {
+  const {onSelect, onEdit} = actions
 
   const onClick = useCallback(e => {
     if (e.target.closest('[data-editable]') && isEditingEnabled) {
-      onEdit(id)
+      onEdit()
     } else if (onSelect && e.target.closest('[data-browsable]')) {
-      onSelect(id)
+      onSelect()
     }
-  }, [id, isEditingEnabled, onEdit, onSelect])
+  }, [isEditingEnabled, onEdit, onSelect])
 
   return (
     <Table.Row onClick={onClick} paddingRight={8}>
@@ -23,7 +23,7 @@ const TableRow = React.memo(({id, label, complement, secondary, notifications, i
         <Table.Cell flex='0 1 1'>
           <Checkbox
             checked={isSelected}
-            onChange={() => handleSelect(id)}
+            onChange={handleSelect}
           />
         </Table.Cell>
       )}
@@ -46,18 +46,13 @@ const TableRow = React.memo(({id, label, complement, secondary, notifications, i
       )}
 
       {isEditingEnabled && actions && (
-        <TableRowActions
-          onSelect={() => onSelect(id)}
-          onEdit={() => onEdit(id)}
-          onRemove={() => onRemove(id)}
-        />
+        <TableRowActions {...actions} />
       )}
     </Table.Row>
   )
 })
 
 TableRow.propTypes = {
-  id: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
   complement: PropTypes.string,
   secondary: PropTypes.string,
@@ -68,7 +63,6 @@ TableRow.propTypes = {
   actions: PropTypes.shape({
     onSelect: PropTypes.func,
     onEdit: PropTypes.func,
-    onRemove: PropTypes.func
   }).isRequired
 }
 

--- a/components/table-row/index.js
+++ b/components/table-row/index.js
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types'
 import {Table, Checkbox} from 'evergreen-ui'
 
 import TableRowActions from '@/components/table-row/table-row-actions'
-import TableRowEditShortcut from './table-row/table-row-edit-shortcut'
-import TableRowNotifications from './table-row/table-row-notifications'
+import TableRowEditShortcut from '@/components/table-row/table-row-edit-shortcut'
+import TableRowNotifications from '@/components/table-row/table-row-notifications'
 
 const TableRow = React.memo(({id, label, complement, secondary, notifications, isSelected, isEditingEnabled, handleSelect, actions}) => {
   const {onSelect, onEdit, onRemove} = actions

--- a/components/table-row/table-row-actions.js
+++ b/components/table-row/table-row-actions.js
@@ -1,0 +1,50 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import {Table, Popover, Menu, Position, IconButton, EditIcon, MoreIcon, SendToMapIcon, TrashIcon} from 'evergreen-ui'
+
+const TableRowActions = React.memo(({onSelect, onEdit, onRemove}) => {
+  return (
+    <Table.TextCell flex='0 1 1'>
+      <Popover
+        position={Position.BOTTOM_LEFT}
+        content={
+          <Menu>
+            <Menu.Group>
+              {onSelect && (
+                <Menu.Item icon={SendToMapIcon} onSelect={onSelect}>
+                  Consulter
+                </Menu.Item>
+              )}
+              {onEdit && (
+                <Menu.Item icon={EditIcon} onSelect={onEdit}>
+                  Modifier
+                </Menu.Item>
+              )}
+              {onRemove && (
+                <Menu.Item icon={TrashIcon} intent='danger' onSelect={onRemove}>
+                  Supprimer…
+                </Menu.Item>
+              )}
+            </Menu.Group>
+          </Menu>
+        }
+      >
+        <IconButton type='button' height={24} icon={MoreIcon} appearance='minimal' />
+      </Popover>
+    </Table.TextCell>
+  )
+})
+
+TableRowActions.propTypes = {
+  onSelect: PropTypes.func,
+  onEdit: PropTypes.func,
+  onRemove: PropTypes.func
+}
+
+TableRowActions.defaultProps = {
+  onEdit: null,
+  onSelect: null,
+  onRemove: null
+}
+
+export default TableRowActions

--- a/components/table-row/table-row-edit-shortcut.js
+++ b/components/table-row/table-row-edit-shortcut.js
@@ -1,0 +1,55 @@
+import React, {useState} from 'react'
+import PropTypes from 'prop-types'
+import {Pane, Table, EditIcon} from 'evergreen-ui'
+
+const TableRowEditShortcut = React.memo(({label, complement, isEditingEnabled, isSelectable}) => {
+  const [hovered, setHovered] = useState(false)
+
+  return (
+    <Table.Cell
+      data-browsable
+      style={isSelectable ? {cursor: 'pointer', backgroundColor: hovered ? '#E4E7EB' : '#fff'} : null}
+      onMouseEnter={() => setHovered(isSelectable)}
+      onMouseLeave={() => setHovered(false)}
+    >
+      <Table.TextCell
+        data-editable
+        flex='0 1 1'
+        style={{cursor: isEditingEnabled ? 'text' : 'pointer'}}
+        className='edit-cell'
+      >
+        <Pane padding={1}>
+          {label} {complement && <i>{` - ${complement}`}</i>}
+          {isEditingEnabled && (
+            <span className='pencil-icon'>
+              <EditIcon marginBottom={-4} marginLeft={8} />
+            </span>
+          )}
+        </Pane>
+      </Table.TextCell>
+
+      <style global jsx>{`
+        .edit-cell .pencil-icon {
+          display: none;
+        }
+
+        .edit-cell:hover .pencil-icon {
+          display: inline-block;
+        }
+        `}</style>
+    </Table.Cell>
+  )
+})
+
+TableRowEditShortcut.propTypes = {
+  label: PropTypes.string.isRequired,
+  complement: PropTypes.string,
+  isEditingEnabled: PropTypes.bool.isRequired,
+  isSelectable: PropTypes.bool.isRequired
+}
+
+TableRowEditShortcut.defaultProps = {
+  complement: null
+}
+
+export default TableRowEditShortcut

--- a/components/table-row/table-row-notifications.js
+++ b/components/table-row/table-row-notifications.js
@@ -1,0 +1,49 @@
+import PropTypes from 'prop-types'
+import {Table, Position, Tooltip, EndorsedIcon, WarningSignIcon, CommentIcon} from 'evergreen-ui'
+
+function TableRowNotifications({isCertified, comment, warning}) {
+  return (
+    <>
+      {comment && (
+        <Table.Cell flex='0 1 1'>
+          <Tooltip
+            content={comment}
+            position={Position.BOTTOM_RIGHT}
+          >
+            <CommentIcon color='muted' />
+          </Tooltip>
+        </Table.Cell>
+      )}
+
+      {isCertified && (
+        <Table.TextCell flex='0 1 1'>
+          <Tooltip content='Cette adresse est certifiée par la commune' position={Position.BOTTOM}>
+            <EndorsedIcon color='success' style={{verticalAlign: 'bottom'}} />
+          </Tooltip>
+        </Table.TextCell>
+      )}
+
+      {warning && (
+        <Table.TextCell flex='0 1 1'>
+          <Tooltip content={warning} position={Position.BOTTOM}>
+            <WarningSignIcon color='warning' style={{verticalAlign: 'bottom'}} />
+          </Tooltip>
+        </Table.TextCell>
+      )}
+    </>
+  )
+}
+
+TableRowNotifications.propTypes = {
+  isCertified: PropTypes.bool,
+  comment: PropTypes.string,
+  warning: PropTypes.string
+}
+
+TableRowNotifications.defaultProps = {
+  isCertified: null,
+  comment: null,
+  warning: null
+}
+
+export default TableRowNotifications

--- a/components/voie/numeros-list.js
+++ b/components/voie/numeros-list.js
@@ -197,9 +197,6 @@ function NumerosList({token, voieId, numeros, isEditionDisabled, handleEditing})
             key={numero._id}
             {...numero}
             id={numero._id}
-            isCertified={numero.certifie}
-            comment={numero.comment}
-            warning={numero.positions.some(p => p.type === 'inconnue') ? 'Le type d’une position est inconnu' : null}
             isSelectable={!isEditionDisabled && filtered.length > 1}
             label={numero.numeroComplet}
             secondary={numero.positions.length > 1 ? `${numero.positions.length} positions` : null}
@@ -207,6 +204,11 @@ function NumerosList({token, voieId, numeros, isEditionDisabled, handleEditing})
             handleSelect={handleSelect}
             isSelected={selectedNumerosIds.includes(numero._id)}
             isEditingEnabled={Boolean(!isEditing && token)}
+            notifications={{
+              isCertified: numero.certifie,
+              comment: numero.comment,
+              warning: numero.positions.some(p => p.type === 'inconnue') ? 'Le type d’une position est inconnu' : null
+            }}
             actions={{
               onRemove,
               onEdit: handleEditing

--- a/components/voie/numeros-list.js
+++ b/components/voie/numeros-list.js
@@ -17,7 +17,7 @@ function NumerosList({token, voieId, numeros, isEditionDisabled, handleEditing})
   const [selectedNumerosIds, setSelectedNumerosIds] = useState([])
   const [error, setError] = useState(null)
 
-  const {reloadNumeros, refreshBALSync} = useContext(BalDataContext)
+  const {isEditing, reloadNumeros, refreshBALSync} = useContext(BalDataContext)
 
   const [filtered, setFilter] = useFuse(numeros, 200, {
     keys: [
@@ -199,6 +199,7 @@ function NumerosList({token, voieId, numeros, isEditionDisabled, handleEditing})
             toponymeId={numero.toponyme}
             handleSelect={handleSelect}
             isSelected={selectedNumerosIds.includes(numero._id)}
+            isEditingEnabled={Boolean(!isEditing && token)}
             actions={{
               onRemove,
               onEdit: handleEditing

--- a/components/voie/numeros-list.js
+++ b/components/voie/numeros-list.js
@@ -17,7 +17,7 @@ function NumerosList({token, voieId, numeros, isEditionDisabled, handleEditing})
   const [selectedNumerosIds, setSelectedNumerosIds] = useState([])
   const [error, setError] = useState(null)
 
-  const {isEditing, reloadNumeros, refreshBALSync} = useContext(BalDataContext)
+  const {isEditing, reloadNumeros, toponymes, refreshBALSync} = useContext(BalDataContext)
 
   const [filtered, setFilter] = useFuse(numeros, 200, {
     keys: [
@@ -44,6 +44,13 @@ function NumerosList({token, voieId, numeros, isEditionDisabled, handleEditing})
 
     return filteredCertifieNumeros?.length === selectedNumerosIds.length
   }, [numeros, selectedNumerosIds])
+
+  const getToponymeName = useCallback(toponymeId => {
+    if (toponymeId) {
+      const toponyme = toponymes.find(({_id}) => _id === toponymeId)
+      return toponyme?.nom
+    }
+  }, [toponymes])
 
   const handleSelect = useCallback(id => {
     setSelectedNumerosIds(selectedNumero => {
@@ -193,10 +200,10 @@ function NumerosList({token, voieId, numeros, isEditionDisabled, handleEditing})
             isCertified={numero.certifie}
             comment={numero.comment}
             warning={numero.positions.some(p => p.type === 'inconnue') ? 'Le type d’une position est inconnu' : null}
-            isSelectable={!isEditionDisabled}
+            isSelectable={!isEditionDisabled && filtered.length > 1}
             label={numero.numeroComplet}
             secondary={numero.positions.length > 1 ? `${numero.positions.length} positions` : null}
-            toponymeId={numero.toponyme}
+            complement={getToponymeName(numero.toponyme)}
             handleSelect={handleSelect}
             isSelected={selectedNumerosIds.includes(numero._id)}
             isEditingEnabled={Boolean(!isEditing && token)}

--- a/components/voie/numeros-list.js
+++ b/components/voie/numeros-list.js
@@ -70,7 +70,7 @@ function NumerosList({token, voieId, numeros, isEditionDisabled, handleEditing})
     }
   }
 
-  const onRemove = useCallback(async (idNumero, isToasterDisabled) => {
+  const onRemove = useCallback(async (idNumero, isToasterDisabled = false) => {
     await removeNumero(idNumero, token, isToasterDisabled)
     await reloadNumeros()
     refreshBALSync()
@@ -195,11 +195,10 @@ function NumerosList({token, voieId, numeros, isEditionDisabled, handleEditing})
         {filtered.map(numero => (
           <TableRow
             key={numero._id}
-            id={numero._id}
             label={numero.numeroComplet}
             secondary={numero.positions.length > 1 ? `${numero.positions.length} positions` : null}
             complement={getToponymeName(numero.toponyme)}
-            handleSelect={!isEditionDisabled && filtered.length > 1 ? handleSelect : null}
+            handleSelect={!isEditionDisabled && filtered.length > 1 ? () => handleSelect(numero._id) : null}
             isSelected={selectedNumerosIds.includes(numero._id)}
             isEditingEnabled={Boolean(!isEditing && token)}
             notifications={{
@@ -208,8 +207,8 @@ function NumerosList({token, voieId, numeros, isEditionDisabled, handleEditing})
               warning: numero.positions.some(p => p.type === 'inconnue') ? 'Le type d’une position est inconnu' : null
             }}
             actions={{
-              onRemove,
-              onEdit: handleEditing
+              onRemove: () => onRemove(numero._id),
+              onEdit: () => handleEditing(numero._id)
             }}
           />
         ))}

--- a/components/voie/numeros-list.js
+++ b/components/voie/numeros-list.js
@@ -199,8 +199,10 @@ function NumerosList({token, voieId, numeros, isEditionDisabled, handleEditing})
             toponymeId={numero.toponyme}
             handleSelect={handleSelect}
             isSelected={selectedNumerosIds.includes(numero._id)}
-            onEdit={handleEditing}
-            onRemove={onRemove}
+            actions={{
+              onRemove,
+              onEdit: handleEditing
+            }}
           />
         ))}
       </Pane>

--- a/components/voie/numeros-list.js
+++ b/components/voie/numeros-list.js
@@ -195,13 +195,11 @@ function NumerosList({token, voieId, numeros, isEditionDisabled, handleEditing})
         {filtered.map(numero => (
           <TableRow
             key={numero._id}
-            {...numero}
             id={numero._id}
-            isSelectable={!isEditionDisabled && filtered.length > 1}
             label={numero.numeroComplet}
             secondary={numero.positions.length > 1 ? `${numero.positions.length} positions` : null}
             complement={getToponymeName(numero.toponyme)}
-            handleSelect={handleSelect}
+            handleSelect={!isEditionDisabled && filtered.length > 1 ? handleSelect : null}
             isSelected={selectedNumerosIds.includes(numero._id)}
             isEditingEnabled={Boolean(!isEditing && token)}
             notifications={{

--- a/pages/bal/commune.js
+++ b/pages/bal/commune.js
@@ -16,7 +16,6 @@ import ToponymesList from '@/components/bal/toponymes-list'
 
 const Commune = React.memo(({baseLocale, commune}) => {
   const [isAdding, setIsAdding] = useState(false)
-  const [isPopulating, setIsPopulating] = useState(false)
   const [toRemove, setToRemove] = useState(null)
   const [selectedTab, setSelectedTab] = useState('voie')
 
@@ -39,13 +38,13 @@ const Commune = React.memo(({baseLocale, commune}) => {
   useHelp(selectedTab === 'voie' ? 1 : 2)
 
   const onPopulate = useCallback(async () => {
-    setIsPopulating(true)
+    setIsEditing(true)
 
     await populateCommune(baseLocale._id, commune.code, token)
     await reloadVoies()
 
-    setIsPopulating(false)
-  }, [baseLocale._id, commune, reloadVoies, token])
+    setIsEditing(false)
+  }, [baseLocale._id, commune, reloadVoies, setIsEditing, token])
 
   const onAdd = useCallback(async ({nom, positions, typeNumerotation, trace, parcelles}) => {
     if (selectedTab === 'voie') {
@@ -216,7 +215,7 @@ const Commune = React.memo(({baseLocale, commune}) => {
               iconBefore={AddIcon}
               appearance='primary'
               intent='success'
-              disabled={isAdding || isPopulating || Boolean(editingId) || isEditing}
+              disabled={isAdding || isEditing}
               onClick={() => setIsAdding(true)}
             >
               Ajouter {selectedTab === 'voie' ? 'une voie' : 'un toponyme'}
@@ -228,7 +227,6 @@ const Commune = React.memo(({baseLocale, commune}) => {
       {selectedTab === 'voie' ? (
         <VoiesList
           voies={voies}
-          isPopulating={isPopulating}
           isAdding={isAdding}
           setToRemove={setToRemove}
           onEnableEditing={onEnableEditing}
@@ -240,7 +238,6 @@ const Commune = React.memo(({baseLocale, commune}) => {
       ) : (
         <ToponymesList
           toponymes={toponymes}
-          isPopulating={isPopulating}
           isAdding={isAdding}
           setToRemove={setToRemove}
           onEnableEditing={onEnableEditing}
@@ -256,8 +253,14 @@ const Commune = React.memo(({baseLocale, commune}) => {
           <Paragraph size={300} color='muted'>
             Vous souhaitez importer les voies de la commune de {commune.nom} depuis la Base Adresse Nationale ?
           </Paragraph>
-          <Button marginTop={10} appearance='primary' disabled={isAdding || isPopulating} onClick={onPopulate}>
-            Importer les données de la BAN
+          <Button
+            marginTop={10}
+            appearance='primary'
+            disabled={isAdding || isEditing}
+            isLoading={isEditing}
+            onClick={onPopulate}
+          >
+            {isEditing ? 'Récupération des adresses…' : 'Récupérer les adresses de la BAN'}
           </Button>
         </Pane>
       )}


### PR DESCRIPTION
## Contexte
Le composant `<TableRow />` est un composant crucial et hautement utilisé dans l'outil. En effet, celui-ci s'occupe de la gestion des voies, toponymes et numéros dans leur liste respective. Il doit donc à la fois gérer les différents affichages (voie, toponyme, numéro) et leurs subtilités propres, permettre les différentes éditions possibles, mais dois également offrir un affichage sans aucune édition.

Il est devenu au fur et à mesure du temps un composant "fourre tout", d'une grande complexité et d'une rigidité ne permettant aucune évolution.

## Évolutions
Cette PR propose de modifier le composant `<TableRow />` afin que celui-ci soit de nouveau réutilisable par les différents objet possible (voie, toponyme, numéro), que sa complexité soit éclatée dans différent composant dédié et qu'il prépare les futures évolutions permettant une séparation simple des modes de consultation et d'édition.

### Synthèse des évolutions
- Tous les contextes ont été supprimés de `<TableRow />` afin de donner le contrôle du contexte au parent
- Les variables inutiles ont été retirées ou fusionnées (ex : `isSelected` et `handleSelect`, désormais si `handleSelect` est défini, c'est que l'objet peut être sélectionné)
- `EditingEnabled` est désormais la seule variable qui permet de passer du mode consultation à édition

### Nouveaux composants dédiés
- `<TableRowActions />` regroupe les différentes actions (consulter, éditer et supprimer)
- `<TableRowEditShortcut />` encapsule la complexité apportée par le raccourci d'édition
- `<TableRowNotifications />` regroupe les différentes notifications (certification, commentaire et avertissement)` 

----
### Autres modifications mineures
- Ajout d'un `paddingRight` afin de ne pas être gêné par la barre de défilement
- Homogénéisation du fond (fond blanc par défaut et grisé au survol)
- Suppression du state `isPopulating` qui a été remplacé par `isEditing`