### PR TITLE
Mise à jour @etalab/bal en v2.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.15.4",
-    "@etalab/bal": "^2.3.3",
+    "@etalab/bal": "^2.4.0",
     "@next/bundle-analyzer": "^12.0.1",
     "@turf/bbox": "^6.5.0",
     "@turf/buffer": "^6.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -358,10 +358,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@etalab/bal@^2.3.3":
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/@etalab/bal/-/bal-2.3.3.tgz#2b5b3d0baab9d44e82261ac1aaa8f0a70fdcb6b5"
-  integrity sha512-7TOTAVD1lRbf3aKzW43ep6vXJ7StXkhCymaXVrvA3w3drTZohvLRLx/n1KtArtpXVQnyCuej8S3vgx2vCqz5Tg==
+"@etalab/bal@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@etalab/bal/-/bal-2.4.0.tgz#aa90f60046110d7d76f46c3210acb4c47c7ab25d"
+  integrity sha512-yFmz3hCjDCaw6MEKezUHBhLPhdubaX2aG0TTLLKC8ByYhMSnZLDp7EJxkvOpD8wyB/ROub2TPHTPE5UXYenQkA==
   dependencies:
     blob-to-buffer "^1.2.9"
     bluebird "^3.7.2"
@@ -371,8 +371,8 @@
     file-type "^12.4.2"
     iconv-lite "^0.6.3"
     lodash "^4.17.21"
-    papaparse "^5.3.1"
-    yargs "^17.3.1"
+    papaparse "^5.3.2"
+    yargs "^17.4.1"
 
 "@hapi/accept@5.0.2":
   version "5.0.2"
@@ -6010,7 +6010,7 @@ pako@~1.0.5:
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.8.tgz#6844890aab9c635af868ad5fecc62e8acbba3ea4"
   integrity sha512-6i0HVbUfcKaTv+EG8ZTr75az7GFXcLYk9UyLEg7Notv/Ma+z/UG3TCoz6GiNeOrn1E/e63I0X/Hpw18jHOTUnA==
 
-papaparse@^5.3.1:
+papaparse@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/papaparse/-/papaparse-5.3.2.tgz#d1abed498a0ee299f103130a6109720404fbd467"
   integrity sha512-6dNZu0Ki+gyV0eBsFKJhYr+MdQYAzFUGlBMNj3GNrmHxmz1lfRa24CjFObPXtjcetlOv5Ad299MhIK0znp3afw==
@@ -8211,10 +8211,10 @@ yargs-parser@^21.0.0:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.0.1.tgz#0267f286c877a4f0f728fceb6f8a3e4cb95c6e35"
   integrity sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==
 
-yargs@^17.3.1:
-  version "17.3.1"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.3.1.tgz#da56b28f32e2fd45aefb402ed9c26f42be4c07b9"
-  integrity sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==
+yargs@^17.4.1:
+  version "17.4.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.4.1.tgz#ebe23284207bb75cee7c408c33e722bfb27b5284"
+  integrity sha512-WSZD9jgobAg3ZKuCQZSa3g9QOJeCCqLoLAykiWgmXnDo9EPnn4RPf5qVTtzgOx66o6/oqhcA5tHtJXpG8pMt3g==
   dependencies:
     cliui "^7.0.2"
     escalade "^3.1.1"


### PR DESCRIPTION
## Contexte
Mise à jour de la dépendance `@etalab/bal` de la `v2.3.3` à la `v2.4.0`.
[Release v2.4.0](https://github.com/BaseAdresseNationale/bal/releases/tag/v2.4.0)