### PR TITLE
Corrige la réinitialisation du fond de carte au changement de page

### DIFF
--- a/components/map/map.js
+++ b/components/map/map.js
@@ -106,6 +106,8 @@ function Map({commune, isAddressFormOpen, handleAddressForm}) {
   const {modeId} = useContext(DrawContext)
   const {token} = useContext(TokenContext)
 
+  const communeHasOrtho = useMemo(() => commune.hasOrtho, [commune])
+
   const [handleHover, handleMouseLeave] = useHovered(map)
   const [voieTraceData, positionsData, voiesData] = useSources(isStyleLoaded)
   const bounds = useBounds(commune, voie, toponyme)
@@ -209,14 +211,14 @@ function Map({commune, isAddressFormOpen, handleAddressForm}) {
   // Auto switch to ortho on draw and save previous style
   useEffect(() => {
     setStyle(style => {
-      if (modeId && commune.hasOrtho) {
+      if (modeId && communeHasOrtho) {
         prevStyle.current = style
         return 'ortho'
       }
 
       return prevStyle.current
     })
-  }, [modeId, setStyle, commune])
+  }, [modeId, setStyle, communeHasOrtho])
 
   useEffect(() => {
     if (isStyleLoaded) {


### PR DESCRIPTION
## Contexte
Lorsque que l'on change de page, la prop `commune` provoque le déclenchement d'un `useEffect` destiné à restituer le fond de carte précédent dans le cas où celui-ci aurait été volontairement changé par l'outil (ex : tracer une voie).

## Correction
Cette PR propose de mémoriser la propriété `commune.hasOrtho` afin de ne pas déclencher de manière intempestive ce `useEffect`.

Fix #674 