### PR TITLE
Ajouter le formulaire de gestion des langues régionales

### DIFF
--- a/components/assisted-text-field.js
+++ b/components/assisted-text-field.js
@@ -6,7 +6,7 @@ import useFocus from '@/hooks/focus'
 
 import AccentTool from '@/components/accent-tool'
 
-function AssistedTextField({label, placeholder, value, validationMessage, onChange, isFocus, isDisabled}) {
+function AssistedTextField({label, ariaLabel, placeholder, value, validationMessage, onChange, isFocus, isDisabled, isRequired, isFullWidth}) {
   const [cursorPosition, setCursorPosition] = useState({start: 0, end: 0})
   const [focusRef, ref] = useFocus()
 
@@ -25,16 +25,18 @@ function AssistedTextField({label, placeholder, value, validationMessage, onChan
     <Pane display='flex' alignItems={validationMessage ? 'last baseline' : 'flex-end'} marginBottom='1em'>
       <TextInputField
         ref={isFocus && focusRef}
-        required
+        required={isRequired}
         marginBottom={0}
         disabled={isDisabled}
         label={label}
         placeholder={placeholder}
         value={value}
+        aria-label={ariaLabel}
         isInvalid={Boolean(validationMessage)}
         validationMessage={validationMessage}
         onBlur={e => setCursorPosition({start: e.target.selectionStart, end: e.target.selectionEnd})}
         onChange={e => handleChangeInput(e)}
+        width={isFullWidth ? '100%' : ''}
       />
       <Pane
         display='flex'
@@ -53,7 +55,10 @@ AssistedTextField.defaultProps = {
   placeholder: '',
   isFocus: false,
   isDisabled: false,
-  validationMessage: null
+  validationMessage: null,
+  ariaLabel: '',
+  isRequired: true,
+  isFullWidth: false
 }
 
 AssistedTextField.propTypes = {
@@ -63,7 +68,10 @@ AssistedTextField.propTypes = {
   validationMessage: PropTypes.string,
   onChange: PropTypes.func.isRequired,
   isFocus: PropTypes.bool,
-  isDisabled: PropTypes.bool
+  isDisabled: PropTypes.bool,
+  ariaLabel: PropTypes.string,
+  isRequired: PropTypes.bool,
+  isFullWidth: PropTypes.bool
 }
 
 export default AssistedTextField

--- a/components/assisted-text-field.js
+++ b/components/assisted-text-field.js
@@ -22,7 +22,7 @@ function AssistedTextField({label, placeholder, value, validationMessage, onChan
   }
 
   return (
-    <Pane display='flex' alignItems={validationMessage ? 'last baseline' : 'flex-end'}>
+    <Pane display='flex' alignItems={validationMessage ? 'last baseline' : 'flex-end'} marginBottom='1em'>
       <TextInputField
         ref={isFocus && focusRef}
         required

--- a/components/bal/language-field.js
+++ b/components/bal/language-field.js
@@ -1,0 +1,91 @@
+import PropTypes from 'prop-types'
+import {Pane, Button, SelectMenu, TextInputField, Tooltip, TrashIcon} from 'evergreen-ui'
+
+function LanguageField({field, index, selectedLanguages, handleLanguageChange, handleLanguageSelect, removeLanguage}) {
+  const languagesList = [
+    {label: 'Breton', value: 'bre', disabled: false},
+    {label: 'Basque', value: 'eus', disabled: false},
+    {label: 'Alsacien', value: 'asw', disabled: false},
+    {label: 'Corse', value: 'cos', disabled: false},
+    {label: 'Créole martiquais | guadeloupéen', value: 'gyn', disabled: false},
+    {label: 'Créole réunionais', value: 'rcf', disabled: false},
+    {label: 'Occitan', value: 'oci', disabled: false},
+  ]
+
+  for (const language of languagesList) {
+    for (const selected of selectedLanguages) {
+      if (selected.value === language.value) {
+        language.disabled = true
+      }
+    }
+  }
+
+  const detectLanguage = field => {
+    for (const language of languagesList) {
+      if (field.value === language.value) {
+        return language.label
+      }
+    }
+  }
+
+  const handlePlaceholder = field.label === '' && field.value ? `Nom de la voie en ${detectLanguage(field).toLowerCase()}` : 'Nom de la voie en langue régionale'
+
+  return (
+    <Pane width='100%' display='flex' flexDirection='column' height='fit-content' marginBottom={18}>
+      <SelectMenu
+        title='Select Option'
+        options={languagesList}
+        selected={field ? detectLanguage(field) : null}
+        onSelect={item => handleLanguageSelect(item.value, index)}
+        width='fit-content'
+      >
+        <Button
+          type='button'
+          width='fit-content'
+          margin={0}
+          fontStyle={detectLanguage(field) ? '' : 'italic'}
+        >
+          {detectLanguage(field) || 'Sélectionner une langue régionale...'}
+        </Button>
+      </SelectMenu>
+      <Pane display='grid' gridTemplateColumns='1fr 40px' gap='10px' marginTop='5px'>
+        <TextInputField
+          onChange={e => handleLanguageChange(e, index)}
+          value={field.label}
+          label=''
+          aria-label={`Écrire le ${handlePlaceholder}`}
+          placeholder={handlePlaceholder}
+          width='100%'
+          display='flex'
+          padding={0}
+          margin={0}
+        />
+
+        <Tooltip content='Supprimer la langue régionale'>
+          <Button
+            type='button'
+            aria-label='Supprimer la langue régionale'
+            onClick={() => removeLanguage(index)}
+            intent='danger'
+            width='fit-content'
+            padding={0}
+            margin={0}
+          >
+            <TrashIcon size={14} color='danger' />
+          </Button>
+        </Tooltip>
+      </Pane>
+    </Pane>
+  )
+}
+
+LanguageField.propTypes = {
+  field: PropTypes.object.isRequired,
+  index: PropTypes.number.isRequired,
+  selectedLanguages: PropTypes.array.isRequired,
+  handleLanguageChange: PropTypes.func.isRequired,
+  handleLanguageSelect: PropTypes.func.isRequired,
+  removeLanguage: PropTypes.func.isRequired
+}
+
+export default LanguageField

--- a/components/bal/language-field.js
+++ b/components/bal/language-field.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import {Pane, Button, SelectMenu, TextInputField, Tooltip, TrashIcon} from 'evergreen-ui'
 
-function LanguageField({field, index, selectedLanguages, onChange, onSelect, onDelete}) {
+function LanguageField({field, index, selectedLanguages, onChange, onSelect, onDelete, isToponyme}) {
   const languagesList = [
     {label: 'Breton', value: 'bre', disabled: false},
     {label: 'Basque', value: 'eus', disabled: false},
@@ -28,7 +28,7 @@ function LanguageField({field, index, selectedLanguages, onChange, onSelect, onD
     }
   }
 
-  const handlePlaceholder = field.label === '' && field.value ? `Nom de la voie en ${detectLanguage(field).toLowerCase()}` : 'Nom de la voie en langue régionale'
+  const handlePlaceholder = field.label === '' && field.value ? `Nom ${isToponyme ? 'du toponyme' : 'de la voie'} en ${detectLanguage(field).toLowerCase()}` : `Nom ${isToponyme ? 'du toponyme' : 'de la voie'} en langue régionale`
 
   return (
     <Pane width='100%' display='flex' flexDirection='column' height='fit-content' marginBottom={18}>
@@ -85,7 +85,12 @@ LanguageField.propTypes = {
   selectedLanguages: PropTypes.array.isRequired,
   onChange: PropTypes.func.isRequired,
   onSelect: PropTypes.func.isRequired,
-  onDelete: PropTypes.func.isRequired
+  onDelete: PropTypes.func.isRequired,
+  isToponyme: PropTypes.bool
+}
+
+LanguageField.defaultProps = {
+  isToponyme: false
 }
 
 export default LanguageField

--- a/components/bal/language-field.js
+++ b/components/bal/language-field.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import {Pane, Button, SelectMenu, TextInputField, Tooltip, TrashIcon} from 'evergreen-ui'
 
-function LanguageField({field, index, selectedLanguages, handleLanguageChange, handleLanguageSelect, removeLanguage}) {
+function LanguageField({field, index, selectedLanguages, onChange, onSelect, onDelete}) {
   const languagesList = [
     {label: 'Breton', value: 'bre', disabled: false},
     {label: 'Basque', value: 'eus', disabled: false},
@@ -36,7 +36,7 @@ function LanguageField({field, index, selectedLanguages, handleLanguageChange, h
         title='Select Option'
         options={languagesList}
         selected={field ? detectLanguage(field) : null}
-        onSelect={item => handleLanguageSelect(item.value, index)}
+        onSelect={item => onSelect(item.value, index)}
         width='fit-content'
       >
         <Button
@@ -50,7 +50,7 @@ function LanguageField({field, index, selectedLanguages, handleLanguageChange, h
       </SelectMenu>
       <Pane display='grid' gridTemplateColumns='1fr 40px' gap='10px' marginTop='5px'>
         <TextInputField
-          onChange={e => handleLanguageChange(e, index)}
+          onChange={e => onChange(e, index)}
           value={field.label}
           label=''
           aria-label={`Écrire le ${handlePlaceholder}`}
@@ -65,7 +65,7 @@ function LanguageField({field, index, selectedLanguages, handleLanguageChange, h
           <Button
             type='button'
             aria-label='Supprimer la langue régionale'
-            onClick={() => removeLanguage(index)}
+            onClick={() => onDelete(index)}
             intent='danger'
             width='fit-content'
             padding={0}
@@ -83,9 +83,9 @@ LanguageField.propTypes = {
   field: PropTypes.object.isRequired,
   index: PropTypes.number.isRequired,
   selectedLanguages: PropTypes.array.isRequired,
-  handleLanguageChange: PropTypes.func.isRequired,
-  handleLanguageSelect: PropTypes.func.isRequired,
-  removeLanguage: PropTypes.func.isRequired
+  onChange: PropTypes.func.isRequired,
+  onSelect: PropTypes.func.isRequired,
+  onDelete: PropTypes.func.isRequired
 }
 
 export default LanguageField

--- a/components/bal/language-field.js
+++ b/components/bal/language-field.js
@@ -1,5 +1,7 @@
 import PropTypes from 'prop-types'
-import {Pane, Button, SelectMenu, TextInputField, Tooltip, TrashIcon} from 'evergreen-ui'
+import {Pane, Button, SelectMenu, Tooltip, TrashIcon} from 'evergreen-ui'
+
+import AssistedTextField from '@/components/assisted-text-field'
 
 function LanguageField({field, index, selectedLanguages, onChange, onSelect, onDelete, isToponyme}) {
   const languagesList = [
@@ -48,19 +50,17 @@ function LanguageField({field, index, selectedLanguages, onChange, onSelect, onD
           {detectLanguage(field) || 'Sélectionner une langue régionale...'}
         </Button>
       </SelectMenu>
-      <Pane display='grid' gridTemplateColumns='1fr 40px' gap='10px' marginTop='5px'>
-        <TextInputField
-          onChange={e => onChange(e, index)}
-          value={field.label}
+      <Pane display='grid' gridTemplateColumns='1fr 40px' gap='10px' marginTop='5px' alignItems='center' justifyContent='flex-start'>
+        <AssistedTextField
+          isFocus
           label=''
+          isRequired={false}
           aria-label={`Écrire le ${handlePlaceholder}`}
           placeholder={handlePlaceholder}
-          width='100%'
-          display='flex'
-          padding={0}
-          margin={0}
+          value={field.label}
+          onChange={e => onChange(e, index)}
+          isFullWidth
         />
-
         <Tooltip content='Supprimer la langue régionale'>
           <Button
             type='button'
@@ -69,7 +69,7 @@ function LanguageField({field, index, selectedLanguages, onChange, onSelect, onD
             intent='danger'
             width='fit-content'
             padding={0}
-            margin={0}
+            marginBottom={8}
           >
             <TrashIcon size={14} color='danger' />
           </Button>

--- a/components/bal/toponyme-editor.js
+++ b/components/bal/toponyme-editor.js
@@ -1,7 +1,7 @@
 import {useState, useMemo, useContext, useCallback, useEffect} from 'react'
 import PropTypes from 'prop-types'
 import {difference} from 'lodash'
-import {Button} from 'evergreen-ui'
+import {Button, AddIcon} from 'evergreen-ui'
 
 import {addToponyme, editToponyme} from '@/lib/bal-api'
 
@@ -12,6 +12,7 @@ import ParcellesContext from '@/contexts/parcelles'
 
 import {useInput} from '@/hooks/input'
 import useValidationMessage from '@/hooks/validation-messages'
+import useLanguages from '@/hooks/languages'
 
 import FormMaster from '@/components/form-master'
 import Form from '@/components/form'
@@ -20,9 +21,15 @@ import FormInput from '@/components/form-input'
 import PositionEditor from '@/components/bal/position-editor'
 import SelectParcelles from '@/components/bal/numero-editor/select-parcelles'
 import DisabledFormInput from '@/components/disabled-form-input'
+import LanguageField from './language-field'
+
 import router from 'next/router'
 
+const nomVoieAlt = null
+
 function ToponymeEditor({initialValue, commune, closeForm}) {
+  const [selectedLanguages, onAddLanguage, handleLanguageSelect, handleLanguageChange, removeLanguage] = useLanguages(nomVoieAlt)
+
   const [isLoading, setIsLoading] = useState(false)
   const [nom, onNomChange, resetNom] = useInput(initialValue?.nom || '')
   const [getValidationMessage, setValidationMessages] = useValidationMessage(null)
@@ -118,6 +125,31 @@ function ToponymeEditor({initialValue, commune, closeForm}) {
             onChange={onNomChange}
             validationMessage={getValidationMessage('nom')}
           />
+
+          {selectedLanguages.map((field, index) => {
+            return (
+              <LanguageField
+                key={field.id}
+                index={index}
+                field={field}
+                selectedLanguages={selectedLanguages}
+                onChange={handleLanguageChange}
+                onSelect={handleLanguageSelect}
+                onDelete={removeLanguage}
+                isToponyme
+              />
+            )
+          })}
+          <Button
+            type='button'
+            appearance='primary'
+            intent='success'
+            iconBefore={AddIcon}
+            width='100%'
+            onClick={onAddLanguage}
+          >
+            Ajouter une langue régionale
+          </Button>
         </FormInput>
 
         <FormInput>

--- a/components/bal/toponyme-editor.js
+++ b/components/bal/toponyme-editor.js
@@ -25,10 +25,8 @@ import LanguageField from './language-field'
 
 import router from 'next/router'
 
-const nomVoieAlt = null
-
 function ToponymeEditor({initialValue, commune, closeForm}) {
-  const [selectedLanguages, onAddLanguage, handleLanguageSelect, handleLanguageChange, removeLanguage] = useLanguages(nomVoieAlt)
+  const [selectedLanguages, onAddLanguage, handleLanguageSelect, handleLanguageChange, removeLanguage, sanitizedAltVoieNames] = useLanguages(initialValue?.nomVoieAlt)
 
   const [isLoading, setIsLoading] = useState(false)
   const [nom, onNomChange, resetNom] = useInput(initialValue?.nom || '')
@@ -47,6 +45,7 @@ function ToponymeEditor({initialValue, commune, closeForm}) {
 
     const body = {
       nom,
+      nomVoieAlt: sanitizedAltVoieNames,
       positions: [],
       parcelles: selectedParcelles
     }
@@ -91,7 +90,7 @@ function ToponymeEditor({initialValue, commune, closeForm}) {
     } catch {
       setIsLoading(false)
     }
-  }, [token, baseLocale._id, initialValue, nom, markers, selectedParcelles, setToponyme, closeForm, refreshBALSync, reloadToponymes, reloadParcelles, reloadGeojson, setValidationMessages])
+  }, [token, baseLocale._id, initialValue, nom, markers, selectedParcelles, setToponyme, closeForm, refreshBALSync, reloadToponymes, reloadParcelles, reloadGeojson, setValidationMessages, sanitizedAltVoieNames])
 
   const onFormCancel = useCallback(e => {
     e.preventDefault()
@@ -118,7 +117,7 @@ function ToponymeEditor({initialValue, commune, closeForm}) {
         <FormInput>
           <AssistedTextField
             isFocus
-            dsiabled={isLoading}
+            disabled={isLoading}
             label='Nom du toponyme'
             placeholder='Nom du toponyme'
             value={nom}
@@ -190,6 +189,7 @@ ToponymeEditor.propTypes = {
   initialValue: PropTypes.shape({
     _id: PropTypes.string.isRequired,
     nom: PropTypes.string.isRequired,
+    nomVoieAlt: PropTypes.object.isRequired,
     parcelles: PropTypes.array.isRequired,
     positions: PropTypes.array.isRequired
   }),

--- a/components/bal/voie-editor.js
+++ b/components/bal/voie-editor.js
@@ -2,7 +2,6 @@ import {useState, useContext, useCallback, useEffect} from 'react'
 import PropTypes from 'prop-types'
 import router from 'next/router'
 import {Button, Checkbox, AddIcon} from 'evergreen-ui'
-import {uniqueId} from 'lodash'
 
 import {addVoie, editVoie} from '@/lib/bal-api'
 
@@ -12,6 +11,7 @@ import TokenContext from '@/contexts/token'
 
 import {useInput, useCheckboxInput} from '@/hooks/input'
 import useValidationMessage from '@/hooks/validation-messages'
+import useLanguages from '@/hooks/languages'
 
 import FormMaster from '@/components/form-master'
 import Form from '@/components/form'
@@ -20,22 +20,14 @@ import AssistedTextField from '@/components/assisted-text-field'
 import DrawEditor from '@/components/bal/draw-editor'
 import LanguageField from './language-field'
 
-// Const nomVoieAlt = {bre: 'Gwidel', cos: 'Carghjese'}
-const nomVoieAlt = null
+const nomVoieAlt = {bre: 'Gwidel', cos: 'Carghjese'}
 function VoieEditor({initialValue, closeForm}) {
-  // Const initialLanguageList = initialValue.nomVoieAlt && Object.keys(initialValue.nomVoieAlt).map(language => {
-  //   return {label: initialValue.nomVoieAlt[language], value: language, disabled: true, id: uniqueId()}
-  // })
-
-  const initialLanguageList = nomVoieAlt && Object.keys(nomVoieAlt).map(language => {
-    return {label: nomVoieAlt[language], value: language, disabled: true, id: uniqueId()}
-  })
+  const [selectedLanguages, onAddLanguage, handleLanguageSelect, handleLanguageChange, removeLanguage] = useLanguages(nomVoieAlt)
 
   const [isLoading, setIsLoading] = useState(false)
   const [isMetric, onIsMetricChange] = useCheckboxInput(initialValue ? initialValue.typeNumerotation === 'metrique' : false)
   const [nom, onNomChange] = useInput(initialValue ? initialValue.nom : '')
   const [getValidationMessage, setValidationMessages] = useValidationMessage()
-  const [selectedLanguages, setSelectedLanguages] = useState(initialLanguageList || [])
 
   const {token} = useContext(TokenContext)
   const {baseLocale, refreshBALSync, reloadVoies, reloadGeojson, setVoie} = useContext(BalDataContext)
@@ -101,25 +93,6 @@ function VoieEditor({initialValue, closeForm}) {
   const onUnmount = useCallback(() => {
     disableDraw()
   }, [disableDraw])
-
-  const onAddLanguage = () => {
-    setSelectedLanguages([...selectedLanguages, {label: '', value: '', disabled: false, id: uniqueId()}])
-  }
-
-  const handleLanguageSelect = (codeISO, index) => {
-    selectedLanguages[index].value = codeISO
-    setSelectedLanguages([...selectedLanguages])
-  }
-
-  const handleLanguageChange = (event, index) => {
-    selectedLanguages[index].label = event.target.value
-    setSelectedLanguages([...selectedLanguages])
-  }
-
-  const removeLanguage = index => {
-    selectedLanguages.splice(index, 1)
-    setSelectedLanguages([...selectedLanguages])
-  }
 
   return (
     <FormMaster editingId={initialValue?._id} unmountForm={onUnmount} closeForm={closeForm}>

--- a/components/bal/voie-editor.js
+++ b/components/bal/voie-editor.js
@@ -19,15 +19,12 @@ import FormInput from '@/components/form-input'
 import AssistedTextField from '@/components/assisted-text-field'
 import DrawEditor from '@/components/bal/draw-editor'
 import LanguageField from './language-field'
-
-const nomVoieAlt = {bre: 'Gwidel', cos: 'Carghjese'}
 function VoieEditor({initialValue, closeForm}) {
-  const [selectedLanguages, onAddLanguage, handleLanguageSelect, handleLanguageChange, removeLanguage] = useLanguages(nomVoieAlt)
-
   const [isLoading, setIsLoading] = useState(false)
   const [isMetric, onIsMetricChange] = useCheckboxInput(initialValue ? initialValue.typeNumerotation === 'metrique' : false)
   const [nom, onNomChange] = useInput(initialValue ? initialValue.nom : '')
   const [getValidationMessage, setValidationMessages] = useValidationMessage()
+  const [selectedLanguages, onAddLanguage, handleLanguageSelect, handleLanguageChange, removeLanguage, sanitizedAltVoieNames] = useLanguages(initialValue?.nomVoieAlt)
 
   const {token} = useContext(TokenContext)
   const {baseLocale, refreshBALSync, reloadVoies, reloadGeojson, setVoie} = useContext(BalDataContext)
@@ -42,6 +39,7 @@ function VoieEditor({initialValue, closeForm}) {
     try {
       const body = {
         nom,
+        nomVoieAlt: sanitizedAltVoieNames,
         typeNumerotation: isMetric ? 'metrique' : 'numerique',
         trace: data ? data.geometry : null
       }
@@ -68,7 +66,7 @@ function VoieEditor({initialValue, closeForm}) {
     } catch {
       setIsLoading(false)
     }
-  }, [baseLocale._id, initialValue, nom, isMetric, data, token, closeForm, setValidationMessages, setVoie, reloadVoies, reloadGeojson, refreshBALSync])
+  }, [baseLocale._id, initialValue, nom, isMetric, data, token, closeForm, setValidationMessages, setVoie, reloadVoies, reloadGeojson, refreshBALSync, sanitizedAltVoieNames])
 
   const onFormCancel = useCallback(e => {
     e.preventDefault()
@@ -121,9 +119,9 @@ function VoieEditor({initialValue, closeForm}) {
                 index={index}
                 field={field}
                 selectedLanguages={selectedLanguages}
-                handleLanguageChange={handleLanguageChange}
-                handleLanguageSelect={handleLanguageSelect}
-                removeLanguage={removeLanguage}
+                onChange={handleLanguageChange}
+                onSelect={handleLanguageSelect}
+                onDelete={removeLanguage}
               />
             )
           })}

--- a/hooks/languages.js
+++ b/hooks/languages.js
@@ -1,0 +1,32 @@
+import {useState} from 'react'
+import {uniqueId} from 'lodash'
+
+export default function useLanguages(initialValue) {
+  const initialLanguageList = initialValue && Object.keys(initialValue).map(language => {
+    return {label: initialValue[language], value: language, disabled: true, id: uniqueId()}
+  })
+
+  const [selectedLanguages, setSelectedLanguages] = useState(initialLanguageList || [])
+
+  const onAddLanguage = () => {
+    setSelectedLanguages([...selectedLanguages, {label: '', value: '', disabled: false, id: uniqueId()}])
+  }
+
+  const handleLanguageSelect = (codeISO, index) => {
+    selectedLanguages[index].value = codeISO
+    setSelectedLanguages([...selectedLanguages])
+  }
+
+  const handleLanguageChange = (event, index) => {
+    selectedLanguages[index].label = event.target.value
+    setSelectedLanguages([...selectedLanguages])
+  }
+
+  const removeLanguage = index => {
+    selectedLanguages.splice(index, 1)
+    setSelectedLanguages([...selectedLanguages])
+  }
+
+  return [selectedLanguages, onAddLanguage, handleLanguageSelect, handleLanguageChange, removeLanguage]
+}
+

--- a/hooks/languages.js
+++ b/hooks/languages.js
@@ -1,4 +1,4 @@
-import {useState} from 'react'
+import {useState, useMemo} from 'react'
 import {uniqueId} from 'lodash'
 
 export default function useLanguages(initialValue) {
@@ -7,6 +7,19 @@ export default function useLanguages(initialValue) {
   })
 
   const [selectedLanguages, setSelectedLanguages] = useState(initialLanguageList || [])
+
+  const sanitizedAltVoieNames = useMemo(() => {
+    const sanitizedLanguages = {}
+    selectedLanguages.map(language => {
+      if (language.label) {
+        sanitizedLanguages[language.value] = language.label
+      }
+
+      return language
+    })
+
+    return Object.keys(sanitizedLanguages).length > 0 ? sanitizedLanguages : null
+  }, [selectedLanguages])
 
   const onAddLanguage = () => {
     setSelectedLanguages([...selectedLanguages, {label: '', value: '', disabled: false, id: uniqueId()}])
@@ -27,6 +40,6 @@ export default function useLanguages(initialValue) {
     setSelectedLanguages([...selectedLanguages])
   }
 
-  return [selectedLanguages, onAddLanguage, handleLanguageSelect, handleLanguageChange, removeLanguage]
+  return [selectedLanguages, onAddLanguage, handleLanguageSelect, handleLanguageChange, removeLanguage, sanitizedAltVoieNames]
 }
 


### PR DESCRIPTION
Cette PR fait suite au ticket suivant : **Ajouter des champs texte alternatifs pour les langues régionales [#625](https://github.com/BaseAdresseNationale/mes-adresses/issues/625)**

La section "Nom" des formulaires d’édition des voies et des toponymes propose à présent un bouton `Ajouter une langue régionale` permettant d'ajouter un champ texte supplémentaire afin d'indiquer une alternative du nom. 

Ce nouveau champ texte est accompagné : 
- d’un sélecteur pour indiquer la langue régionale utilisée pour cette alternative ([Liste des langues supportées](https://github.com/BaseAdresseNationale/mes-adresses/issues/128))
- d’un bouton "corbeille" permettant de supprimer le champ
- du bouton "assistance à la saisie des accents"

Si le formulaire est validé alors qu'un champ "nom alternatif" est vide, alors le formulaire ignore cette langues régionales.

### **VOIES**
<img width="499" alt="Capture d’écran 2022-07-11 à 16 14 39" src="https://user-images.githubusercontent.com/66621960/178294715-97e333d3-423b-42b9-b1e8-d75eaee65a98.png">
<img width="501" alt="Capture d’écran 2022-07-11 à 16 46 09" src="https://user-images.githubusercontent.com/66621960/178294720-5658f372-b8d6-4886-9b48-4084bc6de750.png">
<img width="502" alt="Capture d’écran 2022-07-11 à 16 46 36" src="https://user-images.githubusercontent.com/66621960/178294721-1d6b1fca-8585-4df7-976b-a80126e690b1.png">
-----------------------------------
### **TOPONYMES**
<img width="501" alt="Capture d’écran 2022-07-11 à 16 53 02" src="https://user-images.githubusercontent.com/66621960/178294722-83573684-a9b9-418f-b994-cbdf1d7ee1ee.png">
<img width="498" alt="Capture d’écran 2022-07-11 à 16 53 20" src="https://user-images.githubusercontent.com/66621960/178294724-ff9e8762-0af2-4951-9a36-8a920bb0a345.png">

