### PR TITLE
Corrige un problème d‘affichage du badge "synchronisation en cours"

### DIFF
--- a/components/map/numeros-markers.js
+++ b/components/map/numeros-markers.js
@@ -16,7 +16,7 @@ function NumerosMarkers({numeros, voie, isLabelDisplayed, isContextMenuDisplayed
   const [setError] = useError()
 
   const {token} = useContext(TokenContext)
-  const {setEditingId, isEditing, reloadNumeros} = useContext(BalDataContext)
+  const {setEditingId, isEditing, reloadNumeros, refreshBALSync} = useContext(BalDataContext)
 
   const onEnableEditing = useCallback((e, numeroId) => {
     e.stopPropagation()
@@ -70,12 +70,13 @@ function NumerosMarkers({numeros, voie, isLabelDisplayed, isContextMenuDisplayed
     try {
       await removeNumero(numeroId, token)
       await reloadNumeros()
+      refreshBALSync()
     } catch (error) {
       setError(error.message)
     }
 
     setIsContextMenuDisplayed(null)
-  }, [token, reloadNumeros, setError, setIsContextMenuDisplayed])
+  }, [token, reloadNumeros, setError, setIsContextMenuDisplayed, refreshBALSync])
 
   return (
     numeros.map(numero => (


### PR DESCRIPTION
Lorsqu'une modification est apportée à une Base Adresse Locale **publiée**, le status "Synchronisation en cours" apparait.

Si le status apparaissait bien lors de la suppression depuis la liste des numéros, ce n'était pas le cas lors de la suppression depuis un marqueur de la carte.

Cette PR ajoute la fonction `refreshBALSync` dans le composant `numeros-markers` afin d’afficher le badge de synchronisation après une modification depuis la carte.


Fix #543 