### PR TITLE
Remplissage automatique du champ BAL à la sélection de la commune

### DIFF
--- a/components/base-locale-card/index.js
+++ b/components/base-locale-card/index.js
@@ -65,7 +65,7 @@ function BaseLocaleCard({baseLocale, isAdmin, userEmail, isDefaultOpen, onSelect
                 </Text>
 
                 {commune && (
-                  <Text fontStyle='italic'> {commune.nom} ({commune.codeDepartement || 'Collectivité d’Outre-Mer'})</Text>
+                  <Text fontStyle='italic'> {commune.nom} {commune.codeDepartement ? `(${commune.codeDepartement})` : ''}</Text>
                 )}
               </Pane>
             </Pane>

--- a/components/commune-search/commune-search.js
+++ b/components/commune-search/commune-search.js
@@ -23,7 +23,7 @@ function CommuneSearch({placeholder, innerRef, initialSelectedItem, onSelect, ..
       isFilterDisabled
       initialSelectedItem={initialSelectedItem}
       items={communes}
-      itemToString={item => item ? `${item.nom} (${item.departement ? `${item.departement.nom} - ${item.departement.code}` : 'Collectivité d’Outre-Mer'})` : ''}
+      itemToString={item => item ? `${item.nom} ${item.departement ? `(${item.departement.nom} - ${item.departement.code})` : ''}` : ''}
       onChange={onSelect}
     >
       {({getInputProps, getRef, inputValue}) => {

--- a/components/new/create-form.js
+++ b/components/new/create-form.js
@@ -91,6 +91,29 @@ function CreateForm({defaultCommune, nom, onNomChange, email, onEmailChange}) {
         )}
 
         <FormInput>
+          <CommuneSearchField
+            required
+            id='commune'
+            initialSelectedItem={defaultCommune}
+            label='Commune'
+            hint='Pour affiner la recherche, renseignez le code département'
+            placeholder='Roche 42'
+            appearance='default'
+            maxWidth={500}
+            disabled={isLoading}
+            onSelect={onSelect}
+          />
+
+          <Checkbox
+            label='Importer les voies et numéros depuis la BAN'
+            checked={populate}
+            disabled={isLoading}
+            marginBottom={0}
+            onChange={onPopulateChange}
+          />
+        </FormInput>
+
+        <FormInput>
           <TextInputField
             ref={focusedElement}
             required
@@ -120,29 +143,6 @@ function CreateForm({defaultCommune, nom, onNomChange, email, onEmailChange}) {
             label='Votre adresse email'
             placeholder='nom@example.com'
             onChange={onEmailChange}
-          />
-        </FormInput>
-
-        <FormInput>
-          <CommuneSearchField
-            required
-            id='commune'
-            initialSelectedItem={defaultCommune}
-            label='Commune'
-            hint='Pour affiner la recherche, renseignez le code département'
-            placeholder='Roche 42'
-            appearance='default'
-            maxWidth={500}
-            disabled={isLoading}
-            onSelect={onSelect}
-          />
-
-          <Checkbox
-            label='Importer les voies et numéros depuis la BAN'
-            checked={populate}
-            disabled={isLoading}
-            marginBottom={0}
-            onChange={onPopulateChange}
           />
         </FormInput>
 

--- a/components/new/create-form.js
+++ b/components/new/create-form.js
@@ -14,7 +14,7 @@ import FormInput from '@/components/form-input'
 import CommuneSearchField from '@/components/commune-search/commune-search-field'
 import AlertPublishedBAL from '@/components/new/alert-published-bal'
 
-function CreateForm({defaultCommune, nom, onNomChange, email, onEmailChange, setSelectedCommune, resetInput}) {
+function CreateForm({defaultCommune, nom, onNomChange, email, onEmailChange, setSelectedCommune}) {
   const {addBalAccess} = useContext(LocalStorageContext)
 
   const [isLoading, setIsLoading] = useState(false)
@@ -31,13 +31,9 @@ function CreateForm({defaultCommune, nom, onNomChange, email, onEmailChange, set
   }, [ref])
 
   const onSelect = useCallback(async commune => {
-    if (nom === '') {
-      resetInput(`Adresses de ${commune.nom}`)
-    }
-
     setSelectedCommune(commune)
     setCodeCommune(commune.code)
-  }, [nom, resetInput, setSelectedCommune])
+  }, [setSelectedCommune])
 
   const createNewBal = useCallback(async () => {
     if (codeCommune) {
@@ -174,8 +170,7 @@ CreateForm.propTypes = {
   onNomChange: PropTypes.func.isRequired,
   email: PropTypes.string.isRequired,
   onEmailChange: PropTypes.func.isRequired,
-  setSelectedCommune: PropTypes.func.isRequired,
-  resetInput: PropTypes.func.isRequired
+  setSelectedCommune: PropTypes.func.isRequired
 }
 
 CreateForm.defaultProps = {

--- a/components/new/create-form.js
+++ b/components/new/create-form.js
@@ -1,4 +1,4 @@
-import {useState, useCallback, useContext} from 'react'
+import {useState, useCallback, useContext, useEffect} from 'react'
 import PropTypes from 'prop-types'
 import Router from 'next/router'
 import {Pane, TextInputField, Checkbox, Button, PlusIcon} from 'evergreen-ui'
@@ -7,7 +7,6 @@ import {createBaseLocale, populateCommune, searchBAL} from '@/lib/bal-api'
 
 import LocalStorageContext from '@/contexts/local-storage'
 
-import useFocus from '@/hooks/focus'
 import {useCheckboxInput} from '@/hooks/input'
 
 import FormContainer from '@/components/form-container'
@@ -23,7 +22,13 @@ function CreateForm({defaultCommune, nom, onNomChange, email, onEmailChange, set
   const [codeCommune, setCodeCommune] = useState(defaultCommune ? defaultCommune.code : null)
   const [isShown, setIsShown] = useState(false)
   const [userBALs, setUserBALs] = useState([])
-  const [focusedElement] = useFocus(true)
+  const [ref, setRef] = useState()
+
+  useEffect(() => {
+    if (ref) {
+      ref.focus()
+    }
+  }, [ref])
 
   const onSelect = useCallback(async commune => {
     if (nom === '') {
@@ -98,6 +103,7 @@ function CreateForm({defaultCommune, nom, onNomChange, email, onEmailChange, set
         <FormInput>
           <CommuneSearchField
             required
+            innerRef={setRef}
             id='commune'
             initialSelectedItem={defaultCommune}
             label='Commune'
@@ -120,7 +126,6 @@ function CreateForm({defaultCommune, nom, onNomChange, email, onEmailChange, set
 
         <FormInput>
           <TextInputField
-            ref={focusedElement}
             required
             autoComplete='new-password' // Hack to bypass chrome autocomplete
             name='nom'

--- a/components/new/create-form.js
+++ b/components/new/create-form.js
@@ -14,12 +14,11 @@ import FormInput from '@/components/form-input'
 import CommuneSearchField from '@/components/commune-search/commune-search-field'
 import AlertPublishedBAL from '@/components/new/alert-published-bal'
 
-function CreateForm({defaultCommune, nom, onNomChange, email, onEmailChange, setSelectedCommune}) {
+function CreateForm({commune, nom, onNomChange, email, onEmailChange, handleCommune}) {
   const {addBalAccess} = useContext(LocalStorageContext)
 
   const [isLoading, setIsLoading] = useState(false)
   const [populate, onPopulateChange] = useCheckboxInput(true)
-  const [codeCommune, setCodeCommune] = useState(defaultCommune ? defaultCommune.code : null)
   const [isShown, setIsShown] = useState(false)
   const [userBALs, setUserBALs] = useState([])
   const [ref, setRef] = useState()
@@ -30,19 +29,14 @@ function CreateForm({defaultCommune, nom, onNomChange, email, onEmailChange, set
     }
   }, [ref])
 
-  const onSelect = useCallback(async commune => {
-    setSelectedCommune(commune)
-    setCodeCommune(commune.code)
-  }, [setSelectedCommune])
-
   const createNewBal = useCallback(async () => {
-    if (codeCommune) {
+    if (commune) {
       const bal = await createBaseLocale({
         nom,
         emails: [
           email
         ],
-        commune: codeCommune
+        commune: commune.code
       })
 
       addBalAccess(bal._id, bal.token)
@@ -56,13 +50,13 @@ function CreateForm({defaultCommune, nom, onNomChange, email, onEmailChange, set
         `/bal/${bal._id}`
       )
     }
-  }, [email, nom, populate, codeCommune, addBalAccess])
+  }, [email, nom, populate, commune, addBalAccess])
 
   const onSubmit = async e => {
     e.preventDefault()
     setIsLoading(true)
 
-    checkUserBALs(codeCommune, email)
+    checkUserBALs(commune.code, email)
   }
 
   const onCancel = () => {
@@ -71,7 +65,7 @@ function CreateForm({defaultCommune, nom, onNomChange, email, onEmailChange, set
   }
 
   const checkUserBALs = async () => {
-    const userBALs = await searchBAL(codeCommune, email)
+    const userBALs = await searchBAL(commune.code, email)
 
     if (userBALs.length > 0) {
       setUserBALs(userBALs)
@@ -90,7 +84,7 @@ function CreateForm({defaultCommune, nom, onNomChange, email, onEmailChange, set
             isShown={isShown}
             userEmail={email}
             basesLocales={userBALs}
-            updateBAL={() => checkUserBALs(codeCommune, email)}
+            updateBAL={() => checkUserBALs(commune.code, email)}
             onConfirm={createNewBal}
             onClose={() => onCancel()}
           />
@@ -101,14 +95,14 @@ function CreateForm({defaultCommune, nom, onNomChange, email, onEmailChange, set
             required
             innerRef={setRef}
             id='commune'
-            initialSelectedItem={defaultCommune}
+            initialSelectedItem={commune}
             label='Commune'
             hint='Pour affiner la recherche, renseignez le code département'
             placeholder='Roche 42'
             appearance='default'
             maxWidth={500}
             disabled={isLoading}
-            onSelect={onSelect}
+            onSelect={handleCommune}
           />
 
           <Checkbox
@@ -157,12 +151,15 @@ function CreateForm({defaultCommune, nom, onNomChange, email, onEmailChange, set
         </Button>
       </FormContainer>
     </Pane>
-
   )
 }
 
+CreateForm.defaultProps = {
+  commune: null
+}
+
 CreateForm.propTypes = {
-  defaultCommune: PropTypes.shape({
+  commune: PropTypes.shape({
     nom: PropTypes.string.isRequired,
     code: PropTypes.string.isRequired
   }),
@@ -170,11 +167,7 @@ CreateForm.propTypes = {
   onNomChange: PropTypes.func.isRequired,
   email: PropTypes.string.isRequired,
   onEmailChange: PropTypes.func.isRequired,
-  setSelectedCommune: PropTypes.func.isRequired
-}
-
-CreateForm.defaultProps = {
-  defaultCommune: null
+  handleCommune: PropTypes.func.isRequired
 }
 
 export default CreateForm

--- a/components/new/create-form.js
+++ b/components/new/create-form.js
@@ -14,7 +14,7 @@ import FormInput from '@/components/form-input'
 import CommuneSearchField from '@/components/commune-search/commune-search-field'
 import AlertPublishedBAL from '@/components/new/alert-published-bal'
 
-function CreateForm({commune, nom, onNomChange, email, onEmailChange, handleCommune}) {
+function CreateForm({namePlaceholder, commune, nom, onNomChange, email, onEmailChange, handleCommune}) {
   const {addBalAccess} = useContext(LocalStorageContext)
 
   const [isLoading, setIsLoading] = useState(false)
@@ -125,7 +125,7 @@ function CreateForm({commune, nom, onNomChange, email, onEmailChange, handleComm
             marginBottom={0}
             disabled={isLoading}
             label='Nom de la Base Adresse Locale'
-            placeholder='Nom'
+            placeholder={namePlaceholder}
             onChange={onNomChange}
           />
         </FormInput>
@@ -155,10 +155,12 @@ function CreateForm({commune, nom, onNomChange, email, onEmailChange, handleComm
 }
 
 CreateForm.defaultProps = {
+  namePlaceholder: 'Nom',
   commune: null
 }
 
 CreateForm.propTypes = {
+  namePlaceholder: PropTypes.string,
   commune: PropTypes.shape({
     nom: PropTypes.string.isRequired,
     code: PropTypes.string.isRequired

--- a/components/new/create-form.js
+++ b/components/new/create-form.js
@@ -15,7 +15,7 @@ import FormInput from '@/components/form-input'
 import CommuneSearchField from '@/components/commune-search/commune-search-field'
 import AlertPublishedBAL from '@/components/new/alert-published-bal'
 
-function CreateForm({defaultCommune, nom, onNomChange, email, onEmailChange}) {
+function CreateForm({defaultCommune, nom, onNomChange, email, onEmailChange, resetInput}) {
   const {addBalAccess} = useContext(LocalStorageContext)
 
   const [isLoading, setIsLoading] = useState(false)
@@ -25,9 +25,10 @@ function CreateForm({defaultCommune, nom, onNomChange, email, onEmailChange}) {
   const [userBALs, setUserBALs] = useState([])
   const [focusedElement] = useFocus(true)
 
-  const onSelect = useCallback(commune => {
+  const onSelect = useCallback(async commune => {
+    resetInput(`Adresses de ${commune.nom}`)
     setCodeCommune(commune.code)
-  }, [])
+  }, [resetInput])
 
   const createNewBal = useCallback(async () => {
     if (codeCommune) {
@@ -163,7 +164,8 @@ CreateForm.propTypes = {
   nom: PropTypes.string.isRequired,
   onNomChange: PropTypes.func.isRequired,
   email: PropTypes.string.isRequired,
-  onEmailChange: PropTypes.func.isRequired
+  onEmailChange: PropTypes.func.isRequired,
+  resetInput: PropTypes.func.isRequired
 }
 
 CreateForm.defaultProps = {

--- a/components/new/create-form.js
+++ b/components/new/create-form.js
@@ -15,7 +15,7 @@ import FormInput from '@/components/form-input'
 import CommuneSearchField from '@/components/commune-search/commune-search-field'
 import AlertPublishedBAL from '@/components/new/alert-published-bal'
 
-function CreateForm({defaultCommune, nom, onNomChange, email, onEmailChange, resetInput}) {
+function CreateForm({defaultCommune, nom, onNomChange, email, onEmailChange, setSelectedCommune, resetInput}) {
   const {addBalAccess} = useContext(LocalStorageContext)
 
   const [isLoading, setIsLoading] = useState(false)
@@ -26,9 +26,13 @@ function CreateForm({defaultCommune, nom, onNomChange, email, onEmailChange, res
   const [focusedElement] = useFocus(true)
 
   const onSelect = useCallback(async commune => {
-    resetInput(`Adresses de ${commune.nom}`)
+    if (nom === '') {
+      resetInput(`Adresses de ${commune.nom}`)
+    }
+
+    setSelectedCommune(commune)
     setCodeCommune(commune.code)
-  }, [resetInput])
+  }, [nom, resetInput, setSelectedCommune])
 
   const createNewBal = useCallback(async () => {
     if (codeCommune) {
@@ -165,6 +169,7 @@ CreateForm.propTypes = {
   onNomChange: PropTypes.func.isRequired,
   email: PropTypes.string.isRequired,
   onEmailChange: PropTypes.func.isRequired,
+  setSelectedCommune: PropTypes.func.isRequired,
   resetInput: PropTypes.func.isRequired
 }
 

--- a/components/new/upload-form.js
+++ b/components/new/upload-form.js
@@ -48,7 +48,7 @@ function extractCommuneFromCSV(rows) {
   return uniqBy(communes, 'code')
 }
 
-function UploadForm({nom, onNomChange, email, onEmailChange, setSelectedCommune}) {
+function UploadForm({nom, onNomChange, email, onEmailChange, handleCommune}) {
   const [bal, setBal] = useState(null)
   const [file, setFile] = useState(null)
   const [error, setError] = useState(null)
@@ -66,6 +66,7 @@ function UploadForm({nom, onNomChange, email, onEmailChange, setSelectedCommune}
   const onDrop = async ([file]) => {
     setError(null)
     setCommunes(null)
+    handleCommune(null)
     setSelectedCodeCommune(null)
 
     if (file) {
@@ -78,7 +79,7 @@ function UploadForm({nom, onNomChange, email, onEmailChange, setSelectedCommune}
       const communes = extractCommuneFromCSV(validationReport.rows)
 
       if (communes[0]) {
-        setSelectedCommune(communes[0])
+        handleCommune(communes[0])
         setSelectedCodeCommune(communes[0].code)
         if (communes.length > 1) {
           setCommunes(communes)
@@ -124,6 +125,7 @@ function UploadForm({nom, onNomChange, email, onEmailChange, setSelectedCommune}
     setIsShown(false)
     setIsLoading(false)
     setCommunes(null)
+    handleCommune(null)
     setSelectedCodeCommune(null)
     setValidationReport(null)
     setInvalidRowsCount(null)
@@ -341,7 +343,7 @@ UploadForm.propTypes = {
   onNomChange: PropTypes.func.isRequired,
   email: PropTypes.string.isRequired,
   onEmailChange: PropTypes.func.isRequired,
-  setSelectedCommune: PropTypes.func.isRequired
+  handleCommune: PropTypes.func.isRequired
 }
 
 export default UploadForm

--- a/components/new/upload-form.js
+++ b/components/new/upload-form.js
@@ -48,7 +48,7 @@ function extractCommuneFromCSV(rows) {
   return uniqBy(communes, 'code')
 }
 
-function UploadForm({nom, onNomChange, email, onEmailChange}) {
+function UploadForm({nom, onNomChange, email, onEmailChange, resetInput, setSelectedCommune}) {
   const [bal, setBal] = useState(null)
   const [file, setFile] = useState(null)
   const [error, setError] = useState(null)
@@ -78,6 +78,11 @@ function UploadForm({nom, onNomChange, email, onEmailChange}) {
       const communes = extractCommuneFromCSV(validationReport.rows)
 
       if (communes[0]) {
+        if (nom === '') {
+          resetInput(`Adresses de ${communes[0].nom}`)
+        }
+
+        setSelectedCommune(communes[0])
         setSelectedCodeCommune(communes[0].code)
         if (communes.length > 1) {
           setCommunes(communes)
@@ -339,7 +344,9 @@ UploadForm.propTypes = {
   nom: PropTypes.string.isRequired,
   onNomChange: PropTypes.func.isRequired,
   email: PropTypes.string.isRequired,
-  onEmailChange: PropTypes.func.isRequired
+  onEmailChange: PropTypes.func.isRequired,
+  resetInput: PropTypes.func.isRequired,
+  setSelectedCommune: PropTypes.func.isRequired
 }
 
 export default UploadForm

--- a/components/new/upload-form.js
+++ b/components/new/upload-form.js
@@ -48,7 +48,7 @@ function extractCommuneFromCSV(rows) {
   return uniqBy(communes, 'code')
 }
 
-function UploadForm({nom, onNomChange, email, onEmailChange, resetInput, setSelectedCommune}) {
+function UploadForm({nom, onNomChange, email, onEmailChange, setSelectedCommune}) {
   const [bal, setBal] = useState(null)
   const [file, setFile] = useState(null)
   const [error, setError] = useState(null)
@@ -78,10 +78,6 @@ function UploadForm({nom, onNomChange, email, onEmailChange, resetInput, setSele
       const communes = extractCommuneFromCSV(validationReport.rows)
 
       if (communes[0]) {
-        if (nom === '') {
-          resetInput(`Adresses de ${communes[0].nom}`)
-        }
-
         setSelectedCommune(communes[0])
         setSelectedCodeCommune(communes[0].code)
         if (communes.length > 1) {
@@ -345,7 +341,6 @@ UploadForm.propTypes = {
   onNomChange: PropTypes.func.isRequired,
   email: PropTypes.string.isRequired,
   onEmailChange: PropTypes.func.isRequired,
-  resetInput: PropTypes.func.isRequired,
   setSelectedCommune: PropTypes.func.isRequired
 }
 

--- a/components/new/upload-form.js
+++ b/components/new/upload-form.js
@@ -48,7 +48,7 @@ function extractCommuneFromCSV(rows) {
   return uniqBy(communes, 'code')
 }
 
-function UploadForm({nom, onNomChange, email, onEmailChange, handleCommune}) {
+function UploadForm({namePlaceholder, nom, onNomChange, email, onEmailChange, handleCommune}) {
   const [bal, setBal] = useState(null)
   const [file, setFile] = useState(null)
   const [error, setError] = useState(null)
@@ -231,7 +231,7 @@ function UploadForm({nom, onNomChange, email, onEmailChange, handleCommune}) {
                   value={nom}
                   disabled={isLoading}
                   label='Nom de la Base Adresse Locale'
-                  placeholder='Nom'
+                  placeholder={namePlaceholder}
                   onChange={onNomChange}
                 />
               </FormInput>
@@ -339,6 +339,11 @@ function UploadForm({nom, onNomChange, email, onEmailChange, handleCommune}) {
 }
 
 UploadForm.propTypes = {
+  namePlaceholder: 'Nom'
+}
+
+UploadForm.propTypes = {
+  namePlaceholder: PropTypes.string,
   nom: PropTypes.string.isRequired,
   onNomChange: PropTypes.func.isRequired,
   email: PropTypes.string.isRequired,

--- a/pages/new.js
+++ b/pages/new.js
@@ -76,6 +76,7 @@ function Index({defaultCommune, isDemo}) {
 
             <Pane flex={1} overflowY='scroll'>
               <Form
+                namePlaceholder={suggestedBALName.current.suggested}
                 commune={selectedCommune}
                 nom={nom}
                 onNomChange={onNomChange}

--- a/pages/new.js
+++ b/pages/new.js
@@ -76,12 +76,12 @@ function Index({defaultCommune, isDemo}) {
 
             <Pane flex={1} overflowY='scroll'>
               <Form
-                defaultCommune={defaultCommune}
+                commune={selectedCommune}
                 nom={nom}
                 onNomChange={onNomChange}
                 email={email}
                 onEmailChange={onEmailChange}
-                setSelectedCommune={setSelectedCommune}
+                handleCommune={setSelectedCommune}
               />
             </Pane>
           </>)}

--- a/pages/new.js
+++ b/pages/new.js
@@ -19,7 +19,7 @@ import DemoForm from '@/components/new/demo-form'
 function Index({defaultCommune, isDemo}) {
   const {balAccess} = useContext(LocalStorageContext)
 
-  const [nom, onNomChange] = useInput(
+  const [nom, onNomChange, resetInput] = useInput(
     defaultCommune ? `Adresses de ${defaultCommune.nom}` : ''
   )
   const [email, onEmailChange] = useInput('')
@@ -57,6 +57,7 @@ function Index({defaultCommune, isDemo}) {
                 onNomChange={onNomChange}
                 email={email}
                 onEmailChange={onEmailChange}
+                resetInput={resetInput}
               />
             </Pane>
           </>)}

--- a/pages/new.js
+++ b/pages/new.js
@@ -1,4 +1,4 @@
-import {useState, useContext} from 'react'
+import {useState, useContext, useRef, useEffect} from 'react'
 import PropTypes from 'prop-types'
 import {Pane, TabNavigation, Tab, Heading, Paragraph, Button} from 'evergreen-ui'
 import Link from 'next/link'
@@ -16,6 +16,16 @@ import CreateForm from '@/components/new/create-form'
 import UploadForm from '@/components/new/upload-form'
 import DemoForm from '@/components/new/demo-form'
 
+const useStoredNomBAL = commune => {
+  const ref = useRef()
+
+  useEffect(() => {
+    ref.current = commune ? `Adresses de ${commune.nom}` : null
+  })
+
+  return ref.current
+}
+
 function Index({defaultCommune, isDemo}) {
   const {balAccess} = useContext(LocalStorageContext)
 
@@ -23,10 +33,18 @@ function Index({defaultCommune, isDemo}) {
     defaultCommune ? `Adresses de ${defaultCommune.nom}` : ''
   )
   const [email, onEmailChange] = useInput('')
+  const [selectedCommune, setSelectedCommune] = useState(defaultCommune)
 
   const [index, setIndex] = useState(0)
 
   const Form = index === 0 ? CreateForm : UploadForm
+  const storedNomBAL = useStoredNomBAL(selectedCommune)
+
+  useEffect(() => {
+    if (selectedCommune && storedNomBAL && nom === storedNomBAL) {
+      resetInput(`Adresses de ${selectedCommune.nom}`)
+    }
+  }, [selectedCommune, storedNomBAL, nom, resetInput])
 
   return (
     <Main>
@@ -58,6 +76,8 @@ function Index({defaultCommune, isDemo}) {
                 email={email}
                 onEmailChange={onEmailChange}
                 resetInput={resetInput}
+                useStoredNomBAL={useStoredNomBAL}
+                setSelectedCommune={setSelectedCommune}
               />
             </Pane>
           </>)}

--- a/pages/new.js
+++ b/pages/new.js
@@ -76,7 +76,6 @@ function Index({defaultCommune, isDemo}) {
                 email={email}
                 onEmailChange={onEmailChange}
                 resetInput={resetInput}
-                useStoredNomBAL={useStoredNomBAL}
                 setSelectedCommune={setSelectedCommune}
               />
             </Pane>


### PR DESCRIPTION
Resolves #608 
Resolves #615

- Le champ Commune est déplacé vers le haut du formulaire
- Le champ Nom de la Base Adresse Locale est rempli à la sélection de la commune : Adresse de 'commune sélectionnée' 

[Capture vidéo 2022-09-06 16:28:50.webm](https://user-images.githubusercontent.com/45098730/188635513-b8291c09-7ea2-4641-8d61-e390f534596a.webm)


edit : *09/09*
- Amélioration du remplissage automatique 
- Focus automatique sur la barre de recherche
