### PR TITLE
Correction de la vérification de validité de l’habilitation

### DIFF
--- a/components/habilitation-process/index.js
+++ b/components/habilitation-process/index.js
@@ -183,7 +183,7 @@ HabilitationProcess.propTypes = {
   token: PropTypes.string.isRequired,
   baseLocale: PropTypes.shape({
     _id: PropTypes.string.isRequired,
-    sync: PropTypes.string
+    sync: PropTypes.object
   }).isRequired,
   commune: PropTypes.shape({
     code: PropTypes.string.isRequired,

--- a/components/sub-header/bal-status/publication.js
+++ b/components/sub-header/bal-status/publication.js
@@ -67,7 +67,7 @@ Publication.propTypes = {
     communes: PropTypes.array.isRequired
   }).isRequired,
   status: PropTypes.oneOf([
-    'draft', 'ready-to-publish'
+    'draft', 'ready-to-publish', 'published'
   ]).isRequired,
   handleBackToDraft: PropTypes.func.isRequired,
   onPublish: PropTypes.func.isRequired

--- a/lib/bal-api/index.js
+++ b/lib/bal-api/index.js
@@ -52,14 +52,22 @@ export async function getHabilitation(token, baseLocaleId) {
   })
 }
 
-export function createHabilitation(token, baseLocaleId) {
-  return request(`/bases-locales/${baseLocaleId}/habilitation`, {
-    method: 'POST',
-    headers: {
-      authorization: `Token ${token}`,
-      'content-type': 'application/json'
-    }
-  })
+export async function createHabilitation(token, baseLocaleId) {
+  try {
+    const response = await request(`/bases-locales/${baseLocaleId}/habilitation`, {
+      method: 'POST',
+      headers: {
+        authorization: `Token ${token}`,
+        'content-type': 'application/json'
+      }
+    })
+
+    return response
+  } catch (error) {
+    toaster.danger('Impossible de demander une habilitation', {
+      description: error.message
+    })
+  }
 }
 
 export async function sendAuthenticationCode(token, baseLocale, communeEmail) {


### PR DESCRIPTION
## Contexte
Une commune nous a remontée que rien ne se passait après avoir cliqué sur "Publier". 
Après vérification, il s'est avéré que l'API renvoyée l'erreur `Cette Base Adresse Locale possède déjà une habilitation` mais celle-ci n'était pas affichée à l'utilisateur.

La vérification de validité de l'habilitation ne considère une habilitation valide uniquement si la BAL est déjà publiée, or ici la commune a dû recevoir une habilitation et ne pas continuer le processus de publication. Cette erreur bloque donc tout le processus de publication.

## Correction
Cette PR modifie la vérification de la validité de l'habilitation en ne prenant en compte l'état de synchronisation de la BAL uniquement pour afficher des erreurs à l'utilisateur. La validité de l'habilitation n'est plus liée à `baseLocale.sync`.

- Ajout d'une notification d’erreur quand la demande d’habilitation échoue
- Correction de processus de vérification de la validité de l'habilitation
- Correction des certains `prop-types` liés à l'habilitation