### PR TITLE
Amélioration du système de sélection de numéros pour les toponymes

### DIFF
--- a/components/toponyme/add-numeros.js
+++ b/components/toponyme/add-numeros.js
@@ -105,7 +105,7 @@ function AddNumeros({onSubmit, onCancel, isLoading}) {
               isMultiSelect
               hasFilter={false}
               title='Sélection des numéros'
-              options={numeroOptions}
+              options={voieNumeros.length > 0 ? numeroOptions : []}
               selected={selectedVoieNumeros}
               emptyView={(
                 <Pane height='100%' paddingX='1em' display='flex' alignItems='center' justifyContent='center' textAlign='center'>
@@ -120,7 +120,7 @@ function AddNumeros({onSubmit, onCancel, isLoading}) {
               </Button>
             </SelectMenu>
 
-            <Text size={300} fontStyle='italic' color='#2E56CD'>{selectedVoiesCount}</Text>
+            {voieNumeros.length > 0 && <Text size={300} fontStyle='italic' color='#2E56CD'>{selectedVoiesCount}</Text>}
           </Pane>
         )}
 

--- a/components/toponyme/add-numeros.js
+++ b/components/toponyme/add-numeros.js
@@ -70,9 +70,14 @@ function AddNumeros({onSubmit, onCancel, isLoading}) {
   }, [selectedVoieNumeros.length, voieNumeros.length])
 
   const numeroOptions = useMemo(() => {
-    const toggleFullSelect = {label: selectedVoieNumeros.length > 0 ? 'Désélectionner tous les numéros' : 'Sélectionner tous les numéros', value: 'toggle'}
-    const options = [toggleFullSelect]
-    voieNumeros.map(({_id, numero, suffixe}) => options.push({label: `${numero}${suffixe ? suffixe : ''}`, value: _id}))
+    let options = []
+
+    if (voieNumeros.length > 0) {
+      const toggleFullSelect = {label: selectedVoieNumeros.length > 0 ? 'Désélectionner tous les numéros' : 'Sélectionner tous les numéros', value: 'toggle'}
+      const numeros = voieNumeros.map(({_id, numero, suffixe}) => ({label: `${numero}${suffixe ? suffixe : ''}`, value: _id}))
+
+      options = [toggleFullSelect, ...numeros]
+    }
 
     return options
   }, [selectedVoieNumeros, voieNumeros])
@@ -105,7 +110,7 @@ function AddNumeros({onSubmit, onCancel, isLoading}) {
               isMultiSelect
               hasFilter={false}
               title='Sélection des numéros'
-              options={voieNumeros.length > 0 ? numeroOptions : []}
+              options={numeroOptions}
               selected={selectedVoieNumeros}
               emptyView={(
                 <Pane height='100%' paddingX='1em' display='flex' alignItems='center' justifyContent='center' textAlign='center'>

--- a/components/toponyme/add-numeros.js
+++ b/components/toponyme/add-numeros.js
@@ -1,7 +1,7 @@
 import {useState, useCallback, useContext, useMemo} from 'react'
 import PropTypes from 'prop-types'
 import {sortBy} from 'lodash'
-import {SelectField, SelectMenu, Pane, Button, Alert, Text} from 'evergreen-ui'
+import {SelectField, SelectMenu, Pane, Button, Text} from 'evergreen-ui'
 
 import {normalizeSort} from '@/lib/normalize'
 import {getNumeros} from '@/lib/bal-api'
@@ -23,31 +23,25 @@ function AddNumeros({onSubmit, onCancel, isLoading}) {
     if (idVoie) {
       const numeros = await getNumeros(idVoie)
       setVoieNumeros(numeros)
+      setSelectedVoieNumeros(numeros.map(({_id}) => _id))
     }
   }
 
   const handleSelectNumero = ({value}) => {
-    setSelectedVoieNumeros(selectedNumeros => {
-      return selectedNumeros.includes(value) ?
-        selectedNumeros.filter(id => id !== value) :
-        [...selectedNumeros, value]
-    })
+    if (value === 'toggle') {
+      if (selectedVoieNumeros.length === voieNumeros.length) {
+        setSelectedVoieNumeros([])
+      } else {
+        setSelectedVoieNumeros(voieNumeros.map(({_id}) => _id))
+      }
+    } else {
+      setSelectedVoieNumeros(selectedNumeros => {
+        return selectedNumeros.includes(value) ?
+          selectedNumeros.filter(id => id !== value) :
+          [...selectedNumeros, value]
+      })
+    }
   }
-
-  const numerosLabel = useMemo(() => {
-    const selectedNumeroCount = selectedVoieNumeros.length
-    if (selectedNumeroCount === 0) {
-      return 'Choisir les numéros'
-    }
-
-    if (selectedNumeroCount === 1) {
-      const numero = voieNumeros.find(({_id}) => _id === selectedVoieNumeros[0])
-      const voie = voies.find(({_id}) => _id === selectedVoieId)
-      return `le ${numero.numero} ${voie.nom}`
-    }
-
-    return `${selectedNumeroCount} numéros sélectionnés`
-  }, [selectedVoieId, voieNumeros, selectedVoieNumeros, voies])
 
   const handleSubmit = useCallback(event => {
     event.preventDefault()
@@ -58,6 +52,30 @@ function AddNumeros({onSubmit, onCancel, isLoading}) {
 
     onSubmit(numeros)
   }, [selectedVoieNumeros, voieNumeros, onSubmit])
+
+  const selectedVoiesCount = useMemo(() => {
+    if (selectedVoieNumeros.length === voieNumeros.length) {
+      return 'Tous les numéros sont sélectionnés'
+    }
+
+    if (selectedVoieNumeros.length === 0) {
+      return 'Aucun numéro n’est sélectionné'
+    }
+
+    if (selectedVoieNumeros.length === 1) {
+      return '1 numéro est sélectionné'
+    }
+
+    return `${selectedVoieNumeros.length} numéros sont sélectionnés`
+  }, [selectedVoieNumeros.length, voieNumeros.length])
+
+  const numeroOptions = useMemo(() => {
+    const toggleFullSelect = {label: selectedVoieNumeros.length > 0 ? 'Désélectionner tous les numéros' : 'Sélectionner tous les numéros', value: 'toggle'}
+    const options = [toggleFullSelect]
+    voieNumeros.map(({_id, numero, suffixe}) => options.push({label: `${numero}${suffixe ? suffixe : ''}`, value: _id}))
+
+    return options
+  }, [selectedVoieNumeros, voieNumeros])
 
   return (
     <Pane>
@@ -82,32 +100,28 @@ function AddNumeros({onSubmit, onCancel, isLoading}) {
         </Pane>
 
         {selectedVoieId && (
-          <Alert marginY={8} title='Préciser les numéros à ajouter au toponyme'>
-            <Text>
-              Sélectionnez les numéros que vous souhaitez ajouter au toponyme. Si aucun numéro n’est spécifié, alors tous les numéros de la voie seront ajoutés.
-            </Text>
+          <Pane display='flex' justifyContent='space-between' alignItems='center' marginY={8}>
+            <SelectMenu
+              isMultiSelect
+              hasFilter={false}
+              title='Sélection des numéros'
+              options={numeroOptions}
+              selected={selectedVoieNumeros}
+              emptyView={(
+                <Pane height='100%' paddingX='1em' display='flex' alignItems='center' justifyContent='center' textAlign='center'>
+                  <Text size={300}>Aucun numéro n’est disponible pour cette voie</Text>
+                </Pane>
+              )}
+              onSelect={handleSelectNumero}
+              onDeselect={handleSelectNumero}
+            >
+              <Button marginTop={0} type='button'>
+                Sélectionner les numéros
+              </Button>
+            </SelectMenu>
 
-            <Pane diplay='flex'>
-              <SelectMenu
-                isMultiSelect
-                hasFilter={false}
-                title='Sélection des numéros'
-                options={voieNumeros.map(({_id, numero, suffixe}) => ({label: `${numero}${suffixe ? suffixe : ''}`, value: _id}))}
-                selected={selectedVoieNumeros}
-                emptyView={(
-                  <Pane height='100%' paddingX='1em' display='flex' alignItems='center' justifyContent='center' textAlign='center'>
-                    <Text size={300}>Aucun numéro n’est disponible pour cette voie</Text>
-                  </Pane>
-                )}
-                onSelect={handleSelectNumero}
-                onDeselect={handleSelectNumero}
-              >
-                <Button marginTop={8} type='button'>
-                  {numerosLabel}
-                </Button>
-              </SelectMenu>
-            </Pane>
-          </Alert>
+            <Text size={300} fontStyle='italic' color='#2E56CD'>{selectedVoiesCount}</Text>
+          </Pane>
         )}
 
         <Button
@@ -115,7 +129,7 @@ function AddNumeros({onSubmit, onCancel, isLoading}) {
           type='submit'
           appearance='primary'
           intent='success'
-          disabled={!(selectedVoieId && voieNumeros.length > 0)}
+          disabled={!(selectedVoieId && voieNumeros.length > 0) || selectedVoieNumeros.length === 0}
         >
           {isLoading ? 'Enregistrement…' : 'Enregistrer'}
         </Button>


### PR DESCRIPTION
Le système de sélection des numéros pour les toponymes souffrait de problèmes de clarté pour l'utilisateur.
La refonte complète de cette section permet à l'utilisateur de facilement sélectionner/désélectionner les numéros sans avoir besoin de consignes pour le guider.

- Tous les numéros sont sélectionnés par défaut
- En plus de la sélection individuelle, l'utilisateur a la possibilité de sélectionner / désélectionner l'entièreté des numéros
- La quantité totale de numéros sélectionnés s'affichent à droite du bouton

### **AVANT**
![Capture d’écran 2022-04-13 à 15 15 51](https://user-images.githubusercontent.com/66621960/163188481-1bf96afa-7c8f-4c91-9dcd-ce64d501f955.png)

### **APRÈS**
![Capture d’écran 2022-04-13 à 14 58 23](https://user-images.githubusercontent.com/66621960/163186161-e9feb48e-f004-46f0-9776-ff0d28656111.png)
![Capture d’écran 2022-04-13 à 14 58 32](https://user-images.githubusercontent.com/66621960/163186158-92972347-3161-413a-ade3-655d121e6145.png)
![Capture d’écran 2022-04-13 à 14 58 41](https://user-images.githubusercontent.com/66621960/163186152-a829f667-c06e-4bae-9c75-57b96a962bb6.png)

