### PR TITLE
Correction du renouvellement d’habilitation

### DIFF
--- a/components/habilitation-process/index.js
+++ b/components/habilitation-process/index.js
@@ -27,7 +27,7 @@ function getStep(habilitation) {
   return 0
 }
 
-function HabilitationProcess({isShown, token, baseLocale, commune, habilitation, handleSync, resetHabilitationProcess, handleClose}) {
+function HabilitationProcess({token, baseLocale, commune, habilitation, handleSync, resetHabilitationProcess, handleClose}) {
   const [step, setStep] = useState(getStep(habilitation))
   const [isLoading, setIsLoading] = useState(false)
   const [isConflicted, setIsConflicted] = useState(false)
@@ -116,12 +116,12 @@ function HabilitationProcess({isShown, token, baseLocale, commune, habilitation,
     }
 
     setStep(step)
-  }, [isShown, habilitation, checkConflictingRevision])
+  }, [habilitation, checkConflictingRevision])
 
   return (
     <Dialog
+      isShown
       width={1200}
-      isShown={isShown}
       preventBodyScrolling
       hasHeader={false}
       intent={isConflicted ? 'danger' : 'success'}
@@ -176,7 +176,6 @@ function HabilitationProcess({isShown, token, baseLocale, commune, habilitation,
 }
 
 HabilitationProcess.propTypes = {
-  isShown: PropTypes.bool.isRequired,
   token: PropTypes.string.isRequired,
   baseLocale: PropTypes.shape({
     _id: PropTypes.string.isRequired,

--- a/components/habilitation-process/index.js
+++ b/components/habilitation-process/index.js
@@ -112,11 +112,15 @@ function HabilitationProcess({token, baseLocale, commune, habilitation, handleSy
   useEffect(() => {
     const step = getStep(habilitation)
     if (step === 2) {
-      checkConflictingRevision()
+      if (baseLocale.sync) { // Skip publication step when renewing accreditation
+        handleClose()
+      } else {
+        checkConflictingRevision()
+      }
     }
 
     setStep(step)
-  }, [habilitation, checkConflictingRevision])
+  }, [baseLocale, habilitation, checkConflictingRevision, handleClose])
 
   return (
     <Dialog
@@ -179,6 +183,7 @@ HabilitationProcess.propTypes = {
   token: PropTypes.string.isRequired,
   baseLocale: PropTypes.shape({
     _id: PropTypes.string.isRequired,
+    sync: PropTypes.string
   }).isRequired,
   commune: PropTypes.shape({
     code: PropTypes.string.isRequired,

--- a/components/sub-header/bal-status/index.js
+++ b/components/sub-header/bal-status/index.js
@@ -8,7 +8,7 @@ import BANSync from '@/components/sub-header/bal-status/ban-sync'
 import Publication from '@/components/sub-header/bal-status/publication'
 import RefreshSyncBadge from '@/components/sub-header/bal-status/refresh-sync-badge'
 
-function BALStatus({baseLocale, commune, token, isRefrehSyncStat, handleChangeStatus, handleHabilitation, reloadBaseLocale}) {
+function BALStatus({baseLocale, commune, token, isHabilitationValid, isRefrehSyncStat, handleChangeStatus, handleHabilitation, reloadBaseLocale}) {
   const handleSync = async () => {
     await sync(baseLocale._id, token)
     await reloadBaseLocale()
@@ -35,7 +35,7 @@ function BALStatus({baseLocale, commune, token, isRefrehSyncStat, handleChangeSt
       </Pane>
 
       {token ? (
-        baseLocale.sync ? (
+        baseLocale.sync && isHabilitationValid ? (
           <BANSync
             baseLocale={baseLocale}
             commune={commune}
@@ -84,6 +84,7 @@ BALStatus.propTypes = {
   }).isRequired,
   commune: PropTypes.object.isRequired,
   token: PropTypes.string,
+  isHabilitationValid: PropTypes.bool.isRequired,
   isRefrehSyncStat: PropTypes.bool.isRequired,
   handleChangeStatus: PropTypes.func.isRequired,
   handleHabilitation: PropTypes.func.isRequired,

--- a/components/sub-header/index.js
+++ b/components/sub-header/index.js
@@ -116,10 +116,9 @@ const SubHeader = React.memo(() => {
         <DemoWarning baseLocale={baseLocale} token={token} />
       )}
 
-      {isAdmin && commune && habilitation && (
+      {isAdmin && commune && habilitation && isHabilitationDisplayed && (
         <HabilitationProcess
           token={token}
-          isShown={isHabilitationDisplayed}
           baseLocale={baseLocale}
           commune={commune}
           habilitation={habilitation}

--- a/components/sub-header/index.js
+++ b/components/sub-header/index.js
@@ -25,6 +25,7 @@ const SubHeader = React.memo(() => {
     habilitation,
     reloadBaseLocale,
     reloadHabilitation,
+    isHabilitationValid,
     commune,
     voie,
     toponyme,
@@ -35,7 +36,6 @@ const SubHeader = React.memo(() => {
   const [setError] = useError(null)
 
   const csvUrl = getBaseLocaleCsvUrl(baseLocale._id)
-  const isEntitled = habilitation && habilitation.status === 'accepted'
   const isAdmin = Boolean(token)
 
   const handleChangeStatus = async status => {
@@ -49,9 +49,11 @@ const SubHeader = React.memo(() => {
   }
 
   const handleHabilitation = async () => {
-    await handleChangeStatus('ready-to-publish')
+    if (baseLocale.status === 'draft') {
+      await handleChangeStatus('ready-to-publish')
+    }
 
-    if (!habilitation || habilitation.status === 'rejected') {
+    if (!habilitation || !isHabilitationValid) {
       await createHabilitation(token, baseLocale._id)
       await reloadHabilitation()
     }
@@ -83,7 +85,7 @@ const SubHeader = React.memo(() => {
         alignItems='center'
         padding={8}
       >
-        {isEntitled && commune && <HabilitationTag communeName={commune.nom} />}
+        {isHabilitationValid && commune && <HabilitationTag communeName={commune.nom} />}
 
         <Breadcrumbs
           baseLocale={baseLocale}
@@ -100,6 +102,7 @@ const SubHeader = React.memo(() => {
               baseLocale={baseLocale}
               commune={commune}
               token={token}
+              isHabilitationValid={isHabilitationValid}
               isRefrehSyncStat={isRefrehSyncStat}
               handleChangeStatus={handleChangeStatus}
               handleHabilitation={handleHabilitation}

--- a/contexts/bal-data.js
+++ b/contexts/bal-data.js
@@ -38,7 +38,7 @@ export const BalDataContextProvider = React.memo(({
 
   const {token} = useContext(TokenContext)
 
-  const [habilitation, reloadHabilitation, isHabilitationValid] = useHabilitation(initialBaseLocale._id, token)
+  const [habilitation, reloadHabilitation, isHabilitationValid] = useHabilitation(initialBaseLocale, token)
 
   const reloadParcelles = useCallback(async () => {
     const parcelles = await getParcelles(baseLocale._id, commune.code)

--- a/contexts/bal-data.js
+++ b/contexts/bal-data.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types'
 import {toaster} from 'evergreen-ui'
 
 import {
-  getHabilitation,
   getParcelles,
   getCommuneGeoJson,
   getCommune,
@@ -16,6 +15,8 @@ import {
 } from '@/lib/bal-api'
 
 import TokenContext from '@/contexts/token'
+
+import useHabilitation from '@/hooks/habilitation'
 
 const BalDataContext = React.createContext()
 
@@ -33,21 +34,11 @@ export const BalDataContextProvider = React.memo(({
   const [toponyme, setToponyme] = useState(initialToponyme)
   const [commune, setCommune] = useState(initialCommune)
   const [baseLocale, setBaseLocale] = useState(initialBaseLocale)
-  const [habilitation, setHabilitation] = useState(null)
   const [isRefrehSyncStat, setIsRefrehSyncStat] = useState(false)
 
   const {token} = useContext(TokenContext)
 
-  const reloadHabilitation = useCallback(async () => {
-    if (token) {
-      try {
-        const habilitation = await getHabilitation(token, baseLocale._id)
-        setHabilitation(habilitation)
-      } catch {
-        setHabilitation(null)
-      }
-    }
-  }, [baseLocale._id, token])
+  const [habilitation, reloadHabilitation, isHabilitationValid] = useHabilitation(initialBaseLocale._id, token)
 
   const reloadParcelles = useCallback(async () => {
     const parcelles = await getParcelles(baseLocale._id, commune.code)
@@ -94,7 +85,7 @@ export const BalDataContextProvider = React.memo(({
 
   const refreshBALSync = useCallback(async () => {
     const {sync} = baseLocale
-    if (sync && sync.status === 'synced' && !sync.isPaused && !isRefrehSyncStat) {
+    if (isHabilitationValid && sync && sync.status === 'synced' && !sync.isPaused && !isRefrehSyncStat) {
       setIsRefrehSyncStat(true)
       setTimeout(() => {
         reloadBaseLocale()
@@ -105,7 +96,7 @@ export const BalDataContextProvider = React.memo(({
         })
       }, 30000) // Maximum interval between CRON job
     }
-  }, [baseLocale, isRefrehSyncStat, reloadBaseLocale])
+  }, [baseLocale, isHabilitationValid, isRefrehSyncStat, reloadBaseLocale])
 
   const setEditingId = useCallback(editingId => {
     if (token) {
@@ -134,10 +125,6 @@ export const BalDataContextProvider = React.memo(({
 
     refreshBALSync()
   }, [baseLocale._id, commune, token, reloadNumeros, refreshBALSync])
-
-  useEffect(() => {
-    reloadHabilitation()
-  }, [token, reloadHabilitation])
 
   // Update states on client side load
   useEffect(() => {
@@ -175,6 +162,7 @@ export const BalDataContextProvider = React.memo(({
     reloadGeojson,
     baseLocale,
     habilitation,
+    isHabilitationValid,
     commune,
     geojson,
     parcelles,
@@ -208,6 +196,7 @@ export const BalDataContextProvider = React.memo(({
     baseLocale,
     reloadBaseLocale,
     habilitation,
+    isHabilitationValid,
     reloadHabilitation,
     reloadCommune,
     commune,

--- a/hooks/habilitation.js
+++ b/hooks/habilitation.js
@@ -1,0 +1,46 @@
+import {useState, useCallback, useEffect} from 'react'
+import {toaster} from 'evergreen-ui'
+
+import {getHabilitation} from '@/lib/bal-api'
+
+export default function useHabilitation(baseLocaleId, token) {
+  const [habilitation, setHabilitation] = useState(null)
+  const [isValid, setIsValid] = useState(false)
+
+  const reloadHabilitation = useCallback(async () => {
+    if (token) {
+      try {
+        const habilitation = await getHabilitation(token, baseLocaleId)
+        setHabilitation(habilitation)
+      } catch {
+        setHabilitation(null)
+      }
+    }
+  }, [baseLocaleId, token])
+
+  useEffect(() => {
+    if (habilitation) {
+      let isExpired = null
+      if (habilitation.expiresAt) {
+        const expiresAt = new Date(habilitation.expiresAt)
+        isExpired = expiresAt < new Date()
+        if (isExpired) {
+          toaster.danger('L’habilitaton est expirée', {
+            description: 'Les prochaines modifications ne seront pas prises en compte dans la Base Adresses Nationale. Cliquer sur "Publier" pour renouveler l’habilitation.',
+            duration: 10
+          })
+        }
+      }
+
+      const isRejected = habilitation.status === 'rejected'
+      const isValid = isExpired === false && !isRejected
+      setIsValid(isValid)
+    }
+  }, [habilitation])
+
+  useEffect(() => {
+    reloadHabilitation()
+  }, [token, reloadHabilitation])
+
+  return [habilitation, reloadHabilitation, isValid]
+}

--- a/hooks/habilitation.js
+++ b/hooks/habilitation.js
@@ -26,7 +26,7 @@ export default function useHabilitation(baseLocaleId, token) {
         isExpired = expiresAt < new Date()
         if (isExpired) {
           toaster.danger('L’habilitaton est expirée', {
-            description: 'Les prochaines modifications ne seront pas prises en compte dans la Base Adresses Nationale. Cliquer sur "Publier" pour renouveler l’habilitation.',
+            description: 'Les prochaines modifications ne seront pas prises en compte dans la Base Adresse Nationale. Cliquez sur "Publier" pour renouveler l’habilitation.',
             duration: 10
           })
         }


### PR DESCRIPTION
## Contexte
Il est actuellement impossible pour une commune de renouveler son habilitation afin de poursuivre ses publications dans la BAN.

## Correction
Cette PR améliore la détection des habilitations invalides et affiche une notification avertissant l'utilisateur qu'il est nécessaire de la renouveler.

Pour renouveler l'habilitation, il suffit à l'utilisateur de cliquer sur "Publier" et de recommencer le processus d'habilitation. 
![Capture d’écran 2022-05-23 à 15 13 01](https://user-images.githubusercontent.com/7040549/169991984-955c4a51-2f95-4fcb-95de-d9324e230ce3.png)
![Capture d’écran 2022-05-24 à 16 55 16](https://user-images.githubusercontent.com/7040549/170068195-9c4747ae-ac6a-449c-a778-3212e52c35fc.png)
 
## Détails technique
Un nouveau hook `useHabilitation` permet de mieux gérer l'habilitation d'une BAL et de propager son état de validité.