### PR TITLE
Correction du rafraîchissement des données cartographiques 

### DIFF
--- a/components/map/numeros-markers.js
+++ b/components/map/numeros-markers.js
@@ -1,4 +1,4 @@
-import {useCallback, useContext, useEffect} from 'react'
+import {useCallback, useContext, useEffect, useRef} from 'react'
 import PropTypes from 'prop-types'
 import {css} from 'glamor'
 import randomColor from 'randomcolor'
@@ -12,13 +12,13 @@ import useError from '@/hooks/error'
 
 import NumeroMarker from '@/components/map/numero-marker'
 
-let needGeojsonUpdate = true
-
 function NumerosMarkers({numeros, voie, isLabelDisplayed, isContextMenuDisplayed, setIsContextMenuDisplayed}) {
   const [setError] = useError()
 
   const {token} = useContext(TokenContext)
   const {setEditingId, isEditing, reloadNumeros, reloadGeojson, refreshBALSync} = useContext(BalDataContext)
+
+  const needGeojsonUpdateRef = useRef(false)
 
   const onEnableEditing = useCallback((e, numeroId) => {
     e.stopPropagation()
@@ -72,7 +72,7 @@ function NumerosMarkers({numeros, voie, isLabelDisplayed, isContextMenuDisplayed
     try {
       await removeNumero(numeroId, token)
       await reloadNumeros()
-      needGeojsonUpdate = true
+      needGeojsonUpdateRef.current = true
       refreshBALSync()
     } catch (error) {
       setError(error.message)
@@ -83,9 +83,9 @@ function NumerosMarkers({numeros, voie, isLabelDisplayed, isContextMenuDisplayed
 
   useEffect(() => {
     return () => {
-      if (needGeojsonUpdate) {
+      if (needGeojsonUpdateRef.current) {
         reloadGeojson()
-        needGeojsonUpdate = false
+        needGeojsonUpdateRef.current = false
       }
     }
   }, [voie, reloadGeojson])

--- a/pages/bal/voie.js
+++ b/pages/bal/voie.js
@@ -1,4 +1,4 @@
-import React, {useState, useCallback, useEffect, useMemo, useContext} from 'react'
+import React, {useState, useCallback, useEffect, useMemo, useRef, useContext} from 'react'
 import PropTypes from 'prop-types'
 import {Pane, Table} from 'evergreen-ui'
 
@@ -13,14 +13,13 @@ import NumeroEditor from '@/components/bal/numero-editor'
 import VoieHeading from '@/components/voie/voie-heading'
 import NumerosList from '@/components/voie/numeros-list'
 
-let needGeojsonUpdate = false
-
 const Voie = React.memo(({baseLocale, commune}) => {
   const [isFormOpen, setIsFormOpen] = useState(false)
 
   useHelp(3)
 
   const {token} = useContext(TokenContext)
+  const needGeojsonUpdateRef = useRef(false)
 
   const {
     voie,
@@ -54,7 +53,7 @@ const Voie = React.memo(({baseLocale, commune}) => {
 
   const handleGeojsonRefresh = useCallback(async editedVoie => {
     if (editedVoie._id === voie._id) {
-      needGeojsonUpdate = true
+      needGeojsonUpdateRef.current = true
     } else {
       await reloadGeojson()
     }
@@ -107,9 +106,9 @@ const Voie = React.memo(({baseLocale, commune}) => {
 
   useEffect(() => {
     return () => {
-      if (needGeojsonUpdate) {
+      if (needGeojsonUpdateRef.current) {
         reloadGeojson()
-        needGeojsonUpdate = false
+        needGeojsonUpdateRef.current = false
       }
     }
   }, [voie, reloadGeojson])


### PR DESCRIPTION
## Contexte
Lorsqu'un numéro est créé ou modifié, les données cartographiques `geojson` sont mises à jour uniquement si le numéro ne fais pas partie de la voie courante (ex : Changement de la voie du numéro). Cependant, le rechargement du `geojson` ne se faisant plus à chaque changement de voie comme précédemment pour des raisons de performances, les données n'étaient plus mises à jour.

## Correctif
Le nécessité de recharger les données cartographiques est désormais détectée, grâce à une variable `needGeojsonUpdate` extérieur au composant. Au lieu d'être effectuée à chaque modification et inutilement (la voie en cours étant filtrée pour afficher les marqueurs) la mise à jour des données ne se fera que si des changements ont été détectés et lorsqu'une nouvelle voie est chargée.

Fix #553