### PR TITLE
Corriger le badge de statut "à jour" écrasé des BALs

### DIFF
--- a/components/base-locale-card/index.js
+++ b/components/base-locale-card/index.js
@@ -82,6 +82,7 @@ function BaseLocaleCard({baseLocale, isAdmin, userEmail, isDefaultOpen, onSelect
             flex={1}
             justifyContent='center'
             height='40px'
+            minWidth='200px'
             borderRadius={5}
             alignItems='center'
           >


### PR DESCRIPTION
Sur la page` /dashboard`, lorsque l’on ouvrait le panneau des BALs, le badge de statut "à jour" n’avait pas la même taille que les autres badges.

Cette PR ajoute une taille minimum aux badges afin qu'ils aient la même taille au moment du wrap, peu importe la longueur du contenu.

----------------------------
### **AVANT**
![186698047-ddc03c19-d080-4fae-b1b0-6b8aa27bc2e8](https://user-images.githubusercontent.com/66621960/188184000-5627c638-69ad-4bba-aad1-ec8f58e1230e.png)

### **APRÈS**
<img width="741" alt="Capture d’écran 2022-09-02 à 17 29 24" src="https://user-images.githubusercontent.com/66621960/188184061-30f113c7-d892-40c1-a604-04118ad70cc8.png">
<img width="678" alt="Capture d’écran 2022-09-02 à 17 29 38" src="https://user-images.githubusercontent.com/66621960/188184079-2b044902-8f35-416d-8b68-2fb5fd339b42.png">

Close #681