### PR TITLE
Correction de la gestion du focus dans le composant <AssistedTextField/>

### DIFF
--- a/components/assisted-text-field.js
+++ b/components/assisted-text-field.js
@@ -1,27 +1,22 @@
-import {useState} from 'react'
+import {useState, useEffect, useRef} from 'react'
 import PropTypes from 'prop-types'
 import {Pane, TextInputField} from 'evergreen-ui'
-
-import useFocus from '@/hooks/focus'
 
 import AccentTool from '@/components/accent-tool'
 
 function AssistedTextField({label, placeholder, value, validationMessage, onChange, isFocus, isDisabled, isRequired}) {
   const [cursorPosition, setCursorPosition] = useState({start: 0, end: 0})
-  const [focusRef, ref] = useFocus()
+  const textFieldRef = useRef()
+
+  useEffect(() => {
+    if (isFocus) {
+      textFieldRef.current.focus()
+    }
+  }, [isFocus])
 
   const handleChangeAccent = e => {
     if (isFocus) {
-      ref.focus()
-      ref.setSelectionRange(cursorPosition.start, cursorPosition.end) // Put the cursor back to his position
-    }
-
-    onChange(e)
-  }
-
-  const handleChangeInput = e => {
-    if (isFocus) {
-      ref.focus()
+      textFieldRef.current.focus()
     }
 
     onChange(e)
@@ -30,7 +25,7 @@ function AssistedTextField({label, placeholder, value, validationMessage, onChan
   return (
     <Pane display='flex' alignItems={validationMessage ? 'last baseline' : 'flex-end'}>
       <TextInputField
-        ref={isFocus ? focusRef : null}
+        ref={textFieldRef}
         required={isRequired}
         marginBottom={0}
         disabled={isDisabled}
@@ -39,8 +34,8 @@ function AssistedTextField({label, placeholder, value, validationMessage, onChan
         value={value}
         isInvalid={Boolean(validationMessage)}
         validationMessage={validationMessage}
+        onChange={e => onChange(e)}
         onBlur={e => setCursorPosition({start: e.target.selectionStart, end: e.target.selectionEnd})}
-        onChange={e => handleChangeInput(e)}
       />
       <Pane
         display='flex'

--- a/components/assisted-text-field.js
+++ b/components/assisted-text-field.js
@@ -44,7 +44,12 @@ function AssistedTextField({label, placeholder, value, validationMessage, onChan
         marginLeft={8}
         marginTop={3}
       >
-        <AccentTool input={value} handleAccent={e => handleChangeAccent(e)} cursorPosition={cursorPosition} isDisabled={isDisabled} />
+        <AccentTool
+          input={value}
+          handleAccent={e => handleChangeAccent(e)}
+          cursorPosition={cursorPosition}
+          isDisabled={isDisabled}
+        />
       </Pane>
     </Pane>
   )

--- a/components/assisted-text-field.js
+++ b/components/assisted-text-field.js
@@ -24,8 +24,8 @@ function AssistedTextField({label, placeholder, value, validationMessage, onChan
   return (
     <Pane display='flex' alignItems={validationMessage ? 'last baseline' : 'flex-end'}>
       <TextInputField
-        ref={isFocus && focusRef}
-        required={isRequired}
+        ref={isFocus ? focusRef : null}
+        required
         marginBottom={0}
         disabled={isDisabled}
         label={label}

--- a/components/assisted-text-field.js
+++ b/components/assisted-text-field.js
@@ -11,13 +11,19 @@ function AssistedTextField({label, placeholder, value, validationMessage, onChan
   const [focusRef, ref] = useFocus()
 
   const handleChangeAccent = e => {
-    ref.focus()
+    if (isFocus) {
+      ref.focus()
+      ref.setSelectionRange(cursorPosition.start, cursorPosition.end) // Put the cursor back to his position
+    }
+
     onChange(e)
-    ref.setSelectionRange(cursorPosition.start, cursorPosition.end) // Put the cursor back to his position
   }
 
   const handleChangeInput = e => {
-    ref.focus()
+    if (isFocus) {
+      ref.focus()
+    }
+
     onChange(e)
   }
 

--- a/components/assisted-text-field.js
+++ b/components/assisted-text-field.js
@@ -25,7 +25,7 @@ function AssistedTextField({label, placeholder, value, validationMessage, onChan
     <Pane display='flex' alignItems={validationMessage ? 'last baseline' : 'flex-end'}>
       <TextInputField
         ref={isFocus ? focusRef : null}
-        required
+        required={isRequired}
         marginBottom={0}
         disabled={isDisabled}
         label={label}

--- a/components/assisted-text-field.js
+++ b/components/assisted-text-field.js
@@ -34,7 +34,7 @@ function AssistedTextField({label, placeholder, value, validationMessage, onChan
         value={value}
         isInvalid={Boolean(validationMessage)}
         validationMessage={validationMessage}
-        onChange={e => onChange(e)}
+        onChange={onChange}
         onBlur={e => setCursorPosition({start: e.target.selectionStart, end: e.target.selectionEnd})}
       />
       <Pane
@@ -46,7 +46,7 @@ function AssistedTextField({label, placeholder, value, validationMessage, onChan
       >
         <AccentTool
           input={value}
-          handleAccent={e => handleChangeAccent(e)}
+          handleAccent={handleChangeAccent}
           cursorPosition={cursorPosition}
           isDisabled={isDisabled}
         />

--- a/components/langues-regionales-form/language-field.js
+++ b/components/langues-regionales-form/language-field.js
@@ -54,7 +54,6 @@ function LanguageField({initialValue, availableLanguages, onChange, onDelete}) {
 
       <Pane display='grid' gridTemplateColumns='1fr 40px' gap='10px' marginTop='5px' alignItems='center' justifyContent='flex-start'>
         <AssistedTextField
-          isFocus
           label=''
           isRequired={false}
           placeholder={`Nom en ${codeISO ? languageLabel : 'langue régionale'}`}


### PR DESCRIPTION
La condition permettant la gestion du focus passe par une ref dans le composant AssistedTextField. Mais si isFocus est à false, alors la ref reçoit un booléen et provoque un crash de l'application, car une ref ne peut pas recevoir un booléen.
Ce fix permet d'éviter cette erreur en retournant `null` si `isFocus` vaut `false`


Close  #634