### PR TITLE
Correction du tracé de nouvelles voies

### DIFF
--- a/contexts/draw.js
+++ b/contexts/draw.js
@@ -39,6 +39,7 @@ export function DrawContextProvider(props) {
       setModeId(null)
       setHint(null)
       setVoie(null)
+      setData(null)
     }
   }, [drawEnabled, data])
 


### PR DESCRIPTION
## Contexte
Depuis la dernière modification #642, il s'est avéré que la création de voie métrique pouvait poser un problème. En effet, après avoir créé une première voie avec un tracé, la création d'une seconde obtenait le tracé de la première.

## Reproduire le problème
1. Créer une voie A
2. Ajouter un tracé à cette voie A
3. Créer une voie B
4. Cocher la case "Cette voie utilise la numérotation métrique"

Le tracé de la voie A devrait être copié sur la voie B. 