### PR TITLE
Correction de l’affichage de l'éditeur d’adresse

### DIFF
--- a/components/bal/address-editor.js
+++ b/components/bal/address-editor.js
@@ -13,7 +13,7 @@ function AddressEditor({closeForm}) {
   const {voie} = useContext(BalDataContext)
 
   return (
-    <Pane overflowY='scroll'>
+    <Pane display='flex' flexDirection='column' height='100%'>
       <Pane padding={12}>
         <Heading is='h4'>Nouvelle adresse</Heading>
         <SelectField
@@ -26,11 +26,13 @@ function AddressEditor({closeForm}) {
         </SelectField>
       </Pane>
 
-      {isToponyme ? (
-        <ToponymeEditor closeForm={closeForm} />
-      ) : (
-        <NumeroEditor initialVoieId={voie?._id} closeForm={closeForm} />
-      )}
+      <Pane display='flex' flexDirection='column' flex={1} overflowY='auto'>
+        {isToponyme ? (
+          <ToponymeEditor closeForm={closeForm} />
+        ) : (
+          <NumeroEditor initialVoieId={voie?._id} hasPreview closeForm={closeForm} />
+        )}
+      </Pane>
     </Pane>
   )
 }

--- a/components/form.js
+++ b/components/form.js
@@ -3,7 +3,7 @@ import {Pane} from 'evergreen-ui'
 
 function Form({children, onFormSubmit}) {
   return (
-    <Pane is='form' background='gray300' flex={1} padding={12} height='100%' onSubmit={onFormSubmit}>
+    <Pane is='form' background='gray300' flex={1} padding={12} height='auto' onSubmit={onFormSubmit}>
       {children}
     </Pane>
   )


### PR DESCRIPTION
## Contexte
Le formulaire d'édition d'adresse ne s'adapte pas correctement à la hauteur du menu latéral. Deux problèmes d'affichage surviennent à cause de cela :
-  le formulaire de toponyme ne prend pas toute la hauteur du menu
- la prévisualisation de l'adresse sur le formulaire de numéro passe par-dessus le formulaire au moment du défilement.

**Exemple :**
![Capture d’écran 2022-05-30 à 14 41 51](https://user-images.githubusercontent.com/7040549/170995311-95c4889d-e3f2-47b9-b58b-61e808516c04.png)
https://user-images.githubusercontent.com/7040549/170995321-ebab9d21-70ab-4d69-b2fc-4e23ec834f9a.mov

## Modifications
- Correction de l'affichage des formulaires sur toute la hauteur du menu
- Ajoute de la prévisualisation de l'adresse sur la création d'un numéro

