### PR TITLE
Ajout d'une description d'image pour la langue régionale disponible

### DIFF
--- a/components/bal/language-preview.js
+++ b/components/bal/language-preview.js
@@ -2,6 +2,8 @@ import PropTypes from 'prop-types'
 import Image from 'next/image'
 import {Pane, UnorderedList, ListItem, Tooltip, Position, HelpIcon} from 'evergreen-ui'
 
+import languesRegionales from '@ban-team/shared-data/langues-regionales.json'
+
 import availableFlags from '../../available-flags.json'
 
 function LanguagePreview({nomAlt}) {
@@ -35,6 +37,7 @@ function LanguagePreview({nomAlt}) {
           src={isFlagExist ? `/static/images/flags/${Object.keys(nomAlt)[0]}.svg` : '/static/images/flags/ntr.svg'}
           height={18}
           width={18}
+          alt={`Nom de la voie en ${languesRegionales.find(lr => lr.code === Object.keys(nomAlt)[0]).label}`}
         />
         <Pane fontWeight='lighter' fontSize={14}>{nomAlt[Object.keys(nomAlt)]}</Pane>
       </Pane>


### PR DESCRIPTION
Cette PR prépare le terrain pour la mise à niveau de l'accessibilité de mes-adresses.
Sans contexte, l'utilisateur de lecteur d'écran ne peut pas savoir quelle est la langue régionale qui est ciblée, car il ne peut pas voir les drapeaux. Un `alt` est donc rajouté afin d'apporter ce contexte.

**Attention : 
La navigation au lecteur d'écran est très difficile sur mes-adresse, voir, comme dans ce cas précis, irréalisable. À terme, il sera nécessaire de s'assurer que tous les éléments interactifs soient cibables par le lecteur d'écran** 