### PR TITLE
Ajoute un message informatif pour la recherche de commune à la création d’une BAL

### DIFF
--- a/components/new/create-form.js
+++ b/components/new/create-form.js
@@ -133,7 +133,7 @@ function CreateForm({defaultCommune}) {
             id='commune'
             initialSelectedItem={defaultCommune}
             label='Commune'
-            hint='Si vous ne trouvez pas votre commune, essayez d’ajouter le code département'
+            hint='Pour affiner la recherche, renseignez le code département'
             placeholder='Roche 42'
             appearance='default'
             maxWidth={500}

--- a/components/new/create-form.js
+++ b/components/new/create-form.js
@@ -133,6 +133,8 @@ function CreateForm({defaultCommune}) {
             id='commune'
             initialSelectedItem={defaultCommune}
             label='Commune'
+            hint='Si vous ne trouvez pas votre commune, essayez d’ajouter le code département'
+            placeholder='Roche 42'
             appearance='default'
             maxWidth={500}
             disabled={isLoading}


### PR DESCRIPTION
## Contexte : 
Certains utilisateurs se plaignent de ne pas trouver leur commune dans le formulaire de recherche au moment de la création de leur Base Adresse Locale.

## Solutions envisagées : 
- Afficher tous les résultats en provenance de l’API : Cette solution demanderait le téléchargement d’un grand nombre de données dans l’application. Surtout que l’autocomplétion commence les appels à l’API dès les premiers caractères entrés dans la recherche.
- Modifier l’API : Cette solution nous obligerait à modifier un outil qui fonctionne très bien, avec le risque de ne plus afficher les résultats voulus dans ses autres utilisations.


Nous avons donc décidé d’ajouter simplement un message invitant l’utilisateur à entrer, en plus du nom de la commune, le numéro du département afin de pousser l’API à renvoyer la commune recherchée.

### Captures : 
Avant :

![image](https://user-images.githubusercontent.com/56537238/165103337-4b3512f1-662e-40f0-9157-899b83e33d95.png)

Après : 

![image](https://user-images.githubusercontent.com/56537238/165103399-1fbbda4d-d332-4d7b-995d-ca8b1ce76843.png)


Fix #521  
