### PR TITLE
Add 30s duration on error publication toaster

### DIFF
--- a/lib/bal-api/index.js
+++ b/lib/bal-api/index.js
@@ -108,6 +108,7 @@ export async function sync(balId, token) {
     return response
   } catch (error) {
     toaster.danger('Impossible de mettre à jour la Base Adresses Nationale', {
+      duration: 30,
       description: error.message
     })
   }


### PR DESCRIPTION
## Contexte
Le message d'erreur afficher lorsqu'une tentative de publication échoue ne reste affiché que 5 secondes (valeur par défaut). Or ce message pouvant s'afficher lorsqu'une BAL n'est pas valide, il est important que les utilisateurs aient le temps de voir et de lire la notification les invitants à contacter le support.

## Modification
Cette PR augmente à 30 secondes le temps d'affichage de la notification.