### PR TITLE
Amélioration du système de focus

### DIFF
--- a/components/accent-tool.js
+++ b/components/accent-tool.js
@@ -34,17 +34,13 @@ const ACCENTS = [
   'Œ'
 ]
 
-function AccentTool({input, handleAccent, cursorPosition, isDisabled}) {
+function AccentTool({input, handleAccent, updateCaret, forwadedRef, isDisabled}) {
   const handleClick = event => {
-    const stringArray = input.split('')
-    const {start, end} = cursorPosition
-    stringArray.splice(start, end - start, event.target.value)
+    const {selectionStart, selectionEnd} = forwadedRef.current
+    const valueWithAccent = {target: {value: input.slice(0, selectionStart) + event.target.value + input.slice(selectionEnd)}}
 
-    cursorPosition.start += 1
-    cursorPosition.end += 1
-
-    const valueWithAccent = {target: {value: stringArray.join('')}}
     handleAccent(valueWithAccent)
+    updateCaret()
   }
 
   return (
@@ -69,7 +65,8 @@ function AccentTool({input, handleAccent, cursorPosition, isDisabled}) {
 AccentTool.propTypes = {
   input: PropTypes.string.isRequired,
   handleAccent: PropTypes.func.isRequired,
-  cursorPosition: PropTypes.objectOf(PropTypes.number).isRequired,
+  updateCaret: PropTypes.func.isRequired,
+  forwadedRef: PropTypes.object.isRequired,
   isDisabled: PropTypes.bool
 }
 

--- a/components/assisted-text-field.js
+++ b/components/assisted-text-field.js
@@ -50,8 +50,7 @@ AssistedTextField.defaultProps = {
   placeholder: '',
   isDisabled: false,
   validationMessage: null,
-  isRequired: true,
-  exitFocus: () => {}
+  isRequired: true
 }
 
 AssistedTextField.propTypes = {
@@ -63,7 +62,7 @@ AssistedTextField.propTypes = {
   forwadedRef: PropTypes.object.isRequired,
   isDisabled: PropTypes.bool,
   isRequired: PropTypes.bool,
-  exitFocus: PropTypes.func
+  exitFocus: PropTypes.func.isRequired
 }
 
 export default AssistedTextField

--- a/components/assisted-text-field.js
+++ b/components/assisted-text-field.js
@@ -1,31 +1,21 @@
-import {useState, useEffect, useRef} from 'react'
 import PropTypes from 'prop-types'
 import {Pane, TextInputField} from 'evergreen-ui'
 
+import useCaretPosition from '@/hooks/caret-position'
 import AccentTool from '@/components/accent-tool'
 
-function AssistedTextField({label, placeholder, value, validationMessage, onChange, isFocus, isDisabled, isRequired}) {
-  const [cursorPosition, setCursorPosition] = useState({start: 0, end: 0})
-  const textFieldRef = useRef()
-
-  useEffect(() => {
-    if (isFocus) {
-      textFieldRef.current.focus()
-    }
-  }, [isFocus])
+function AssistedTextField({label, placeholder, value, validationMessage, onChange, isDisabled, isRequired, isFocus}) {
+  const {ref: inputRef, updateCaretPosition} = useCaretPosition({initialValue: value, isFocus})
 
   const handleChangeAccent = e => {
-    if (isFocus) {
-      textFieldRef.current.focus()
-    }
-
     onChange(e)
+    updateCaretPosition()
   }
 
   return (
     <Pane display='flex' alignItems={validationMessage ? 'last baseline' : 'flex-end'}>
       <TextInputField
-        ref={textFieldRef}
+        ref={inputRef}
         required={isRequired}
         marginBottom={0}
         disabled={isDisabled}
@@ -35,7 +25,6 @@ function AssistedTextField({label, placeholder, value, validationMessage, onChan
         isInvalid={Boolean(validationMessage)}
         validationMessage={validationMessage}
         onChange={onChange}
-        onBlur={e => setCursorPosition({start: e.target.selectionStart, end: e.target.selectionEnd})}
       />
       <Pane
         display='flex'
@@ -47,8 +36,9 @@ function AssistedTextField({label, placeholder, value, validationMessage, onChan
         <AccentTool
           input={value}
           handleAccent={handleChangeAccent}
-          cursorPosition={cursorPosition}
+          updateCaret={updateCaretPosition}
           isDisabled={isDisabled}
+          forwadedRef={inputRef}
         />
       </Pane>
     </Pane>
@@ -57,10 +47,10 @@ function AssistedTextField({label, placeholder, value, validationMessage, onChan
 
 AssistedTextField.defaultProps = {
   placeholder: '',
-  isFocus: false,
   isDisabled: false,
   validationMessage: null,
-  isRequired: true
+  isRequired: true,
+  isFocus: false
 }
 
 AssistedTextField.propTypes = {
@@ -69,9 +59,9 @@ AssistedTextField.propTypes = {
   value: PropTypes.string.isRequired,
   validationMessage: PropTypes.string,
   onChange: PropTypes.func.isRequired,
-  isFocus: PropTypes.bool,
   isDisabled: PropTypes.bool,
-  isRequired: PropTypes.bool
+  isRequired: PropTypes.bool,
+  isFocus: PropTypes.bool
 }
 
 export default AssistedTextField

--- a/components/assisted-text-field.js
+++ b/components/assisted-text-field.js
@@ -4,9 +4,8 @@ import {Pane, TextInputField} from 'evergreen-ui'
 import useCaretPosition from '@/hooks/caret-position'
 import AccentTool from '@/components/accent-tool'
 
-function AssistedTextField({label, placeholder, value, validationMessage, onChange, isDisabled, isRequired, isFocus}) {
+function AssistedTextField({label, placeholder, value, isFocus, validationMessage, onChange, isDisabled, isRequired, exitFocus}) {
   const {ref: inputRef, updateCaretPosition} = useCaretPosition({initialValue: value, isFocus})
-
   const handleChangeAccent = e => {
     onChange(e)
     updateCaretPosition()
@@ -25,6 +24,7 @@ function AssistedTextField({label, placeholder, value, validationMessage, onChan
         isInvalid={Boolean(validationMessage)}
         validationMessage={validationMessage}
         onChange={onChange}
+        onBlur={exitFocus}
       />
       <Pane
         display='flex'
@@ -50,7 +50,8 @@ AssistedTextField.defaultProps = {
   isDisabled: false,
   validationMessage: null,
   isRequired: true,
-  isFocus: false
+  isFocus: false,
+  exitFocus: () => {}
 }
 
 AssistedTextField.propTypes = {
@@ -61,7 +62,8 @@ AssistedTextField.propTypes = {
   onChange: PropTypes.func.isRequired,
   isDisabled: PropTypes.bool,
   isRequired: PropTypes.bool,
-  isFocus: PropTypes.bool
+  isFocus: PropTypes.bool,
+  exitFocus: PropTypes.func
 }
 
 export default AssistedTextField

--- a/components/assisted-text-field.js
+++ b/components/assisted-text-field.js
@@ -4,8 +4,8 @@ import {Pane, TextInputField} from 'evergreen-ui'
 import useCaretPosition from '@/hooks/caret-position'
 import AccentTool from '@/components/accent-tool'
 
-function AssistedTextField({label, forwadedRef, placeholder, value, isFocus, validationMessage, onChange, isDisabled, isRequired, exitFocus}) {
-  const {updateCaretPosition} = useCaretPosition({initialValue: value, isFocus, ref: forwadedRef})
+function AssistedTextField({label, forwadedRef, placeholder, value, validationMessage, onChange, isDisabled, isRequired, exitFocus}) {
+  const {updateCaretPosition} = useCaretPosition({initialValue: value, ref: forwadedRef})
 
   const handleChangeAccent = e => {
     onChange(e)
@@ -60,7 +60,6 @@ AssistedTextField.propTypes = {
   value: PropTypes.string.isRequired,
   validationMessage: PropTypes.string,
   onChange: PropTypes.func.isRequired,
-  isFocus: PropTypes.bool.isRequired,
   forwadedRef: PropTypes.object.isRequired,
   isDisabled: PropTypes.bool,
   isRequired: PropTypes.bool,

--- a/components/assisted-text-field.js
+++ b/components/assisted-text-field.js
@@ -4,8 +4,9 @@ import {Pane, TextInputField} from 'evergreen-ui'
 import useCaretPosition from '@/hooks/caret-position'
 import AccentTool from '@/components/accent-tool'
 
-function AssistedTextField({label, placeholder, value, isFocus, validationMessage, onChange, isDisabled, isRequired, exitFocus}) {
-  const {ref: inputRef, updateCaretPosition} = useCaretPosition({initialValue: value, isFocus})
+function AssistedTextField({label, forwadedRef, placeholder, value, isFocus, validationMessage, onChange, isDisabled, isRequired, exitFocus}) {
+  const {updateCaretPosition} = useCaretPosition({initialValue: value, isFocus, ref: forwadedRef})
+
   const handleChangeAccent = e => {
     onChange(e)
     updateCaretPosition()
@@ -14,7 +15,7 @@ function AssistedTextField({label, placeholder, value, isFocus, validationMessag
   return (
     <Pane display='flex' alignItems={validationMessage ? 'last baseline' : 'flex-end'}>
       <TextInputField
-        ref={inputRef}
+        ref={forwadedRef}
         required={isRequired}
         marginBottom={0}
         disabled={isDisabled}
@@ -38,7 +39,7 @@ function AssistedTextField({label, placeholder, value, isFocus, validationMessag
           handleAccent={handleChangeAccent}
           updateCaret={updateCaretPosition}
           isDisabled={isDisabled}
-          forwadedRef={inputRef}
+          forwadedRef={forwadedRef}
         />
       </Pane>
     </Pane>
@@ -50,7 +51,6 @@ AssistedTextField.defaultProps = {
   isDisabled: false,
   validationMessage: null,
   isRequired: true,
-  isFocus: false,
   exitFocus: () => {}
 }
 
@@ -60,9 +60,10 @@ AssistedTextField.propTypes = {
   value: PropTypes.string.isRequired,
   validationMessage: PropTypes.string,
   onChange: PropTypes.func.isRequired,
+  isFocus: PropTypes.bool.isRequired,
+  forwadedRef: PropTypes.object.isRequired,
   isDisabled: PropTypes.bool,
   isRequired: PropTypes.bool,
-  isFocus: PropTypes.bool,
   exitFocus: PropTypes.func
 }
 

--- a/components/bal/numero-editor.js
+++ b/components/bal/numero-editor.js
@@ -50,7 +50,7 @@ function NumeroEditor({initialVoieId, initialValue, commune, hasPreview, closeFo
 
   const needGeojsonUpdateRef = useRef(false)
 
-  const [ref] = useFocus({autofocus: true})
+  const [ref] = useFocus(true)
 
   const handleGeojsonRefresh = useCallback(async editedVoie => {
     if (editedVoie._id === initialVoieId) {

--- a/components/bal/numero-editor.js
+++ b/components/bal/numero-editor.js
@@ -50,7 +50,7 @@ function NumeroEditor({initialVoieId, initialValue, commune, hasPreview, closeFo
 
   const needGeojsonUpdateRef = useRef(false)
 
-  const [focusedElement] = useFocus({value: null, isFocus: true})
+  const [focusedElement] = useFocus(true)
 
   const handleGeojsonRefresh = useCallback(async editedVoie => {
     if (editedVoie._id === initialVoieId) {

--- a/components/bal/numero-editor.js
+++ b/components/bal/numero-editor.js
@@ -50,7 +50,7 @@ function NumeroEditor({initialVoieId, initialValue, commune, hasPreview, closeFo
 
   const needGeojsonUpdateRef = useRef(false)
 
-  const [focusRef] = useFocus()
+  const [focusedElement] = useFocus({value: null, isFocus: true})
 
   const handleGeojsonRefresh = useCallback(async editedVoie => {
     if (editedVoie._id === initialVoieId) {
@@ -215,7 +215,7 @@ function NumeroEditor({initialVoieId, initialValue, commune, hasPreview, closeFo
           <FormInput>
             <Pane display='flex' alignItems='flex-start'>
               <TextInputField
-                ref={focusRef}
+                ref={focusedElement}
                 required
                 label='Numéro'
                 display='block'

--- a/components/bal/numero-editor.js
+++ b/components/bal/numero-editor.js
@@ -50,7 +50,7 @@ function NumeroEditor({initialVoieId, initialValue, commune, hasPreview, closeFo
 
   const needGeojsonUpdateRef = useRef(false)
 
-  const [focusedElement] = useFocus(true)
+  const [ref] = useFocus({autofocus: true})
 
   const handleGeojsonRefresh = useCallback(async editedVoie => {
     if (editedVoie._id === initialVoieId) {
@@ -215,7 +215,7 @@ function NumeroEditor({initialVoieId, initialValue, commune, hasPreview, closeFo
           <FormInput>
             <Pane display='flex' alignItems='flex-start'>
               <TextInputField
-                ref={focusedElement}
+                ref={ref}
                 required
                 label='Numéro'
                 display='block'

--- a/components/bal/numero-editor/numero-voie-selector.js
+++ b/components/bal/numero-editor/numero-voie-selector.js
@@ -37,7 +37,6 @@ function NumeroVoieSelector({voieId, voies, nomVoie, mode, validationMessage, ha
       <Pane>
         {isCreateMode ? (
           <AssistedTextField
-            isFocus={isFocus}
             forwadedRef={ref}
             label='Nouvelle voie'
             placeholder='Nom de la voie'

--- a/components/bal/numero-editor/numero-voie-selector.js
+++ b/components/bal/numero-editor/numero-voie-selector.js
@@ -5,10 +5,13 @@ import {Button, Pane, Text, PlusIcon, PropertyIcon, SelectField} from 'evergreen
 
 import {normalizeSort} from '@/lib/normalize'
 
+import useFocus from '@/hooks/focus'
+
 import AssistedTextField from '@/components/assisted-text-field'
 
 function NumeroVoieSelector({voieId, voies, nomVoie, mode, validationMessage, handleVoie, handleNomVoie}) {
   const [isCreateMode, setIsCreateMode] = useState(mode === 'creation' || !voieId)
+  const [ref, isFocus] = useFocus({autofocus: true})
 
   const toggleMode = () => {
     setIsCreateMode(mode => !mode)
@@ -34,7 +37,8 @@ function NumeroVoieSelector({voieId, voies, nomVoie, mode, validationMessage, ha
       <Pane>
         {isCreateMode ? (
           <AssistedTextField
-            isFocus
+            isFocus={isFocus}
+            forwadedRef={ref}
             label='Nouvelle voie'
             placeholder='Nom de la voie'
             value={nomVoie}

--- a/components/bal/numero-editor/numero-voie-selector.js
+++ b/components/bal/numero-editor/numero-voie-selector.js
@@ -11,7 +11,7 @@ import AssistedTextField from '@/components/assisted-text-field'
 
 function NumeroVoieSelector({voieId, voies, nomVoie, mode, validationMessage, handleVoie, handleNomVoie}) {
   const [isCreateMode, setIsCreateMode] = useState(mode === 'creation' || !voieId)
-  const [ref] = useFocus(true)
+  const [ref, setIsFocus] = useFocus(true)
 
   const toggleMode = () => {
     setIsCreateMode(mode => !mode)
@@ -38,6 +38,7 @@ function NumeroVoieSelector({voieId, voies, nomVoie, mode, validationMessage, ha
         {isCreateMode ? (
           <AssistedTextField
             forwadedRef={ref}
+            exitFocus={() => setIsFocus(false)}
             label='Nouvelle voie'
             placeholder='Nom de la voie'
             value={nomVoie}

--- a/components/bal/numero-editor/numero-voie-selector.js
+++ b/components/bal/numero-editor/numero-voie-selector.js
@@ -11,7 +11,7 @@ import AssistedTextField from '@/components/assisted-text-field'
 
 function NumeroVoieSelector({voieId, voies, nomVoie, mode, validationMessage, handleVoie, handleNomVoie}) {
   const [isCreateMode, setIsCreateMode] = useState(mode === 'creation' || !voieId)
-  const [ref, isFocus] = useFocus({autofocus: true})
+  const [ref, isFocus] = useFocus(true)
 
   const toggleMode = () => {
     setIsCreateMode(mode => !mode)

--- a/components/bal/numero-editor/numero-voie-selector.js
+++ b/components/bal/numero-editor/numero-voie-selector.js
@@ -11,7 +11,7 @@ import AssistedTextField from '@/components/assisted-text-field'
 
 function NumeroVoieSelector({voieId, voies, nomVoie, mode, validationMessage, handleVoie, handleNomVoie}) {
   const [isCreateMode, setIsCreateMode] = useState(mode === 'creation' || !voieId)
-  const [ref, isFocus] = useFocus(true)
+  const [ref] = useFocus(true)
 
   const toggleMode = () => {
     setIsCreateMode(mode => !mode)

--- a/components/bal/toponyme-editor.js
+++ b/components/bal/toponyme-editor.js
@@ -12,6 +12,7 @@ import MarkersContext from '@/contexts/markers'
 import ParcellesContext from '@/contexts/parcelles'
 
 import {useInput} from '@/hooks/input'
+import useFocus from '@/hooks/focus'
 import useValidationMessage from '@/hooks/validation-messages'
 
 import FormMaster from '@/components/form-master'
@@ -33,6 +34,7 @@ function ToponymeEditor({initialValue, commune, closeForm}) {
   const {baseLocale, setToponyme, reloadToponymes, refreshBALSync, reloadGeojson, reloadParcelles} = useContext(BalDataContext)
   const {markers} = useContext(MarkersContext)
   const {selectedParcelles} = useContext(ParcellesContext)
+  const [ref, isFocus] = useFocus({autofocus: true})
 
   const onFormSubmit = useCallback(async e => {
     e.preventDefault()
@@ -114,7 +116,8 @@ function ToponymeEditor({initialValue, commune, closeForm}) {
         <Pane>
           <FormInput>
             <AssistedTextField
-              isFocus
+              isFocus={isFocus}
+              forwadedRef={ref}
               disabled={isLoading}
               label='Nom du toponyme'
               placeholder='Nom du toponyme'

--- a/components/bal/toponyme-editor.js
+++ b/components/bal/toponyme-editor.js
@@ -34,7 +34,7 @@ function ToponymeEditor({initialValue, commune, closeForm}) {
   const {baseLocale, setToponyme, reloadToponymes, refreshBALSync, reloadGeojson, reloadParcelles} = useContext(BalDataContext)
   const {markers} = useContext(MarkersContext)
   const {selectedParcelles} = useContext(ParcellesContext)
-  const [ref, isFocus] = useFocus(true)
+  const [ref] = useFocus(true)
 
   const onFormSubmit = useCallback(async e => {
     e.preventDefault()

--- a/components/bal/toponyme-editor.js
+++ b/components/bal/toponyme-editor.js
@@ -34,7 +34,7 @@ function ToponymeEditor({initialValue, commune, closeForm}) {
   const {baseLocale, setToponyme, reloadToponymes, refreshBALSync, reloadGeojson, reloadParcelles} = useContext(BalDataContext)
   const {markers} = useContext(MarkersContext)
   const {selectedParcelles} = useContext(ParcellesContext)
-  const [ref] = useFocus(true)
+  const [ref, setIsFocus] = useFocus(true)
 
   const onFormSubmit = useCallback(async e => {
     e.preventDefault()
@@ -117,6 +117,7 @@ function ToponymeEditor({initialValue, commune, closeForm}) {
           <FormInput>
             <AssistedTextField
               forwadedRef={ref}
+              exitFocus={() => setIsFocus(false)}
               disabled={isLoading}
               label='Nom du toponyme'
               placeholder='Nom du toponyme'

--- a/components/bal/toponyme-editor.js
+++ b/components/bal/toponyme-editor.js
@@ -116,7 +116,6 @@ function ToponymeEditor({initialValue, commune, closeForm}) {
         <Pane>
           <FormInput>
             <AssistedTextField
-              isFocus={isFocus}
               forwadedRef={ref}
               disabled={isLoading}
               label='Nom du toponyme'

--- a/components/bal/toponyme-editor.js
+++ b/components/bal/toponyme-editor.js
@@ -34,7 +34,7 @@ function ToponymeEditor({initialValue, commune, closeForm}) {
   const {baseLocale, setToponyme, reloadToponymes, refreshBALSync, reloadGeojson, reloadParcelles} = useContext(BalDataContext)
   const {markers} = useContext(MarkersContext)
   const {selectedParcelles} = useContext(ParcellesContext)
-  const [ref, isFocus] = useFocus({autofocus: true})
+  const [ref, isFocus] = useFocus(true)
 
   const onFormSubmit = useCallback(async e => {
     e.preventDefault()

--- a/components/bal/voie-editor.js
+++ b/components/bal/voie-editor.js
@@ -12,6 +12,7 @@ import TokenContext from '@/contexts/token'
 
 import {useInput, useCheckboxInput} from '@/hooks/input'
 import useValidationMessage from '@/hooks/validation-messages'
+import useFocus from '@/hooks/focus'
 
 import FormMaster from '@/components/form-master'
 import Form from '@/components/form'
@@ -29,6 +30,7 @@ function VoieEditor({initialValue, closeForm}) {
   const {token} = useContext(TokenContext)
   const {baseLocale, refreshBALSync, reloadVoies, reloadGeojson, setVoie} = useContext(BalDataContext)
   const {drawEnabled, data, enableDraw, disableDraw} = useContext(DrawContext)
+  const [ref, isFocus] = useFocus({autofocus: true})
 
   const onFormSubmit = useCallback(async e => {
     e.preventDefault()
@@ -102,7 +104,8 @@ function VoieEditor({initialValue, closeForm}) {
         <Pane maxHeight={400} overflowY='scroll'>
           <FormInput>
             <AssistedTextField
-              isFocus
+              isFocus={isFocus}
+              forwadedRef={ref}
               label='Nom de la voie'
               placeholder='Nom de la voie'
               value={nom}

--- a/components/bal/voie-editor.js
+++ b/components/bal/voie-editor.js
@@ -104,7 +104,6 @@ function VoieEditor({initialValue, closeForm}) {
         <Pane maxHeight={400} overflowY='scroll'>
           <FormInput>
             <AssistedTextField
-              isFocus={isFocus}
               forwadedRef={ref}
               label='Nom de la voie'
               placeholder='Nom de la voie'

--- a/components/bal/voie-editor.js
+++ b/components/bal/voie-editor.js
@@ -30,7 +30,7 @@ function VoieEditor({initialValue, closeForm}) {
   const {token} = useContext(TokenContext)
   const {baseLocale, refreshBALSync, reloadVoies, reloadGeojson, setVoie} = useContext(BalDataContext)
   const {drawEnabled, data, enableDraw, disableDraw} = useContext(DrawContext)
-  const [ref, isFocus] = useFocus(true)
+  const [ref] = useFocus(true)
 
   const onFormSubmit = useCallback(async e => {
     e.preventDefault()

--- a/components/bal/voie-editor.js
+++ b/components/bal/voie-editor.js
@@ -30,7 +30,7 @@ function VoieEditor({initialValue, closeForm}) {
   const {token} = useContext(TokenContext)
   const {baseLocale, refreshBALSync, reloadVoies, reloadGeojson, setVoie} = useContext(BalDataContext)
   const {drawEnabled, data, enableDraw, disableDraw} = useContext(DrawContext)
-  const [ref, isFocus] = useFocus({autofocus: true})
+  const [ref, isFocus] = useFocus(true)
 
   const onFormSubmit = useCallback(async e => {
     e.preventDefault()

--- a/components/bal/voie-editor.js
+++ b/components/bal/voie-editor.js
@@ -30,7 +30,7 @@ function VoieEditor({initialValue, closeForm}) {
   const {token} = useContext(TokenContext)
   const {baseLocale, refreshBALSync, reloadVoies, reloadGeojson, setVoie} = useContext(BalDataContext)
   const {drawEnabled, data, enableDraw, disableDraw} = useContext(DrawContext)
-  const [ref] = useFocus(true)
+  const [ref, setIsFocus] = useFocus(true)
 
   const onFormSubmit = useCallback(async e => {
     e.preventDefault()
@@ -105,6 +105,7 @@ function VoieEditor({initialValue, closeForm}) {
           <FormInput>
             <AssistedTextField
               forwadedRef={ref}
+              exitFocus={() => setIsFocus(false)}
               label='Nom de la voie'
               placeholder='Nom de la voie'
               value={nom}

--- a/components/demo-warning.js
+++ b/components/demo-warning.js
@@ -15,7 +15,7 @@ function DemoWarning({baseLocale, communeName}) {
   const [isLoading, setIsLoading] = useState(false)
   const [nom, setNom] = useState(`Adresses de ${communeName}`)
   const [email, onEmailChange] = useInput()
-  const [focusedElement] = useFocus({value: null, isFocus: true})
+  const [focusedElement] = useFocus(true)
 
   const {reloadBaseLocale} = useContext(BalDataContext)
   const {token} = useContext(TokenContext)

--- a/components/demo-warning.js
+++ b/components/demo-warning.js
@@ -15,7 +15,7 @@ function DemoWarning({baseLocale, communeName}) {
   const [isLoading, setIsLoading] = useState(false)
   const [nom, setNom] = useState(`Adresses de ${communeName}`)
   const [email, onEmailChange] = useInput()
-  const [focusedElement] = useFocus(true)
+  const [ref, , setIsFocus] = useFocus({})
 
   const {reloadBaseLocale} = useContext(BalDataContext)
   const {token} = useContext(TokenContext)
@@ -70,12 +70,12 @@ function DemoWarning({baseLocale, communeName}) {
         confirmLabel='Conserver'
         hasFooter={false}
         onCloseComplete={() => setIsShown(false)}
-        onOpenComplete={() => focusedElement.current.focus()}
+        onOpenComplete={() => setIsFocus(true)}
       >
         <form onSubmit={onSubmit}>
 
           <TextInputField
-            ref={focusedElement}
+            ref={ref}
             required
             autoComplete='new-password' // Hack to bypass chrome autocomplete
             name='nom'

--- a/components/demo-warning.js
+++ b/components/demo-warning.js
@@ -15,7 +15,7 @@ function DemoWarning({baseLocale, communeName}) {
   const [isLoading, setIsLoading] = useState(false)
   const [nom, setNom] = useState(`Adresses de ${communeName}`)
   const [email, onEmailChange] = useInput()
-  const [ref, , setIsFocus] = useFocus({})
+  const [ref, , setIsFocus] = useFocus()
 
   const {reloadBaseLocale} = useContext(BalDataContext)
   const {token} = useContext(TokenContext)

--- a/components/demo-warning.js
+++ b/components/demo-warning.js
@@ -15,8 +15,7 @@ function DemoWarning({baseLocale, communeName}) {
   const [isLoading, setIsLoading] = useState(false)
   const [nom, setNom] = useState(`Adresses de ${communeName}`)
   const [email, onEmailChange] = useInput()
-
-  const [focusRef] = useFocus()
+  const [focusedElement] = useFocus({value: null, isFocus: true})
 
   const {reloadBaseLocale} = useContext(BalDataContext)
   const {token} = useContext(TokenContext)
@@ -71,11 +70,12 @@ function DemoWarning({baseLocale, communeName}) {
         confirmLabel='Conserver'
         hasFooter={false}
         onCloseComplete={() => setIsShown(false)}
+        onOpenComplete={() => focusedElement.current.focus()}
       >
         <form onSubmit={onSubmit}>
 
           <TextInputField
-            ref={focusRef}
+            ref={focusedElement}
             required
             autoComplete='new-password' // Hack to bypass chrome autocomplete
             name='nom'

--- a/components/demo-warning.js
+++ b/components/demo-warning.js
@@ -15,7 +15,7 @@ function DemoWarning({baseLocale, communeName}) {
   const [isLoading, setIsLoading] = useState(false)
   const [nom, setNom] = useState(`Adresses de ${communeName}`)
   const [email, onEmailChange] = useInput()
-  const [ref, , setIsFocus] = useFocus()
+  const [ref, setIsFocus] = useFocus()
 
   const {reloadBaseLocale} = useContext(BalDataContext)
   const {token} = useContext(TokenContext)

--- a/components/langues-regionales-form/language-field.js
+++ b/components/langues-regionales-form/language-field.js
@@ -10,6 +10,7 @@ import AssistedTextField from '@/components/assisted-text-field'
 function LanguageField({initialValue, availableLanguages, onChange, onDelete}) {
   const [codeISO, setCodeISO] = useState(initialValue?.code)
   const [input, setInput] = useState(initialValue?.value || '')
+  const [isFocus, setIsFocus] = useState(false)
 
   const languageLabel = useMemo(() => {
     if (codeISO) {
@@ -20,6 +21,7 @@ function LanguageField({initialValue, availableLanguages, onChange, onDelete}) {
   const handleLanguageCode = codeISO => {
     setCodeISO(codeISO)
     onChange({code: codeISO, value: input})
+    setIsFocus(true)
   }
 
   const handleLanguageChange = useCallback(event => {
@@ -55,7 +57,7 @@ function LanguageField({initialValue, availableLanguages, onChange, onDelete}) {
       <Pane display='grid' gridTemplateColumns='1fr 40px' gap='10px' marginTop='5px' alignItems='center' justifyContent='flex-start'>
         <AssistedTextField
           label=''
-          isFocus={Boolean(codeISO)}
+          isFocus={isFocus}
           isRequired={false}
           placeholder={`Nom en ${codeISO ? languageLabel : 'langue régionale'}`}
           value={input}

--- a/components/langues-regionales-form/language-field.js
+++ b/components/langues-regionales-form/language-field.js
@@ -12,7 +12,7 @@ import AssistedTextField from '@/components/assisted-text-field'
 function LanguageField({initialValue, availableLanguages, onChange, onDelete}) {
   const [codeISO, setCodeISO] = useState(initialValue?.code)
   const [input, setInput] = useState(initialValue?.value || '')
-  const [ref, isFocus, setIsFocus] = useFocus()
+  const [ref, setIsFocus] = useFocus()
 
   const languageLabel = useMemo(() => {
     if (codeISO) {

--- a/components/langues-regionales-form/language-field.js
+++ b/components/langues-regionales-form/language-field.js
@@ -55,6 +55,7 @@ function LanguageField({initialValue, availableLanguages, onChange, onDelete}) {
       <Pane display='grid' gridTemplateColumns='1fr 40px' gap='10px' marginTop='5px' alignItems='center' justifyContent='flex-start'>
         <AssistedTextField
           label=''
+          isFocus={Boolean(codeISO)}
           isRequired={false}
           placeholder={`Nom en ${codeISO ? languageLabel : 'langue régionale'}`}
           value={input}

--- a/components/langues-regionales-form/language-field.js
+++ b/components/langues-regionales-form/language-field.js
@@ -5,12 +5,14 @@ import {capitalize} from 'lodash'
 
 import languesRegionales from '@ban-team/shared-data/langues-regionales.json'
 
+import useFocus from '@/hooks/focus'
+
 import AssistedTextField from '@/components/assisted-text-field'
 
 function LanguageField({initialValue, availableLanguages, onChange, onDelete}) {
   const [codeISO, setCodeISO] = useState(initialValue?.code)
   const [input, setInput] = useState(initialValue?.value || '')
-  const [isFocus, setIsFocus] = useState(false)
+  const [ref, isFocus, setIsFocus] = useFocus({})
 
   const languageLabel = useMemo(() => {
     if (codeISO) {
@@ -57,6 +59,7 @@ function LanguageField({initialValue, availableLanguages, onChange, onDelete}) {
       <Pane display='grid' gridTemplateColumns='1fr 40px' gap='10px' marginTop='5px' alignItems='center' justifyContent='flex-start'>
         <AssistedTextField
           label=''
+          forwadedRef={ref}
           isFocus={isFocus}
           exitFocus={() => setIsFocus(false)}
           isRequired={false}

--- a/components/langues-regionales-form/language-field.js
+++ b/components/langues-regionales-form/language-field.js
@@ -12,7 +12,7 @@ import AssistedTextField from '@/components/assisted-text-field'
 function LanguageField({initialValue, availableLanguages, onChange, onDelete}) {
   const [codeISO, setCodeISO] = useState(initialValue?.code)
   const [input, setInput] = useState(initialValue?.value || '')
-  const [ref, isFocus, setIsFocus] = useFocus({})
+  const [ref, isFocus, setIsFocus] = useFocus()
 
   const languageLabel = useMemo(() => {
     if (codeISO) {

--- a/components/langues-regionales-form/language-field.js
+++ b/components/langues-regionales-form/language-field.js
@@ -60,7 +60,6 @@ function LanguageField({initialValue, availableLanguages, onChange, onDelete}) {
         <AssistedTextField
           label=''
           forwadedRef={ref}
-          isFocus={isFocus}
           exitFocus={() => setIsFocus(false)}
           isRequired={false}
           placeholder={`Nom en ${codeISO ? languageLabel : 'langue régionale'}`}

--- a/components/langues-regionales-form/language-field.js
+++ b/components/langues-regionales-form/language-field.js
@@ -58,6 +58,7 @@ function LanguageField({initialValue, availableLanguages, onChange, onDelete}) {
         <AssistedTextField
           label=''
           isFocus={isFocus}
+          exitFocus={() => setIsFocus(false)}
           isRequired={false}
           placeholder={`Nom en ${codeISO ? languageLabel : 'langue régionale'}`}
           value={input}

--- a/components/new/create-form.js
+++ b/components/new/create-form.js
@@ -27,7 +27,7 @@ function CreateForm({defaultCommune}) {
   const [codeCommune, setCodeCommune] = useState(defaultCommune ? defaultCommune.code : null)
   const [isShown, setIsShown] = useState(false)
   const [userBALs, setUserBALs] = useState([])
-  const [focusedElement] = useFocus({value: null, isFocus: true})
+  const [focusedElement] = useFocus(true)
 
   const onSelect = useCallback(commune => {
     setCodeCommune(commune.code)

--- a/components/new/create-form.js
+++ b/components/new/create-form.js
@@ -27,7 +27,7 @@ function CreateForm({defaultCommune}) {
   const [codeCommune, setCodeCommune] = useState(defaultCommune ? defaultCommune.code : null)
   const [isShown, setIsShown] = useState(false)
   const [userBALs, setUserBALs] = useState([])
-  const [focusRef] = useFocus()
+  const [focusedElement] = useFocus({value: null, isFocus: true})
 
   const onSelect = useCallback(commune => {
     setCodeCommune(commune.code)
@@ -96,7 +96,7 @@ function CreateForm({defaultCommune}) {
 
         <FormInput>
           <TextInputField
-            ref={focusRef}
+            ref={focusedElement}
             required
             autoComplete='new-password' // Hack to bypass chrome autocomplete
             name='nom'

--- a/components/new/demo-form.js
+++ b/components/new/demo-form.js
@@ -1,4 +1,4 @@
-import {useState, useCallback, useContext} from 'react'
+import {useState, useCallback, useContext, useEffect} from 'react'
 import PropTypes from 'prop-types'
 import Router from 'next/router'
 import {Pane, Checkbox, Button, Alert, PlusIcon} from 'evergreen-ui'
@@ -7,7 +7,6 @@ import {createBaseLocaleDemo} from '@/lib/bal-api'
 
 import LocalStorageContext from '@/contexts/local-storage'
 
-import useFocus from '@/hooks/focus'
 import {useCheckboxInput} from '@/hooks/input'
 
 import Form from '@/components/form'
@@ -21,7 +20,13 @@ function DemoForm({defaultCommune}) {
 
   const [populate, onPopulateChange] = useCheckboxInput(true)
   const [codeCommune, setCodeCommune] = useState(defaultCommune ? defaultCommune.code : null)
-  const [focusRef] = useFocus()
+  const [ref, setRef] = useState()
+
+  useEffect(() => {
+    if (ref) {
+      ref.focus()
+    }
+  }, [ref])
 
   const onSelect = useCallback(commune => {
     setCodeCommune(commune.code)
@@ -43,13 +48,12 @@ function DemoForm({defaultCommune}) {
   }, [codeCommune, populate, addBalAccess])
 
   return (
-
     <Pane overflowY='scroll'>
       <Form onFormSubmit={onSubmit}>
         <FormInput>
           <CommuneSearchField
             required
-            innerRef={focusRef}
+            innerRef={setRef}
             id='commune'
             initialSelectedItem={defaultCommune}
             label='Commune'

--- a/components/new/upload-form.js
+++ b/components/new/upload-form.js
@@ -55,7 +55,7 @@ function UploadForm() {
   const [isLoading, setIsLoading] = useState(false)
   const [nom, onNomChange] = useInput('')
   const [email, onEmailChange] = useInput('')
-  const [focusRef] = useFocus()
+  const [focusRef] = useFocus(true)
   const [userBALs, setUserBALs] = useState([])
   const [isShown, setIsShown] = useState(false)
   const [communes, setCommunes] = useState(null)

--- a/hooks/caret-position.js
+++ b/hooks/caret-position.js
@@ -1,0 +1,34 @@
+
+import {useState, useRef, useEffect, useCallback} from 'react'
+
+import useFocus from './focus'
+
+function useCaretPosition({initialValue, isFocus}) {
+  const [focusedElement] = useFocus({value: null, isFocus})
+  const value = useRef(initialValue) // Save initial input value state on first render
+
+  const [start, setStart] = useState(value.current ? value.current.length : 0)
+  const [end, setEnd] = useState(value.current ? value.current.length : 0)
+
+  const updateCaretPosition = useCallback(() => {
+    if (focusedElement && focusedElement.current) {
+      const {selectionStart, selectionEnd} = focusedElement.current
+
+      setStart(selectionStart)
+      setEnd(selectionEnd)
+
+      focusedElement.current.focus()
+    }
+  }, [focusedElement])
+
+  useEffect(() => {
+    if (focusedElement && focusedElement.current) {
+      const newCursorPosition = start + 1
+      focusedElement.current.setSelectionRange(newCursorPosition, newCursorPosition)
+    }
+  }, [start, end, isFocus, focusedElement])
+
+  return {ref: focusedElement, updateCaretPosition}
+}
+
+export default useCaretPosition

--- a/hooks/caret-position.js
+++ b/hooks/caret-position.js
@@ -1,7 +1,7 @@
 
 import {useState, useEffect, useCallback} from 'react'
 
-function useCaretPosition({initialValue, isFocus, ref}) {
+function useCaretPosition({initialValue, ref}) {
   const [caretPosition, setCaretPosition] = useState(initialValue ? initialValue.length : 0)
 
   const updateCaretPosition = useCallback(() => {
@@ -11,7 +11,7 @@ function useCaretPosition({initialValue, isFocus, ref}) {
 
   useEffect(() => {
     ref.current.setSelectionRange(caretPosition + 1, caretPosition + 1)
-  }, [caretPosition, isFocus, ref])
+  }, [caretPosition, ref])
 
   return {updateCaretPosition}
 }

--- a/hooks/caret-position.js
+++ b/hooks/caret-position.js
@@ -15,9 +15,7 @@ function useCaretPosition({initialValue, isFocus}) {
   }, [focusedElement])
 
   useEffect(() => {
-    if (focusedElement && focusedElement.current) {
-      focusedElement.current.setSelectionRange(caretPosition + 1, caretPosition + 1)
-    }
+    focusedElement.current.setSelectionRange(caretPosition + 1, caretPosition + 1)
   }, [caretPosition, isFocus, focusedElement])
 
   return {ref: focusedElement, updateCaretPosition}

--- a/hooks/caret-position.js
+++ b/hooks/caret-position.js
@@ -5,27 +5,20 @@ import useFocus from './focus'
 
 function useCaretPosition({initialValue, isFocus}) {
   const [focusedElement] = useFocus({value: null, isFocus})
-
-  const [start, setStart] = useState(initialValue ? initialValue.length : 0)
-  const [end, setEnd] = useState(initialValue ? initialValue.length : 0)
+  const [caretPosition, setCaretPosition] = useState(initialValue ? initialValue.length : 0)
 
   const updateCaretPosition = useCallback(() => {
     if (focusedElement && focusedElement.current) {
-      const {selectionStart, selectionEnd} = focusedElement.current
-
-      setStart(selectionStart)
-      setEnd(selectionEnd)
-
+      setCaretPosition(focusedElement.current.selectionStart)
       focusedElement.current.focus()
     }
   }, [focusedElement])
 
   useEffect(() => {
     if (focusedElement && focusedElement.current) {
-      const newCursorPosition = start + 1
-      focusedElement.current.setSelectionRange(newCursorPosition, newCursorPosition)
+      focusedElement.current.setSelectionRange(caretPosition + 1, caretPosition + 1)
     }
-  }, [start, end, isFocus, focusedElement])
+  }, [caretPosition, isFocus, focusedElement])
 
   return {ref: focusedElement, updateCaretPosition}
 }

--- a/hooks/caret-position.js
+++ b/hooks/caret-position.js
@@ -1,22 +1,19 @@
 
 import {useState, useEffect, useCallback} from 'react'
 
-import useFocus from './focus'
-
-function useCaretPosition({initialValue, isFocus}) {
-  const [focusedElement] = useFocus(isFocus)
+function useCaretPosition({initialValue, isFocus, ref}) {
   const [caretPosition, setCaretPosition] = useState(initialValue ? initialValue.length : 0)
 
   const updateCaretPosition = useCallback(() => {
-    setCaretPosition(focusedElement.current.selectionStart)
-    focusedElement.current.focus()
-  }, [focusedElement])
+    setCaretPosition(ref.current.selectionStart)
+    ref.current.focus()
+  }, [ref])
 
   useEffect(() => {
-    focusedElement.current.setSelectionRange(caretPosition + 1, caretPosition + 1)
-  }, [caretPosition, isFocus, focusedElement])
+    ref.current.setSelectionRange(caretPosition + 1, caretPosition + 1)
+  }, [caretPosition, isFocus, ref])
 
-  return {ref: focusedElement, updateCaretPosition}
+  return {updateCaretPosition}
 }
 
 export default useCaretPosition

--- a/hooks/caret-position.js
+++ b/hooks/caret-position.js
@@ -4,7 +4,7 @@ import {useState, useEffect, useCallback} from 'react'
 import useFocus from './focus'
 
 function useCaretPosition({initialValue, isFocus}) {
-  const [focusedElement] = useFocus({value: null, isFocus})
+  const [focusedElement] = useFocus(isFocus)
   const [caretPosition, setCaretPosition] = useState(initialValue ? initialValue.length : 0)
 
   const updateCaretPosition = useCallback(() => {

--- a/hooks/caret-position.js
+++ b/hooks/caret-position.js
@@ -1,14 +1,13 @@
 
-import {useState, useRef, useEffect, useCallback} from 'react'
+import {useState, useEffect, useCallback} from 'react'
 
 import useFocus from './focus'
 
 function useCaretPosition({initialValue, isFocus}) {
   const [focusedElement] = useFocus({value: null, isFocus})
-  const value = useRef(initialValue) // Save initial input value state on first render
 
-  const [start, setStart] = useState(value.current ? value.current.length : 0)
-  const [end, setEnd] = useState(value.current ? value.current.length : 0)
+  const [start, setStart] = useState(initialValue ? initialValue.length : 0)
+  const [end, setEnd] = useState(initialValue ? initialValue.length : 0)
 
   const updateCaretPosition = useCallback(() => {
     if (focusedElement && focusedElement.current) {

--- a/hooks/caret-position.js
+++ b/hooks/caret-position.js
@@ -8,10 +8,8 @@ function useCaretPosition({initialValue, isFocus}) {
   const [caretPosition, setCaretPosition] = useState(initialValue ? initialValue.length : 0)
 
   const updateCaretPosition = useCallback(() => {
-    if (focusedElement && focusedElement.current) {
-      setCaretPosition(focusedElement.current.selectionStart)
-      focusedElement.current.focus()
-    }
+    setCaretPosition(focusedElement.current.selectionStart)
+    focusedElement.current.focus()
   }, [focusedElement])
 
   useEffect(() => {

--- a/hooks/focus.js
+++ b/hooks/focus.js
@@ -3,14 +3,14 @@ import {useState, useRef, useEffect} from 'react'
 function useFocus(autofocus = false) {
   const ref = useRef()
   const [isFocus, setIsFocus] = useState(autofocus)
-  console.log(isFocus)
+
   useEffect(() => {
     if (ref?.current && isFocus) {
       ref.current.focus()
     }
   }, [ref, isFocus])
 
-  return [ref, isFocus, setIsFocus]
+  return [ref, setIsFocus]
 }
 
 export default useFocus

--- a/hooks/focus.js
+++ b/hooks/focus.js
@@ -1,9 +1,9 @@
 import {useState, useRef, useEffect} from 'react'
 
-function useFocus({autofocus = false}) {
+function useFocus(autofocus = false) {
   const ref = useRef()
   const [isFocus, setIsFocus] = useState(autofocus)
-
+  console.log(isFocus)
   useEffect(() => {
     if (ref?.current && isFocus) {
       ref.current.focus()

--- a/hooks/focus.js
+++ b/hooks/focus.js
@@ -1,15 +1,16 @@
-import {useRef, useEffect} from 'react'
+import {useState, useRef, useEffect} from 'react'
 
-function useFocus(isFocus) {
-  const focusedElement = useRef()
+function useFocus({autofocus = false}) {
+  const ref = useRef()
+  const [isFocus, setIsFocus] = useState(autofocus)
 
   useEffect(() => {
-    if (focusedElement?.current && isFocus) {
-      focusedElement.current.focus()
+    if (ref?.current && isFocus) {
+      ref.current.focus()
     }
-  }, [isFocus])
+  }, [ref, isFocus])
 
-  return [focusedElement]
+  return [ref, isFocus, setIsFocus]
 }
 
 export default useFocus

--- a/hooks/focus.js
+++ b/hooks/focus.js
@@ -1,15 +1,15 @@
-import {useState, useEffect} from 'react'
+import {useRef, useEffect} from 'react'
 
-function useFocus() {
-  const [ref, setRef] = useState()
+function useFocus({value, isFocus}) {
+  const focusedElement = useRef(value || null)
 
   useEffect(() => {
-    if (ref) {
-      ref.focus()
+    if (focusedElement?.current && isFocus) {
+      focusedElement.current.focus()
     }
-  }, [ref])
+  }, [isFocus])
 
-  return [setRef, ref]
+  return [focusedElement]
 }
 
 export default useFocus

--- a/hooks/focus.js
+++ b/hooks/focus.js
@@ -1,7 +1,7 @@
 import {useRef, useEffect} from 'react'
 
-function useFocus({value, isFocus}) {
-  const focusedElement = useRef(value || null)
+function useFocus(isFocus) {
+  const focusedElement = useRef()
 
   useEffect(() => {
     if (focusedElement?.current && isFocus) {


### PR DESCRIPTION
Le système de gestion de focus était obsolète. Nous utilisions un custom hook pour gérer les `ref` et ainsi, le focus sur les inputs.

Cette PR remplace le système mis en place par custom hook `useFocus` et exploite le hook `useRef` proposé par React, plus adapté. 
La refonte de la gestion du focus permet aussi de corriger le souci de retour du curseur à la fin du champ et non à sa position lorsqu'un caractère spécial est rajouté par l'outil d'accents.

Close #647 #646