### PR TITLE
Empêcher la publication de BAL sans adresse

### DIFF
--- a/components/sub-header/index.js
+++ b/components/sub-header/index.js
@@ -49,13 +49,18 @@ const SubHeader = React.memo(({commune}) => {
   }
 
   const handleHabilitation = async () => {
+    const isReadyToPublish = baseLocale.status === 'ready-to-publish'
+
     if (baseLocale.status === 'draft') {
       await handleChangeStatus('ready-to-publish')
     }
 
-    if ((!habilitation || !isHabilitationValid) && !commune.isCOM) {
-      await createHabilitation(token, baseLocale._id)
-      await reloadHabilitation()
+    if (isReadyToPublish && (!habilitation || !isHabilitationValid) && !commune.isCOM) {
+      const habilitation = await createHabilitation(token, baseLocale._id)
+
+      if (habilitation) {
+        await reloadHabilitation()
+      }
     }
 
     setIsHabilitationDisplayed(true)

--- a/components/sub-header/index.js
+++ b/components/sub-header/index.js
@@ -8,8 +8,6 @@ import {createHabilitation, getBaseLocaleCsvUrl, sync, updateBaseLocale} from '@
 import BalDataContext from '@/contexts/bal-data'
 import TokenContext from '@/contexts/token'
 
-import useError from '@/hooks/error'
-
 import HabilitationProcess from '@/components/habilitation-process/index'
 import Breadcrumbs from '@/components/breadcrumbs'
 import HabilitationTag from '@/components/habilitation-tag'
@@ -33,19 +31,12 @@ const SubHeader = React.memo(({commune}) => {
   } = useContext(BalDataContext)
   const {token} = useContext(TokenContext)
 
-  const [setError] = useError(null)
-
   const csvUrl = getBaseLocaleCsvUrl(baseLocale._id)
   const isAdmin = Boolean(token)
 
   const handleChangeStatus = async status => {
-    try {
-      await updateBaseLocale(baseLocale._id, {status}, token)
-
-      await reloadBaseLocale()
-    } catch (error) {
-      setError(error.message)
-    }
+    await updateBaseLocale(baseLocale._id, {status}, token)
+    await reloadBaseLocale()
   }
 
   const handleHabilitation = async () => {

--- a/lib/bal-api/index.js
+++ b/lib/bal-api/index.js
@@ -221,14 +221,22 @@ export function createBaseLocaleDemo(body) {
 }
 
 export async function updateBaseLocale(balId, body, token) {
-  return request(`/bases-locales/${balId}`, {
-    method: 'PUT',
-    headers: {
-      authorization: `Token ${token}`,
-      'content-type': 'application/json'
-    },
-    body: JSON.stringify(body)
-  })
+  try {
+    const response = request(`/bases-locales/${balId}`, {
+      method: 'PUT',
+      headers: {
+        authorization: `Token ${token}`,
+        'content-type': 'application/json'
+      },
+      body: JSON.stringify(body)
+    })
+
+    return response
+  } catch (error) {
+    toaster.danger('La Base Adresse Locale n’a pas pu être mise à jour', {
+      description: error.message
+    })
+  }
 }
 
 export async function transformToDraft(balId, body, token) {

--- a/lib/bal-api/index.js
+++ b/lib/bal-api/index.js
@@ -222,7 +222,7 @@ export function createBaseLocaleDemo(body) {
 
 export async function updateBaseLocale(balId, body, token) {
   try {
-    const response = request(`/bases-locales/${balId}`, {
+    const response = await request(`/bases-locales/${balId}`, {
       method: 'PUT',
       headers: {
         authorization: `Token ${token}`,


### PR DESCRIPTION
## Contexte
L'API renvoi désormais une erreur lorsqu'un BAL tente d'être publiée sans adresse.

## Évolution
Cette PR récupère correctement ce message et arrête le processus de publication si une erreur survient.

## Prérequis
- [x] BaseAdresseNationale/mes-adresses-api/pull/355
