### PR TITLE
Fix csv import

### DIFF
--- a/components/new/upload-form.js
+++ b/components/new/upload-form.js
@@ -30,10 +30,10 @@ function getFileExtension(name) {
 
 function extractCommuneFromCSV(response) {
   // Get cle_interop and slice it to get the commune's code
-  const communes = response.rows.map(r => (
+  const communes = response.rows.map(({parsedValues, additionalValues}) => (
     {
-      code: r.parsedValues.cle_interop?.toUpperCase().slice(0, 5),
-      nom: r.parsedValues.commune_nom
+      code: parsedValues.commune_insee || additionalValues?.cle_interop?.codeCommune,
+      nom: parsedValues.commune_nom
     }
   ))
 

--- a/components/new/upload-form.js
+++ b/components/new/upload-form.js
@@ -32,7 +32,7 @@ function extractCommuneFromCSV(response) {
   // Get cle_interop and slice it to get the commune's code
   const communes = response.rows.map(r => (
     {
-      code: r.parsedValues.cle_interop.slice(0, 5),
+      code: r.parsedValues.cle_interop?.toUpperCase().slice(0, 5),
       nom: r.parsedValues.commune_nom
     }
   ))


### PR DESCRIPTION
## Contexte
Un problème de comparaison entre code commune et clé interopérabilité a été découvert côté API lors de l'extraction des données [#323](https://github.com/BaseAdresseNationale/mes-adresses-api/pull/323).
Une comparaison semblable est également faite côté front afin d'extraire un code commune depuis la clé interopérabilité.

## Modification
La `cle_interop` est passée en majuscule quand elle existe dans le but de concorder avec les codes communes utilisant des lettres (ex: 2B112)

**Mise à jour** :
Le code commune est extrait de `additionalValues.cle_interop.codeCommune` ou de `parsedValues.commune_insee`.