### PR TITLE
Désactive les fonds de carte indisponible sur le territoire

### DIFF
--- a/components/map/controls/style-control.js
+++ b/components/map/controls/style-control.js
@@ -28,22 +28,29 @@ function StyleControl({style, commune, handleStyle, isCadastreDisplayed, handleC
       cursor='pointer'
       onClick={() => setShowPopover(!showPopover)}
     >
-      <SelectMenu
-        closeOnSelect
-        position={Position.TOP_LEFT}
-        title='Choix du fond de carte'
-        hasFilter={false}
-        height={40 + (33 * availableStyles.length)}
-        options={availableStyles}
-        selected={style}
-        onSelect={style => handleStyle(style.value)}
-      >
+      {availableStyles.length > 1 ? (
+        <SelectMenu
+          closeOnSelect
+          position={Position.TOP_LEFT}
+          title='Choix du fond de carte'
+          hasFilter={false}
+          height={40 + (33 * availableStyles.length)}
+          options={availableStyles}
+          selected={style}
+          onSelect={style => handleStyle(style.value)}
+        >
+          <Button className='map-style-button' style={{borderRadius: '3px 0 0 3px'}}>
+            <LayersIcon style={{marginRight: '.5em', borderRadius: '0 3px 3px 0'}} />
+            <div className='map-style-label'>{availableStyles.find(({value}) => value === style).label}</div>
+          </Button>
+
+        </SelectMenu>
+      ) : (
         <Button className='map-style-button' style={{borderRadius: '3px 0 0 3px'}}>
           <LayersIcon style={{marginRight: '.5em', borderRadius: '0 3px 3px 0'}} />
-          <div className='map-style-label'>{availableStyles.find(({value}) => value === style).label}</div>
+          <div className='map-style-label'>{availableStyles[0].label}</div>
         </Button>
-
-      </SelectMenu>
+      )}
       <CadastreControl
         hasCadastre={commune.hasCadastre}
         isCadastreDisplayed={isCadastreDisplayed}

--- a/components/map/controls/style-control.js
+++ b/components/map/controls/style-control.js
@@ -1,17 +1,20 @@
-import {useState} from 'react'
+import {useMemo, useState} from 'react'
 import PropTypes from 'prop-types'
 import {Pane, SelectMenu, Button, Position, LayersIcon} from 'evergreen-ui'
 
 import CadastreControl from '@/components/map/controls/cadastre-control.js'
 
-const STYLES = [
-  {label: 'Plan OpenMapTiles', value: 'vector'},
-  {label: 'Plan IGN (Bêta)', value: 'plan-ign'},
-  {label: 'Photographie aérienne', value: 'ortho'}
-]
-
-function StyleControl({style, handleStyle, isCadastreDisplayed, handleCadastre, hasCadastre}) {
+function StyleControl({style, commune, handleStyle, isCadastreDisplayed, handleCadastre}) {
   const [showPopover, setShowPopover] = useState(false)
+
+  const availableStyles = useMemo(() => {
+    const {hasOrtho, hasOpenMapTiles, hasPlanIGN} = commune
+    return [
+      {label: 'Plan OpenMapTiles', value: 'vector', isAvailable: hasOpenMapTiles},
+      {label: 'Plan IGN (Bêta)', value: 'plan-ign', isAvailable: hasPlanIGN},
+      {label: 'Photographie aérienne', value: 'ortho', isAvailable: hasOrtho}
+    ].filter(({isAvailable}) => isAvailable)
+  }, [commune])
 
   return (
     <Pane
@@ -30,19 +33,19 @@ function StyleControl({style, handleStyle, isCadastreDisplayed, handleCadastre, 
         position={Position.TOP_LEFT}
         title='Choix du fond de carte'
         hasFilter={false}
-        height={140}
-        options={STYLES}
+        height={40 + (33 * availableStyles.length)}
+        options={availableStyles}
         selected={style}
         onSelect={style => handleStyle(style.value)}
       >
         <Button className='map-style-button' style={{borderRadius: '3px 0 0 3px'}}>
           <LayersIcon style={{marginRight: '.5em', borderRadius: '0 3px 3px 0'}} />
-          <div className='map-style-label'>{STYLES.find(({value}) => value === style).label}</div>
+          <div className='map-style-label'>{availableStyles.find(({value}) => value === style).label}</div>
         </Button>
 
       </SelectMenu>
       <CadastreControl
-        hasCadastre={hasCadastre}
+        hasCadastre={commune.hasCadastre}
         isCadastreDisplayed={isCadastreDisplayed}
         onClick={() => handleCadastre(show => !show)}
       />
@@ -55,7 +58,12 @@ StyleControl.propTypes = {
   handleStyle: PropTypes.func.isRequired,
   isCadastreDisplayed: PropTypes.bool.isRequired,
   handleCadastre: PropTypes.func.isRequired,
-  hasCadastre: PropTypes.bool.isRequired
+  commune: PropTypes.shape({
+    hasCadastre: PropTypes.bool.isRequired,
+    hasOpenMapTiles: PropTypes.bool.isRequired,
+    hasOrtho: PropTypes.bool.isRequired,
+    hasPlanIGN: PropTypes.bool.isRequired
+  }).isRequired
 }
 
 export default StyleControl

--- a/components/map/map.js
+++ b/components/map/map.js
@@ -200,7 +200,7 @@ function Map({commune, isAddressFormOpen, handleAddressForm}) {
       <StyleControl
         style={style}
         handleStyle={setStyle}
-        hasCadastre={commune.hasCadastre}
+        commune={commune}
         isCadastreDisplayed={isCadastreDisplayed}
         handleCadastre={setIsCadastreDisplayed}
       />
@@ -292,7 +292,7 @@ function Map({commune, isAddressFormOpen, handleAddressForm}) {
 
 Map.propTypes = {
   commune: PropTypes.shape({
-    hasCadastre: PropTypes.bool.isRequired
+    hasOrtho: PropTypes.bool.isRequired
   }).isRequired,
   isAddressFormOpen: PropTypes.bool.isRequired,
   handleAddressForm: PropTypes.func.isRequired

--- a/components/map/map.js
+++ b/components/map/map.js
@@ -164,14 +164,14 @@ function Map({commune, isAddressFormOpen, handleAddressForm}) {
 
   useEffect(() => {
     setStyle(prevStyle => {
-      if (modeId) {
+      if (modeId && commune.hasOrtho) {
         setEditPrevSyle(prevStyle)
         return 'ortho'
       }
 
       return editPrevStyle
     })
-  }, [modeId]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [modeId, commune]) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     if (map) {


### PR DESCRIPTION
## Contexte
Certains territoires, comme les COM notamment, ne disposent pas de tous les fonds de carte que propose Mes Adresses (OpenMapTiles, Orthophoto, Plan IGN vecteur).

## Évolution
Cette PR propose de ne plus afficher les fonds de carte qui ne sont pas disponibles sur le territoire choisi en se basant sur les nouvelles propriétés `hasOrtho`, `hasOpenMapTiles` et `hasPlanIGN` .

Fix #590 

-----------

⚠️ Cette PR ne peut pas être merge avant https://github.com/BaseAdresseNationale/mes-adresses-api/pull/334