### PR TITLE
Corrige le calcul du nombre de communes uniques dans le dashboard

### DIFF
--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -14,7 +14,7 @@ import PublishedBalStats from '@/components/dashboard/published-bal-stats'
 function Index({basesLocales, basesLoclesStats}) {
   const communeCount = uniq(
     basesLocales
-      .filter(({commune}) => commune)
+      .map(({commune}) => commune)
   ).length
 
   return (


### PR DESCRIPTION
- `communeCount` retournait le nombre de commune sans prendre en compte leur caractère unique

resolves #624 