### PR TITLE
Mise à jour de @ban-team/shared-data vers la version 1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.17.9",
-    "@ban-team/shared-data": "^1.0.0",
+    "@ban-team/shared-data": "^1.0.1",
     "@ban-team/validateur-bal": "^2.9.0",
     "@next/bundle-analyzer": "^12.1.6",
     "@turf/bbox": "^6.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -573,6 +573,11 @@
   resolved "https://registry.yarnpkg.com/@ban-team/shared-data/-/shared-data-1.0.0.tgz#b45dc45a33ff0f9421ffa876f77f0f4671087e10"
   integrity sha512-P5qTuSvRkLcDM2Rm6hriLbM4bC15SLTD6i9oquhSSnIbTkt235kmY+ThDTER5DcSircHeKOsQcD/5j0Mluv8SQ==
 
+"@ban-team/shared-data@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@ban-team/shared-data/-/shared-data-1.0.1.tgz#bc3f49beab5bf492ad5da4d2a3852a539e68416b"
+  integrity sha512-eRrAZ2QJRiYd3wiPQE1ejA8fwn18AWvKASaEn7ajGVxIjOD5ty3E2hKlLPDOjdrg/bsVrabzOvxnnUN0sxboIA==
+
 "@ban-team/validateur-bal@^2.9.0":
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/@ban-team/validateur-bal/-/validateur-bal-2.9.0.tgz#09fa914d42bedaf09c8369126ceed1b0a110945e"


### PR DESCRIPTION
Resolves #649 

Corrige la typo `créole-réunionais` => `créole-réunionnais`