### PR TITLE
Masque l’éditeur de parcelle lorsque le cadastre n’est pas disponible

### DIFF
--- a/components/bal/address-editor.js
+++ b/components/bal/address-editor.js
@@ -7,7 +7,7 @@ import BalDataContext from '@/contexts/bal-data'
 import NumeroEditor from '@/components/bal/numero-editor'
 import ToponymeEditor from '@/components/bal/toponyme-editor'
 
-function AddressEditor({closeForm}) {
+function AddressEditor({closeForm, hasCadastre}) {
   const [isToponyme, setIsToponyme] = useState(false)
 
   const {voie} = useContext(BalDataContext)
@@ -28,9 +28,9 @@ function AddressEditor({closeForm}) {
 
       <Pane display='flex' flexDirection='column' flex={1} overflowY='auto'>
         {isToponyme ? (
-          <ToponymeEditor closeForm={closeForm} />
+          <ToponymeEditor hasCadastre={hasCadastre} closeForm={closeForm} />
         ) : (
-          <NumeroEditor initialVoieId={voie?._id} hasPreview closeForm={closeForm} />
+          <NumeroEditor hasCadastre={hasCadastre} initialVoieId={voie?._id} hasPreview closeForm={closeForm} />
         )}
       </Pane>
     </Pane>
@@ -38,7 +38,8 @@ function AddressEditor({closeForm}) {
 }
 
 AddressEditor.propTypes = {
-  closeForm: PropTypes.func.isRequired
+  closeForm: PropTypes.func.isRequired,
+  hasCadastre: PropTypes.bool.isRequired
 }
 
 export default AddressEditor

--- a/components/bal/numero-editor.js
+++ b/components/bal/numero-editor.js
@@ -233,6 +233,7 @@ function NumeroEditor({initialVoieId, initialValue, hasPreview, closeForm, hasCa
               />
 
               <TextInputField
+                label=''
                 style={{textTransform: 'lowercase'}}
                 display='block'
                 marginTop={18}

--- a/components/bal/numero-editor.js
+++ b/components/bal/numero-editor.js
@@ -26,6 +26,7 @@ import PositionEditor from '@/components/bal/position-editor'
 import SelectParcelles from '@/components/bal/numero-editor/select-parcelles'
 import NumeroVoieSelector from '@/components/bal/numero-editor/numero-voie-selector'
 import AddressPreview from '@/components/bal/address-preview'
+import DisabledFormInput from '@/components/disabled-form-input'
 
 const REMOVE_TOPONYME_LABEL = 'Aucun toponyme'
 
@@ -256,10 +257,12 @@ function NumeroEditor({initialVoieId, initialValue, hasPreview, closeForm, hasCa
             />
           </FormInput>
 
-          {hasCadastre && (
+          {hasCadastre ? (
             <FormInput>
               <SelectParcelles initialParcelles={initialValue?.parcelles} />
             </FormInput>
+          ) : (
+            <DisabledFormInput label='Parcelles' />
           )}
 
           <Comment input={comment} onChange={onCommentChange} />

--- a/components/bal/numero-editor.js
+++ b/components/bal/numero-editor.js
@@ -29,7 +29,7 @@ import AddressPreview from '@/components/bal/address-preview'
 
 const REMOVE_TOPONYME_LABEL = 'Aucun toponyme'
 
-function NumeroEditor({initialVoieId, initialValue, hasPreview, closeForm}) {
+function NumeroEditor({initialVoieId, initialValue, hasPreview, closeForm, hasCadastre}) {
   const [voieId, setVoieId] = useState(initialVoieId || initialValue?.voie._id)
   const [selectedNomToponyme, setSelectedNomToponyme] = useState('')
   const [toponymeId, setToponymeId] = useState(initialValue?.toponyme)
@@ -256,9 +256,11 @@ function NumeroEditor({initialVoieId, initialValue, hasPreview, closeForm}) {
             />
           </FormInput>
 
-          <FormInput>
-            <SelectParcelles initialParcelles={initialValue?.parcelles} />
-          </FormInput>
+          {hasCadastre && (
+            <FormInput>
+              <SelectParcelles initialParcelles={initialValue?.parcelles} />
+            </FormInput>
+          )}
 
           <Comment input={comment} onChange={onCommentChange} />
 
@@ -291,7 +293,8 @@ NumeroEditor.propTypes = {
     certifie: PropTypes.bool // eslint-disable-line react/boolean-prop-naming
   }),
   hasPreview: PropTypes.bool,
-  closeForm: PropTypes.func
+  closeForm: PropTypes.func,
+  hasCadastre: PropTypes.bool.isRequired
 }
 
 NumeroEditor.defaultProps = {

--- a/components/bal/position-editor.js
+++ b/components/bal/position-editor.js
@@ -22,6 +22,7 @@ function Position({marker, isRemovable, handleChange, onRemove}) {
   return (
     <>
       <Select
+        label=''
         value={marker.type}
         marginBottom={8}
         height={32}
@@ -94,7 +95,7 @@ function PositionEditor({initialPositions, isToponyme, validationMessage}) {
   }, [initialPositions, disableMarkers]) // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
-    <FormField validationMessage={validationMessage}>
+    <FormField label='' validationMessage={validationMessage}>
       <InputLabel
         title='Positions'
         help={markers.length > 1 ?

--- a/components/bal/toponyme-editor.js
+++ b/components/bal/toponyme-editor.js
@@ -19,6 +19,7 @@ import AssistedTextField from '@/components/assisted-text-field'
 import FormInput from '@/components/form-input'
 import PositionEditor from '@/components/bal/position-editor'
 import SelectParcelles from '@/components/bal/numero-editor/select-parcelles'
+import DisabledFormInput from '@/components/disabled-form-input'
 
 function ToponymeEditor({initialValue, closeForm, hasCadastre}) {
   const [isLoading, setIsLoading] = useState(false)
@@ -126,10 +127,12 @@ function ToponymeEditor({initialValue, closeForm, hasCadastre}) {
           />
         </FormInput>
 
-        {hasCadastre && (
+        {hasCadastre ? (
           <FormInput>
             <SelectParcelles initialParcelles={initialValue?.parcelles} isToponyme />
           </FormInput>
+        ) : (
+          <DisabledFormInput label='Parcelles' />
         )}
 
         <Button isLoading={isLoading} type='submit' appearance='primary' intent='success'>

--- a/components/bal/toponyme-editor.js
+++ b/components/bal/toponyme-editor.js
@@ -20,7 +20,7 @@ import FormInput from '@/components/form-input'
 import PositionEditor from '@/components/bal/position-editor'
 import SelectParcelles from '@/components/bal/numero-editor/select-parcelles'
 
-function ToponymeEditor({initialValue, closeForm}) {
+function ToponymeEditor({initialValue, closeForm, hasCadastre}) {
   const [isLoading, setIsLoading] = useState(false)
   const [nom, onNomChange, resetNom] = useInput(initialValue?.nom || '')
   const [getValidationMessage, setValidationMessages] = useValidationMessage(null)
@@ -126,9 +126,11 @@ function ToponymeEditor({initialValue, closeForm}) {
           />
         </FormInput>
 
-        <FormInput>
-          <SelectParcelles initialParcelles={initialValue?.parcelles} isToponyme />
-        </FormInput>
+        {hasCadastre && (
+          <FormInput>
+            <SelectParcelles initialParcelles={initialValue?.parcelles} isToponyme />
+          </FormInput>
+        )}
 
         <Button isLoading={isLoading} type='submit' appearance='primary' intent='success'>
           {submitLabel}
@@ -155,7 +157,8 @@ ToponymeEditor.propTypes = {
     parcelles: PropTypes.array.isRequired,
     positions: PropTypes.array.isRequired
   }),
-  closeForm: PropTypes.func.isRequired
+  closeForm: PropTypes.func.isRequired,
+  hasCadastre: PropTypes.bool.isRequired
 }
 
 ToponymeEditor.defaultProps = {

--- a/components/bal/toponyme-editor.js
+++ b/components/bal/toponyme-editor.js
@@ -21,7 +21,7 @@ import PositionEditor from '@/components/bal/position-editor'
 import SelectParcelles from '@/components/bal/numero-editor/select-parcelles'
 import DisabledFormInput from '@/components/disabled-form-input'
 
-function ToponymeEditor({initialValue, closeForm, hasCadastre}) {
+function ToponymeEditor({initialValue, closeForm}) {
   const [isLoading, setIsLoading] = useState(false)
   const [nom, onNomChange, resetNom] = useInput(initialValue?.nom || '')
   const [getValidationMessage, setValidationMessages] = useValidationMessage(null)
@@ -127,7 +127,7 @@ function ToponymeEditor({initialValue, closeForm, hasCadastre}) {
           />
         </FormInput>
 
-        {hasCadastre ? (
+        {commune.hasCadastre ? (
           <FormInput>
             <SelectParcelles initialParcelles={initialValue?.parcelles} isToponyme />
           </FormInput>
@@ -160,8 +160,10 @@ ToponymeEditor.propTypes = {
     parcelles: PropTypes.array.isRequired,
     positions: PropTypes.array.isRequired
   }),
-  closeForm: PropTypes.func.isRequired,
-  hasCadastre: PropTypes.bool.isRequired
+  commune: PropTypes.shape({
+    hasCadastre: PropTypes.bool.isRequired
+  }).isRequired,
+  closeForm: PropTypes.func.isRequired
 }
 
 ToponymeEditor.defaultProps = {

--- a/components/bal/toponymes-list.js
+++ b/components/bal/toponymes-list.js
@@ -13,7 +13,7 @@ import useFuse from '@/hooks/fuse'
 import TableRow from '@/components/table-row'
 import ToponymeEditor from '@/components/bal/toponyme-editor'
 
-function ToponymesList({toponymes, editedId, onCancel, onSelect, onEnableEditing, setToRemove}) {
+function ToponymesList({toponymes, editedId, onCancel, onSelect, onEnableEditing, setToRemove, hasCadastre}) {
   const {token} = useContext(TokenContext)
   const {isEditing} = useContext(BalDataContext)
 
@@ -43,7 +43,7 @@ function ToponymesList({toponymes, editedId, onCancel, onSelect, onEnableEditing
           .map(toponyme => toponyme._id === editedId ? (
             <Table.Row key={toponyme._id} height='auto'>
               <Table.Cell display='block' padding={0} background='tint1'>
-                <ToponymeEditor initialValue={toponyme} closeForm={onCancel} />
+                <ToponymeEditor initialValue={toponyme} closeForm={onCancel} hasCadastre={hasCadastre} />
               </Table.Cell>
             </Table.Row>
           ) : (
@@ -72,7 +72,8 @@ ToponymesList.propTypes = {
   setToRemove: PropTypes.func.isRequired,
   onEnableEditing: PropTypes.func.isRequired,
   onSelect: PropTypes.func.isRequired,
-  onCancel: PropTypes.func.isRequired
+  onCancel: PropTypes.func.isRequired,
+  hasCadastre: PropTypes.bool.isRequired
 }
 
 ToponymesList.defaultProps = {

--- a/components/disabled-form-input.js
+++ b/components/disabled-form-input.js
@@ -1,0 +1,23 @@
+import {Pane, Alert, Label} from 'evergreen-ui'
+
+function DisabledFormInput({label}) {
+  return (
+    <Pane
+      background='white'
+      padding={8}
+      borderRadius={8}
+      marginBottom={8}
+      width='100%'
+    >
+      <Label>
+        {label}
+      </Label>
+      <Alert
+        intent='warning'
+        title='Cette fonctionnalité n’est pas disponible pour cette commune.'
+      />
+    </Pane>
+  )
+}
+
+export default DisabledFormInput

--- a/components/disabled-form-input.js
+++ b/components/disabled-form-input.js
@@ -10,10 +10,9 @@ function DisabledFormInput({label}) {
       marginBottom={8}
       width='100%'
     >
-      <Label>
-        {label}
-      </Label>
+      <Label>{label}</Label>
       <Alert
+        marginY={4}
         intent='warning'
         title='Cette fonctionnalité n’est pas disponible pour cette commune.'
       />

--- a/components/disabled-form-input.js
+++ b/components/disabled-form-input.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types'
 import {Pane, Alert, Label} from 'evergreen-ui'
 
 function DisabledFormInput({label}) {
@@ -18,6 +19,10 @@ function DisabledFormInput({label}) {
       />
     </Pane>
   )
+}
+
+DisabledFormInput.propTypes = {
+  label: PropTypes.string.isRequired
 }
 
 export default DisabledFormInput

--- a/components/map/cadastre-control.js
+++ b/components/map/cadastre-control.js
@@ -1,0 +1,28 @@
+import PropTypes from 'prop-types'
+import {Tooltip, Button, ControlIcon} from 'evergreen-ui'
+
+function CadastreControl({hasCadastre, isCadastreDisplayed, onClick}) {
+  return (
+    hasCadastre ? (
+      <Tooltip content={isCadastreDisplayed ? 'Masquer le cadastre' : 'Afficher le cadastre'}>
+        <Button style={{padding: '.8em'}} onClick={onClick}>
+          <ControlIcon color={isCadastreDisplayed ? 'selected' : 'muted'} />
+        </Button>
+      </Tooltip>
+    ) : (
+      <Tooltip content='Le cadastre n’est pas disponible pour cette commune'>
+        <Button style={{padding: '.8em'}}>
+          <ControlIcon color='muted' />
+        </Button>
+      </Tooltip>
+    )
+  )
+}
+
+CadastreControl.propTypes = {
+  hasCadastre: PropTypes.bool.isRequired,
+  isCadastreDisplayed: PropTypes.bool.isRequired,
+  onClick: PropTypes.func.isRequired
+}
+
+export default CadastreControl

--- a/components/map/cadastre-control.js
+++ b/components/map/cadastre-control.js
@@ -11,7 +11,7 @@ function CadastreControl({hasCadastre, isCadastreDisplayed, onClick}) {
       </Tooltip>
     ) : (
       <Tooltip content='Le cadastre n’est pas disponible pour cette commune'>
-        <Button style={{padding: '.8em'}}>
+        <Button style={{padding: '.8em'}} cursor='not-allowed'>
           <ControlIcon color='muted' />
         </Button>
       </Tooltip>

--- a/components/map/map.js
+++ b/components/map/map.js
@@ -67,7 +67,7 @@ function generateNewStyle(style, sources, layers) {
   return baseStyle.updateIn(['layers'], arr => arr.push(...layers))
 }
 
-function Map({isAddressFormOpen, handleAddressForm}) {
+function Map({isAddressFormOpen, handleAddressForm, hasCadastre}) {
   const router = useRouter()
   const {map, setMap, style, setStyle, defaultStyle, viewport, setViewport, isCadastreDisplayed, setIsCadastreDisplayed} = useContext(MapContext)
   const {isParcelleSelectionEnabled, handleParcelle} = useContext(ParcellesContext)
@@ -201,6 +201,7 @@ function Map({isAddressFormOpen, handleAddressForm}) {
       <StyleSelector
         style={style}
         handleStyle={setStyle}
+        hasCadastre={hasCadastre}
         isCadastreDisplayed={isCadastreDisplayed}
         handleCadastre={setIsCadastreDisplayed}
       />
@@ -292,7 +293,8 @@ function Map({isAddressFormOpen, handleAddressForm}) {
 
 Map.propTypes = {
   isAddressFormOpen: PropTypes.bool.isRequired,
-  handleAddressForm: PropTypes.func.isRequired
+  handleAddressForm: PropTypes.func.isRequired,
+  hasCadastre: PropTypes.bool.isRequired
 }
 
 export default Map

--- a/components/map/style-selector.js
+++ b/components/map/style-selector.js
@@ -39,10 +39,16 @@ function StyleSelector({style, handleStyle, isCadastreDisplayed, handleCadastre,
         </Button>
 
       </SelectMenu>
-      {hasCadastre && (
+      {hasCadastre ? (
         <Tooltip content={isCadastreDisplayed ? 'Masquer le cadastre' : 'Afficher le cadastre'}>
           <Button style={{padding: '.8em'}} onClick={() => handleCadastre(show => !show)}>
             <ControlIcon color={isCadastreDisplayed ? 'selected' : 'muted'} />
+          </Button>
+        </Tooltip>
+      ) : (
+        <Tooltip content='Le cadastre n’est pas disponible pour cette commune'>
+          <Button style={{padding: '.8em'}}>
+            <ControlIcon color='muted' />
           </Button>
         </Tooltip>
       )}

--- a/components/map/style-selector.js
+++ b/components/map/style-selector.js
@@ -8,7 +8,7 @@ const STYLES = [
   {label: 'Photographie aérienne', value: 'ortho'}
 ]
 
-function StyleSelector({style, handleStyle, isCadastreDisplayed, handleCadastre}) {
+function StyleSelector({style, handleStyle, isCadastreDisplayed, handleCadastre, hasCadastre}) {
   const [showPopover, setShowPopover] = useState(false)
 
   return (
@@ -39,11 +39,13 @@ function StyleSelector({style, handleStyle, isCadastreDisplayed, handleCadastre}
         </Button>
 
       </SelectMenu>
-      <Tooltip content={isCadastreDisplayed ? 'Masquer le cadastre' : 'Afficher le cadastre'}>
-        <Button style={{padding: '.8em'}} onClick={() => handleCadastre(show => !show)}>
-          <ControlIcon color={isCadastreDisplayed ? 'selected' : 'muted'} />
-        </Button>
-      </Tooltip>
+      {hasCadastre && (
+        <Tooltip content={isCadastreDisplayed ? 'Masquer le cadastre' : 'Afficher le cadastre'}>
+          <Button style={{padding: '.8em'}} onClick={() => handleCadastre(show => !show)}>
+            <ControlIcon color={isCadastreDisplayed ? 'selected' : 'muted'} />
+          </Button>
+        </Tooltip>
+      )}
     </Pane>
   )
 }
@@ -52,7 +54,8 @@ StyleSelector.propTypes = {
   style: PropTypes.string.isRequired,
   handleStyle: PropTypes.func.isRequired,
   isCadastreDisplayed: PropTypes.bool.isRequired,
-  handleCadastre: PropTypes.func.isRequired
+  handleCadastre: PropTypes.func.isRequired,
+  hasCadastre: PropTypes.bool.isRequired
 }
 
 export default StyleSelector

--- a/components/map/style-selector.js
+++ b/components/map/style-selector.js
@@ -1,6 +1,8 @@
 import {useState} from 'react'
 import PropTypes from 'prop-types'
-import {Pane, SelectMenu, Button, Position, Tooltip, LayersIcon, ControlIcon} from 'evergreen-ui'
+import {Pane, SelectMenu, Button, Position, LayersIcon} from 'evergreen-ui'
+
+import CadastreControl from '@/components/map/cadastre-control.js'
 
 const STYLES = [
   {label: 'Plan OpenMapTiles', value: 'vector'},
@@ -39,19 +41,11 @@ function StyleSelector({style, handleStyle, isCadastreDisplayed, handleCadastre,
         </Button>
 
       </SelectMenu>
-      {hasCadastre ? (
-        <Tooltip content={isCadastreDisplayed ? 'Masquer le cadastre' : 'Afficher le cadastre'}>
-          <Button style={{padding: '.8em'}} onClick={() => handleCadastre(show => !show)}>
-            <ControlIcon color={isCadastreDisplayed ? 'selected' : 'muted'} />
-          </Button>
-        </Tooltip>
-      ) : (
-        <Tooltip content='Le cadastre n’est pas disponible pour cette commune'>
-          <Button style={{padding: '.8em'}}>
-            <ControlIcon color='muted' />
-          </Button>
-        </Tooltip>
-      )}
+      <CadastreControl
+        hasCadastre={hasCadastre}
+        isCadastreDisplayed={isCadastreDisplayed}
+        onClick={() => handleCadastre(show => !show)}
+      />
     </Pane>
   )
 }

--- a/layouts/editor.js
+++ b/layouts/editor.js
@@ -17,7 +17,7 @@ import CertificationMessage from '@/components/certification-message'
 import Settings from '@/components/settings'
 import AddressEditor from '@/components/bal/address-editor'
 
-function Editor({baseLocale, commune, voie, toponyme, voies, toponymes, numeros, children}) {
+function Editor({baseLocale, commune, voie, toponyme, voies, toponymes, numeros, hasCadastre, children}) {
   const [isHidden, setIsHidden] = useState(false)
   const [isAddressFormOpen, setIsAddressFormOpen] = useState(false)
 
@@ -49,7 +49,12 @@ function Editor({baseLocale, commune, voie, toponyme, voies, toponymes, numeros,
                 <SubHeader />
               </SettingsContextProvider>
 
-              <Map top={116} left={leftOffset} isAddressFormOpen={isAddressFormOpen} handleAddressForm={setIsAddressFormOpen} />
+              <Map
+                top={116} left={leftOffset}
+                isAddressFormOpen={isAddressFormOpen}
+                handleAddressForm={setIsAddressFormOpen}
+                hasCadastre={hasCadastre}
+              />
 
               <Sidebar
                 top={topOffset}
@@ -68,7 +73,7 @@ function Editor({baseLocale, commune, voie, toponyme, voies, toponymes, numeros,
                   )}
 
                   {isAddressFormOpen ? (
-                    <AddressEditor closeForm={() => setIsAddressFormOpen(false)} />
+                    <AddressEditor hasCadastre={hasCadastre} closeForm={() => setIsAddressFormOpen(false)} />
                   ) : (
                     children
                   )}
@@ -95,7 +100,8 @@ Editor.propTypes = {
   voies: PropTypes.array,
   toponymes: PropTypes.array,
   numeros: PropTypes.array,
-  children: PropTypes.node.isRequired
+  children: PropTypes.node.isRequired,
+  hasCadastre: PropTypes.bool.isRequired
 }
 
 export default Editor

--- a/layouts/editor.js
+++ b/layouts/editor.js
@@ -17,7 +17,7 @@ import CertificationMessage from '@/components/certification-message'
 import Settings from '@/components/settings'
 import AddressEditor from '@/components/bal/address-editor'
 
-function Editor({baseLocale, commune, voie, toponyme, voies, toponymes, numeros, hasCadastre, children}) {
+function Editor({baseLocale, commune, voie, toponyme, voies, toponymes, numeros, children}) {
   const [isHidden, setIsHidden] = useState(false)
   const [isAddressFormOpen, setIsAddressFormOpen] = useState(false)
 
@@ -53,7 +53,7 @@ function Editor({baseLocale, commune, voie, toponyme, voies, toponymes, numeros,
                 top={116} left={leftOffset}
                 isAddressFormOpen={isAddressFormOpen}
                 handleAddressForm={setIsAddressFormOpen}
-                hasCadastre={hasCadastre}
+                hasCadastre={commune.hasCadastre}
               />
 
               <Sidebar
@@ -73,7 +73,7 @@ function Editor({baseLocale, commune, voie, toponyme, voies, toponymes, numeros,
                   )}
 
                   {isAddressFormOpen ? (
-                    <AddressEditor hasCadastre={hasCadastre} closeForm={() => setIsAddressFormOpen(false)} />
+                    <AddressEditor hasCadastre={commune.hasCadastre} closeForm={() => setIsAddressFormOpen(false)} />
                   ) : (
                     children
                   )}
@@ -94,14 +94,14 @@ Editor.propTypes = {
   }).isRequired,
   commune: PropTypes.shape({
     code: PropTypes.string.isRequired,
+    hasCadastre: PropTypes.bool.isRequired
   }),
   voie: PropTypes.object,
   toponyme: PropTypes.object,
   voies: PropTypes.array,
   toponymes: PropTypes.array,
   numeros: PropTypes.array,
-  children: PropTypes.node.isRequired,
-  hasCadastre: PropTypes.bool.isRequired
+  children: PropTypes.node.isRequired
 }
 
 export default Editor

--- a/lib/bal-api/index.js
+++ b/lib/bal-api/index.js
@@ -574,6 +574,6 @@ export async function searchBAL(codeCommune, userEmail) {
   return request(`/bases-locales/search?codeCommune=${codeCommune}&userEmail=${userEmail}`)
 }
 
-export async function checkCadastreCommune(codeCommune) {
+export async function getCommuneExtras(codeCommune) {
   return request(`/commune/${codeCommune}`)
 }

--- a/lib/bal-api/index.js
+++ b/lib/bal-api/index.js
@@ -573,3 +573,7 @@ export function getContoursCommunes() {
 export async function searchBAL(codeCommune, userEmail) {
   return request(`/bases-locales/search?codeCommune=${codeCommune}&userEmail=${userEmail}`)
 }
+
+export async function checkCadastreCommune(codeCommune) {
+  return request(`/commune/${codeCommune}`)
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -6,7 +6,7 @@ import {Pane, Dialog, Paragraph} from 'evergreen-ui'
 import 'mapbox-gl/dist/mapbox-gl.css'
 
 import {getCommune as getGeoCommune} from '@/lib/geo-api'
-import {getBaseLocale, getCommune, getVoies, getToponymes} from '@/lib/bal-api'
+import {getBaseLocale, getCommune, getVoies, getToponymes, checkCadastreCommune} from '@/lib/bal-api'
 
 import {LocalStorageContextProvider} from '@/contexts/local-storage'
 import {HelpContextProvider} from '@/contexts/help'
@@ -96,6 +96,7 @@ App.getInitialProps = async ({Component, ctx}) => {
   let commune
   let voies
   let toponymes
+  let communeCadastre
 
   try {
     if (query.balId) {
@@ -114,6 +115,8 @@ App.getInitialProps = async ({Component, ctx}) => {
       commune = {...baseLocaleCommune, ...geoCommune}
       voies = await getVoies(query.balId, codeCommune)
       toponymes = await getToponymes(query.balId, codeCommune)
+
+      communeCadastre = await checkCadastreCommune(codeCommune)
     }
 
     if (Component.getInitialProps) {
@@ -122,7 +125,8 @@ App.getInitialProps = async ({Component, ctx}) => {
         baseLocale,
         commune,
         voies,
-        toponymes
+        toponymes,
+        hasCadastre: communeCadastre?.hasCadastre
       })
     }
   } catch {
@@ -140,6 +144,7 @@ App.getInitialProps = async ({Component, ctx}) => {
       commune,
       voies,
       toponymes,
+      hasCadastre: communeCadastre?.hasCadastre,
       ...pageProps
     },
     query

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -6,7 +6,7 @@ import {Pane, Dialog, Paragraph} from 'evergreen-ui'
 import 'mapbox-gl/dist/mapbox-gl.css'
 
 import {getCommune as getGeoCommune} from '@/lib/geo-api'
-import {getBaseLocale, getCommune, getVoies, getToponymes, checkCadastreCommune} from '@/lib/bal-api'
+import {getBaseLocale, getCommune, getVoies, getToponymes, getCommuneExtras} from '@/lib/bal-api'
 
 import {LocalStorageContextProvider} from '@/contexts/local-storage'
 import {HelpContextProvider} from '@/contexts/help'
@@ -96,7 +96,6 @@ App.getInitialProps = async ({Component, ctx}) => {
   let commune
   let voies
   let toponymes
-  let communeCadastre
 
   try {
     if (query.balId) {
@@ -112,11 +111,11 @@ App.getInitialProps = async ({Component, ctx}) => {
         fields: 'contour'
       })
 
-      commune = {...baseLocaleCommune, ...geoCommune}
+      const communeExtras = await getCommuneExtras(codeCommune)
+
+      commune = {...baseLocaleCommune, ...geoCommune, ...communeExtras}
       voies = await getVoies(query.balId, codeCommune)
       toponymes = await getToponymes(query.balId, codeCommune)
-
-      communeCadastre = await checkCadastreCommune(codeCommune)
     }
 
     if (Component.getInitialProps) {
@@ -125,8 +124,7 @@ App.getInitialProps = async ({Component, ctx}) => {
         baseLocale,
         commune,
         voies,
-        toponymes,
-        hasCadastre: communeCadastre?.hasCadastre
+        toponymes
       })
     }
   } catch {
@@ -144,7 +142,6 @@ App.getInitialProps = async ({Component, ctx}) => {
       commune,
       voies,
       toponymes,
-      hasCadastre: communeCadastre?.hasCadastre,
       ...pageProps
     },
     query

--- a/pages/bal/commune.js
+++ b/pages/bal/commune.js
@@ -16,7 +16,7 @@ import VoieEditor from '@/components/bal/voie-editor'
 import ToponymesList from '@/components/bal/toponymes-list'
 import ToponymeEditor from '@/components/bal/toponyme-editor'
 
-const Commune = React.memo(({baseLocale, commune}) => {
+const Commune = React.memo(({baseLocale, commune, hasCadastre}) => {
   const [editedId, setEditedId] = useState(null)
   const [isCreateFormOpen, setIsCreateFormOpen] = useState(false)
   const [toRemove, setToRemove] = useState(null)
@@ -138,7 +138,7 @@ const Commune = React.memo(({baseLocale, commune}) => {
           {selectedTab === 'voie' ? (
             <VoieEditor closeForm={() => setIsCreateFormOpen(false)} />
           ) : (
-            <ToponymeEditor closeForm={() => setIsCreateFormOpen(false)} />
+            <ToponymeEditor hasCadastre={hasCadastre} closeForm={() => setIsCreateFormOpen(false)} />
           )}
         </Pane>
       ) : (
@@ -183,6 +183,7 @@ const Commune = React.memo(({baseLocale, commune}) => {
           setToRemove={setToRemove}
           onEnableEditing={setEditedId}
           onSelect={onSelect}
+          hasCadastre={hasCadastre}
           onCancel={() => setEditedId(null)}
         />
       )}
@@ -238,7 +239,8 @@ Commune.propTypes = {
   commune: PropTypes.shape({
     code: PropTypes.string.isRequired,
     nom: PropTypes.string.isRequired
-  }).isRequired
+  }).isRequired,
+  hasCadastre: PropTypes.bool.isRequired
 }
 
 export default Commune

--- a/pages/bal/commune.js
+++ b/pages/bal/commune.js
@@ -16,7 +16,7 @@ import VoieEditor from '@/components/bal/voie-editor'
 import ToponymesList from '@/components/bal/toponymes-list'
 import ToponymeEditor from '@/components/bal/toponyme-editor'
 
-const Commune = React.memo(({baseLocale, commune, hasCadastre}) => {
+const Commune = React.memo(({baseLocale, commune}) => {
   const [editedId, setEditedId] = useState(null)
   const [isCreateFormOpen, setIsCreateFormOpen] = useState(false)
   const [toRemove, setToRemove] = useState(null)
@@ -138,7 +138,7 @@ const Commune = React.memo(({baseLocale, commune, hasCadastre}) => {
           {selectedTab === 'voie' ? (
             <VoieEditor closeForm={() => setIsCreateFormOpen(false)} />
           ) : (
-            <ToponymeEditor hasCadastre={hasCadastre} closeForm={() => setIsCreateFormOpen(false)} />
+            <ToponymeEditor hasCadastre={commune.hasCadastre} closeForm={() => setIsCreateFormOpen(false)} />
           )}
         </Pane>
       ) : (
@@ -183,7 +183,7 @@ const Commune = React.memo(({baseLocale, commune, hasCadastre}) => {
           setToRemove={setToRemove}
           onEnableEditing={setEditedId}
           onSelect={onSelect}
-          hasCadastre={hasCadastre}
+          hasCadastre={commune.hasCadastre}
           onCancel={() => setEditedId(null)}
         />
       )}
@@ -238,9 +238,9 @@ Commune.propTypes = {
   }).isRequired,
   commune: PropTypes.shape({
     code: PropTypes.string.isRequired,
-    nom: PropTypes.string.isRequired
-  }).isRequired,
-  hasCadastre: PropTypes.bool.isRequired
+    nom: PropTypes.string.isRequired,
+    hasCadastre: PropTypes.bool.isRequired
+  }).isRequired
 }
 
 export default Commune

--- a/pages/bal/toponyme.js
+++ b/pages/bal/toponyme.js
@@ -15,7 +15,7 @@ import ToponymeNumeros from '@/components/toponyme/toponyme-numeros'
 import AddNumeros from '@/components/toponyme/add-numeros'
 import ToponymeHeading from '@/components/toponyme/toponyme-heading'
 
-function Toponyme({baseLocale}) {
+function Toponyme({baseLocale, hasCadastre}) {
   const [isFormOpen, setIsFormOpen] = useState(false)
   const [editedNumeroId, setEditedNumeroId] = useState(null)
   const [error, setError] = useState(null)
@@ -142,6 +142,7 @@ function Toponyme({baseLocale}) {
               <Table.Cell display='block' padding={0} background='tint1'>
                 <NumeroEditor
                   hasPreview
+                  hasCadastre={hasCadastre}
                   initialValue={editedNumero}
                   closeForm={onCancel}
                 />
@@ -169,7 +170,8 @@ Toponyme.getInitialProps = async ({query}) => {
 Toponyme.propTypes = {
   baseLocale: PropTypes.shape({
     _id: PropTypes.string.isRequired
-  }).isRequired
+  }).isRequired,
+  hasCadastre: PropTypes.bool.isRequired
 }
 
 export default Toponyme

--- a/pages/bal/toponyme.js
+++ b/pages/bal/toponyme.js
@@ -15,7 +15,7 @@ import ToponymeNumeros from '@/components/toponyme/toponyme-numeros'
 import AddNumeros from '@/components/toponyme/add-numeros'
 import ToponymeHeading from '@/components/toponyme/toponyme-heading'
 
-function Toponyme({baseLocale, hasCadastre}) {
+function Toponyme({baseLocale, commune}) {
   const [isFormOpen, setIsFormOpen] = useState(false)
   const [editedNumeroId, setEditedNumeroId] = useState(null)
   const [error, setError] = useState(null)
@@ -142,7 +142,7 @@ function Toponyme({baseLocale, hasCadastre}) {
               <Table.Cell display='block' padding={0} background='tint1'>
                 <NumeroEditor
                   hasPreview
-                  hasCadastre={hasCadastre}
+                  hasCadastre={commune.hasCadastre}
                   initialValue={editedNumero}
                   closeForm={onCancel}
                 />
@@ -171,7 +171,9 @@ Toponyme.propTypes = {
   baseLocale: PropTypes.shape({
     _id: PropTypes.string.isRequired
   }).isRequired,
-  hasCadastre: PropTypes.bool.isRequired
+  commune: PropTypes.shape({
+    hasCadastre: PropTypes.bool.isRequired
+  }).isRequired
 }
 
 export default Toponyme

--- a/pages/bal/voie.js
+++ b/pages/bal/voie.js
@@ -13,7 +13,7 @@ import NumeroEditor from '@/components/bal/numero-editor'
 import VoieHeading from '@/components/voie/voie-heading'
 import NumerosList from '@/components/voie/numeros-list'
 
-const Voie = React.memo(({hasCadastre}) => {
+const Voie = React.memo(({commune}) => {
   const [formState, setFormState] = useState({isOpen: false, editedNumero: null})
 
   useHelp(3)
@@ -50,7 +50,7 @@ const Voie = React.memo(({hasCadastre}) => {
             <Table.Cell display='block' padding={0} background='tint1'>
               <NumeroEditor
                 hasPreview
-                hasCadastre={hasCadastre}
+                hasCadastre={commune.hasCadastre}
                 initialVoieId={voie._id}
                 initialValue={formState.editedNumero}
                 closeForm={closeForm}
@@ -86,9 +86,9 @@ Voie.propTypes = {
     _id: PropTypes.string.isRequired
   }).isRequired,
   commune: PropTypes.shape({
-    code: PropTypes.string.isRequired
-  }).isRequired,
-  hasCadastre: PropTypes.bool.isRequired
+    code: PropTypes.string.isRequired,
+    hasCadastre: PropTypes.bool.isRequired
+  }).isRequired
 }
 
 export default Voie

--- a/pages/bal/voie.js
+++ b/pages/bal/voie.js
@@ -13,7 +13,7 @@ import NumeroEditor from '@/components/bal/numero-editor'
 import VoieHeading from '@/components/voie/voie-heading'
 import NumerosList from '@/components/voie/numeros-list'
 
-const Voie = React.memo(() => {
+const Voie = React.memo(({hasCadastre}) => {
   const [formState, setFormState] = useState({isOpen: false, editedNumero: null})
 
   useHelp(3)
@@ -50,6 +50,7 @@ const Voie = React.memo(() => {
             <Table.Cell display='block' padding={0} background='tint1'>
               <NumeroEditor
                 hasPreview
+                hasCadastre={hasCadastre}
                 initialVoieId={voie._id}
                 initialValue={formState.editedNumero}
                 closeForm={closeForm}
@@ -86,7 +87,8 @@ Voie.propTypes = {
   }).isRequired,
   commune: PropTypes.shape({
     code: PropTypes.string.isRequired
-  }).isRequired
+  }).isRequired,
+  hasCadastre: PropTypes.bool.isRequired
 }
 
 export default Voie


### PR DESCRIPTION
Actuellement, lorsque le cadastre n’est pas disponible pour une commune, rien dans l'affichage ne permet de le savoir.

Cette PR propose donc de masquer l’éditeur de parcelle cadastrale et de le remplacer par un message informant l’utilisateur de l’absence de cadastre pour la commune actuellement éditée.

Modifications effectuées : 
- Ajout de la propriété `hasCadastre` en provenance de l’API, permettant de savoir si le cadastre de la commune est disponible
- Ajout d’un composant `disabledInputForm` afin d’afficher un message lorsque le cadastre est indisponible
- Ajout d’une condition sur le bouton de la carte afin de le griser lorsque le cadastre est indisponible
- Correction des alertes en rapport avec le label de composants Evergreen
 
---
## ⚠️ Cette PR nécessite l’utilisation de [la PR #880](https://github.com/BaseAdresseNationale/mes-adresses-api/pull/330)

### ⚠️  Ne pas merger cette pull request avant le merge de la PR #880   ⚠️
---

_Pour tester cette PR, vous pouvez utiliser la commune **Suzan - 09304**_

Captures : 

![image](https://user-images.githubusercontent.com/56537238/172422679-811b34ff-4eea-46e5-b30e-2afc92862abc.png)

![Capture d’écran 2022-06-07 à 17 39 09](https://user-images.githubusercontent.com/56537238/172422835-c6b7b86b-e3a6-42c2-97f1-9427195fbcfa.png)


