### PR TITLE
Amélioration UX/UI de la création d'adresse

### DIFF
--- a/components/bal/address-editor.js
+++ b/components/bal/address-editor.js
@@ -1,5 +1,6 @@
 import {useState, useEffect, useContext, useRef} from 'react'
 import PropTypes from 'prop-types'
+import {useRouter} from 'next/router'
 import {Pane, Heading, SelectField} from 'evergreen-ui'
 
 import {addNumero, addToponyme, addVoie} from '@/lib/bal-api'
@@ -17,6 +18,7 @@ function AddressEditor({closeForm}) {
   const [isToponyme, setIsToponyme] = useState(false)
 
   const formRef = useRef(false)
+  const router = useRouter()
 
   const onAddToponyme = async toponymeData => {
     await addToponyme(baseLocale._id, commune.code, toponymeData, token)
@@ -57,6 +59,13 @@ function AddressEditor({closeForm}) {
       closeForm()
     }
   }, [isEditing, closeForm])
+
+  // Close form on page changes
+  useEffect(() => {
+    if (formRef.current) {
+      closeForm()
+    }
+  }, [router, closeForm])
 
   useEffect(() => {
     setIsEditing(true)

--- a/components/bal/address-editor.js
+++ b/components/bal/address-editor.js
@@ -1,4 +1,4 @@
-import {useState, useContext} from 'react'
+import {useState, useEffect, useContext, useRef} from 'react'
 import PropTypes from 'prop-types'
 import {Pane, Heading, SelectField} from 'evergreen-ui'
 
@@ -10,14 +10,16 @@ import BalDataContext from '@/contexts/bal-data'
 import NumeroEditor from '@/components/bal/numero-editor'
 import ToponymeEditor from '@/components/bal/toponyme-editor'
 
-function AddressEditor({balId, commune, closeForm}) {
+function AddressEditor({closeForm}) {
   const {token} = useContext(TokenContext)
-  const {voie, reloadVoies, reloadNumeros, reloadToponymes, reloadGeojson, refreshBALSync} = useContext(BalDataContext)
+  const {baseLocale, commune, voie, isEditing, setIsEditing, reloadVoies, reloadNumeros, reloadToponymes, reloadGeojson, refreshBALSync} = useContext(BalDataContext)
 
   const [isToponyme, setIsToponyme] = useState(false)
 
+  const formRef = useRef(false)
+
   const onAddToponyme = async toponymeData => {
-    await addToponyme(balId, commune.code, toponymeData, token)
+    await addToponyme(baseLocale._id, commune.code, toponymeData, token)
     await reloadToponymes()
     await reloadGeojson()
     refreshBALSync()
@@ -30,7 +32,7 @@ function AddressEditor({balId, commune, closeForm}) {
     const isNewVoie = !editedVoie._id
 
     if (isNewVoie) {
-      editedVoie = await addVoie(balId, commune.code, editedVoie, token)
+      editedVoie = await addVoie(baseLocale._id, commune.code, editedVoie, token)
     }
 
     await addNumero(editedVoie._id, numero, token)
@@ -49,8 +51,23 @@ function AddressEditor({balId, commune, closeForm}) {
     closeForm()
   }
 
+  // Close form when edition is canceled
+  useEffect(() => {
+    if (formRef.current && !isEditing) {
+      closeForm()
+    }
+  }, [isEditing, closeForm])
+
+  useEffect(() => {
+    setIsEditing(true)
+    formRef.current = true
+    return () => {
+      setIsEditing(false)
+    }
+  }, [setIsEditing])
+
   return (
-    <Pane>
+    <Pane overflowY='scroll'>
       <Pane padding={12}>
         <Heading is='h4' >Nouvelle adresse</Heading>
         <SelectField
@@ -73,8 +90,6 @@ function AddressEditor({balId, commune, closeForm}) {
 }
 
 AddressEditor.propTypes = {
-  balId: PropTypes.string.isRequired,
-  commune: PropTypes.object.isRequired,
   closeForm: PropTypes.func.isRequired
 }
 

--- a/components/map/address-editor-control.js
+++ b/components/map/address-editor-control.js
@@ -1,0 +1,28 @@
+import PropTypes from 'prop-types'
+import {Tooltip, Position, IconButton, AddIcon, CrossIcon} from 'evergreen-ui'
+
+function AddressEditorControl({isAddressFormOpen, isDisabled, handleAddressForm}) {
+  return (
+    <Tooltip position={Position.LEFT} content={isAddressFormOpen ? 'Annuler' : 'Créer une adresse'}>
+      {isAddressFormOpen ? (
+        <IconButton icon={CrossIcon} onClick={() => handleAddressForm(false)} />
+      ) : (
+        <IconButton
+          icon={AddIcon}
+          disabled={isDisabled}
+          intent='success'
+          appearance='primary'
+          onClick={() => handleAddressForm(true)}
+        />
+      )}
+    </Tooltip>
+  )
+}
+
+AddressEditorControl.propTypes = {
+  isAddressFormOpen: PropTypes.bool.isRequired,
+  isDisabled: PropTypes.bool.isRequired,
+  handleAddressForm: PropTypes.func.isRequired
+}
+
+export default AddressEditorControl

--- a/components/map/map.js
+++ b/components/map/map.js
@@ -1,4 +1,5 @@
 import {useState, useMemo, useEffect, useCallback, useContext} from 'react'
+import PropTypes from 'prop-types'
 import {useRouter} from 'next/router'
 import MapGl from 'react-map-gl'
 import {fromJS} from 'immutable'
@@ -10,7 +11,6 @@ import TokenContext from '@/contexts/token'
 import DrawContext from '@/contexts/draw'
 import ParcellesContext from '@/contexts/parcelles'
 
-import AddressEditor from '@/components/bal/address-editor'
 import {vector, ortho, planIGN} from '@/components/map/styles'
 import NavControl from '@/components/map/nav-control'
 import EditableMarker from '@/components/map/editable-marker'
@@ -66,13 +66,12 @@ function generateNewStyle(style, sources, layers) {
   return baseStyle.updateIn(['layers'], arr => arr.push(...layers))
 }
 
-function Map() {
+function Map({isAddressFormOpen, handleAddressForm}) {
   const router = useRouter()
   const {map, setMap, style, setStyle, defaultStyle, viewport, setViewport, isCadastreDisplayed, setIsCadastreDisplayed} = useContext(MapContext)
   const {isParcelleSelectionEnabled, handleParcelle} = useContext(ParcellesContext)
 
   const [isLabelsDisplayed, setIsLabelsDisplayed] = useState(true)
-  const [openForm, setOpenForm] = useState(false)
   const [isContextMenuDisplayed, setIsContextMenuDisplayed] = useState(null)
   const [editPrevStyle, setEditPrevSyle] = useState(defaultStyle)
   const [mapStyle, setMapStyle] = useState(getBaseStyle(defaultStyle))
@@ -87,7 +86,6 @@ function Map() {
     toponymes,
     editingId,
     setEditingId,
-    setIsEditing,
     isEditing
   } = useContext(BalDataContext)
   const {modeId} = useContext(DrawContext)
@@ -197,22 +195,9 @@ function Map() {
     }
   }, [map, bounds, setViewport])
 
-  useEffect(() => {
-    if (openForm) {
-      setIsEditing(true)
-    }
-  }, [setIsEditing, openForm])
-
-  useEffect(() => {
-    if (!isEditing) {
-      setOpenForm(false) // Force closing editing form when isEditing is false
-    }
-  }, [isEditing, setOpenForm])
-
   return (
     <Pane display='flex' flexDirection='column' flex={1}>
       <StyleSelector
-        isFormOpen={openForm}
         style={style}
         handleStyle={setStyle}
         isCadastreDisplayed={isCadastreDisplayed}
@@ -237,14 +222,14 @@ function Map() {
           />
         )}
 
-        {token && commune && (
+        {token && (
           <Control
             icon={MapMarkerIcon}
-            isEnabled={openForm}
-            isDisabled={isEditing}
+            isEnabled={isAddressFormOpen}
+            isDisabled={isEditing && !isAddressFormOpen}
             enabledHint='Annuler'
             disabledHint='Créer une adresse'
-            onChange={setOpenForm}
+            onChange={handleAddressForm}
           />
         )}
       </Pane>
@@ -301,18 +286,13 @@ function Map() {
           <Draw />
         </MapGl>
       </Pane>
-
-      {commune && openForm && (
-        <Pane background='white' height={400} overflowY='auto'>
-          <AddressEditor
-            balId={balId}
-            commune={commune}
-            closeForm={() => setOpenForm(false)}
-          />
-        </Pane>
-      )}
     </Pane>
   )
+}
+
+Map.propTypes = {
+  isAddressFormOpen: PropTypes.bool.isRequired,
+  handleAddressForm: PropTypes.func.isRequired
 }
 
 export default Map

--- a/components/map/map.js
+++ b/components/map/map.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import {useRouter} from 'next/router'
 import MapGl from 'react-map-gl'
 import {fromJS} from 'immutable'
-import {Pane, MapMarkerIcon, EyeOffIcon, EyeOpenIcon} from 'evergreen-ui'
+import {Pane, EyeOffIcon, EyeOpenIcon} from 'evergreen-ui'
 
 import MapContext from '@/contexts/map'
 import BalDataContext from '@/contexts/bal-data'
@@ -19,6 +19,7 @@ import NumerosMarkers from '@/components/map/numeros-markers'
 import ToponymeMarker from '@/components/map/toponyme-marker'
 import Draw from '@/components/map/draw'
 import StyleSelector from '@/components/map/style-selector'
+import AddressEditorControl from '@/components/map/address-editor-control'
 import useBounds from '@/components/map/hooks/bounds'
 import useSources from '@/components/map/hooks/sources'
 import useLayers from '@/components/map/hooks/layers'
@@ -221,18 +222,17 @@ function Map({isAddressFormOpen, handleAddressForm}) {
             onChange={setIsLabelsDisplayed}
           />
         )}
-
-        {token && (
-          <Control
-            icon={MapMarkerIcon}
-            isEnabled={isAddressFormOpen}
-            isDisabled={isEditing && !isAddressFormOpen}
-            enabledHint='Annuler'
-            disabledHint='Créer une adresse'
-            onChange={handleAddressForm}
-          />
-        )}
       </Pane>
+
+      {token && (
+        <Pane position='absolute' zIndex={1} top={130} right={15}>
+          <AddressEditorControl
+            isAddressFormOpen={isAddressFormOpen}
+            handleAddressForm={handleAddressForm}
+            isDisabled={isEditing && !isAddressFormOpen}
+          />
+        </Pane>
+      )}
 
       <Pane display='flex' flex={1}>
         <MapGl

--- a/components/map/style-selector.js
+++ b/components/map/style-selector.js
@@ -8,15 +8,15 @@ const STYLES = [
   {label: 'Photographie aérienne', value: 'ortho'}
 ]
 
-function StyleSelector({style, isFormOpen, handleStyle, isCadastreDisplayed, handleCadastre}) {
+function StyleSelector({style, handleStyle, isCadastreDisplayed, handleCadastre}) {
   const [showPopover, setShowPopover] = useState(false)
 
   return (
     <Pane
       position='absolute'
       display='flex'
-      left={16}
-      bottom={isFormOpen ? 410 : 16}
+      left={22}
+      bottom={22}
       border='none'
       elevation={2}
       zIndex={2}
@@ -50,7 +50,6 @@ function StyleSelector({style, isFormOpen, handleStyle, isCadastreDisplayed, han
 
 StyleSelector.propTypes = {
   style: PropTypes.string.isRequired,
-  isFormOpen: PropTypes.bool.isRequired,
   handleStyle: PropTypes.func.isRequired,
   isCadastreDisplayed: PropTypes.bool.isRequired,
   handleCadastre: PropTypes.func.isRequired

--- a/layouts/editor.js
+++ b/layouts/editor.js
@@ -15,9 +15,11 @@ import Map from '@/components/map'
 import WelcomeMessage from '@/components/welcome-message'
 import CertificationMessage from '@/components/certification-message'
 import Settings from '@/components/settings'
+import AddressEditor from '@/components/bal/address-editor'
 
 function Editor({baseLocale, commune, voie, toponyme, voies, toponymes, numeros, children}) {
   const [isHidden, setIsHidden] = useState(false)
+  const [isAddressFormOpen, setIsAddressFormOpen] = useState(false)
 
   const leftOffset = useMemo(() => {
     return isHidden ? 0 : 500
@@ -47,7 +49,7 @@ function Editor({baseLocale, commune, voie, toponyme, voies, toponymes, numeros,
                 <SubHeader />
               </SettingsContextProvider>
 
-              <Map top={116} left={leftOffset} />
+              <Map top={116} left={leftOffset} isAddressFormOpen={isAddressFormOpen} handleAddressForm={setIsAddressFormOpen} />
 
               <Sidebar
                 top={topOffset}
@@ -65,7 +67,11 @@ function Editor({baseLocale, commune, voie, toponyme, voies, toponymes, numeros,
                     <CertificationMessage balId={baseLocale._id} codeCommune={commune.code} />
                   )}
 
-                  {children}
+                  {isAddressFormOpen ? (
+                    <AddressEditor closeForm={() => setIsAddressFormOpen(false)} />
+                  ) : (
+                    children
+                  )}
                 </>
               </Sidebar>
             </ParcellesContextProvider>


### PR DESCRIPTION
## Contexte
L'ouverture du formulaire de création d'adresse se fait aujourd'hui sous la carte. Cependant, l'espace et les dimensions dédiés à ce formulaire ne sont pas adaptés et offrent une très mauvaise expérience utilisateur. 
Ce formulaire étant le seul permettant de créer une adresse de zéro (voie + numéro) il est important de le rendre plus accessible afin de faciliter le travail des utilisateurs.

## Évolutions
- Nouveau bouton `control` sur la carte, plus visible, reprenant les codes graphiques des autres boutons de création de l'outil. Ce bouton permettant également d'annuler la création lorsque le formulaire est ouvert.
- Le formulaire s'ouvre désormais dans le menu latéral. En plus de rester dans une zone "habituelle" d'édition pour l'utilisateur, l'espace y est bien plus adapté et limite les actions possibles.

---------
## Contrôle
### Avant
![Capture d’écran 2022-04-26 à 17 34 47](https://user-images.githubusercontent.com/7040549/165338565-a8d1c080-56ec-4dd1-95a8-1973dd59d0a7.png)

### Après
![Capture d’écran 2022-04-26 à 17 31 49](https://user-images.githubusercontent.com/7040549/165338147-d1219c76-4351-4d7a-8ce4-fd09f137080a.png)
![Capture d’écran 2022-04-26 à 17 32 01](https://user-images.githubusercontent.com/7040549/165338142-c6233945-6c83-4932-9233-e4716d2df069.png)

## Formulaire
### Avant
![Capture d’écran 2022-04-26 à 17 35 07](https://user-images.githubusercontent.com/7040549/165338128-b014c1b2-b539-42dd-91ef-d2adbde804c1.png)
### Après
![Capture d’écran 2022-04-26 à 17 32 14](https://user-images.githubusercontent.com/7040549/165339164-8505bd01-e1ff-45ce-9a2a-8ca135f97097.png)

