### PR TITLE
Correction du rechargement des tracés de voie

### DIFF
--- a/components/bal/voie-editor.js
+++ b/components/bal/voie-editor.js
@@ -28,7 +28,7 @@ function VoieEditor({initialValue, closeForm}) {
   const [nomAlt, setNomAlt] = useState(initialValue?.nomAlt)
   const {token} = useContext(TokenContext)
   const {baseLocale, refreshBALSync, reloadVoies, reloadGeojson, setVoie} = useContext(BalDataContext)
-  const {drawEnabled, data, enableDraw, disableDraw, setModeId} = useContext(DrawContext)
+  const {drawEnabled, data, enableDraw, disableDraw} = useContext(DrawContext)
 
   const onFormSubmit = useCallback(async e => {
     e.preventDefault()
@@ -86,12 +86,11 @@ function VoieEditor({initialValue, closeForm}) {
 
   useEffect(() => {
     if (isMetric) {
-      // SetModeId(data ? 'editing' : 'drawLineString')
-      enableDraw()
+      enableDraw(initialValue)
     } else if (!isMetric && drawEnabled) {
       disableDraw()
     }
-  }, [data, disableDraw, drawEnabled, enableDraw, isMetric, setModeId])
+  }, [initialValue, disableDraw, drawEnabled, enableDraw, isMetric])
 
   const onUnmount = useCallback(() => {
     disableDraw()

--- a/components/bal/voie-editor.js
+++ b/components/bal/voie-editor.js
@@ -1,6 +1,7 @@
 import {useState, useContext, useCallback, useEffect} from 'react'
 import PropTypes from 'prop-types'
 import router from 'next/router'
+import {isEqual} from 'lodash'
 import {Pane, Button, Checkbox} from 'evergreen-ui'
 
 import {addVoie, editVoie} from '@/lib/bal-api'
@@ -55,6 +56,11 @@ function VoieEditor({initialValue, closeForm}) {
 
       if (initialValue?._id === voie._id && router.query.idVoie) {
         setVoie(voie)
+
+        // Reload voie trace
+        if (!isEqual(initialValue.trace, data?.geometry) || body.typeNumerotation !== initialValue.typeNumerotation) {
+          await reloadGeojson()
+        }
       } else {
         await reloadVoies()
         await reloadGeojson()
@@ -80,7 +86,7 @@ function VoieEditor({initialValue, closeForm}) {
 
   useEffect(() => {
     if (isMetric) {
-      setModeId(data ? 'editing' : 'drawLineString')
+      // SetModeId(data ? 'editing' : 'drawLineString')
       enableDraw()
     } else if (!isMetric && drawEnabled) {
       disableDraw()

--- a/components/map/draw.js
+++ b/components/map/draw.js
@@ -1,4 +1,4 @@
-import {useState, useCallback, useMemo, useContext} from 'react'
+import React, {useCallback, useMemo, useContext, useRef} from 'react'
 import {Editor, EditingMode, DrawLineStringMode} from 'react-map-gl-draw'
 import {Portal, Pane, Alert} from 'evergreen-ui'
 
@@ -67,4 +67,4 @@ function Draw() {
   )
 }
 
-export default Draw
+export default React.memo(Draw)

--- a/components/map/draw.js
+++ b/components/map/draw.js
@@ -10,14 +10,8 @@ const MODES = {
 }
 
 function Draw() {
-  const [editor, setEditor] = useState(null)
   const {drawEnabled, modeId, hint, data, setHint, setData} = useContext(DrawContext)
-
-  const editorRef = useCallback(ref => {
-    if (ref) {
-      setEditor(ref)
-    }
-  }, [])
+  const editorRef = useRef()
 
   const _onUpdate = useCallback(({data, editType}) => {
     if (editType === 'addTentativePosition') {
@@ -38,8 +32,8 @@ function Draw() {
     return null
   }
 
-  if (!data && editor) {
-    editor.deleteFeatures(0)
+  if (!data && editorRef?.current) {
+    editorRef.current.deleteFeatures(0)
   }
 
   return (

--- a/components/voie/voie-heading.js
+++ b/components/voie/voie-heading.js
@@ -1,4 +1,4 @@
-import {useState, useContext} from 'react'
+import {useState, useContext, useEffect, useCallback} from 'react'
 import PropTypes from 'prop-types'
 import {Pane, Heading, EditIcon, Text} from 'evergreen-ui'
 
@@ -15,12 +15,18 @@ function VoieHeading({voie}) {
   const {token} = useContext(TokenContext)
   const {editingId, isEditing, numeros} = useContext(BalDataContext)
 
-  const onEnableVoieEditing = () => {
+  const onEnableVoieEditing = useCallback(() => {
     if (!isEditing) {
       setIsFormOpen(true)
       setHovered(false)
     }
-  }
+  }, [isEditing])
+
+  useEffect(() => {
+    if (editingId === voie._id) {
+      onEnableVoieEditing()
+    }
+  }, [voie, editingId, onEnableVoieEditing])
 
   return isFormOpen ? (
     <Pane background='tint1' padding={0}>

--- a/contexts/draw.js
+++ b/contexts/draw.js
@@ -10,46 +10,34 @@ export function DrawContextProvider(props) {
   const [hint, setHint] = useState(null)
   const [data, setData] = useState(null)
 
-  const {editingItem} = useContext(BalDataContext)
+  const {voie} = useContext(BalDataContext)
 
   useEffect(() => {
-    if (modeId === 'drawLineString') {
-      setHint('Indiquez le début de la voie')
-    }
-  }, [modeId])
-
-  useEffect(() => {
-    if (data) {
-      setHint(null)
-      setModeId('editing')
-    }
-  }, [data, setModeId])
-
-  useEffect(() => {
-    if (editingItem) {
-      if (editingItem.typeNumerotation === 'metrique') {
-        if (editingItem.trace) {
-          setData({
-            type: 'Feature',
-            properties: {},
-            geometry: editingItem.trace
-          })
-          setModeId('editing')
-        } else {
-          setModeId('drawLineString')
-        }
-      }
+    if (voie?.trace) {
+      setData({
+        type: 'Feature',
+        properties: {},
+        geometry: voie.trace
+      })
     } else {
-      setModeId(null)
+      setData(null)
     }
-  }, [editingItem])
+  }, [voie])
 
   useEffect(() => {
-    if (!drawEnabled) {
-      setData(null)
+    if (drawEnabled) {
+      if (data) { // Edition mode
+        setModeId('editing')
+        setHint(null)
+      } else { // Creation mode
+        setModeId('drawLineString')
+        setHint('Indiquez le début de la voie')
+      }
+    } else { // Reset states
       setModeId(null)
+      setHint(null)
     }
-  }, [drawEnabled])
+  }, [drawEnabled, data])
 
   const value = useMemo(() => ({
     drawEnabled,

--- a/contexts/draw.js
+++ b/contexts/draw.js
@@ -1,6 +1,4 @@
-import React, {useState, useEffect, useContext, useMemo} from 'react'
-
-import BalDataContext from '@/contexts/bal-data'
+import React, {useState, useEffect, useMemo, useCallback} from 'react'
 
 const DrawContext = React.createContext()
 
@@ -9,8 +7,12 @@ export function DrawContextProvider(props) {
   const [modeId, setModeId] = useState(null)
   const [hint, setHint] = useState(null)
   const [data, setData] = useState(null)
+  const [voie, setVoie] = useState(null)
 
-  const {voie} = useContext(BalDataContext)
+  const enableDraw = useCallback(voie => {
+    setVoie(voie)
+    setDrawEnabled(true)
+  }, [])
 
   useEffect(() => {
     if (voie?.trace) {
@@ -41,7 +43,7 @@ export function DrawContextProvider(props) {
 
   const value = useMemo(() => ({
     drawEnabled,
-    enableDraw: () => setDrawEnabled(true),
+    enableDraw,
     disableDraw: () => setDrawEnabled(false),
     modeId,
     setModeId,
@@ -50,6 +52,7 @@ export function DrawContextProvider(props) {
     data,
     setData
   }), [
+    enableDraw,
     drawEnabled,
     modeId,
     hint,

--- a/contexts/draw.js
+++ b/contexts/draw.js
@@ -38,6 +38,7 @@ export function DrawContextProvider(props) {
     } else { // Reset states
       setModeId(null)
       setHint(null)
+      setVoie(null)
     }
   }, [drawEnabled, data])
 


### PR DESCRIPTION
## Contexte
Un utilisateur nous a remonté qu'il était devenu impossible d'éditer le tracé des voies.
En réalité l'édition était bien prise en compte, mais ce sont les données apportées au fond de carte qui n'était pas mise à jour.

## Correctif
Cette PR apporte les corrections et évolutions suivantes : 
- Corrige le rafraichissement des tracés de voies
- Corrige l'édition d'une voie en la sélectionnant depuis la carte
- Corrige l'édition du tracé en choisissant l'édition depuis le menu "..."
- Amélioration du nombre de rendus du composant de dessin (`ReactMapGLDraw`)
- Simplification du code du contexte `Draw` grâce à `BalDataContext.voie`