### PR TITLE
Refonte du montage et démontage des composants d’édition

### DIFF
--- a/components/bal/numero-editor.js
+++ b/components/bal/numero-editor.js
@@ -26,7 +26,7 @@ import AddressPreview from '@/components/bal/address-preview'
 const REMOVE_TOPONYME_LABEL = 'Aucun toponyme'
 
 function NumeroEditor({initialVoieId, initialValue, commune, hasPreview, onSubmit, onCancel}) {
-  const {voies, toponymes, setIsEditing} = useContext(BalDataContext)
+  const {voies, toponymes} = useContext(BalDataContext)
   const {selectedParcelles, setSelectedParcelles, setIsParcelleSelectionEnabled} = useContext(ParcellesContext)
 
   const [voieId, setVoieId] = useState(initialVoieId || initialValue?.voie._id)
@@ -134,14 +134,13 @@ function NumeroEditor({initialVoieId, initialValue, commune, hasPreview, onSubmi
   }, [setOverrideText, numero, suffixe])
 
   useEffect(() => {
-    setIsEditing(true)
     setIsParcelleSelectionEnabled(true)
     return () => {
+      onCancel()
       disableMarkers()
-      setIsEditing(false)
       setIsParcelleSelectionEnabled(false)
     }
-  }, [setIsEditing, disableMarkers, setIsParcelleSelectionEnabled])
+  }, [disableMarkers, setIsParcelleSelectionEnabled, onCancel])
 
   useEffect(() => {
     let nom = null

--- a/components/bal/toponyme-editor.js
+++ b/components/bal/toponyme-editor.js
@@ -2,7 +2,6 @@ import {useState, useMemo, useContext, useCallback, useEffect} from 'react'
 import PropTypes from 'prop-types'
 import {Button, Alert} from 'evergreen-ui'
 
-import BalDataContext from '@/contexts/bal-data'
 import MarkersContext from '@/contexts/markers'
 import ParcellesContext from '@/contexts/parcelles'
 
@@ -16,7 +15,6 @@ import PositionEditor from '@/components/bal/position-editor'
 import SelectParcelles from '@/components/bal/numero-editor/select-parcelles'
 
 function ToponymeEditor({initialValue, onSubmit, onCancel}) {
-  const {setIsEditing} = useContext(BalDataContext)
   const {markers, addMarker, disableMarkers} = useContext(MarkersContext)
   const {selectedParcelles, setSelectedParcelles, setIsParcelleSelectionEnabled} = useContext(ParcellesContext)
 
@@ -87,17 +85,6 @@ function ToponymeEditor({initialValue, onSubmit, onCancel}) {
   }, [resetNom, setError, setSelectedParcelles, initialValue])
 
   useEffect(() => {
-    setIsEditing(true)
-    setIsParcelleSelectionEnabled(true)
-
-    return () => {
-      setIsEditing(false)
-      setIsParcelleSelectionEnabled(false)
-      disableMarkers()
-    }
-  }, [setIsEditing, disableMarkers, setIsParcelleSelectionEnabled])
-
-  useEffect(() => {
     if (initialValue) {
       const positions = initialValue.positions.map(position => (
         {
@@ -112,6 +99,17 @@ function ToponymeEditor({initialValue, onSubmit, onCancel}) {
       addMarker({type: 'segment'})
     }
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    setIsParcelleSelectionEnabled(true)
+
+    // Disable edition on component unmount
+    return () => {
+      onCancel()
+      setIsParcelleSelectionEnabled(false)
+      disableMarkers()
+    }
+  }, [onCancel, disableMarkers, setIsParcelleSelectionEnabled])
 
   return (
     <Form onFormSubmit={onFormSubmit}>

--- a/components/bal/toponymes-list.js
+++ b/components/bal/toponymes-list.js
@@ -17,6 +17,8 @@ function ToponymesList({toponymes, isAdding, onAdd, onEdit, onCancel, onSelect, 
   const {token} = useContext(TokenContext)
   const {isEditing, editingId} = useContext(BalDataContext)
 
+  const isEditable = Boolean(!isEditing && !isAdding && token)
+
   const [filtered, setFilter] = useFuse(toponymes, 200, {
     keys: [
       'nom'
@@ -64,7 +66,7 @@ function ToponymesList({toponymes, isAdding, onAdd, onEdit, onCancel, onSelect, 
             <TableRow
               key={toponyme._id}
               label={toponyme.nom}
-              isEditingEnabled={Boolean(!isEditing && token)}
+              isEditingEnabled={isEditable}
               notifications={{
                 warning: toponyme.positions.length === 0 ? 'Ce toponyme n’a pas de position' : null
               }}

--- a/components/bal/voie-editor.js
+++ b/components/bal/voie-editor.js
@@ -60,11 +60,13 @@ function VoieEditor({initialValue, onSubmit, onCancel}) {
     }
   }, [data, disableDraw, drawEnabled, enableDraw, isMetric, setModeId])
 
+  // Disable edit mode on component unmount
   useEffect(() => {
     return () => {
       disableDraw()
+      onCancel()
     }
-  }, [disableDraw])
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <Form onFormSubmit={onFormSubmit}>

--- a/components/bal/voie-editor.js
+++ b/components/bal/voie-editor.js
@@ -66,7 +66,7 @@ function VoieEditor({initialValue, onSubmit, onCancel}) {
       disableDraw()
       onCancel()
     }
-  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [onCancel, disableDraw])
 
   return (
     <Form onFormSubmit={onFormSubmit}>

--- a/components/bal/voies-list.js
+++ b/components/bal/voies-list.js
@@ -17,6 +17,7 @@ function VoiesList({voies, onEnableEditing, isAdding, onSelect, onAdd, onEdit, o
   const {token} = useContext(TokenContext)
   const {isEditing, editingId} = useContext(BalDataContext)
 
+  const isEditable = Boolean(!isEditing && !isAdding && token)
   const [filtered, setFilter] = useFuse(voies, 200, {
     keys: [
       'nom'
@@ -64,7 +65,7 @@ function VoiesList({voies, onEnableEditing, isAdding, onSelect, onAdd, onEdit, o
             <TableRow
               key={voie._id}
               label={voie.nom}
-              isEditingEnabled={Boolean(!isEditing && token)}
+              isEditingEnabled={isEditable}
               actions={{
                 onSelect: () => onSelect(voie._id),
                 onEdit: () => onEnableEditing(voie._id),

--- a/components/toponyme/add-numeros.js
+++ b/components/toponyme/add-numeros.js
@@ -1,4 +1,4 @@
-import {useState, useCallback, useContext, useMemo} from 'react'
+import {useState, useEffect, useCallback, useContext, useMemo} from 'react'
 import PropTypes from 'prop-types'
 import {sortBy} from 'lodash'
 import {SelectField, SelectMenu, Pane, Button, Text} from 'evergreen-ui'
@@ -81,6 +81,12 @@ function AddNumeros({onSubmit, onCancel, isLoading}) {
 
     return options
   }, [selectedVoieNumeros, voieNumeros])
+
+  useEffect(() => {
+    return () => {
+      onCancel()
+    }
+  }, [onCancel])
 
   return (
     <Pane>

--- a/contexts/draw.js
+++ b/contexts/draw.js
@@ -1,4 +1,4 @@
-import React, {useState, useEffect, useContext, useMemo} from 'react'
+import React, {useState, useEffect, useContext, useMemo, useCallback} from 'react'
 
 import BalDataContext from '@/contexts/bal-data'
 
@@ -51,10 +51,24 @@ export function DrawContextProvider(props) {
     }
   }, [drawEnabled])
 
+  const enableDraw = useCallback(
+    () => {
+      setDrawEnabled(true)
+    },
+    [setDrawEnabled],
+  )
+
+  const disableDraw = useCallback(
+    () => {
+      setDrawEnabled(false)
+    },
+    [setDrawEnabled],
+  )
+
   const value = useMemo(() => ({
     drawEnabled,
-    enableDraw: () => setDrawEnabled(true),
-    disableDraw: () => setDrawEnabled(false),
+    enableDraw,
+    disableDraw,
     modeId,
     setModeId,
     hint,
@@ -63,6 +77,8 @@ export function DrawContextProvider(props) {
     setData
   }), [
     drawEnabled,
+    enableDraw,
+    disableDraw,
     modeId,
     hint,
     data

--- a/pages/bal/commune.js
+++ b/pages/bal/commune.js
@@ -1,4 +1,4 @@
-import React, {useState, useCallback, useContext, useEffect} from 'react'
+import React, {useState, useCallback, useContext, useEffect, useMemo} from 'react'
 import PropTypes from 'prop-types'
 import {useRouter} from 'next/router'
 import {Pane, Heading, Text, Paragraph, Button, AddIcon} from 'evergreen-ui'
@@ -15,10 +15,8 @@ import VoiesList from '@/components/bal/voies-list'
 import ToponymesList from '@/components/bal/toponymes-list'
 
 const Commune = React.memo(({baseLocale, commune}) => {
-  const [isAdding, setIsAdding] = useState(false)
   const [toRemove, setToRemove] = useState(null)
   const [selectedTab, setSelectedTab] = useState('voie')
-
   const {token} = useContext(TokenContext)
   const router = useRouter()
 
@@ -34,6 +32,8 @@ const Commune = React.memo(({baseLocale, commune}) => {
     isEditing,
     setIsEditing
   } = useContext(BalDataContext)
+
+  const isAdding = useMemo(() => isEditing && !editingId, [isEditing, editingId])
 
   useHelp(selectedTab === 'voie' ? 1 : 2)
 
@@ -71,11 +71,9 @@ const Commune = React.memo(({baseLocale, commune}) => {
 
     refreshBALSync()
     setIsEditing(false)
-    setIsAdding(false)
   }, [baseLocale._id, commune, reloadVoies, token, selectedTab, refreshBALSync, reloadToponymes, reloadGeojson, setIsEditing])
 
   const onEnableEditing = useCallback(async id => {
-    setIsAdding(false)
     setEditingId(id)
   }, [setEditingId])
 
@@ -118,7 +116,6 @@ const Commune = React.memo(({baseLocale, commune}) => {
   }, [reloadVoies, refreshBALSync, reloadToponymes, reloadGeojson, selectedTab, toRemove, token])
 
   const onCancel = useCallback(() => {
-    setIsAdding(false)
     setEditingId(null)
   }, [setEditingId])
 
@@ -204,7 +201,7 @@ const Commune = React.memo(({baseLocale, commune}) => {
               appearance='primary'
               intent='success'
               disabled={isAdding || isEditing}
-              onClick={() => setIsAdding(true)}
+              onClick={() => setIsEditing(true)}
             >
               Ajouter {selectedTab === 'voie' ? 'une voie' : 'un toponyme'}
             </Button>

--- a/pages/bal/commune.js
+++ b/pages/bal/commune.js
@@ -141,18 +141,6 @@ const Commune = React.memo(({baseLocale, commune}) => {
   }, [baseLocale._id, router, editingId, isAdding, commune, selectedTab, onCancel])
 
   useEffect(() => {
-    if (isAdding) {
-      setIsEditing(true)
-    }
-  }, [isAdding, setIsEditing])
-
-  useEffect(() => {
-    if (!isEditing) {
-      setIsAdding(false) // Force closing editing form when isEditing is false
-    }
-  }, [isEditing, setIsAdding])
-
-  useEffect(() => {
     if (editingId && toponymes.some(toponyme => toponyme._id === editingId)) {
       setSelectedTab('toponyme')
     }

--- a/pages/bal/toponyme.js
+++ b/pages/bal/toponyme.js
@@ -69,11 +69,6 @@ function Toponyme({baseLocale, commune}) {
     setIsEditing(false)
   }
 
-  const onEnableAdding = () => {
-    setIsAdding(true)
-    setIsEditing(true)
-  }
-
   const onEdit = useCallback(async (voieData, body) => {
     let editedVoie = voieData
 
@@ -144,7 +139,7 @@ function Toponyme({baseLocale, commune}) {
               appearance='primary'
               intent='success'
               disabled={isAdding || isEditing}
-              onClick={onEnableAdding}
+              onClick={() => setIsAdding(true)}
             >
               Ajouter des numéros
             </Button>
@@ -185,7 +180,7 @@ function Toponyme({baseLocale, commune}) {
             </Table.Row>
           )}
 
-          {editingId && editingId !== toponyme._id ? (
+          {editingId && editingId !== toponyme._id && !isAdding ? (
             <Table.Row height='auto'>
               <Table.Cell display='block' padding={0} background='tint1'>
                 <NumeroEditor
@@ -198,7 +193,7 @@ function Toponyme({baseLocale, commune}) {
               </Table.Cell>
             </Table.Row>
           ) : (
-            <ToponymeNumeros numeros={filtered} handleSelect={handleSelection} isEditable={token && !isEditing} />
+            <ToponymeNumeros numeros={filtered} handleSelect={handleSelection} isEditable={token && !isAdding} />
           )}
         </Table>
       </Pane>

--- a/pages/bal/toponyme.js
+++ b/pages/bal/toponyme.js
@@ -1,4 +1,4 @@
-import {useState, useCallback, useContext} from 'react'
+import {useState, useCallback, useContext, useMemo} from 'react'
 import PropTypes from 'prop-types'
 import {Pane, Heading, Table, Button, Alert, AddIcon, toaster} from 'evergreen-ui'
 
@@ -16,7 +16,6 @@ import AddNumeros from '@/components/toponyme/add-numeros'
 import ToponymeHeading from '@/components/toponyme/toponyme-heading'
 
 function Toponyme({baseLocale, commune}) {
-  const [isAdding, setIsAdding] = useState(false)
   const [error, setError] = useState()
   const [isLoading, setIsLoading] = useState(false)
 
@@ -31,6 +30,8 @@ function Toponyme({baseLocale, commune}) {
     isEditing,
     setIsEditing
   } = useContext(BalDataContext)
+
+  const isAdding = useMemo(() => isEditing && !editingId, [isEditing, editingId])
 
   useHelp(2)
   const [filtered, setFilter] = useFuse(numeros, 200, {
@@ -64,7 +65,6 @@ function Toponyme({baseLocale, commune}) {
     }
 
     setIsLoading(false)
-    setIsAdding(false)
     setIsEditing(false)
   }
 
@@ -92,7 +92,6 @@ function Toponyme({baseLocale, commune}) {
   }, [isEditing, setEditingId])
 
   const onCancel = useCallback(() => {
-    setIsAdding(false)
     setEditingId(null)
     setError(null)
   }, [setEditingId])
@@ -118,8 +117,8 @@ function Toponyme({baseLocale, commune}) {
               iconBefore={AddIcon}
               appearance='primary'
               intent='success'
-              disabled={isAdding || isEditing}
-              onClick={() => setIsAdding(true)}
+              disabled={isEditing}
+              onClick={() => setIsEditing(true)}
             >
               Ajouter des numéros
             </Button>

--- a/pages/bal/toponyme.js
+++ b/pages/bal/toponyme.js
@@ -1,4 +1,4 @@
-import {useState, useCallback, useEffect, useContext} from 'react'
+import {useState, useCallback, useContext} from 'react'
 import PropTypes from 'prop-types'
 import {Pane, Heading, Table, Button, Alert, AddIcon, toaster} from 'evergreen-ui'
 
@@ -16,7 +16,6 @@ import AddNumeros from '@/components/toponyme/add-numeros'
 import ToponymeHeading from '@/components/toponyme/toponyme-heading'
 
 function Toponyme({baseLocale, commune}) {
-  const [isEdited, setEdited] = useState(false)
   const [isAdding, setIsAdding] = useState(false)
   const [error, setError] = useState()
   const [isLoading, setIsLoading] = useState(false)
@@ -97,25 +96,6 @@ function Toponyme({baseLocale, commune}) {
     setEditingId(null)
     setError(null)
   }, [setEditingId])
-
-  useEffect(() => {
-    if (editingId) {
-      setEdited(false)
-    }
-  }, [editingId])
-
-  useEffect(() => {
-    if (isEdited) {
-      setError(null)
-      setEditingId(null)
-    }
-  }, [isEdited, setEditingId])
-
-  useEffect(() => {
-    if (!isEditing) {
-      setIsAdding(false) // Force closing editing form when isEditing is false
-    }
-  }, [isEditing, setIsAdding])
 
   return (
     <>

--- a/pages/bal/voie.js
+++ b/pages/bal/voie.js
@@ -95,16 +95,6 @@ const Voie = React.memo(({baseLocale, commune}) => {
   }, [baseLocale._id, commune.code, editingId, refreshBALSync, reloadNumeros, resetEditing, token, handleGeojsonRefresh])
 
   useEffect(() => {
-    setIsFormOpen(Boolean(editedNumero))
-  }, [editedNumero])
-
-  useEffect(() => {
-    if (!isEditing) {
-      setIsFormOpen(false) // Force closing editing form when isEditing is false
-    }
-  }, [isEditing])
-
-  useEffect(() => {
     return () => {
       if (needGeojsonUpdateRef.current) {
         reloadGeojson()


### PR DESCRIPTION
### Contexte
L'issue [L'ajout de numéros à un toponyme ne se réinitialise pas correctement](https://github.com/BaseAdresseNationale/mes-adresses/issues/555) relevait le problème suivant : 

_Lorsque l'on quitte le formulaire permettant d'ajouter des numéros à un toponyme, en retournant à la liste des voies par exemple, celui-ci ne se réinitialise pas correctement et bloque les autres formulaires._

Après la découverte d'une solution, il s'est avéré que le système global de montage et démontage des composants d’édition n'est pas optimal et manque de cohérence. Le remaniement de ce système est donc devenu nécessaire.

### Tâches

- [x] Fix l'issue [L'ajout de numéros à un toponyme ne se réinitialise pas correctement](https://github.com/BaseAdresseNationale/mes-adresses/issues/555).

- [x] Assurer la désactivation du mode édition lors du changement d'onglet Voies/Toponymes et qu'une édition est en cours.

- [x] Assurer la désactivation du mode édition lors du démontage des composants directement concernés et favoriser la réutilisation des fonctions déjà existantes (type `onCancel`).

- [x] Supprimer les useEffects inutiles et/ou provoquant des effets de bord.


Close #555