### PR TITLE
Corrige le problème d’affichage des parcelles dans l’éditeur de numéro

### DIFF
--- a/components/bal/numero-editor/select-parcelles.js
+++ b/components/bal/numero-editor/select-parcelles.js
@@ -36,6 +36,7 @@ function SelectParcelles({initialParcelles, isToponyme}) {
               <Badge
                 key={parcelle}
                 isInteractive
+                fontSize={12}
                 color={parcelle === hoveredParcelle?.id ? 'red' : 'green'}
                 margin={4}
                 onClick={() => handleParcelle(parcelle)}

--- a/components/bal/numero-editor/select-parcelles.js
+++ b/components/bal/numero-editor/select-parcelles.js
@@ -27,9 +27,9 @@ function SelectParcelles({initialParcelles, isToponyme}) {
         title='Parcelles cadastre'
         help={`Depuis la carte, cliquez sur les parcelles que vous souhaitez ajouter au ${addressType}. En précisant les parcelles associées à cette adresse, vous accélérez sa réutilisation par de nombreux services, DDFiP, opérateurs de courrier, de fibre et de GPS.`}
       />
-      <Pane display='grid' gridTemplateColumns='1fr 1fr 1fr'>
-        {selectedParcelles.length > 0 ?
-          selectedParcelles.map(parcelle => {
+      {selectedParcelles.length > 0 ? (
+        <Pane display='grid' gridTemplateColumns='1fr 1fr 1fr'>
+          {selectedParcelles.map(parcelle => {
             const isHovered = parcelle === hoveredParcelle?.id
 
             return (
@@ -45,14 +45,17 @@ function SelectParcelles({initialParcelles, isToponyme}) {
                 {parcelle}{isHovered && <TrashIcon marginLeft={4} size={14} color='danger' verticalAlign='text-bottom' />}
               </Badge>
             )
-          }) : (
-            <Alert marginTop={8}>
-              <Text>
-                Depuis la carte, cliquez sur les parcelles que vous souhaitez ajouter au {addressType}.
-              </Text>
-            </Alert>
-          )}
-      </Pane>
+          })}
+        </Pane>
+      ) : (
+        <Pane>
+          <Alert marginTop={8}>
+            <Text>
+              Depuis la carte, cliquez sur les parcelles que vous souhaitez ajouter au {addressType}.
+            </Text>
+          </Alert>
+        </Pane>
+      )}
 
       <Button
         type='button'

--- a/components/bal/numero-editor/select-parcelles.js
+++ b/components/bal/numero-editor/select-parcelles.js
@@ -27,7 +27,7 @@ function SelectParcelles({initialParcelles, isToponyme}) {
         title='Parcelles cadastre'
         help={`Depuis la carte, cliquez sur les parcelles que vous souhaitez ajouter au ${addressType}. En précisant les parcelles associées à cette adresse, vous accélérez sa réutilisation par de nombreux services, DDFiP, opérateurs de courrier, de fibre et de GPS.`}
       />
-      <Pane>
+      <Pane display='grid' gridTemplateColumns='1fr 1fr 1fr'>
         {selectedParcelles.length > 0 ?
           selectedParcelles.map(parcelle => {
             const isHovered = parcelle === hoveredParcelle?.id
@@ -36,7 +36,6 @@ function SelectParcelles({initialParcelles, isToponyme}) {
               <Badge
                 key={parcelle}
                 isInteractive
-                fontSize={12}
                 color={parcelle === hoveredParcelle?.id ? 'red' : 'green'}
                 margin={4}
                 onClick={() => handleParcelle(parcelle)}


### PR DESCRIPTION
Lors du survol d’un badge de parcelle dans l’éditeur de numéro, l’agrandissement de la taille du badge créait un clignotement et/ou un décalage perturbant pour l’utilisateur.

Ce comportement n’est pas présent sous MacOs.

Cette Pr propose d’augmenter légèrement la taille de la police de caractère afin d’éviter le clignotement.

### Captures : 

#### Avant :

![capture_bug_parcelle](https://user-images.githubusercontent.com/56537238/186120297-303917b9-c412-4f52-b929-0699f50cb0da.gif)

#### Après : 

![capture_correction_parcelle](https://user-images.githubusercontent.com/56537238/186128031-462905e8-d45a-4ef4-84de-b6174f06aff1.gif)

Fix #661  