### PR TITLE
Afficher les drapeaux de toutes les langues régionales dispo

### DIFF
--- a/components/bal/language-preview.js
+++ b/components/bal/language-preview.js
@@ -2,6 +2,8 @@ import PropTypes from 'prop-types'
 import Image from 'next/image'
 import {Pane, UnorderedList, ListItem, Tooltip, Position, HelpIcon} from 'evergreen-ui'
 
+import languesRegionales from '@ban-team/shared-data/langues-regionales.json'
+
 import availableFlags from '../../available-flags.json'
 
 function LanguagePreview({nomAlt}) {
@@ -28,6 +30,7 @@ function LanguagePreview({nomAlt}) {
                     src={isFlagExist ? `/static/images/flags/${language}.svg` : '/images/icons/flags/ntr.svg'}
                     height={22}
                     width={22}
+                    alt={`Nom de la voie en ${languesRegionales.find(lr => lr.code === language).label}`}
                   />
                   {nomAlt[language]}
                 </ListItem>

--- a/components/bal/language-preview.js
+++ b/components/bal/language-preview.js
@@ -11,7 +11,7 @@ function LanguagePreview({nomAlt}) {
 
   return (
     Object.keys(nomAlt).length > 1 ? (
-      <Pane fontStyle='italic' fontSize={14} fontWeight='lighter'>
+      <Pane fontStyle='italic' fontWeight='lighter' display='flex' gap='5px' alignItems='center' fontSize={13}>
         <Tooltip
           content={
             <UnorderedList display='flex' flexDirection='column' padding={0} margin={0}>
@@ -47,10 +47,9 @@ function LanguagePreview({nomAlt}) {
           }
           position={Position.BOTTOM_LEFT}
         >
-          <Pane fontSize={12} display='flex' alignItems='center' gap='5px'>
-            <HelpIcon size={12} />Afficher les alternatives régionales
-          </Pane>
+          <HelpIcon size={16} />
         </Tooltip>
+        Alternatives régionales
       </Pane>
     ) : (
       <Pane fontStyle='italic' fontWeight='lighter' display='flex' gap={8} alignItems='center'>

--- a/components/bal/language-preview.js
+++ b/components/bal/language-preview.js
@@ -11,7 +11,14 @@ function LanguagePreview({nomAlt}) {
 
   return (
     Object.keys(nomAlt).length > 1 ? (
-      <Pane fontStyle='italic' fontWeight='lighter' display='flex' gap='5px' alignItems='center' fontSize={13}>
+      <Pane
+        fontStyle='italic'
+        fontWeight='lighter'
+        display='flex'
+        gap={5}
+        alignItems='center'
+        fontSize={13}
+      >
         <Tooltip
           content={
             <UnorderedList display='flex' flexDirection='column' padding={0} margin={0}>

--- a/components/bal/language-preview.js
+++ b/components/bal/language-preview.js
@@ -12,17 +12,29 @@ function LanguagePreview({nomAlt}) {
       <Pane fontStyle='italic' fontSize={14} fontWeight='lighter'>
         <Tooltip
           content={
-            <UnorderedList>
+            <UnorderedList display='flex' flexDirection='column' padding={0} margin={0}>
               {Object.keys(nomAlt).map(language => (
-                <ListItem color='white' key={language}>
+                <ListItem
+                  key={language}
+                  color='white'
+                  listStyleType='hidden'
+                  display='grid'
+                  alignItems='start'
+                  gridTemplateColumns='22px 1fr'
+                  gap={8}
+                  marginLeft={-15}
+                >
+                  <Image
+                    src={isFlagExist ? `/static/images/flags/${language}.svg` : '/images/icons/flags/ntr.svg'}
+                    height={22}
+                    width={22}
+                  />
                   {nomAlt[language]}
                 </ListItem>
               ))}
             </UnorderedList>
           }
           position={Position.BOTTOM_LEFT}
-          padding={0}
-          margin={0}
         >
           <Pane fontSize={12} display='flex' alignItems='center' gap='5px'>
             <HelpIcon size={12} />Afficher les alternatives régionales

--- a/components/bal/language-preview.js
+++ b/components/bal/language-preview.js
@@ -15,30 +15,34 @@ function LanguagePreview({nomAlt}) {
         <Tooltip
           content={
             <UnorderedList display='flex' flexDirection='column' padding={0} margin={0}>
-              {Object.keys(nomAlt).map(language => (
-                <ListItem
-                  key={language}
-                  color='white'
-                  listStyleType='hidden'
-                  display='grid'
-                  alignItems='start'
-                  gridTemplateColumns='22px 1fr'
-                  gap={8}
-                  marginLeft={-15}
-                >
-                  <Image
-                    src={isFlagExist ? `/static/images/flags/${language}.svg` : '/images/icons/flags/ntr.svg'}
-                    height={22}
-                    width={22}
-                    alt={languesRegionales.some(lr => lr.code === language) ? (
-                      `Nom de la voie en ${languesRegionales.find(lr => lr.code === language).label}`
-                    ) : (
-                      'Nom de la langue régionale introuvable'
-                    )}
-                  />
-                  {nomAlt[language]}
-                </ListItem>
-              ))}
+              {Object.keys(nomAlt).map(language => {
+                const foundLangueRegionale = languesRegionales.find(lr => lr.code === language)
+
+                return (
+                  <ListItem
+                    key={language}
+                    color='white'
+                    listStyleType='hidden'
+                    display='grid'
+                    alignItems='start'
+                    gridTemplateColumns='22px 1fr'
+                    gap={8}
+                    marginLeft={-15}
+                  >
+                    <Image
+                      src={isFlagExist ? `/static/images/flags/${language}.svg` : '/images/icons/flags/ntr.svg'}
+                      height={22}
+                      width={22}
+                      alt={foundLangueRegionale ? (
+                        `Nom de la voie en ${foundLangueRegionale.label}`
+                      ) : (
+                        'Nom de la langue régionale non supportée'
+                      )}
+                    />
+                    {nomAlt[language]}
+                  </ListItem>
+                )
+              })}
             </UnorderedList>
           }
           position={Position.BOTTOM_LEFT}

--- a/components/bal/language-preview.js
+++ b/components/bal/language-preview.js
@@ -30,7 +30,11 @@ function LanguagePreview({nomAlt}) {
                     src={isFlagExist ? `/static/images/flags/${language}.svg` : '/images/icons/flags/ntr.svg'}
                     height={22}
                     width={22}
-                    alt={`Nom de la voie en ${languesRegionales.find(lr => lr.code === language).label}`}
+                    alt={languesRegionales.some(lr => lr.code === language) ? (
+                      `Nom de la voie en ${languesRegionales.find(lr => lr.code === language).label}`
+                    ) : (
+                      'Nom de la langue régionale introuvable'
+                    )}
                   />
                   {nomAlt[language]}
                 </ListItem>

--- a/components/table-row/table-row-edit-shortcut.js
+++ b/components/table-row/table-row-edit-shortcut.js
@@ -20,7 +20,7 @@ const TableRowEditShortcut = React.memo(({label, nomAlt, complement, isEditingEn
         style={{cursor: isEditingEnabled ? 'text' : 'pointer'}}
         className='edit-cell'
       >
-        <Pane padding={1} fontSize={15} marginBottom={8}>
+        <Pane padding={1} fontSize={15}>
           {label} {complement && <i>{` - ${complement}`}</i>}
           {isEditingEnabled && (
             <span className='pencil-icon'>
@@ -28,7 +28,12 @@ const TableRowEditShortcut = React.memo(({label, nomAlt, complement, isEditingEn
             </span>
           )}
         </Pane>
-        {nomAlt && <LanguagePreview nomAlt={nomAlt} />}
+
+        {nomAlt && (
+          <Pane marginTop={4}>
+            <LanguagePreview nomAlt={nomAlt} />
+          </Pane>
+        )}
       </Table.TextCell>
 
       <style global jsx>{`

--- a/components/table-row/table-row-edit-shortcut.js
+++ b/components/table-row/table-row-edit-shortcut.js
@@ -20,7 +20,7 @@ const TableRowEditShortcut = React.memo(({label, nomAlt, complement, isEditingEn
         style={{cursor: isEditingEnabled ? 'text' : 'pointer'}}
         className='edit-cell'
       >
-        <Pane padding={1} fontSize={15}>
+        <Pane padding={1} fontSize={15} marginBottom={8}>
           {label} {complement && <i>{` - ${complement}`}</i>}
           {isEditingEnabled && (
             <span className='pencil-icon'>


### PR DESCRIPTION
Lorsque qu'une adresse a plusieurs langues régionales, une simple liste à puces était affichée.
Pour apporter du contexte et permettre à l'utilisateur de savoir quelle est la langue régionale qu'il est en train de lire, les puces de la liste disparaissent au profit de l'affichage du drapeau correspondant.

### **AVANT**
<img width="498" alt="Capture d’écran 2022-07-25 à 15 30 58" src="https://user-images.githubusercontent.com/66621960/180789836-6559329f-d93a-47de-8578-df96e946c51a.png">

### **APRÈS**
<img width="499" alt="Capture d’écran 2022-07-25 à 15 18 14" src="https://user-images.githubusercontent.com/66621960/180789892-8a3ea4e2-2864-4990-92d9-ef9c3b243e2a.png">
