### PR TITLE
Corrige le problème de fermeture avec la croix

### DIFF
--- a/pages/bal/toponyme.js
+++ b/pages/bal/toponyme.js
@@ -92,7 +92,7 @@ function Toponyme({baseLocale, commune}) {
   return (
     <>
       <ToponymeHeading toponyme={toponyme} commune={commune} />
-      {token && isFormOpen ? (
+      {token && isFormOpen && isEditing ? (
         <AddNumeros isLoading={isLoading} onSubmit={onAdd} onCancel={onCancel} />
       ) : (
         <Pane


### PR DESCRIPTION
## Contexte : 

Lors de l’édition d’un toponyme depuis la page `/toponyme` ,  il n’est pas possible de fermer l’éditeur en cliquant sur la croix du panneau latéral.

## Solution : 
Ajout d’une condition pour fermer l’éditeur lorsque la croix est cliquée.

Fix #597 