### PR TITLE
Corrige le problème d’ouverture de l’éditeur de numéro

### DIFF
--- a/components/toponyme/toponyme-numeros.js
+++ b/components/toponyme/toponyme-numeros.js
@@ -10,6 +10,12 @@ function ToponymeNumeros({numeros, handleSelect, isEditable}) {
     return groupBy(numeros.sort((a, b) => a.numero - b.numero), d => d.voie.nom)
   }, [numeros])
 
+  const handleClick = id => {
+    if (isEditable) {
+      handleSelect(id)
+    }
+  }
+
   return (
     Object.keys(numerosByVoie).sort((a, b) => a > b).map(nomVoie => (
       <React.Fragment key={nomVoie}>
@@ -28,7 +34,7 @@ function ToponymeNumeros({numeros, handleSelect, isEditable}) {
             style={{cursor: 'pointer', backgroundColor: hovered === _id ? '#E4E7EB' : '#f5f6f7'}}
             onMouseEnter={() => setHovered(_id)}
             onMouseLeave={() => setHovered(null)}
-            onClick={() => handleSelect(_id)}
+            onClick={() => handleClick(_id)}
           >
             <Table.Cell data-browsable>
               <Table.TextCell data-editable flex='0 1 1'>


### PR DESCRIPTION
## Contexte : 

Lorsque l’on édite le nom d’un toponyme ou qu’on ajoute un numéro au toponyme sur la page `/toponyme` , il est possible d’ouvrir l’édition d’un numéro.

## Solution : 

Cette PR propose d’ajouter une condition pour éviter l’ouverture de l’éditeur de numéro lorsque l’application est en mode édition.

Fix #607 