### PR TITLE
Correction de la réinitialisation du marqueur au changement de la fenêtre de visualisation de la carte

### DIFF
--- a/components/bal/position-editor.js
+++ b/components/bal/position-editor.js
@@ -89,7 +89,9 @@ function PositionEditor({initialPositions, isToponyme, validationMessage}) {
     return () => {
       disableMarkers()
     }
-  }, [initialPositions, addMarker, handleAddMarker, disableMarkers])
+
+    // Remove addMarker and handleAddMarker from hooks to prevent useEffect running when viewport changing
+  }, [initialPositions, disableMarkers]) // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <FormField validationMessage={validationMessage}>


### PR DESCRIPTION
## Contexte
La fonction `addMarker` est appelé à chaque fois que le `viewport` est mis à jour, ce qui entraine de réinitialisation de marqueur sur la carte.

Cette réinitialisation est due au `useEffect` ayant lieu au montage du composant `PositionEditor` qui vient créer un marqueur par défaut (au centre de la carte avec une position "entrée") si aucune valeur n'est renseignée. Cependant, ce `useEffect` utilise `addMarker` dans ses `hooks`, or cette méthode se base sur le `viewport` de la carte. Ce dernier étant actualisé à chaque zoom/dézoome, le `useEffect` est alors appelé plusieurs fois et remplace le marqueur existant par un nouveau par défaut.

## Correction
Cette PR retire `addMarker` et `handleAddMarker` des `hooks` du `useEffect` afin de ne plus être recalculé à chaque changement du viewport.

Fix #593 