### PR TITLE
Suppression du filtre des Collectivités d’Outre-Mer au formulaire de création

### DIFF
--- a/components/base-locale-card/index.js
+++ b/components/base-locale-card/index.js
@@ -65,7 +65,7 @@ function BaseLocaleCard({baseLocale, isAdmin, userEmail, isDefaultOpen, onSelect
                 </Text>
 
                 {commune && (
-                  <Text fontStyle='italic'> {commune.nom} ({commune.codeDepartement}) </Text>
+                  <Text fontStyle='italic'> {commune.nom} ({commune.codeDepartement || 'Collectivité d’Outre-Mer'})</Text>
                 )}
               </Pane>
             </Pane>

--- a/components/commune-search/commune-search.js
+++ b/components/commune-search/commune-search.js
@@ -5,7 +5,7 @@ import {useDebouncedCallback} from 'use-debounce'
 
 import {searchCommunes} from '@/lib/geo-api'
 
-function CommuneSearch({placeholder, exclude, innerRef, initialSelectedItem, onSelect, ...props}) {
+function CommuneSearch({placeholder, innerRef, initialSelectedItem, onSelect, ...props}) {
   const [communes, setCommunes] = useState([])
 
   const [onSearch] = useDebouncedCallback(async value => {
@@ -15,7 +15,7 @@ function CommuneSearch({placeholder, exclude, innerRef, initialSelectedItem, onS
     })
 
     setCommunes(result.filter(c => c._score > 0.1))
-  }, 300, [exclude])
+  }, 300)
 
   return (
     <Autocomplete
@@ -59,7 +59,6 @@ CommuneSearch.propTypes = {
     }).isRequired
   }),
   placeholder: PropTypes.string,
-  exclude: PropTypes.array,
   innerRef: PropTypes.func,
   onSelect: PropTypes.func
 }
@@ -67,7 +66,6 @@ CommuneSearch.propTypes = {
 CommuneSearch.defaultProps = {
   initialSelectedItem: null,
   placeholder: 'Chercher une commune…',
-  exclude: [],
   innerRef: () => {},
   onSelect: () => {}
 }

--- a/components/commune-search/commune-search.js
+++ b/components/commune-search/commune-search.js
@@ -11,12 +11,10 @@ function CommuneSearch({placeholder, exclude, innerRef, initialSelectedItem, onS
   const [onSearch] = useDebouncedCallback(async value => {
     const result = await searchCommunes(value, {
       fields: 'departement',
-      limit: 7
+      limit: 20
     })
 
-    setCommunes(result
-      .filter(c => !exclude.includes(c.code))
-    )
+    setCommunes(result.filter(c => c._score > 0.1))
   }, 300, [exclude])
 
   return (

--- a/components/commune-search/commune-search.js
+++ b/components/commune-search/commune-search.js
@@ -15,7 +15,6 @@ function CommuneSearch({placeholder, exclude, innerRef, initialSelectedItem, onS
     })
 
     setCommunes(result
-      .filter(c => c.departement) // Filter communes without departements
       .filter(c => !exclude.includes(c.code))
     )
   }, 300, [exclude])
@@ -25,7 +24,7 @@ function CommuneSearch({placeholder, exclude, innerRef, initialSelectedItem, onS
       isFilterDisabled
       initialSelectedItem={initialSelectedItem}
       items={communes}
-      itemToString={item => item ? `${item.nom} (${item.departement.nom} - ${item.departement.code})` : ''}
+      itemToString={item => item ? `${item.nom} (${item.departement ? `${item.departement.nom} - ${item.departement.code}` : 'Collectivité d’Outre-Mer'})` : ''}
       onChange={onSelect}
     >
       {({getInputProps, getRef, inputValue}) => {

--- a/components/commune-search/commune-search.js
+++ b/components/commune-search/commune-search.js
@@ -9,12 +9,13 @@ function CommuneSearch({placeholder, innerRef, initialSelectedItem, onSelect, ..
   const [communes, setCommunes] = useState([])
 
   const [onSearch] = useDebouncedCallback(async value => {
-    const result = await searchCommunes(value, {
+    const results = await searchCommunes(value, {
       fields: 'departement',
       limit: 20
     })
+    const bestResults = results.filter(c => c._score > 0.1)
 
-    setCommunes(result.filter(c => c._score > 0.1))
+    setCommunes(bestResults.length > 5 ? bestResults : results)
   }, 300)
 
   return (

--- a/components/new/demo-form.js
+++ b/components/new/demo-form.js
@@ -53,6 +53,8 @@ function DemoForm({defaultCommune}) {
             id='commune'
             initialSelectedItem={defaultCommune}
             label='Commune'
+            hint='Pour affiner la recherche, renseignez le code département'
+            placeholder='Roche 42'
             appearance='default'
             maxWidth={500}
             disabled={isLoading}


### PR DESCRIPTION
## Contexte
Les Collectivités d’Outre-Mer ne sont pour le moment gérer sur Mes Adresses pour différentes raisons techniques (voir BaseAdresseNationale/ban-bal/issues/4 et #531).

Un filtre est actuellement utilisé pour retirer les Collectivités d’Outre-Mer des territoires suggérés pour la création d’une Base Adresse Locale sur la page `/new`.

## Évolutions
- Suppression du filtre des résultats sans code département (COM)
- Augmentation de la limite des résultats de `7` à `20`
- Seuls les résultats ayant un `_score` supérieur à `0.1` sont affichés

### Autres évolutions mineurs
- Suppression de la props `exclude` inutilisée
- Ajout d'un `hint` et d'un `placeholder` sur le champ de création d'un BAL de démo

-----------
Les problèmes techniques étant en cours de résolution, cette PR propose de retirer le filtre afin que les Collectivités d’Outre-Mer puissent être utilisés pour créer une BAL.

⚠️ Certains de ces territoires ne dispose d'aucune adresse pouvant être extraite de la l'API de dépôt ou de la Base Adresse Nationale. C'est pourquoi cette PR nécessite ces changements avant de pouvoir être mergé.

- [x] BaseAdresseNationale/mes-adresses-api/pull/332
- [x] #590 