### PR TITLE
Corrige la modification du toponyme d'un numéro

### DIFF
--- a/components/bal/numero-editor.js
+++ b/components/bal/numero-editor.js
@@ -194,7 +194,9 @@ function NumeroEditor({initialVoieId, initialValue, hasPreview, closeForm}) {
                 flex={1}
                 marginBottom={0}
                 value={toponymeId || ''}
-                onChange={({target}) => setToponymeId(target.value === (REMOVE_TOPONYME_LABEL || '') ? null : target.value)}
+                onChange={({target}) => {
+                  setToponymeId((target.value === REMOVE_TOPONYME_LABEL || target.value === '- Choisir un toponyme -') ? null : target.value)
+                }}
               >
                 <option value={null}>{initialValue?.toponyme ? REMOVE_TOPONYME_LABEL : '- Choisir un toponyme -'}</option>
                 {sortBy(toponymes, t => normalizeSort(t.nom)).map(({_id, nom}) => (

--- a/components/bal/numero-editor.js
+++ b/components/bal/numero-editor.js
@@ -141,7 +141,7 @@ function NumeroEditor({initialVoieId, initialValue, hasPreview, closeForm}) {
 
   useEffect(() => {
     let nom = null
-    if (toponymeId && toponymeId !== '- Choisir un toponyme -') {
+    if (toponymeId) {
       nom = toponymes.find(toponyme => toponyme._id === toponymeId).nom
     }
 


### PR DESCRIPTION
Cette PR corrige le bug #576 qui envoyait "Choisir un toponyme" lorsque l'utilisateur sélectionnait ce champ.

- Modification de la condition
- Suppression de conditions inutiles

Fix #576 