### PR TITLE
Ajout du composant rapport de validateur

### DIFF
--- a/components/base-locale-card/base-locale-card-content.js
+++ b/components/base-locale-card/base-locale-card-content.js
@@ -1,5 +1,6 @@
 import {useState, useMemo, useContext, useEffect} from 'react'
 import PropTypes from 'prop-types'
+import {useRouter} from 'next/router'
 import {format} from 'date-fns'
 import {fr} from 'date-fns/locale'
 import {Pane, Button, Tooltip, Text, UserIcon, InfoSignIcon, TrashIcon, EditIcon, KeyIcon, EyeOffIcon} from 'evergreen-ui'
@@ -12,7 +13,8 @@ import LocalStorageContext from '@/contexts/local-storage'
 import RecoverBALAlert from '@/components/bal-recovery/recover-bal-alert'
 import ValidateurReport from '../validateur-report'
 
-function BaseLocaleCardContent({isAdmin, baseLocale, voies, userEmail, onSelect, onRemove, onHide}) {
+function BaseLocaleCardContent({isAdmin, voies, baseLocale, userEmail, onSelect, onRemove, onHide}) {
+  const router = useRouter()
   const {status, _created, emails} = baseLocale
 
   const [isBALRecoveryShown, setIsBALRecoveryShown] = useState(false)
@@ -63,8 +65,9 @@ function BaseLocaleCardContent({isAdmin, baseLocale, voies, userEmail, onSelect,
     createBlob()
   }, [baseLocale])
 
-  const handleVoieHref = voieId => {
-    return `/bal/voie?balId=${baseLocale._id}&idVoie=${voieId}`
+  const handleVoieRedirect = name => {
+    const voieId = voies.find(voie => voie.nom === name)._id
+    router.push(`/bal/voie?balId=${baseLocale._id}&idVoie=${voieId}`)
   }
 
   return (
@@ -149,8 +152,7 @@ function BaseLocaleCardContent({isAdmin, baseLocale, voies, userEmail, onSelect,
         <Pane marginTop='1em'>
           <ValidateurReport
             rows={report}
-            voies={voies}
-            onRedirect={handleVoieHref}
+            onRedirect={handleVoieRedirect}
           />
         </Pane>
       )}

--- a/components/base-locale-card/base-locale-card-content.js
+++ b/components/base-locale-card/base-locale-card-content.js
@@ -16,7 +16,6 @@ function BaseLocaleCardContent({isAdmin, baseLocale, voies, userEmail, onSelect,
   const {status, _created, emails} = baseLocale
 
   const [isBALRecoveryShown, setIsBALRecoveryShown] = useState(false)
-  const [csvUrl, setCsvUrl] = useState(null)
   const [isLoading, setIsLoading] = useState(false)
   const [report, setReport] = useState(null)
 
@@ -31,15 +30,6 @@ function BaseLocaleCardContent({isAdmin, baseLocale, voies, userEmail, onSelect,
   const tooltipContent = status === 'ready-to-publish' ?
     'Vous ne pouvez pas supprimer une BAL lorsqu’elle est prête à être publiée' :
     'Vous ne pouvez pas supprimer une Base Adresse Locale qui est publiée. Si vous souhaitez la dé-publier, veuillez contacter le support adresse@data.gouv.fr'
-
-  useEffect(() => {
-    const fetchCsvUrl = async () => {
-      const url = await getBaseLocaleCsvUrl(baseLocale._id)
-      setCsvUrl(url)
-    }
-
-    fetchCsvUrl()
-  }, [baseLocale])
 
   const parseFile = async file => {
     setIsLoading(true)
@@ -59,17 +49,19 @@ function BaseLocaleCardContent({isAdmin, baseLocale, voies, userEmail, onSelect,
   }
 
   useEffect(() => {
-    if (csvUrl) {
-      const xhr = new XMLHttpRequest()
-      xhr.open('GET', csvUrl)
-      xhr.responseType = 'blob'
-      xhr.addEventListener('load', () => {
-        parseFile(xhr.response)
-      })
+    const createBlob = async () => {
+      try {
+        const fetchedCsv = await fetch(getBaseLocaleCsvUrl(baseLocale._id))
+        const blob = await fetchedCsv.blob()
 
-      xhr.send()
+        parseFile(blob)
+      } catch {
+        console.log('Le blob du fichier csv n’a pas pu être créé')
+      }
     }
-  }, [csvUrl])
+
+    createBlob()
+  }, [baseLocale])
 
   const handleVoieHref = voieId => {
     return `/bal/voie?balId=${baseLocale._id}&idVoie=${voieId}`

--- a/components/base-locale-card/base-locale-card-content.js
+++ b/components/base-locale-card/base-locale-card-content.js
@@ -71,6 +71,10 @@ function BaseLocaleCardContent({isAdmin, baseLocale, voies, userEmail, onSelect,
     }
   }, [csvUrl])
 
+  const handleVoieHref = voieId => {
+    return `/bal/voie?balId=${baseLocale._id}&idVoie=${voieId}`
+  }
+
   return (
     <>
       <Pane borderTop flex={3} display='flex' flexDirection='row' paddingTop='1em'>
@@ -154,7 +158,7 @@ function BaseLocaleCardContent({isAdmin, baseLocale, voies, userEmail, onSelect,
           <ValidateurReport
             rows={report}
             voies={voies}
-            baseLocaleId={baseLocale._id}
+            onRedirect={handleVoieHref}
           />
         </Pane>
       )}

--- a/components/base-locale-card/base-locale-card-content.js
+++ b/components/base-locale-card/base-locale-card-content.js
@@ -2,7 +2,7 @@ import {useState, useMemo, useContext, useEffect} from 'react'
 import PropTypes from 'prop-types'
 import {format} from 'date-fns'
 import {fr} from 'date-fns/locale'
-import {Pane, Button, Tooltip, Text, Heading, UserIcon, InfoSignIcon, TrashIcon, EditIcon, KeyIcon, EyeOffIcon} from 'evergreen-ui'
+import {Pane, Button, Tooltip, Text, UserIcon, InfoSignIcon, TrashIcon, EditIcon, KeyIcon, EyeOffIcon} from 'evergreen-ui'
 
 import {getBaseLocaleCsvUrl} from '@/lib/bal-api'
 import {prevalidate} from '@ban-team/validateur-bal'
@@ -151,7 +151,6 @@ function BaseLocaleCardContent({isAdmin, baseLocale, voies, userEmail, onSelect,
 
       {!isLoading && report && (
         <Pane marginTop='1em'>
-          <Heading is='h3' fontSize={17} marginBottom={6}>Anomalies détectées</Heading>
           <ValidateurReport
             rows={report}
             voies={voies}

--- a/components/base-locale-card/base-locale-card-content.js
+++ b/components/base-locale-card/base-locale-card-content.js
@@ -151,7 +151,7 @@ function BaseLocaleCardContent({isAdmin, baseLocale, voies, userEmail, onSelect,
 
       {!isLoading && report && (
         <Pane marginTop='1em'>
-          <Heading as='h3' fontSize={16} marginBottom={6}>Anomalies détectées</Heading>
+          <Heading is='h3' fontSize={17} marginBottom={6}>Anomalies détectées</Heading>
           <ValidateurReport
             rows={report}
             voies={voies}

--- a/components/base-locale-card/base-locale-card-content.js
+++ b/components/base-locale-card/base-locale-card-content.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import {useRouter} from 'next/router'
 import {format} from 'date-fns'
 import {fr} from 'date-fns/locale'
-import {Pane, Button, Tooltip, Text, UserIcon, InfoSignIcon, TrashIcon, EditIcon, KeyIcon, EyeOffIcon} from 'evergreen-ui'
+import {Pane, Button, Tooltip, Text, Spinner, UserIcon, InfoSignIcon, TrashIcon, EditIcon, KeyIcon, EyeOffIcon} from 'evergreen-ui'
 
 import {getBaseLocaleCsvUrl} from '@/lib/bal-api'
 import {prevalidate} from '@ban-team/validateur-bal'
@@ -18,7 +18,7 @@ function BaseLocaleCardContent({isAdmin, voies, baseLocale, userEmail, onSelect,
   const {status, _created, emails} = baseLocale
 
   const [isBALRecoveryShown, setIsBALRecoveryShown] = useState(false)
-  const [isLoading, setIsLoading] = useState(false)
+  const [isLoading, setIsLoading] = useState(true)
   const [report, setReport] = useState(null)
 
   const {getBalToken} = useContext(LocalStorageContext)
@@ -34,7 +34,6 @@ function BaseLocaleCardContent({isAdmin, voies, baseLocale, userEmail, onSelect,
     'Vous ne pouvez pas supprimer une Base Adresse Locale qui est publiée. Si vous souhaitez la dé-publier, veuillez contacter le support adresse@data.gouv.fr'
 
   const parseFile = async file => {
-    setIsLoading(true)
     try {
       const report = await prevalidate(file, {relaxFieldsDetection: true})
       if (report.parseOk) {
@@ -46,8 +45,6 @@ function BaseLocaleCardContent({isAdmin, voies, baseLocale, userEmail, onSelect,
     } catch {
       setReport(null)
     }
-
-    setIsLoading(false)
   }
 
   useEffect(() => {
@@ -57,9 +54,12 @@ function BaseLocaleCardContent({isAdmin, voies, baseLocale, userEmail, onSelect,
         const blob = await fetchedCsv.blob()
 
         parseFile(blob)
+        setIsLoading(false)
       } catch {
         console.log('Le blob du fichier csv n’a pas pu être créé')
       }
+
+      setIsLoading(false)
     }
 
     createBlob()
@@ -148,7 +148,11 @@ function BaseLocaleCardContent({isAdmin, voies, baseLocale, userEmail, onSelect,
         </Pane>
       )}
 
-      {!isLoading && report && (
+      {isLoading && !report ? (
+        <Pane display='flex' justifyContent='center' >
+          <Spinner size={22} />
+        </Pane>
+      ) : (
         <Pane marginTop='1em'>
           <ValidateurReport
             rows={report}

--- a/components/base-locale-card/index.js
+++ b/components/base-locale-card/index.js
@@ -4,7 +4,7 @@ import {formatDistanceToNow} from 'date-fns'
 import {fr} from 'date-fns/locale'
 import {Heading, Card, Pane, Text, ChevronRightIcon, ChevronDownIcon} from 'evergreen-ui'
 
-import {getBaseLocale} from '@/lib/bal-api'
+import {getBaseLocale, getVoies} from '@/lib/bal-api'
 import {getCommune} from '@/lib/geo-api'
 
 import CertificationCount from '@/components/certification-count'
@@ -26,8 +26,9 @@ function BaseLocaleCard({baseLocale, isAdmin, userEmail, isDefaultOpen, onSelect
     const fetchCommune = async () => {
       const communeBal = await getBaseLocale(baseLocale._id)
       const communeGeo = await getCommune(baseLocale.commune)
+      const voies = await getVoies(baseLocale._id)
 
-      setCommune({...communeBal, ...communeGeo})
+      setCommune({...communeBal, ...communeGeo, voies})
     }
 
     fetchCommune()
@@ -96,6 +97,7 @@ function BaseLocaleCard({baseLocale, isAdmin, userEmail, isDefaultOpen, onSelect
           isAdmin={isAdmin}
           userEmail={userEmail}
           baseLocale={baseLocale}
+          voies={commune.voies}
           onSelect={onSelect}
           onRemove={onRemove}
           onHide={onHide}

--- a/components/dropdown.js
+++ b/components/dropdown.js
@@ -1,0 +1,45 @@
+import PropTypes from 'prop-types'
+import {Pane, Button, ChevronDownIcon, ChevronRightIcon} from 'evergreen-ui'
+
+function Dropdown({children, isOpen, handleOpen, dropdownStyle}) {
+  return (
+    <Pane
+      background={dropdownStyle === 'primary' ? 'transparent' : 'gray300'}
+      border={dropdownStyle === 'primary' ? '1px solid #c1c4d6' : 'none'}
+      boxShadow='0px 4px 4px #E6E8F0'
+      padding={15}
+      borderRadius={5}
+      display='flex'
+      justifyContent='space-between'
+      width='100%'
+    >
+      {children}
+
+      <Button
+        onClick={handleOpen}
+        background='none'
+        border='none'
+        height='fit-content'
+        padding={0}
+      >
+        {isOpen ? <ChevronDownIcon size={20} /> : <ChevronRightIcon size={20} />}
+      </Button>
+    </Pane>
+  )
+}
+
+Dropdown.propTypes = {
+  children: PropTypes.node.isRequired,
+  isOpen: PropTypes.bool.isRequired,
+  handleOpen: PropTypes.func.isRequired,
+  dropdownStyle: PropTypes.oneOf([
+    'primary',
+    'secondary'
+  ])
+}
+
+Dropdown.defaultProps = {
+  dropdownStyle: 'primary'
+}
+
+export default Dropdown

--- a/components/dropdown.js
+++ b/components/dropdown.js
@@ -21,6 +21,7 @@ function Dropdown({children, isOpen, handleOpen, dropdownStyle}) {
         border='none'
         height='fit-content'
         padding={0}
+        marginTop={5}
       >
         {isOpen ? <ChevronDownIcon size={20} /> : <ChevronRightIcon size={20} />}
       </Button>

--- a/components/validateur-report/alerts-header.js
+++ b/components/validateur-report/alerts-header.js
@@ -1,30 +1,17 @@
 import PropTypes from 'prop-types'
-import {Pane, WarningSignIcon, BanCircleIcon, MapMarkerIcon} from 'evergreen-ui'
+import {Pane, WarningSignIcon, BanCircleIcon, MapMarkerIcon, InfoSignIcon} from 'evergreen-ui'
 
-import {filter, some, size} from 'lodash'
-
-function AlertHeader({isVoie, voieAlerts, numerosWithAlerts, children}) {
-  const hasVoieWarnings = some(voieAlerts, alert => alert.level === 'W')
-  const hasVoieErrors = some(voieAlerts, alert => alert.level === 'E')
-
-  const hasNumeroErrors = some(numerosWithAlerts, numero => size(filter(numero.alerts, {level: 'E'})) > 0)
-  const hasNumeroWarnings = some(numerosWithAlerts, numero => size(filter(numero.alerts, {level: 'W'})) > 0)
+function AlertHeader({isVoie, hasErrors, hasWarnings, hasInfos, children}) {
+  const hasVoieNoAlerts = !hasWarnings && !hasErrors && !hasInfos
 
   return (
     <Pane display='flex' gap={8} alignItems='center'>
-      {isVoie ? (
-        <Pane display='flex' gap={5}>
-          {hasVoieErrors && <BanCircleIcon color='red500' size={22} />}
-          {hasVoieWarnings && <WarningSignIcon color='orange500' size={22} />}
-          {!hasVoieWarnings && !hasVoieErrors && <MapMarkerIcon size={22} />}
-        </Pane>
-      ) : (
-        <Pane display='flex' gap={5}>
-          {hasNumeroErrors && <BanCircleIcon color='red500' />}
-          {hasNumeroWarnings && <WarningSignIcon color='orange500' /> }
-        </Pane>
-      )}
-
+      <Pane display='flex' gap={5} >
+        {hasErrors && <BanCircleIcon color='red500' size={isVoie ? 22 : 16} />}
+        {hasWarnings && <WarningSignIcon color='orange500' size={isVoie ? 22 : 16} />}
+        {hasInfos && <InfoSignIcon color='blue500' size={isVoie ? 22 : 16} />}
+        {hasVoieNoAlerts && <MapMarkerIcon size={22} />}
+      </Pane>
       {children}
     </Pane>
   )
@@ -32,14 +19,17 @@ function AlertHeader({isVoie, voieAlerts, numerosWithAlerts, children}) {
 
 AlertHeader.propTypes = {
   children: PropTypes.node.isRequired,
-  voieAlerts: PropTypes.array,
-  numerosWithAlerts: PropTypes.array,
-  isVoie: PropTypes.bool
+  isVoie: PropTypes.bool,
+  hasErrors: PropTypes.bool,
+  hasWarnings: PropTypes.bool,
+  hasInfos: PropTypes.bool
 }
 
 AlertHeader.defaultProps = {
-  voieAlerts: [],
-  numerosWithAlerts: []
+  isVoie: false,
+  hasErrors: false,
+  hasWarnings: false,
+  hasInfos: false
 }
 
 export default AlertHeader

--- a/components/validateur-report/alerts-header.js
+++ b/components/validateur-report/alerts-header.js
@@ -1,16 +1,19 @@
 import PropTypes from 'prop-types'
 import {Pane, WarningSignIcon, BanCircleIcon, MapMarkerIcon, InfoSignIcon} from 'evergreen-ui'
 
-function AlertHeader({isVoie, hasErrors, hasWarnings, hasInfos, children}) {
+function AlertHeader({size, hasErrors, hasWarnings, hasInfos, children}) {
   const hasVoieNoAlerts = !hasWarnings && !hasErrors && !hasInfos
 
   return (
     <Pane display='flex' gap={8} alignItems='center'>
       <Pane display='flex' gap={5} >
-        {hasErrors && <BanCircleIcon color='red500' size={isVoie ? 22 : 16} />}
-        {hasWarnings && <WarningSignIcon color='orange500' size={isVoie ? 22 : 16} />}
-        {hasInfos && <InfoSignIcon color='blue500' size={isVoie ? 22 : 16} />}
-        {hasVoieNoAlerts && <MapMarkerIcon size={22} />}
+        {hasVoieNoAlerts ? <MapMarkerIcon size={size} /> : (
+          <>
+            {hasErrors && <BanCircleIcon color='red500' size={size} />}
+            {hasWarnings && <WarningSignIcon color='orange500' size={size} />}
+            {hasInfos && <InfoSignIcon color='blue500' size={size} />}
+          </>
+        )}
       </Pane>
       {children}
     </Pane>
@@ -19,17 +22,14 @@ function AlertHeader({isVoie, hasErrors, hasWarnings, hasInfos, children}) {
 
 AlertHeader.propTypes = {
   children: PropTypes.node.isRequired,
-  isVoie: PropTypes.bool,
-  hasErrors: PropTypes.bool,
-  hasWarnings: PropTypes.bool,
-  hasInfos: PropTypes.bool
+  hasErrors: PropTypes.bool.isRequired,
+  hasWarnings: PropTypes.bool.isRequired,
+  hasInfos: PropTypes.bool.isRequired,
+  size: PropTypes.number
 }
 
 AlertHeader.defaultProps = {
-  isVoie: false,
-  hasErrors: false,
-  hasWarnings: false,
-  hasInfos: false
+  size: 16,
 }
 
 export default AlertHeader

--- a/components/validateur-report/alerts-header.js
+++ b/components/validateur-report/alerts-header.js
@@ -1,0 +1,45 @@
+import PropTypes from 'prop-types'
+import {Pane, WarningSignIcon, BanCircleIcon, MapMarkerIcon} from 'evergreen-ui'
+
+import {filter, some, size} from 'lodash'
+
+function AlertHeader({isVoie, voieAlerts, numerosWithAlerts, children}) {
+  const hasVoieWarnings = some(voieAlerts, alert => alert.level === 'W')
+  const hasVoieErrors = some(voieAlerts, alert => alert.level === 'E')
+
+  const hasNumeroErrors = some(numerosWithAlerts, numero => size(filter(numero.alerts, {level: 'E'})) > 0)
+  const hasNumeroWarnings = some(numerosWithAlerts, numero => size(filter(numero.alerts, {level: 'W'})) > 0)
+
+  return (
+    <Pane display='flex' gap={8} alignItems='center'>
+      {isVoie ? (
+        <Pane display='flex' gap={5}>
+          {hasVoieErrors && <BanCircleIcon color='red500' size={22} />}
+          {hasVoieWarnings && <WarningSignIcon color='orange500' size={22} />}
+          {!hasVoieWarnings && !hasVoieErrors && <MapMarkerIcon size={22} />}
+        </Pane>
+      ) : (
+        <Pane display='flex' gap={5}>
+          {hasNumeroErrors && <BanCircleIcon color='red500' />}
+          {hasNumeroWarnings && <WarningSignIcon color='orange500' /> }
+        </Pane>
+      )}
+
+      {children}
+    </Pane>
+  )
+}
+
+AlertHeader.propTypes = {
+  children: PropTypes.node.isRequired,
+  voieAlerts: PropTypes.array,
+  numerosWithAlerts: PropTypes.array,
+  isVoie: PropTypes.bool
+}
+
+AlertHeader.defaultProps = {
+  voieAlerts: [],
+  numerosWithAlerts: []
+}
+
+export default AlertHeader

--- a/components/validateur-report/index.js
+++ b/components/validateur-report/index.js
@@ -43,7 +43,7 @@ function ValidateurReport({rows, voies, onRedirect}) {
         <VoieRow
           key={sanitizedRowsByVoies[voie].voieId}
           nomVoie={voie}
-          voie={sanitizedRowsByVoies[voie]}
+          {...sanitizedRowsByVoies[voie]}
           onRedirect={onRedirect}
         />
       ))}

--- a/components/validateur-report/index.js
+++ b/components/validateur-report/index.js
@@ -8,29 +8,33 @@ import VoieRow from '@/components/validateur-report/voie-row'
 const validAlertSchemas = new Set(['voie_nom', 'numero', 'suffixe'])
 
 function ValidateurReport({rows, voies, onRedirect}) {
-  const sanitizedRowsByVoies = useMemo(() => ({}), [])
+  const sanitizedRowsByVoies = useMemo(() => {
+    const finalObj = {}
 
-  const rowsByVoies = groupBy(rows, row => row.rawValues.voie_nom)
+    const rowsByVoies = groupBy(rows, row => row.rawValues.voie_nom)
 
-  // Create a new object, grouped by voies names
-  Object.keys(rowsByVoies).forEach(nomVoie => {
-    const rowsWithAlerts = rowsByVoies[nomVoie].filter(row => {
-      row.errors = filter(row.errors, error => validAlertSchemas.has(error.schemaName)) // Keep usefull alerts only
-      return row.errors.length > 0
+    // Create a new object, grouped by voies names
+    Object.keys(rowsByVoies).forEach(nomVoie => {
+      const rowsWithAlerts = rowsByVoies[nomVoie].filter(row => {
+        row.errors = filter(row.errors, error => validAlertSchemas.has(error.schemaName)) // Keep usefull alerts only
+        return row.errors.length > 0
+      })
+
+      const rowWithVoieAlerts = rowsWithAlerts.filter(row => !row.parsedValues.numero)
+      const numerosWithAlerts = rowsWithAlerts.filter(row => row.parsedValues.numero).map(numero => ({address: numero.parsedValues, alerts: numero.errors}))
+
+      // For each voie, add voie's id, it's own alerts list and it's numeros with alerts list
+      if (rowWithVoieAlerts.length > 0 || numerosWithAlerts.length > 0) {
+        finalObj[nomVoie] = {
+          voieId: voies.find(voie => voie.nom === nomVoie)._id,
+          voieAlerts: rowWithVoieAlerts.length > 0 ? rowWithVoieAlerts[0].errors : [],
+          numerosWithAlerts
+        }
+      }
     })
 
-    const rowWithVoieAlerts = rowsWithAlerts.filter(row => !row.parsedValues.numero)
-    const numerosWithAlerts = rowsWithAlerts.filter(row => row.parsedValues.numero).map(numero => ({address: numero.parsedValues, alerts: numero.errors}))
-
-    // For each voie, add voie's id, it's own alerts list and it's numeros with alerts list
-    if (rowWithVoieAlerts.length > 0 || numerosWithAlerts.length > 0) {
-      sanitizedRowsByVoies[nomVoie] = {
-        voieId: voies.find(voie => voie.nom === nomVoie)._id,
-        voieAlerts: rowWithVoieAlerts.length > 0 ? rowWithVoieAlerts[0].errors : [],
-        numerosWithAlerts
-      }
-    }
-  })
+    return finalObj
+  }, [rows, voies])
 
   return Object.keys(sanitizedRowsByVoies).length > 0 && (
     <Pane display='flex' flexDirection='column' justifyContent='center' gap={12}>

--- a/components/validateur-report/index.js
+++ b/components/validateur-report/index.js
@@ -31,9 +31,7 @@ function ValidateurReport({rows, voies, baseLocaleId}) {
 
   return (
     <Pane display='flex' flexDirection='column' gap={12}>
-      {Object.keys(sanitizedRowsByVoies).map(voie => {
-        return <VoieRow key={voie} nomVoie={voie} voie={sanitizedRowsByVoies[voie]} baseLocaleId={baseLocaleId} />
-      })}
+      {Object.keys(sanitizedRowsByVoies).map(voie => <VoieRow key={voie} nomVoie={voie} voie={sanitizedRowsByVoies[voie]} baseLocaleId={baseLocaleId} />)}
     </Pane>
   )
 }

--- a/components/validateur-report/index.js
+++ b/components/validateur-report/index.js
@@ -7,7 +7,7 @@ import VoieRow from '@/components/validateur-report/voie-row'
 
 const validAlertSchemas = new Set(['voie_nom', 'numero', 'suffixe'])
 
-function ValidateurReport({rows, voies, baseLocaleId}) {
+function ValidateurReport({rows, voies, onRedirect}) {
   const sanitizedRowsByVoies = useMemo(() => ({}), [])
 
   const rowsByVoies = groupBy(rows, row => row.rawValues.voie_nom)
@@ -40,7 +40,7 @@ function ValidateurReport({rows, voies, baseLocaleId}) {
           key={sanitizedRowsByVoies[voie].voieId}
           nomVoie={voie}
           voie={sanitizedRowsByVoies[voie]}
-          baseLocaleId={baseLocaleId}
+          onRedirect={onRedirect}
         />
       ))}
     </Pane>
@@ -50,11 +50,7 @@ function ValidateurReport({rows, voies, baseLocaleId}) {
 ValidateurReport.propTypes = {
   voies: PropTypes.array.isRequired,
   rows: PropTypes.array.isRequired,
-  baseLocaleId: PropTypes.string
-}
-
-ValidateurReport.defaultProps = {
-  baseLocaleId: null
+  onRedirect: PropTypes.func.isRequired
 }
 
 export default ValidateurReport

--- a/components/validateur-report/index.js
+++ b/components/validateur-report/index.js
@@ -26,7 +26,7 @@ function ValidateurReport({rows, voies, baseLocaleId}) {
       // For each voie, add voie's id, it's own alerts list and it's numeros with alerts list
       if (rowWithVoieAlerts.length > 0 || numerosWithAlerts.length > 0) {
         sanitizedRowsByVoies[nomVoie] = {
-          voieId: voies.find(voie => voie.nom === nomVoie)?._id,
+          voieId: voies.find(voie => voie.nom === nomVoie)._id,
           voieAlerts: rowWithVoieAlerts.length > 0 ? rowWithVoieAlerts[0].errors : [],
           numerosWithAlerts
         }

--- a/components/validateur-report/index.js
+++ b/components/validateur-report/index.js
@@ -1,0 +1,67 @@
+import {useCallback, useState, useEffect} from 'react'
+import PropTypes from 'prop-types'
+import {Pane} from 'evergreen-ui'
+import {groupBy, remove} from 'lodash'
+
+import {getVoies} from '@/lib/bal-api'
+
+import VoieRow from '@/components/validateur-report/voie-row'
+
+function ValidateurReport({rows, baseLocaleID}) {
+  const [voies, setVoies] = useState()
+  const [rowsByVoie, setRowsByVoie] = useState({})
+
+  const getBalVoies = useCallback(async () => {
+    try {
+      const voiesList = await getVoies(baseLocaleID)
+      setVoies(voiesList)
+    } catch {
+      console.log('Impossible de récupérer la liste des voies')
+    }
+  }, [baseLocaleID])
+
+  useEffect(() => {
+    getBalVoies()
+  }, [getBalVoies])
+
+  useEffect(() => {
+    if (voies) {
+      const rowsByVoies = groupBy(rows, row => row.rawValues.voie_nom)
+      const sanitizedRowByVoies = {}
+
+      // Create a new object, grouped by voies names
+      Object.keys(rowsByVoies).forEach(nomVoie => {
+        const rowsWithAlerts = rowsByVoies[nomVoie].filter(row => {
+          remove(row.errors, error => error.level === 'I') // Remove unusefull "information" type alerts
+          return row.errors.length > 0
+        })
+
+        const rowWithVoieAlerts = rowsWithAlerts.filter(row => !row.parsedValues.numero)
+        const numerosWithAlerts = rowsWithAlerts.filter(row => row.parsedValues.numero).map(numero => ({address: numero.parsedValues, alerts: numero.errors}))
+
+        // For each voie, add voie's id, it's own alerts list and it's numeros with alerts list
+        sanitizedRowByVoies[nomVoie] = {
+          voieId: voies.find(voie => voie.nom === nomVoie)?._id,
+          voieAlerts: rowWithVoieAlerts.length > 0 ? rowWithVoieAlerts[0].errors : [],
+          numerosWithAlerts
+        }
+      })
+      setRowsByVoie(sanitizedRowByVoies)
+    }
+  }, [rows, voies])
+
+  return (
+    <Pane display='flex' flexDirection='column' gap={12}>
+      {Object.keys(rowsByVoie).map(voie => {
+        return <VoieRow key={voie} nomVoie={voie} voie={rowsByVoie[voie]} />
+      })}
+    </Pane>
+  )
+}
+
+ValidateurReport.propTypes = {
+  baseLocaleID: PropTypes.string.isRequired,
+  rows: PropTypes.array.isRequired
+}
+
+export default ValidateurReport

--- a/components/validateur-report/index.js
+++ b/components/validateur-report/index.js
@@ -4,7 +4,7 @@ import {groupBy, remove} from 'lodash'
 
 import VoieRow from '@/components/validateur-report/voie-row'
 
-function ValidateurReport({rows, voies, baseLocaleID}) {
+function ValidateurReport({rows, voies, baseLocaleId}) {
   const sanitizedRowsByVoies = {}
 
   if (voies) {
@@ -32,14 +32,14 @@ function ValidateurReport({rows, voies, baseLocaleID}) {
   return (
     <Pane display='flex' flexDirection='column' gap={12}>
       {Object.keys(sanitizedRowsByVoies).map(voie => {
-        return <VoieRow key={voie} nomVoie={voie} voie={sanitizedRowsByVoies[voie]} baseLocaleID={baseLocaleID} />
+        return <VoieRow key={voie} nomVoie={voie} voie={sanitizedRowsByVoies[voie]} baseLocaleId={baseLocaleId} />
       })}
     </Pane>
   )
 }
 
 ValidateurReport.propTypes = {
-  baseLocaleID: PropTypes.string.isRequired,
+  baseLocaleId: PropTypes.string.isRequired,
   voies: PropTypes.array.isRequired,
   rows: PropTypes.array.isRequired
 }

--- a/components/validateur-report/index.js
+++ b/components/validateur-report/index.js
@@ -1,3 +1,4 @@
+import {useMemo} from 'react'
 import PropTypes from 'prop-types'
 import {Pane} from 'evergreen-ui'
 import {groupBy, remove} from 'lodash'
@@ -7,7 +8,8 @@ import VoieRow from '@/components/validateur-report/voie-row'
 const validAlertSchemas = new Set(['voie_nom', 'numero', 'suffixe'])
 
 function ValidateurReport({rows, voies, baseLocaleId}) {
-  const sanitizedRowsByVoies = {}
+  const sanitizedRowsByVoies = useMemo(() => ({}), [])
+
   if (voies) {
     const rowsByVoies = groupBy(rows, row => row.rawValues.voie_nom)
 

--- a/components/validateur-report/index.js
+++ b/components/validateur-report/index.js
@@ -1,7 +1,7 @@
 import {useMemo} from 'react'
 import PropTypes from 'prop-types'
 import {Pane, Heading} from 'evergreen-ui'
-import {groupBy, filter} from 'lodash'
+import {groupBy, filter, uniqueId} from 'lodash'
 
 import VoieRow from '@/components/validateur-report/voie-row'
 
@@ -41,7 +41,7 @@ function ValidateurReport({rows, voies, onRedirect}) {
       <Heading is='h3' fontSize={17} marginBottom={6}>Anomalies détectées</Heading>
       {Object.keys(sanitizedRowsByVoies).map(voie => (
         <VoieRow
-          key={sanitizedRowsByVoies[voie].voieId}
+          key={uniqueId}
           nomVoie={voie}
           {...sanitizedRowsByVoies[voie]}
           onRedirect={onRedirect}

--- a/components/validateur-report/index.js
+++ b/components/validateur-report/index.js
@@ -1,6 +1,6 @@
 import {useMemo} from 'react'
 import PropTypes from 'prop-types'
-import {Pane} from 'evergreen-ui'
+import {Pane, Heading} from 'evergreen-ui'
 import {groupBy, filter} from 'lodash'
 
 import VoieRow from '@/components/validateur-report/voie-row'
@@ -32,8 +32,9 @@ function ValidateurReport({rows, voies, baseLocaleId}) {
     }
   })
 
-  return (
+  return Object.keys(sanitizedRowsByVoies).length > 0 && (
     <Pane display='flex' flexDirection='column' justifyContent='center' gap={12}>
+      <Heading is='h3' fontSize={17} marginBottom={6}>Anomalies détectées</Heading>
       {Object.keys(sanitizedRowsByVoies).map(voie => (
         <VoieRow
           key={sanitizedRowsByVoies[voie].voieId}

--- a/components/validateur-report/index.js
+++ b/components/validateur-report/index.js
@@ -34,7 +34,14 @@ function ValidateurReport({rows, voies, baseLocaleId}) {
 
   return (
     <Pane display='flex' flexDirection='column' gap={12}>
-      {Object.keys(sanitizedRowsByVoies).map(voie => <VoieRow key={voie} nomVoie={voie} voie={sanitizedRowsByVoies[voie]} baseLocaleId={baseLocaleId} />)}
+      {Object.keys(sanitizedRowsByVoies).map(voie => (
+        <VoieRow
+          key={sanitizedRowsByVoies[voie].voieId}
+          nomVoie={voie}
+          voie={sanitizedRowsByVoies[voie]}
+          baseLocaleId={baseLocaleId}
+        />
+      ))}
     </Pane>
   )
 }

--- a/components/validateur-report/index.js
+++ b/components/validateur-report/index.js
@@ -1,59 +1,38 @@
-import {useCallback, useState, useEffect} from 'react'
 import PropTypes from 'prop-types'
 import {Pane} from 'evergreen-ui'
 import {groupBy, remove} from 'lodash'
 
-import {getVoies} from '@/lib/bal-api'
-
 import VoieRow from '@/components/validateur-report/voie-row'
 
-function ValidateurReport({rows, baseLocaleID}) {
-  const [voies, setVoies] = useState()
-  const [rowsByVoie, setRowsByVoie] = useState({})
+function ValidateurReport({rows, voies, baseLocaleID}) {
+  const sanitizedRowsByVoies = {}
 
-  const getBalVoies = useCallback(async () => {
-    try {
-      const voiesList = await getVoies(baseLocaleID)
-      setVoies(voiesList)
-    } catch {
-      console.log('Impossible de récupérer la liste des voies')
-    }
-  }, [baseLocaleID])
+  if (voies) {
+    const rowsByVoies = groupBy(rows, row => row.rawValues.voie_nom)
 
-  useEffect(() => {
-    getBalVoies()
-  }, [getBalVoies])
-
-  useEffect(() => {
-    if (voies) {
-      const rowsByVoies = groupBy(rows, row => row.rawValues.voie_nom)
-      const sanitizedRowByVoies = {}
-
-      // Create a new object, grouped by voies names
-      Object.keys(rowsByVoies).forEach(nomVoie => {
-        const rowsWithAlerts = rowsByVoies[nomVoie].filter(row => {
-          remove(row.errors, error => error.level === 'I') // Remove unusefull "information" type alerts
-          return row.errors.length > 0
-        })
-
-        const rowWithVoieAlerts = rowsWithAlerts.filter(row => !row.parsedValues.numero)
-        const numerosWithAlerts = rowsWithAlerts.filter(row => row.parsedValues.numero).map(numero => ({address: numero.parsedValues, alerts: numero.errors}))
-
-        // For each voie, add voie's id, it's own alerts list and it's numeros with alerts list
-        sanitizedRowByVoies[nomVoie] = {
-          voieId: voies.find(voie => voie.nom === nomVoie)?._id,
-          voieAlerts: rowWithVoieAlerts.length > 0 ? rowWithVoieAlerts[0].errors : [],
-          numerosWithAlerts
-        }
+    // Create a new object, grouped by voies names
+    Object.keys(rowsByVoies).forEach(nomVoie => {
+      const rowsWithAlerts = rowsByVoies[nomVoie].filter(row => {
+        remove(row.errors, error => error.level === 'I') // Remove unusefull "information" type alerts
+        return row.errors.length > 0
       })
-      setRowsByVoie(sanitizedRowByVoies)
-    }
-  }, [rows, voies])
+
+      const rowWithVoieAlerts = rowsWithAlerts.filter(row => !row.parsedValues.numero)
+      const numerosWithAlerts = rowsWithAlerts.filter(row => row.parsedValues.numero).map(numero => ({address: numero.parsedValues, alerts: numero.errors}))
+
+      // For each voie, add voie's id, it's own alerts list and it's numeros with alerts list
+      sanitizedRowsByVoies[nomVoie] = {
+        voieId: voies.find(voie => voie.nom === nomVoie)?._id,
+        voieAlerts: rowWithVoieAlerts.length > 0 ? rowWithVoieAlerts[0].errors : [],
+        numerosWithAlerts
+      }
+    })
+  }
 
   return (
     <Pane display='flex' flexDirection='column' gap={12}>
-      {Object.keys(rowsByVoie).map(voie => {
-        return <VoieRow key={voie} nomVoie={voie} voie={rowsByVoie[voie]} />
+      {Object.keys(sanitizedRowsByVoies).map(voie => {
+        return <VoieRow key={voie} nomVoie={voie} voie={sanitizedRowsByVoies[voie]} baseLocaleID={baseLocaleID} />
       })}
     </Pane>
   )
@@ -61,6 +40,7 @@ function ValidateurReport({rows, baseLocaleID}) {
 
 ValidateurReport.propTypes = {
   baseLocaleID: PropTypes.string.isRequired,
+  voies: PropTypes.array.isRequired,
   rows: PropTypes.array.isRequired
 }
 

--- a/components/validateur-report/index.js
+++ b/components/validateur-report/index.js
@@ -10,32 +10,30 @@ const validAlertSchemas = new Set(['voie_nom', 'numero', 'suffixe'])
 function ValidateurReport({rows, voies, baseLocaleId}) {
   const sanitizedRowsByVoies = useMemo(() => ({}), [])
 
-  if (voies) {
-    const rowsByVoies = groupBy(rows, row => row.rawValues.voie_nom)
+  const rowsByVoies = groupBy(rows, row => row.rawValues.voie_nom)
 
-    // Create a new object, grouped by voies names
-    Object.keys(rowsByVoies).forEach(nomVoie => {
-      const rowsWithAlerts = rowsByVoies[nomVoie].filter(row => {
-        row.errors = filter(row.errors, error => validAlertSchemas.has(error.schemaName)) // Keep usefull alerts only
-        return row.errors.length > 0
-      })
-
-      const rowWithVoieAlerts = rowsWithAlerts.filter(row => !row.parsedValues.numero)
-      const numerosWithAlerts = rowsWithAlerts.filter(row => row.parsedValues.numero).map(numero => ({address: numero.parsedValues, alerts: numero.errors}))
-
-      // For each voie, add voie's id, it's own alerts list and it's numeros with alerts list
-      if (rowWithVoieAlerts.length > 0 || numerosWithAlerts.length > 0) {
-        sanitizedRowsByVoies[nomVoie] = {
-          voieId: voies.find(voie => voie.nom === nomVoie)._id,
-          voieAlerts: rowWithVoieAlerts.length > 0 ? rowWithVoieAlerts[0].errors : [],
-          numerosWithAlerts
-        }
-      }
+  // Create a new object, grouped by voies names
+  Object.keys(rowsByVoies).forEach(nomVoie => {
+    const rowsWithAlerts = rowsByVoies[nomVoie].filter(row => {
+      row.errors = filter(row.errors, error => validAlertSchemas.has(error.schemaName)) // Keep usefull alerts only
+      return row.errors.length > 0
     })
-  }
+
+    const rowWithVoieAlerts = rowsWithAlerts.filter(row => !row.parsedValues.numero)
+    const numerosWithAlerts = rowsWithAlerts.filter(row => row.parsedValues.numero).map(numero => ({address: numero.parsedValues, alerts: numero.errors}))
+
+    // For each voie, add voie's id, it's own alerts list and it's numeros with alerts list
+    if (rowWithVoieAlerts.length > 0 || numerosWithAlerts.length > 0) {
+      sanitizedRowsByVoies[nomVoie] = {
+        voieId: voies.find(voie => voie.nom === nomVoie)._id,
+        voieAlerts: rowWithVoieAlerts.length > 0 ? rowWithVoieAlerts[0].errors : [],
+        numerosWithAlerts
+      }
+    }
+  })
 
   return (
-    <Pane display='flex' flexDirection='column' gap={12}>
+    <Pane display='flex' flexDirection='column' justifyContent='center' gap={12}>
       {Object.keys(sanitizedRowsByVoies).map(voie => (
         <VoieRow
           key={sanitizedRowsByVoies[voie].voieId}

--- a/components/validateur-report/index.js
+++ b/components/validateur-report/index.js
@@ -49,9 +49,13 @@ function ValidateurReport({rows, voies, baseLocaleId}) {
 }
 
 ValidateurReport.propTypes = {
-  baseLocaleId: PropTypes.string.isRequired,
   voies: PropTypes.array.isRequired,
-  rows: PropTypes.array.isRequired
+  rows: PropTypes.array.isRequired,
+  baseLocaleId: PropTypes.string
+}
+
+ValidateurReport.defaultProps = {
+  baseLocaleId: null
 }
 
 export default ValidateurReport

--- a/components/validateur-report/index.js
+++ b/components/validateur-report/index.js
@@ -1,7 +1,7 @@
 import {useMemo} from 'react'
 import PropTypes from 'prop-types'
 import {Pane} from 'evergreen-ui'
-import {groupBy, remove} from 'lodash'
+import {groupBy, filter} from 'lodash'
 
 import VoieRow from '@/components/validateur-report/voie-row'
 
@@ -16,7 +16,7 @@ function ValidateurReport({rows, voies, baseLocaleId}) {
     // Create a new object, grouped by voies names
     Object.keys(rowsByVoies).forEach(nomVoie => {
       const rowsWithAlerts = rowsByVoies[nomVoie].filter(row => {
-        remove(row.errors, error => !validAlertSchemas.has(error.schemaName)) // Remove unusefull alerts
+        row.errors = filter(row.errors, error => validAlertSchemas.has(error.schemaName)) // Keep usefull alerts only
         return row.errors.length > 0
       })
 

--- a/components/validateur-report/index.js
+++ b/components/validateur-report/index.js
@@ -7,7 +7,7 @@ import VoieRow from '@/components/validateur-report/voie-row'
 
 const validAlertSchemas = new Set(['voie_nom', 'numero', 'suffixe'])
 
-function ValidateurReport({rows, voies, onRedirect}) {
+function ValidateurReport({rows, onRedirect}) {
   const sanitizedRowsByVoies = useMemo(() => {
     const finalObj = {}
 
@@ -26,7 +26,6 @@ function ValidateurReport({rows, voies, onRedirect}) {
       // For each voie, add voie's id, it's own alerts list and it's numeros with alerts list
       if (rowWithVoieAlerts.length > 0 || numerosWithAlerts.length > 0) {
         finalObj[nomVoie] = {
-          voieId: voies.find(voie => voie.nom === nomVoie)._id,
           voieAlerts: rowWithVoieAlerts.length > 0 ? rowWithVoieAlerts[0].errors : [],
           numerosWithAlerts
         }
@@ -34,7 +33,7 @@ function ValidateurReport({rows, voies, onRedirect}) {
     })
 
     return finalObj
-  }, [rows, voies])
+  }, [rows])
 
   return Object.keys(sanitizedRowsByVoies).length > 0 && (
     <Pane display='flex' flexDirection='column' justifyContent='center' gap={12}>
@@ -52,7 +51,6 @@ function ValidateurReport({rows, voies, onRedirect}) {
 }
 
 ValidateurReport.propTypes = {
-  voies: PropTypes.array.isRequired,
   rows: PropTypes.array.isRequired,
   onRedirect: PropTypes.func.isRequired
 }

--- a/components/validateur-report/numero-row.js
+++ b/components/validateur-report/numero-row.js
@@ -34,7 +34,7 @@ function NumeroRow({numero, numerosWithAlerts}) {
             {alerts.map(({code, level}) => (
               <ListItem
                 key={code}
-                color={level === 'E' ? 'red500' : 'orange500'}
+                color={level === 'E' ? 'red500' : (level === 'W' ? 'orange500' : 'blue500')}
                 padding={0}
                 marginX={14}
               >

--- a/components/validateur-report/numero-row.js
+++ b/components/validateur-report/numero-row.js
@@ -1,14 +1,14 @@
 import {useState} from 'react'
 import PropTypes from 'prop-types'
 import {Pane, Text, UnorderedList, ListItem} from 'evergreen-ui'
-import {filter, some, size} from 'lodash'
+import {filter} from 'lodash'
 
 import {getLabel} from '@ban-team/validateur-bal'
 
 import AlertHeader from '@/components/validateur-report/alerts-header'
 import Dropdown from '@/components/dropdown'
 
-function NumeroRow({numero, numerosWithAlerts}) {
+function NumeroRow({numero}) {
   const {address, alerts} = numero
   const [isNumeroOpen, setIsNumeroOpen] = useState(false)
 
@@ -50,8 +50,7 @@ function NumeroRow({numero, numerosWithAlerts}) {
 }
 
 NumeroRow.propTypes = {
-  numero: PropTypes.object.isRequired,
-  numerosWithAlerts: PropTypes.array.isRequired
+  numero: PropTypes.object.isRequired
 }
 
 export default NumeroRow

--- a/components/validateur-report/numero-row.js
+++ b/components/validateur-report/numero-row.js
@@ -1,0 +1,52 @@
+import {useState} from 'react'
+import PropTypes from 'prop-types'
+import {Pane, Text, UnorderedList, ListItem} from 'evergreen-ui'
+
+import {getLabel} from '@ban-team/validateur-bal'
+
+import AlertHeader from '@/components/validateur-report/alerts-header'
+import Dropdown from '@/components/dropdown'
+
+function NumeroRow({numero, numerosWithAlerts}) {
+  const {address, alerts} = numero
+  const [isNumeroOpen, setIsNumeroOpen] = useState(false)
+
+  return (
+    <Dropdown
+      key={address.numero}
+      isOpen={isNumeroOpen}
+      handleOpen={() => setIsNumeroOpen(!isNumeroOpen)}
+      dropdownStyle='secondary'
+    >
+      <Pane width='100%' display='flex' flexDirection='column' gap={20} justifyContent='center'>
+        <AlertHeader numerosWithAlerts={numerosWithAlerts} type='secondary'>
+          <Text fontSize={15} fontWeight={700}>{address.numero} {address.voie_nom}</Text>
+        </AlertHeader>
+
+        {isNumeroOpen && (
+          <UnorderedList background='white' borderRadius={6} padding={8}>
+            {alerts.map(alert => {
+              return (
+                <ListItem
+                  key={alert.code}
+                  color={alert.level === 'E' ? 'red500' : 'orange500'}
+                  padding={0}
+                  marginX={14}
+                >
+                  {getLabel(alert.code)}
+                </ListItem>
+              )
+            })}
+          </UnorderedList>
+        )}
+      </Pane>
+    </Dropdown>
+  )
+}
+
+NumeroRow.propTypes = {
+  numero: PropTypes.object.isRequired,
+  numerosWithAlerts: PropTypes.array.isRequired
+}
+
+export default NumeroRow

--- a/components/validateur-report/numero-row.js
+++ b/components/validateur-report/numero-row.js
@@ -1,7 +1,7 @@
 import {useState, useMemo} from 'react'
 import PropTypes from 'prop-types'
 import {Pane, Text, UnorderedList, ListItem} from 'evergreen-ui'
-import {filter} from 'lodash'
+import {filter, uniqueId} from 'lodash'
 import {getLabel} from '@ban-team/validateur-bal'
 
 import AlertHeader from '@/components/validateur-report/alerts-header'
@@ -20,7 +20,7 @@ function NumeroRow({address, alerts}) {
 
   return (
     <Dropdown
-      key={`${address.long}-${address.lat}`}
+      key={uniqueId}
       isOpen={isNumeroOpen}
       handleOpen={() => setIsNumeroOpen(!isNumeroOpen)}
       dropdownStyle='secondary'

--- a/components/validateur-report/numero-row.js
+++ b/components/validateur-report/numero-row.js
@@ -2,7 +2,6 @@ import {useState} from 'react'
 import PropTypes from 'prop-types'
 import {Pane, Text, UnorderedList, ListItem} from 'evergreen-ui'
 import {filter} from 'lodash'
-
 import {getLabel} from '@ban-team/validateur-bal'
 
 import AlertHeader from '@/components/validateur-report/alerts-header'

--- a/components/validateur-report/numero-row.js
+++ b/components/validateur-report/numero-row.js
@@ -25,18 +25,17 @@ function NumeroRow({numero, numerosWithAlerts}) {
 
         {isNumeroOpen && (
           <UnorderedList background='white' borderRadius={6} padding={8}>
-            {alerts.map(alert => {
-              return (
-                <ListItem
-                  key={alert.code}
-                  color={alert.level === 'E' ? 'red500' : 'orange500'}
-                  padding={0}
-                  marginX={14}
-                >
-                  {getLabel(alert.code)}
-                </ListItem>
-              )
-            })}
+            {alerts.map(alert => (
+              <ListItem
+                key={alert.code}
+                color={alert.level === 'E' ? 'red500' : 'orange500'}
+                padding={0}
+                marginX={14}
+              >
+                {getLabel(alert.code)}
+              </ListItem>
+            )
+            )}
           </UnorderedList>
         )}
       </Pane>

--- a/components/validateur-report/numero-row.js
+++ b/components/validateur-report/numero-row.js
@@ -25,14 +25,14 @@ function NumeroRow({numero, numerosWithAlerts}) {
 
         {isNumeroOpen && (
           <UnorderedList background='white' borderRadius={6} padding={8}>
-            {alerts.map(alert => (
+            {alerts.map(({code, level}) => (
               <ListItem
-                key={alert.code}
-                color={alert.level === 'E' ? 'red500' : 'orange500'}
+                key={code}
+                color={level === 'E' ? 'red500' : 'orange500'}
                 padding={0}
                 marginX={14}
               >
-                {getLabel(alert.code)}
+                {getLabel(code)}
               </ListItem>
             )
             )}

--- a/components/validateur-report/numero-row.js
+++ b/components/validateur-report/numero-row.js
@@ -7,17 +7,16 @@ import {getLabel} from '@ban-team/validateur-bal'
 import AlertHeader from '@/components/validateur-report/alerts-header'
 import Dropdown from '@/components/dropdown'
 
-function NumeroRow({numero}) {
-  const {address, alerts} = numero
+function NumeroRow({address, alerts}) {
   const [isNumeroOpen, setIsNumeroOpen] = useState(false)
 
   const [hasWarnings, hasErrors, hasInfos] = useMemo(() => {
     return [
-      filter(numero.alerts, ({level}) => level === 'W').length > 0,
-      filter(numero.alerts, ({level}) => level === 'E').length > 0,
-      filter(numero.alerts, ({level}) => level === 'I').length > 0
+      filter(alerts, ({level}) => level === 'W').length > 0,
+      filter(alerts, ({level}) => level === 'E').length > 0,
+      filter(alerts, ({level}) => level === 'I').length > 0
     ]
-  }, [numero])
+  }, [alerts])
 
   return (
     <Dropdown
@@ -57,7 +56,8 @@ function NumeroRow({numero}) {
 }
 
 NumeroRow.propTypes = {
-  numero: PropTypes.object.isRequired
+  address: PropTypes.object.isRequired,
+  alerts: PropTypes.array.isRequired
 }
 
 export default NumeroRow

--- a/components/validateur-report/numero-row.js
+++ b/components/validateur-report/numero-row.js
@@ -21,7 +21,7 @@ function NumeroRow({numero}) {
 
   return (
     <Dropdown
-      key={address.numero}
+      key={`${address.long}-${address.lat}`}
       isOpen={isNumeroOpen}
       handleOpen={() => setIsNumeroOpen(!isNumeroOpen)}
       dropdownStyle='secondary'

--- a/components/validateur-report/numero-row.js
+++ b/components/validateur-report/numero-row.js
@@ -1,6 +1,7 @@
 import {useState} from 'react'
 import PropTypes from 'prop-types'
 import {Pane, Text, UnorderedList, ListItem} from 'evergreen-ui'
+import {filter, some, size} from 'lodash'
 
 import {getLabel} from '@ban-team/validateur-bal'
 
@@ -19,7 +20,12 @@ function NumeroRow({numero, numerosWithAlerts}) {
       dropdownStyle='secondary'
     >
       <Pane width='100%' display='flex' flexDirection='column' gap={20} justifyContent='center'>
-        <AlertHeader numerosWithAlerts={numerosWithAlerts} type='secondary'>
+        <AlertHeader
+          type='secondary'
+          hasWarnings={some(numerosWithAlerts, numero => size(filter(numero.alerts, {level: 'W'})) > 0)}
+          hasErrors={some(numerosWithAlerts, numero => size(filter(numero.alerts, {level: 'E'})) > 0)}
+          hasInfos={some(numerosWithAlerts, numero => size(filter(numero.alerts, {level: 'I'})) > 0)}
+        >
           <Text fontSize={15} fontWeight={700}>{address.numero} {address.voie_nom}</Text>
         </AlertHeader>
 

--- a/components/validateur-report/numero-row.js
+++ b/components/validateur-report/numero-row.js
@@ -1,4 +1,4 @@
-import {useState} from 'react'
+import {useState, useMemo} from 'react'
 import PropTypes from 'prop-types'
 import {Pane, Text, UnorderedList, ListItem} from 'evergreen-ui'
 import {filter} from 'lodash'
@@ -11,6 +11,14 @@ function NumeroRow({numero}) {
   const {address, alerts} = numero
   const [isNumeroOpen, setIsNumeroOpen] = useState(false)
 
+  const [hasWarnings, hasErrors, hasInfos] = useMemo(() => {
+    return [
+      filter(numero.alerts, ({level}) => level === 'W').length > 0,
+      filter(numero.alerts, ({level}) => level === 'E').length > 0,
+      filter(numero.alerts, ({level}) => level === 'I').length > 0
+    ]
+  }, [numero])
+
   return (
     <Dropdown
       key={address.numero}
@@ -21,9 +29,9 @@ function NumeroRow({numero}) {
       <Pane width='100%' display='flex' flexDirection='column' gap={20} justifyContent='center'>
         <AlertHeader
           type='secondary'
-          hasWarnings={filter(numero.alerts, ({level}) => level === 'W').length > 0}
-          hasErrors={filter(numero.alerts, ({level}) => level === 'E').length > 0}
-          hasInfos={filter(numero.alerts, ({level}) => level === 'I').length > 0}
+          hasWarnings={hasWarnings}
+          hasErrors={hasErrors}
+          hasInfos={hasInfos}
         >
           <Text fontSize={15} fontWeight={700}>{address.numero} {address.voie_nom}</Text>
         </AlertHeader>

--- a/components/validateur-report/numero-row.js
+++ b/components/validateur-report/numero-row.js
@@ -10,12 +10,12 @@ import Dropdown from '@/components/dropdown'
 function NumeroRow({address, alerts}) {
   const [isNumeroOpen, setIsNumeroOpen] = useState(false)
 
-  const [hasWarnings, hasErrors, hasInfos] = useMemo(() => {
-    return [
-      filter(alerts, ({level}) => level === 'W').length > 0,
-      filter(alerts, ({level}) => level === 'E').length > 0,
-      filter(alerts, ({level}) => level === 'I').length > 0
-    ]
+  const hasAlerts = useMemo(() => {
+    return {
+      hasWarnings: filter(alerts, ({level}) => level === 'W').length > 0,
+      hasErrors: filter(alerts, ({level}) => level === 'E').length > 0,
+      haseInfos: filter(alerts, ({level}) => level === 'I').length > 0
+    }
   }, [alerts])
 
   return (
@@ -26,12 +26,7 @@ function NumeroRow({address, alerts}) {
       dropdownStyle='secondary'
     >
       <Pane width='100%' display='flex' flexDirection='column' gap={20} justifyContent='center'>
-        <AlertHeader
-          type='secondary'
-          hasWarnings={hasWarnings}
-          hasErrors={hasErrors}
-          hasInfos={hasInfos}
-        >
+        <AlertHeader type='secondary' {...hasAlerts}>
           <Text fontSize={15} fontWeight={700}>{address.numero} {address.voie_nom}</Text>
         </AlertHeader>
 

--- a/components/validateur-report/numero-row.js
+++ b/components/validateur-report/numero-row.js
@@ -22,9 +22,9 @@ function NumeroRow({numero, numerosWithAlerts}) {
       <Pane width='100%' display='flex' flexDirection='column' gap={20} justifyContent='center'>
         <AlertHeader
           type='secondary'
-          hasWarnings={some(numerosWithAlerts, numero => size(filter(numero.alerts, {level: 'W'})) > 0)}
-          hasErrors={some(numerosWithAlerts, numero => size(filter(numero.alerts, {level: 'E'})) > 0)}
-          hasInfos={some(numerosWithAlerts, numero => size(filter(numero.alerts, {level: 'I'})) > 0)}
+          hasWarnings={filter(numero.alerts, ({level}) => level === 'W').length > 0}
+          hasErrors={filter(numero.alerts, ({level}) => level === 'E').length > 0}
+          hasInfos={filter(numero.alerts, ({level}) => level === 'I').length > 0}
         >
           <Text fontSize={15} fontWeight={700}>{address.numero} {address.voie_nom}</Text>
         </AlertHeader>

--- a/components/validateur-report/voie-row.js
+++ b/components/validateur-report/voie-row.js
@@ -1,0 +1,95 @@
+import {useState} from 'react'
+import PropTypes from 'prop-types'
+import Link from 'next/link'
+import {Pane, Heading, Text, UnorderedList, ListItem} from 'evergreen-ui'
+import {sortBy} from 'lodash'
+
+import {getLabel} from '@ban-team/validateur-bal'
+
+import NumeroRow from '@/components/validateur-report/numero-row'
+import AlertHeader from '@/components/validateur-report/alerts-header'
+import Dropdown from '@/components/dropdown'
+
+function VoieRow({nomVoie, voie, baseLocaleID}) {
+  const [isVoieOpen, setIsVoieOpen] = useState(false)
+
+  const {voieId, voieAlerts, numerosWithAlerts} = voie
+
+  return (
+    <Dropdown isOpen={isVoieOpen} handleOpen={() => setIsVoieOpen(!isVoieOpen)}>
+      <Pane width='100%'>
+        <Pane display='flex' flexDirection='column' gap={8}>
+          <AlertHeader isVoie voieAlerts={voieAlerts}>
+            <Pane width='100%' display='flex' justifyContent='space-between' alignItems='center'>
+              <Heading as='h2' fontSize={16}>{nomVoie}</Heading>
+              {voieId && (
+                <Link href={`/bal/voie?balId=${baseLocaleID}&idVoie=${voieId}`} passHref>
+                  <Text
+                    marginRight={8}
+                    fontStyle='italic'
+                    color='neutral'
+                    textDecoration='underline'
+                    cursor='pointer'
+                  >
+                    Accéder à la voie
+                  </Text>
+                </Link>
+              )}
+            </Pane>
+          </AlertHeader>
+
+          {numerosWithAlerts.length > 0 && (
+            <Pane paddingLeft={20}>
+              <AlertHeader numerosWithAlerts={numerosWithAlerts}>
+                <Text fontStyle='italic'>
+                  {`${numerosWithAlerts.length} ${numerosWithAlerts.length > 1 ? 'numéros ont' : 'numéro a'} des alertes`}
+                </Text>
+              </AlertHeader>
+            </Pane>
+          )}
+        </Pane>
+
+        {isVoieOpen && (
+          <Pane paddingLeft={20} margin={16}>
+            {voieAlerts.length > 0 && (
+              <Pane marginY={20}>
+                <Text fontWeight={700} fontSize={16}>Alertes concernant la voie</Text>
+                <UnorderedList >
+                  {voieAlerts.map(alert => {
+                    return (
+                      <ListItem
+                        key={alert.code}
+                        color={alert.level === 'E' ? 'red500' : 'orange500'}
+                        fontSize={15}
+                      >
+                        {getLabel(alert.code)}
+                      </ListItem>
+                    )
+                  })}
+                </UnorderedList>
+              </Pane>
+            )}
+
+            {numerosWithAlerts.length > 0 && (
+              <>
+                <Text width='100%' fontWeight={700} fontSize={16}>Alertes concernant les numéros de la voie</Text>
+                <Pane display='flex' flexDirection='column' gap={10} marginTop={6}>
+                  {sortBy(numerosWithAlerts, item => item.address.numero, ['asc']).map(numero =>
+                    <NumeroRow key={numero.address.numero} numero={numero} numerosWithAlerts={numerosWithAlerts} />)}
+                </Pane>
+              </>
+            )}
+          </Pane>
+        )}
+      </Pane>
+    </Dropdown>
+  )
+}
+
+VoieRow.propTypes = {
+  nomVoie: PropTypes.string.isRequired,
+  voie: PropTypes.object.isRequired,
+  baseLocaleID: PropTypes.string.isRequired
+}
+
+export default VoieRow

--- a/components/validateur-report/voie-row.js
+++ b/components/validateur-report/voie-row.js
@@ -1,8 +1,8 @@
-import {useState} from 'react'
+import {useState, useMemo} from 'react'
 import PropTypes from 'prop-types'
 import Link from 'next/link'
 import {Pane, Heading, Text, UnorderedList, ListItem} from 'evergreen-ui'
-import {sortBy, some, size, filter} from 'lodash'
+import {sortBy, some} from 'lodash'
 import {getLabel} from '@ban-team/validateur-bal'
 
 import NumeroRow from '@/components/validateur-report/numero-row'
@@ -14,15 +14,26 @@ function VoieRow({nomVoie, voie, baseLocaleId}) {
 
   const {voieId, voieAlerts, numerosWithAlerts} = voie
 
+  const [hasVoieWarnings, hasVoieErrors, hasVoieInfos, hasNumeroWarnings, hasNumeroErrors, hasNumeroInfos] = useMemo(() => {
+    return [
+      some(voie.voieAlerts, ({level}) => level === 'W'),
+      some(voie.voieAlerts, ({level}) => level === 'E'),
+      some(voie.voieAlerts, ({level}) => level === 'I'),
+      some(numerosWithAlerts, ({alerts}) => alerts.filter(({level}) => level === 'W').length > 0),
+      some(numerosWithAlerts, ({alerts}) => alerts.filter(({level}) => level === 'E').length > 0),
+      some(numerosWithAlerts, ({alerts}) => alerts.filter(({level}) => level === 'I').length > 0),
+    ]
+  }, [numerosWithAlerts, voie])
+
   return (
     <Dropdown isOpen={isVoieOpen} handleOpen={() => setIsVoieOpen(!isVoieOpen)}>
       <Pane width='100%'>
         <Pane display='flex' flexDirection='column' gap={8}>
           <AlertHeader
-            isVoie
-            hasWarnings={some(voieAlerts, ({level}) => level === 'W')}
-            hasErrors={some(voieAlerts, ({level}) => level === 'E')}
-            hasInfos={some(voieAlerts, ({level}) => level === 'I')}
+            size={22}
+            hasWarnings={hasVoieWarnings}
+            hasErrors={hasVoieErrors}
+            hasInfos={hasVoieInfos}
           >
             <Pane width='100%' display='flex' justifyContent='space-between' alignItems='center'>
               <Heading as='h2' fontSize={16}>{nomVoie}</Heading>
@@ -45,9 +56,9 @@ function VoieRow({nomVoie, voie, baseLocaleId}) {
           {numerosWithAlerts.length > 0 && (
             <Pane paddingLeft={20}>
               <AlertHeader
-                hasWarnings={some(numerosWithAlerts, numero => size(filter(numero.alerts, {level: 'W'})) > 0)}
-                hasErrors={some(numerosWithAlerts, numero => size(filter(numero.alerts, {level: 'E'})) > 0)}
-                hasInfos={some(numerosWithAlerts, numero => size(filter(numero.alerts, {level: 'I'})) > 0)}
+                hasWarnings={hasNumeroWarnings}
+                hasErrors={hasNumeroErrors}
+                hasInfos={hasNumeroInfos}
               >
                 <Text fontStyle='italic'>
                   {`${numerosWithAlerts.length} ${numerosWithAlerts.length > 1 ? 'numéros ont' : 'numéro a'} des alertes`}

--- a/components/validateur-report/voie-row.js
+++ b/components/validateur-report/voie-row.js
@@ -36,7 +36,7 @@ function VoieRow({nomVoie, voie, baseLocaleId}) {
             hasInfos={hasVoieInfos}
           >
             <Pane width='100%' display='flex' justifyContent='space-between' alignItems='center'>
-              <Heading as='h2' fontSize={16}>{nomVoie}</Heading>
+              <Heading is='h4' size='400'>{nomVoie}</Heading>
               {voieId && baseLocaleId && (
                 <Link href={`/bal/voie?balId=${baseLocaleId}&idVoie=${voieId}`} passHref>
                   <Text

--- a/components/validateur-report/voie-row.js
+++ b/components/validateur-report/voie-row.js
@@ -10,7 +10,7 @@ import NumeroRow from '@/components/validateur-report/numero-row'
 import AlertHeader from '@/components/validateur-report/alerts-header'
 import Dropdown from '@/components/dropdown'
 
-function VoieRow({nomVoie, voie, baseLocaleID}) {
+function VoieRow({nomVoie, voie, baseLocaleId}) {
   const [isVoieOpen, setIsVoieOpen] = useState(false)
 
   const {voieId, voieAlerts, numerosWithAlerts} = voie
@@ -23,7 +23,7 @@ function VoieRow({nomVoie, voie, baseLocaleID}) {
             <Pane width='100%' display='flex' justifyContent='space-between' alignItems='center'>
               <Heading as='h2' fontSize={16}>{nomVoie}</Heading>
               {voieId && (
-                <Link href={`/bal/voie?balId=${baseLocaleID}&idVoie=${voieId}`} passHref>
+                <Link href={`/bal/voie?balId=${baseLocaleId}&idVoie=${voieId}`} passHref>
                   <Text
                     marginRight={8}
                     fontStyle='italic'
@@ -89,7 +89,7 @@ function VoieRow({nomVoie, voie, baseLocaleID}) {
 VoieRow.propTypes = {
   nomVoie: PropTypes.string.isRequired,
   voie: PropTypes.object.isRequired,
-  baseLocaleID: PropTypes.string.isRequired
+  baseLocaleId: PropTypes.string.isRequired
 }
 
 export default VoieRow

--- a/components/validateur-report/voie-row.js
+++ b/components/validateur-report/voie-row.js
@@ -93,7 +93,7 @@ function VoieRow({nomVoie, voie, onRedirect}) {
                 <Text width='100%' fontWeight={700} fontSize={16}>Alertes concernant les numéros de la voie</Text>
                 <Pane display='flex' flexDirection='column' gap={10} marginTop={6}>
                   {sortBy(numerosWithAlerts, item => item.address.numero, ['asc']).map(numero =>
-                    <NumeroRow key={numero.address.numero} numero={numero} numerosWithAlerts={numerosWithAlerts} />)}
+                    <NumeroRow key={numero.address.numero} {...numero} />)}
                 </Pane>
               </>
             )}

--- a/components/validateur-report/voie-row.js
+++ b/components/validateur-report/voie-row.js
@@ -37,7 +37,7 @@ function VoieRow({nomVoie, voie, baseLocaleId}) {
           >
             <Pane width='100%' display='flex' justifyContent='space-between' alignItems='center'>
               <Heading as='h2' fontSize={16}>{nomVoie}</Heading>
-              {voieId && (
+              {voieId && baseLocaleId && (
                 <Link href={`/bal/voie?balId=${baseLocaleId}&idVoie=${voieId}`} passHref>
                   <Text
                     marginRight={8}
@@ -111,7 +111,11 @@ VoieRow.propTypes = {
     voieAlerts: PropTypes.array.isRequired,
     numerosWithAlerts: PropTypes.array.isRequired
   }).isRequired,
-  baseLocaleId: PropTypes.string.isRequired
+  baseLocaleId: PropTypes.string
+}
+
+VoieRow.defaultProps = {
+  baseLocaleId: null
 }
 
 export default VoieRow

--- a/components/validateur-report/voie-row.js
+++ b/components/validateur-report/voie-row.js
@@ -55,17 +55,16 @@ function VoieRow({nomVoie, voie, baseLocaleId}) {
               <Pane marginY={20}>
                 <Text fontWeight={700} fontSize={16}>Alertes concernant la voie</Text>
                 <UnorderedList >
-                  {voieAlerts.map(alert => {
-                    return (
-                      <ListItem
-                        key={alert.code}
-                        color={alert.level === 'E' ? 'red500' : 'orange500'}
-                        fontSize={15}
-                      >
-                        {getLabel(alert.code)}
-                      </ListItem>
-                    )
-                  })}
+                  {voieAlerts.map(alert => (
+                    <ListItem
+                      key={alert.code}
+                      color={alert.level === 'E' ? 'red500' : 'orange500'}
+                      fontSize={15}
+                    >
+                      {getLabel(alert.code)}
+                    </ListItem>
+                  )
+                  )}
                 </UnorderedList>
               </Pane>
             )}

--- a/components/validateur-report/voie-row.js
+++ b/components/validateur-report/voie-row.js
@@ -55,13 +55,13 @@ function VoieRow({nomVoie, voie, baseLocaleId}) {
               <Pane marginY={20}>
                 <Text fontWeight={700} fontSize={16}>Alertes concernant la voie</Text>
                 <UnorderedList >
-                  {voieAlerts.map(alert => (
+                  {voieAlerts.map(({code, level}) => (
                     <ListItem
-                      key={alert.code}
-                      color={alert.level === 'E' ? 'red500' : 'orange500'}
+                      key={code}
+                      color={level === 'E' ? 'red500' : 'orange500'}
                       fontSize={15}
                     >
-                      {getLabel(alert.code)}
+                      {getLabel(code)}
                     </ListItem>
                   )
                   )}

--- a/components/validateur-report/voie-row.js
+++ b/components/validateur-report/voie-row.js
@@ -14,27 +14,27 @@ function VoieRow({nomVoie, voie, onRedirect}) {
 
   const {voieId, voieAlerts, numerosWithAlerts} = voie
 
-  const [hasVoieWarnings, hasVoieErrors, hasVoieInfos, hasNumeroWarnings, hasNumeroErrors, hasNumeroInfos] = useMemo(() => {
-    return [
-      some(voie.voieAlerts, ({level}) => level === 'W'),
-      some(voie.voieAlerts, ({level}) => level === 'E'),
-      some(voie.voieAlerts, ({level}) => level === 'I'),
-      some(numerosWithAlerts, ({alerts}) => alerts.filter(({level}) => level === 'W').length > 0),
-      some(numerosWithAlerts, ({alerts}) => alerts.filter(({level}) => level === 'E').length > 0),
-      some(numerosWithAlerts, ({alerts}) => alerts.filter(({level}) => level === 'I').length > 0),
-    ]
-  }, [numerosWithAlerts, voie])
+  const hasVoieAlerts = useMemo(() => {
+    return {
+      hasWarnings: some(voieAlerts, ({level}) => level === 'W'),
+      hasErrors: some(voieAlerts, ({level}) => level === 'E'),
+      hasInfos: some(voieAlerts, ({level}) => level === 'I')
+    }
+  }, [voieAlerts])
+
+  const hasNumeroAlerts = useMemo(() => {
+    return {
+      hasWarnings: some(numerosWithAlerts, ({alerts}) => alerts.filter(({level}) => level === 'W').length > 0),
+      hasErrors: some(numerosWithAlerts, ({alerts}) => alerts.filter(({level}) => level === 'E').length > 0),
+      hasInfos: some(numerosWithAlerts, ({alerts}) => alerts.filter(({level}) => level === 'I').length > 0)
+    }
+  }, [numerosWithAlerts])
 
   return (
     <Dropdown isOpen={isVoieOpen} handleOpen={() => setIsVoieOpen(!isVoieOpen)}>
       <Pane width='100%'>
         <Pane display='flex' flexDirection='column' gap={8}>
-          <AlertHeader
-            size={22}
-            hasWarnings={hasVoieWarnings}
-            hasErrors={hasVoieErrors}
-            hasInfos={hasVoieInfos}
-          >
+          <AlertHeader size={22} {...hasVoieAlerts}>
             <Pane width='100%' display='flex' justifyContent='space-between' alignItems='center'>
               <Heading is='h4' size='400'>{nomVoie}</Heading>
               {voieId && (
@@ -55,11 +55,7 @@ function VoieRow({nomVoie, voie, onRedirect}) {
 
           {numerosWithAlerts.length > 0 && (
             <Pane paddingLeft={20}>
-              <AlertHeader
-                hasWarnings={hasNumeroWarnings}
-                hasErrors={hasNumeroErrors}
-                hasInfos={hasNumeroInfos}
-              >
+              <AlertHeader {...hasNumeroAlerts}>
                 <Text fontStyle='italic'>
                   {`${numerosWithAlerts.length} ${numerosWithAlerts.length > 1 ? 'numéros ont' : 'numéro a'} des alertes`}
                 </Text>

--- a/components/validateur-report/voie-row.js
+++ b/components/validateur-report/voie-row.js
@@ -9,7 +9,7 @@ import NumeroRow from '@/components/validateur-report/numero-row'
 import AlertHeader from '@/components/validateur-report/alerts-header'
 import Dropdown from '@/components/dropdown'
 
-function VoieRow({nomVoie, voie, baseLocaleId}) {
+function VoieRow({nomVoie, voie, onRedirect}) {
   const [isVoieOpen, setIsVoieOpen] = useState(false)
 
   const {voieId, voieAlerts, numerosWithAlerts} = voie
@@ -37,8 +37,8 @@ function VoieRow({nomVoie, voie, baseLocaleId}) {
           >
             <Pane width='100%' display='flex' justifyContent='space-between' alignItems='center'>
               <Heading is='h4' size='400'>{nomVoie}</Heading>
-              {voieId && baseLocaleId && (
-                <Link href={`/bal/voie?balId=${baseLocaleId}&idVoie=${voieId}`} passHref>
+              {voieId && (
+                <Link href={onRedirect(voieId)} passHref>
                   <Text
                     marginRight={8}
                     fontStyle='italic'
@@ -111,11 +111,7 @@ VoieRow.propTypes = {
     voieAlerts: PropTypes.array.isRequired,
     numerosWithAlerts: PropTypes.array.isRequired
   }).isRequired,
-  baseLocaleId: PropTypes.string
-}
-
-VoieRow.defaultProps = {
-  baseLocaleId: null
+  onRedirect: PropTypes.func.isRequired
 }
 
 export default VoieRow

--- a/components/validateur-report/voie-row.js
+++ b/components/validateur-report/voie-row.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types'
 import Link from 'next/link'
 import {Pane, Heading, Text, UnorderedList, ListItem} from 'evergreen-ui'
 import {sortBy, some, size, filter} from 'lodash'
-
 import {getLabel} from '@ban-team/validateur-bal'
 
 import NumeroRow from '@/components/validateur-report/numero-row'

--- a/components/validateur-report/voie-row.js
+++ b/components/validateur-report/voie-row.js
@@ -9,10 +9,8 @@ import NumeroRow from '@/components/validateur-report/numero-row'
 import AlertHeader from '@/components/validateur-report/alerts-header'
 import Dropdown from '@/components/dropdown'
 
-function VoieRow({nomVoie, voie, onRedirect}) {
+function VoieRow({nomVoie, voieId, voieAlerts, numerosWithAlerts, onRedirect}) {
   const [isVoieOpen, setIsVoieOpen] = useState(false)
-
-  const {voieId, voieAlerts, numerosWithAlerts} = voie
 
   const hasVoieAlerts = useMemo(() => {
     return {
@@ -102,11 +100,9 @@ function VoieRow({nomVoie, voie, onRedirect}) {
 
 VoieRow.propTypes = {
   nomVoie: PropTypes.string.isRequired,
-  voie: PropTypes.shape({
-    voieId: PropTypes.string.isRequired,
-    voieAlerts: PropTypes.array.isRequired,
-    numerosWithAlerts: PropTypes.array.isRequired
-  }).isRequired,
+  voieId: PropTypes.string.isRequired,
+  voieAlerts: PropTypes.array.isRequired,
+  numerosWithAlerts: PropTypes.array.isRequired,
   onRedirect: PropTypes.func.isRequired
 }
 

--- a/components/validateur-report/voie-row.js
+++ b/components/validateur-report/voie-row.js
@@ -2,7 +2,7 @@ import {useState} from 'react'
 import PropTypes from 'prop-types'
 import Link from 'next/link'
 import {Pane, Heading, Text, UnorderedList, ListItem} from 'evergreen-ui'
-import {sortBy} from 'lodash'
+import {sortBy, some, size, filter} from 'lodash'
 
 import {getLabel} from '@ban-team/validateur-bal'
 
@@ -19,7 +19,12 @@ function VoieRow({nomVoie, voie, baseLocaleId}) {
     <Dropdown isOpen={isVoieOpen} handleOpen={() => setIsVoieOpen(!isVoieOpen)}>
       <Pane width='100%'>
         <Pane display='flex' flexDirection='column' gap={8}>
-          <AlertHeader isVoie voieAlerts={voieAlerts}>
+          <AlertHeader
+            isVoie
+            hasWarnings={some(voieAlerts, ({level}) => level === 'W')}
+            hasErrors={some(voieAlerts, ({level}) => level === 'E')}
+            hasInfos={some(voieAlerts, ({level}) => level === 'I')}
+          >
             <Pane width='100%' display='flex' justifyContent='space-between' alignItems='center'>
               <Heading as='h2' fontSize={16}>{nomVoie}</Heading>
               {voieId && (
@@ -40,7 +45,11 @@ function VoieRow({nomVoie, voie, baseLocaleId}) {
 
           {numerosWithAlerts.length > 0 && (
             <Pane paddingLeft={20}>
-              <AlertHeader numerosWithAlerts={numerosWithAlerts}>
+              <AlertHeader
+                hasWarnings={some(numerosWithAlerts, numero => size(filter(numero.alerts, {level: 'W'})) > 0)}
+                hasErrors={some(numerosWithAlerts, numero => size(filter(numero.alerts, {level: 'E'})) > 0)}
+                hasInfos={some(numerosWithAlerts, numero => size(filter(numero.alerts, {level: 'I'})) > 0)}
+              >
                 <Text fontStyle='italic'>
                   {`${numerosWithAlerts.length} ${numerosWithAlerts.length > 1 ? 'numéros ont' : 'numéro a'} des alertes`}
                 </Text>

--- a/components/validateur-report/voie-row.js
+++ b/components/validateur-report/voie-row.js
@@ -1,7 +1,6 @@
 import {useState, useMemo} from 'react'
 import PropTypes from 'prop-types'
-import Link from 'next/link'
-import {Pane, Heading, Text, UnorderedList, ListItem} from 'evergreen-ui'
+import {Pane, Heading, Text, Button, UnorderedList, ListItem} from 'evergreen-ui'
 import {sortBy, some} from 'lodash'
 import {getLabel} from '@ban-team/validateur-bal'
 
@@ -9,7 +8,7 @@ import NumeroRow from '@/components/validateur-report/numero-row'
 import AlertHeader from '@/components/validateur-report/alerts-header'
 import Dropdown from '@/components/dropdown'
 
-function VoieRow({nomVoie, voieId, voieAlerts, numerosWithAlerts, onRedirect}) {
+function VoieRow({nomVoie, voieAlerts, numerosWithAlerts, onRedirect}) {
   const [isVoieOpen, setIsVoieOpen] = useState(false)
 
   const hasVoieAlerts = useMemo(() => {
@@ -35,19 +34,15 @@ function VoieRow({nomVoie, voieId, voieAlerts, numerosWithAlerts, onRedirect}) {
           <AlertHeader size={22} {...hasVoieAlerts}>
             <Pane width='100%' display='flex' justifyContent='space-between' alignItems='center'>
               <Heading is='h4' size='400'>{nomVoie}</Heading>
-              {voieId && (
-                <Link href={onRedirect(voieId)} passHref>
-                  <Text
-                    marginRight={8}
-                    fontStyle='italic'
-                    color='neutral'
-                    textDecoration='underline'
-                    cursor='pointer'
-                  >
-                    Accéder à la voie
-                  </Text>
-                </Link>
-              )}
+              <Button
+                appearance='minimal'
+                marginRight={8}
+                textDecoration='underline'
+                onClick={() => onRedirect(nomVoie)}
+              >
+                Accéder à la voie
+              </Button>
+
             </Pane>
           </AlertHeader>
 
@@ -100,7 +95,6 @@ function VoieRow({nomVoie, voieId, voieAlerts, numerosWithAlerts, onRedirect}) {
 
 VoieRow.propTypes = {
   nomVoie: PropTypes.string.isRequired,
-  voieId: PropTypes.string.isRequired,
   voieAlerts: PropTypes.array.isRequired,
   numerosWithAlerts: PropTypes.array.isRequired,
   onRedirect: PropTypes.func.isRequired

--- a/components/validateur-report/voie-row.js
+++ b/components/validateur-report/voie-row.js
@@ -107,9 +107,9 @@ function VoieRow({nomVoie, voie, baseLocaleId}) {
 VoieRow.propTypes = {
   nomVoie: PropTypes.string.isRequired,
   voie: PropTypes.shape({
-      voieId: Proptype.string.isRequired,
-      voieAlerts: Protypes.array.isRequired,
-      numerosWithAlerts: Proptypes.array.isRequired
+    voieId: PropTypes.string.isRequired,
+    voieAlerts: PropTypes.array.isRequired,
+    numerosWithAlerts: PropTypes.array.isRequired
   }).isRequired,
   baseLocaleId: PropTypes.string.isRequired
 }


### PR DESCRIPTION
Création d'un rapport du validateur BAL dans un format accessible à l'utilisateur de mes-adresses.

Ce rapport simplifié affiche les erreurs en les regroupant par voie et/ou numéros de la voie plutôt que de lister, par alerte, les champs du fichier au format BAL concernés. 

Les alertes que l'utilisateur n'a pas le pouvoir de modifier lui-même en utilisant mes-adresses ne sont pas affichées.

### **Tester le composant sur la commune de Breux-Sur-Avre**
Rapport du validateur : [report.txt](https://github.com/BaseAdresseNationale/mes-adresses/files/9300940/report.txt)
Voies : [voies.txt](https://github.com/BaseAdresseNationale/mes-adresses/files/9300947/voies.txt)
baseLocaleId : `62ea703aca9248a58616b2d9`


---------------------------------
### **Exemple sur la bal de la commune de Breux-sur-Avre**
<img width="1410" alt="Capture d’écran 2022-08-17 à 15 08 11" src="https://user-images.githubusercontent.com/66621960/185151122-ffbfe44a-7a43-45a1-98fe-fb46a94626cb.png">
<img width="1440" alt="Capture d’écran 2022-08-17 à 15 07 44" src="https://user-images.githubusercontent.com/66621960/185151131-40aa6181-ee0b-4a0a-8dd9-7a1d61b6bf60.png">


-------

Fix #537 