### PR TITLE
Amélioration des espaces sur les contrôleurs de la carte

### DIFF
--- a/components/map/map.js
+++ b/components/map/map.js
@@ -205,15 +205,15 @@ function Map({commune, isAddressFormOpen, handleAddressForm}) {
         handleCadastre={setIsCadastreDisplayed}
       />
 
-      <Pane
-        position='absolute'
-        className='mapboxgl-ctrl-group mapboxgl-ctrl'
-        top={88}
-        right={16}
-        zIndex={2}
-      >
+      {(voie || (toponymes && toponymes.length > 0)) && (
+        <Pane
+          position='absolute'
+          className='mapboxgl-ctrl-group mapboxgl-ctrl'
+          top={100}
+          right={16}
+          zIndex={2}
+        >
 
-        {(voie || (toponymes && toponymes.length > 0)) && (
           <Control
             icon={isLabelsDisplayed ? EyeOffIcon : EyeOpenIcon}
             isEnabled={isLabelsDisplayed}
@@ -221,11 +221,16 @@ function Map({commune, isAddressFormOpen, handleAddressForm}) {
             disabledHint={numeros ? 'Afficher les détails' : 'Afficher les toponymes'}
             onChange={setIsLabelsDisplayed}
           />
-        )}
-      </Pane>
+        </Pane>
+      )}
 
       {token && (
-        <Pane position='absolute' zIndex={1} top={130} right={15}>
+        <Pane
+          position='absolute'
+          zIndex={1}
+          top={voie || (toponymes && toponymes.length > 0) ? 136 : 100}
+          right={15}
+        >
           <AddressEditorControl
             isAddressFormOpen={isAddressFormOpen}
             handleAddressForm={handleAddressForm}


### PR DESCRIPTION
Les espaces entre les boutons de contrôles de zoom et les actions telles qu'afficher/masquer les détails/toponymes et "Créer une adresse" n'étaient pas très harmonieux.
Cette PR tend à réarranger ces espaces afin de mieux séparer et regrouper les différentes actions.

### **AVANT**
<img width="136" alt="Capture d’écran 2022-06-13 à 14 43 03" src="https://user-images.githubusercontent.com/66621960/173356754-283b2553-1bfc-4cbb-b258-c19387e2b386.png">
<img width="163" alt="Capture d’écran 2022-06-13 à 14 42 55" src="https://user-images.githubusercontent.com/66621960/173356758-f2451739-95b1-4d25-abf3-3e98129d646a.png">

### **APRÈS**
<img width="204" alt="Capture d’écran 2022-06-13 à 14 42 18" src="https://user-images.githubusercontent.com/66621960/173356764-4925574c-1908-48b5-b0ba-a1e51937f710.png">
<img width="339" alt="Capture d’écran 2022-06-13 à 14 42 00" src="https://user-images.githubusercontent.com/66621960/173356769-2527e5a1-392b-4049-b93e-5aedfc87e7da.png">
