### PR TITLE
Indiquer les voies sans numéros

### DIFF
--- a/components/bal/voies-list.js
+++ b/components/bal/voies-list.js
@@ -50,6 +50,7 @@ function VoiesList({voies, onEnableEditing, onSelect, setToRemove}) {
             key={voie._id}
             label={voie.nom}
             nomAlt={voie.nomAlt}
+            voieId={voie._id}
             isEditingEnabled={Boolean(!isEditing && token)}
             actions={{
               onSelect: () => onSelect(voie._id),


### PR DESCRIPTION
Il est maintenant possible de repérer facilement les voies sans numéro dans la liste des voies.

------------------------------------------
<img width="500" alt="Capture d’écran 2022-09-02 à 16 13 09" src="https://user-images.githubusercontent.com/66621960/188168795-bc340c71-4e26-44c3-8903-e00f5cc9f17b.png">
<img width="580" alt="Capture d’écran 2022-09-02 à 16 12 51" src="https://user-images.githubusercontent.com/66621960/188168800-8b116af8-73db-4061-bb97-cc2436189e21.png">


Close #684 