### PR TITLE
Ajout des vidéos tutoriels mes-adresses

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -3,3 +3,4 @@ NEXT_PUBLIC_BAL_API_URL=https://api-bal.adresse.data.gouv.fr/v1
 NEXT_PUBLIC_GEO_API_URL=https://geo.api.gouv.fr
 NEXT_PUBLIC_ADRESSE_URL=https://adresse.data.gouv.fr
 NEXT_PUBLIC_BAN_API_DEPOT=https://plateforme.adresse.data.gouv.fr/api-depot
+NEXT_PUBLIC_PEERTUBE=https://peertube.adresse.data.gouv.fr

--- a/components/bal-recovery/recover-bal-alert.js
+++ b/components/bal-recovery/recover-bal-alert.js
@@ -6,6 +6,7 @@ import {recoverBAL} from '@/lib/bal-api'
 import {validateEmail} from '@/lib/utils/email'
 
 import LocalStorageContext from '@/contexts/local-storage'
+import VideoContainer from '@/components/help/video-container'
 
 import {useInput} from '@/hooks/input'
 
@@ -83,11 +84,15 @@ function RecoverBALAlert({isShown, defaultEmail, baseLocaleId, onClose}) {
       <Paragraph marginTop={16}>
         Un courrier électronique va être envoyé à l’adresse que vous avez renseignée.<br />{}
       </Paragraph>
-      <Paragraph marginTop={8}>
+      <Paragraph marginY={8}>
         {baseLocaleId ?
           'Vous y retrouverez un lien d’administration de votre Base Adresse Locale. Il vous suffira alors de cliquer sur le lien afin de pouvoir la retrouver sur votre espace.' :
           'Vous y retrouverez la liste de toutes les Bases Adresses Locales associées à celle-ci. Il vous suffira alors de cliquer sur les liens qui y sont associés afin de pouvoir les retrouver sur votre espace.'}
       </Paragraph>
+      <VideoContainer
+        title='Tutoriel sur la récupération :'
+        link='https://peertube.adresse.data.gouv.fr/w/fdD1tzvPfktHkkVK8p7h5D'
+      />
     </Dialog>
   )
 }

--- a/components/bal-recovery/recover-bal-alert.js
+++ b/components/bal-recovery/recover-bal-alert.js
@@ -6,7 +6,7 @@ import {recoverBAL} from '@/lib/bal-api'
 import {validateEmail} from '@/lib/utils/email'
 
 import LocalStorageContext from '@/contexts/local-storage'
-import VideoContainer from '@/components/help/video-container'
+import {VideoContainer, PEERTUBE_LINK} from '@/components/help/video-container'
 
 import {useInput} from '@/hooks/input'
 
@@ -91,7 +91,7 @@ function RecoverBALAlert({isShown, defaultEmail, baseLocaleId, onClose}) {
       </Paragraph>
       <VideoContainer
         title='Tutoriel sur la récupération :'
-        link='https://peertube.adresse.data.gouv.fr/w/fdD1tzvPfktHkkVK8p7h5D'
+        link={`${PEERTUBE_LINK}/w/fdD1tzvPfktHkkVK8p7h5D`}
       />
     </Dialog>
   )

--- a/components/header.js
+++ b/components/header.js
@@ -1,7 +1,7 @@
 import {useContext} from 'react'
 import NextLink from 'next/link'
 import Image from 'next/image'
-import {Pane, Button, Link, HelpIcon, BookIcon} from 'evergreen-ui'
+import {Pane, Button, Link, HelpIcon, BookIcon, VideoIcon} from 'evergreen-ui'
 
 import HelpContext from '@/contexts/help'
 
@@ -24,6 +24,12 @@ function Header() {
           onClick={() => setShowHelp(!showHelp)}
         >
           Besoin d’aide
+        </Button>
+
+        <Button appearance='minimal' marginRight='12px' minHeight='55px' iconAfter={VideoIcon}>
+          <Link href='https://peertube.adresse.data.gouv.fr' textDecoration='none' color='neutral' target='_blank'>
+            Tutoriels vidéos
+          </Link>
         </Button>
 
         <Button appearance='minimal' marginRight='12px' minHeight='55px' iconAfter={BookIcon}>

--- a/components/header.js
+++ b/components/header.js
@@ -4,8 +4,7 @@ import Image from 'next/image'
 import {Pane, Button, Link, HelpIcon, BookIcon, VideoIcon} from 'evergreen-ui'
 
 import HelpContext from '@/contexts/help'
-
-const PEERTUBE_LINK = process.env.NEXT_PUBLIC_PEERTUBE
+import {PEERTUBE_LINK} from '@/components/help/video-container'
 
 function Header() {
   const {showHelp, setShowHelp} = useContext(HelpContext)

--- a/components/header.js
+++ b/components/header.js
@@ -5,6 +5,8 @@ import {Pane, Button, Link, HelpIcon, BookIcon, VideoIcon} from 'evergreen-ui'
 
 import HelpContext from '@/contexts/help'
 
+const PEERTUBE_LINK = process.env.NEXT_PUBLIC_PEERTUBE
+
 function Header() {
   const {showHelp, setShowHelp} = useContext(HelpContext)
 
@@ -27,7 +29,7 @@ function Header() {
         </Button>
 
         <Button appearance='minimal' marginRight='12px' minHeight='55px' iconAfter={VideoIcon}>
-          <Link href='https://peertube.adresse.data.gouv.fr' textDecoration='none' color='neutral' target='_blank'>
+          <Link href={PEERTUBE_LINK} textDecoration='none' color='neutral' target='_blank'>
             Tutoriels vidéos
           </Link>
         </Button>

--- a/components/help/help-tabs/base-locale.js
+++ b/components/help/help-tabs/base-locale.js
@@ -4,10 +4,15 @@ import BALRecovery from '@/components/bal-recovery/bal-recovery'
 import Tuto from '@/components/help/tuto'
 import Unauthorized from '@/components/help/tuto/unauthorized'
 import Problems from '@/components/help/help-tabs/problems'
+import VideoContainer from '@/components/help/video-container'
 
 function BaseLocale() {
   return (
     <Pane>
+      <VideoContainer
+        title='Création d’une Base Adresse Locale :'
+        link='https://peertube.adresse.data.gouv.fr/w/aNEtMh7fJCzsAPoGkwvFSg'
+      />
       <Tuto title='Créer une nouvelle Base Adresse Locale'>
         <Paragraph marginTop='default'>
           Sur la page <b>Nouvelle Base Adresse Locale</b>, sélectionnez l’onglet <Tab isSelected>Créer</Tab>

--- a/components/help/help-tabs/base-locale.js
+++ b/components/help/help-tabs/base-locale.js
@@ -4,14 +4,14 @@ import BALRecovery from '@/components/bal-recovery/bal-recovery'
 import Tuto from '@/components/help/tuto'
 import Unauthorized from '@/components/help/tuto/unauthorized'
 import Problems from '@/components/help/help-tabs/problems'
-import VideoContainer from '@/components/help/video-container'
+import {VideoContainer, PEERTUBE_LINK} from '@/components/help/video-container'
 
 function BaseLocale() {
   return (
     <Pane>
       <VideoContainer
         title='Création d’une Base Adresse Locale :'
-        link='https://peertube.adresse.data.gouv.fr/w/aNEtMh7fJCzsAPoGkwvFSg'
+        link={`${PEERTUBE_LINK}/w/aNEtMh7fJCzsAPoGkwvFSg`}
       />
       <Tuto title='Créer une nouvelle Base Adresse Locale'>
         <Paragraph marginTop='default'>

--- a/components/help/help-tabs/numeros.js
+++ b/components/help/help-tabs/numeros.js
@@ -5,7 +5,7 @@ import SubTuto from '@/components/help/tuto/sub-tuto'
 import Unauthorized from '@/components/help/tuto/unauthorized'
 import Sidebar from '@/components/help/tuto/sidebar'
 import Problems from '@/components/help/help-tabs/problems'
-import VideoContainer from '@/components/help/video-container'
+import {VideoContainer, PEERTUBE_LINK} from '@/components/help/video-container'
 
 const before = (
   <Paragraph marginTop='default'>
@@ -18,7 +18,7 @@ function Numeros() {
     <Pane>
       <VideoContainer
         title='Création / Modification d’un numéro :'
-        link='https://peertube.adresse.data.gouv.fr/w/un73nNp4kQofNkhT38D6YQ'
+        link={`${PEERTUBE_LINK}/w/un73nNp4kQofNkhT38D6YQ`}
       />
       <Tuto title='Bon à savoir'>
         <ListItem listStyleType='none'>

--- a/components/help/help-tabs/numeros.js
+++ b/components/help/help-tabs/numeros.js
@@ -5,6 +5,7 @@ import SubTuto from '@/components/help/tuto/sub-tuto'
 import Unauthorized from '@/components/help/tuto/unauthorized'
 import Sidebar from '@/components/help/tuto/sidebar'
 import Problems from '@/components/help/help-tabs/problems'
+import VideoContainer from '@/components/help/video-container'
 
 const before = (
   <Paragraph marginTop='default'>
@@ -15,6 +16,10 @@ const before = (
 function Numeros() {
   return (
     <Pane>
+      <VideoContainer
+        title='Création / Modification d’un numéro :'
+        link='https://peertube.adresse.data.gouv.fr/w/un73nNp4kQofNkhT38D6YQ'
+      />
       <Tuto title='Bon à savoir'>
         <ListItem listStyleType='none'>
           Pour renforcer la qualité des adresses, nous vous recommandons de certifier la totalité de vos adresses. <b>Une adresse certifiée est déclarée authentique par la mairie</b>, ce qui renforce la qualité de la Base Adresse Locale et facilite sa réutilisation.

--- a/components/help/help-tabs/publication.js
+++ b/components/help/help-tabs/publication.js
@@ -4,14 +4,14 @@ import StatusBadge from '@/components/status-badge'
 import Tuto from '@/components/help/tuto'
 import Unauthorized from '@/components/help/tuto/unauthorized'
 import Problems from '@/components/help/help-tabs/problems'
-import VideoContainer from '@/components/help/video-container'
+import {VideoContainer, PEERTUBE_LINK} from '@/components/help/video-container'
 
 function Publication() {
   return (
     <Pane>
       <VideoContainer
         title='Publication de votre Base Adresse Locale :'
-        link='https://peertube.adresse.data.gouv.fr/w/4uU6AHpTe7coPyhskBSANB'
+        link={`${PEERTUBE_LINK}/w/4uU6AHpTe7coPyhskBSANB`}
       />
       <Tuto title='Obtenir une habilitation'>
         <Paragraph>

--- a/components/help/help-tabs/publication.js
+++ b/components/help/help-tabs/publication.js
@@ -4,10 +4,15 @@ import StatusBadge from '@/components/status-badge'
 import Tuto from '@/components/help/tuto'
 import Unauthorized from '@/components/help/tuto/unauthorized'
 import Problems from '@/components/help/help-tabs/problems'
+import VideoContainer from '@/components/help/video-container'
 
 function Publication() {
   return (
     <Pane>
+      <VideoContainer
+        title='Publication de votre Base Adresse Locale :'
+        link='https://peertube.adresse.data.gouv.fr/w/4uU6AHpTe7coPyhskBSANB'
+      />
       <Tuto title='Obtenir une habilitation'>
         <Paragraph>
           Avant de pouvoir publier vos adresses, votre Base Adresses Locale doit être habilitée.

--- a/components/help/help-tabs/toponymes.js
+++ b/components/help/help-tabs/toponymes.js
@@ -4,6 +4,7 @@ import Tuto from '@/components/help/tuto'
 import Unauthorized from '@/components/help/tuto/unauthorized'
 import Sidebar from '@/components/help/tuto/sidebar'
 import Problems from '@/components/help/help-tabs/problems'
+import VideoContainer from '@/components/help/video-container'
 
 const before = (
   <Paragraph marginTop='default'>
@@ -14,6 +15,10 @@ const before = (
 function Toponymes() {
   return (
     <Pane>
+      <VideoContainer
+        title='Création / Modification d’un toponyme :'
+        link='https://peertube.adresse.data.gouv.fr/w/ttnYNTcXtcubCHQX8kHdGt'
+      />
       <Tuto title='Ajouter un toponyme'>
         {before}
         <OrderedList margin={8}>

--- a/components/help/help-tabs/toponymes.js
+++ b/components/help/help-tabs/toponymes.js
@@ -4,7 +4,7 @@ import Tuto from '@/components/help/tuto'
 import Unauthorized from '@/components/help/tuto/unauthorized'
 import Sidebar from '@/components/help/tuto/sidebar'
 import Problems from '@/components/help/help-tabs/problems'
-import VideoContainer from '@/components/help/video-container'
+import {VideoContainer, PEERTUBE_LINK} from '@/components/help/video-container'
 
 const before = (
   <Paragraph marginTop='default'>
@@ -17,7 +17,7 @@ function Toponymes() {
     <Pane>
       <VideoContainer
         title='Création / Modification d’un toponyme :'
-        link='https://peertube.adresse.data.gouv.fr/w/ttnYNTcXtcubCHQX8kHdGt'
+        link={`${PEERTUBE_LINK}/w/ttnYNTcXtcubCHQX8kHdGt`}
       />
       <Tuto title='Ajouter un toponyme'>
         {before}

--- a/components/help/help-tabs/voies.js
+++ b/components/help/help-tabs/voies.js
@@ -5,6 +5,7 @@ import SubTuto from '@/components/help/tuto/sub-tuto'
 import Unauthorized from '@/components/help/tuto/unauthorized'
 import Sidebar from '@/components/help/tuto/sidebar'
 import Problems from '@/components/help/help-tabs/problems'
+import VideoContainer from '@/components/help/video-container'
 
 const before = (
   <Paragraph marginTop='default'>
@@ -15,6 +16,10 @@ const before = (
 function Voies() {
   return (
     <Pane>
+      <VideoContainer
+        title='Création / Modification d’une voie :'
+        link='https://peertube.adresse.data.gouv.fr/w/rgksUPigy8KWnmx8WFELDN'
+      />
       <Tuto title='Ajouter une voie'>
         {before}
         <OrderedList margin={8}>

--- a/components/help/help-tabs/voies.js
+++ b/components/help/help-tabs/voies.js
@@ -5,7 +5,7 @@ import SubTuto from '@/components/help/tuto/sub-tuto'
 import Unauthorized from '@/components/help/tuto/unauthorized'
 import Sidebar from '@/components/help/tuto/sidebar'
 import Problems from '@/components/help/help-tabs/problems'
-import VideoContainer from '@/components/help/video-container'
+import {VideoContainer, PEERTUBE_LINK} from '@/components/help/video-container'
 
 const before = (
   <Paragraph marginTop='default'>
@@ -18,7 +18,7 @@ function Voies() {
     <Pane>
       <VideoContainer
         title='Création / Modification d’une voie :'
-        link='https://peertube.adresse.data.gouv.fr/w/rgksUPigy8KWnmx8WFELDN'
+        link={`${PEERTUBE_LINK}/w/rgksUPigy8KWnmx8WFELDN`}
       />
       <Tuto title='Ajouter une voie'>
         {before}

--- a/components/help/video-container.js
+++ b/components/help/video-container.js
@@ -25,11 +25,11 @@ function VideoContainer({title, link}) {
       )}
       <iframe
         title='Création d’une Base Adresse Locale'
-        src={`${TUBE_LINK}/videos/embed/${embedCode}?warningTitle=0`}
+        src={`${TUBE_LINK}/videos/embed/${embedCode}?p2p=0`}
         height='315px'
         width='100%'
         frameBorder='0'
-        sandbox='allow-same-origin allow-scripts'
+        sandbox='allow-same-origin allow-scripts allow-popups'
         allowFullScreen='allowfullscreen'
       />
       <Paragraph paddingTop={10}>

--- a/components/help/video-container.js
+++ b/components/help/video-container.js
@@ -1,0 +1,54 @@
+import PropTypes from 'prop-types'
+import {Pane, Heading, Paragraph, VideoIcon} from 'evergreen-ui'
+import Link from 'next/link'
+
+const TUBE_LINK = 'https://peertube.adresse.data.gouv.fr'
+
+function VideoContainer({title, link}) {
+  // Extract code to use embed video
+  const embedCode = link.replace(`${TUBE_LINK}/w/`, '')
+
+  return (
+    <Pane
+      backgroundColor='white'
+      elevation={1}
+      display='flex'
+      flexDirection='column'
+      marginTop={8}
+      marginBottom={16}
+      padding={16}
+    >
+      {title && (
+        <Heading size={600} marginY={16}>
+          {title}
+        </Heading>
+      )}
+      <iframe
+        title='Création d’une Base Adresse Locale'
+        src={`${TUBE_LINK}/videos/embed/${embedCode}?warningTitle=0`}
+        height='315px'
+        width='100%'
+        frameBorder='0'
+        sandbox='allow-same-origin allow-scripts'
+        allowFullScreen='allowfullscreen'
+      />
+      <Paragraph paddingTop={10}>
+        <VideoIcon paddingRight={5} verticalAlign='middle' size={25} />
+        <Link href={TUBE_LINK}>
+          Retouvez tous les tutoriels vidéos
+        </Link>
+      </Paragraph>
+    </Pane>
+  )
+}
+
+VideoContainer.defaultProps = {
+  title: null
+}
+
+VideoContainer.propTypes = {
+  title: PropTypes.string,
+  link: PropTypes.string.isRequired
+}
+
+export default VideoContainer

--- a/components/help/video-container.js
+++ b/components/help/video-container.js
@@ -2,11 +2,11 @@ import PropTypes from 'prop-types'
 import {Pane, Heading, Paragraph, VideoIcon} from 'evergreen-ui'
 import Link from 'next/link'
 
-const TUBE_LINK = 'https://peertube.adresse.data.gouv.fr'
+const PEERTUBE_LINK = process.env.NEXT_PUBLIC_PEERTUBE
 
 function VideoContainer({title, link}) {
   // Extract code to use embed video
-  const embedCode = link.replace(`${TUBE_LINK}/w/`, '')
+  const embedCode = link.replace(`${PEERTUBE_LINK}/w/`, '')
 
   return (
     <Pane
@@ -25,7 +25,7 @@ function VideoContainer({title, link}) {
       )}
       <iframe
         title='Création d’une Base Adresse Locale'
-        src={`${TUBE_LINK}/videos/embed/${embedCode}?p2p=0`}
+        src={`${PEERTUBE_LINK}/videos/embed/${embedCode}?p2p=0`}
         height='315px'
         width='100%'
         frameBorder='0'
@@ -34,7 +34,7 @@ function VideoContainer({title, link}) {
       />
       <Paragraph paddingTop={10}>
         <VideoIcon paddingRight={5} verticalAlign='middle' size={25} />
-        <Link href={TUBE_LINK}>
+        <Link href={PEERTUBE_LINK}>
           Retouvez tous les tutoriels vidéos
         </Link>
       </Paragraph>

--- a/components/help/video-container.js
+++ b/components/help/video-container.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types'
 import {Pane, Heading, Paragraph, VideoIcon} from 'evergreen-ui'
 import Link from 'next/link'
 
-const PEERTUBE_LINK = process.env.NEXT_PUBLIC_PEERTUBE
+const PEERTUBE_LINK = process.env.NEXT_PUBLIC_PEERTUBE || 'https://peertube.adresse.data.gouv.fr'
 
 function VideoContainer({title, link}) {
   // Extract code to use embed video
@@ -51,4 +51,4 @@ VideoContainer.propTypes = {
   link: PropTypes.string.isRequired
 }
 
-export default VideoContainer
+export {VideoContainer, PEERTUBE_LINK}

--- a/components/welcome-message.js
+++ b/components/welcome-message.js
@@ -27,6 +27,11 @@ function WelcomeMessage() {
         Vous souhaitez <Strong>mettre à jour les adresses</Strong> de votre commune ? Vous êtes au <Strong>bon endroit</Strong> ! 🎉
       </Paragraph>
 
+
+      <VideoContainer
+        link='https://peertube.adresse.data.gouv.fr/w/toyKNe4rKyVD7mUovsWLKd'
+      />
+
       <Pane marginY={16}>
         <Heading size={400}>Comment cela fonctionne ❓</Heading>
         <Paragraph>
@@ -63,11 +68,6 @@ function WelcomeMessage() {
       <Alert intent='none' title='Vous êtes en charge de plusieurs communes'>
         Nous vous recommandons de créer une Base Adresse Locale pour chaque commune afin de faciliter leur publication.
       </Alert>
-
-      <VideoContainer
-        title='Introduction à mes-adresses :'
-        link='https://peertube.adresse.data.gouv.fr/w/toyKNe4rKyVD7mUovsWLKd'
-      />
     </Dialog>
   )
 }

--- a/components/welcome-message.js
+++ b/components/welcome-message.js
@@ -3,6 +3,7 @@ import {Pane, Dialog, Alert, Link, Paragraph, Heading, Strong, HelpIcon} from 'e
 
 import TokenContext from '@/contexts/token'
 import LocalStorageContext from '@/contexts/local-storage'
+import VideoContainer from '@/components/help/video-container'
 
 function WelcomeMessage() {
   const {token} = useContext(TokenContext)
@@ -63,11 +64,10 @@ function WelcomeMessage() {
         Nous vous recommandons de créer une Base Adresse Locale pour chaque commune afin de faciliter leur publication.
       </Alert>
 
-      <style jsx>{`
-        .title {
-
-        }
-        `}</style>
+      <VideoContainer
+        title='Introduction à mes-adresses :'
+        link='https://peertube.adresse.data.gouv.fr/w/toyKNe4rKyVD7mUovsWLKd'
+      />
     </Dialog>
   )
 }

--- a/components/welcome-message.js
+++ b/components/welcome-message.js
@@ -3,7 +3,7 @@ import {Pane, Dialog, Alert, Link, Paragraph, Heading, Strong, HelpIcon} from 'e
 
 import TokenContext from '@/contexts/token'
 import LocalStorageContext from '@/contexts/local-storage'
-import VideoContainer from '@/components/help/video-container'
+import {VideoContainer, PEERTUBE_LINK} from '@/components/help/video-container'
 
 function WelcomeMessage() {
   const {token} = useContext(TokenContext)
@@ -27,9 +27,8 @@ function WelcomeMessage() {
         Vous souhaitez <Strong>mettre à jour les adresses</Strong> de votre commune ? Vous êtes au <Strong>bon endroit</Strong> ! 🎉
       </Paragraph>
 
-
       <VideoContainer
-        link='https://peertube.adresse.data.gouv.fr/w/toyKNe4rKyVD7mUovsWLKd'
+        link={`${PEERTUBE_LINK}/w/toyKNe4rKyVD7mUovsWLKd`}
       />
 
       <Pane marginY={16}>


### PR DESCRIPTION
Cette PR ajoute les tutoriels vidéos en provenance de [peertube.adresse.data.gouv.fr](peertube.adresse.data.gouv.fr)

- Dans la boite de dialogue d’accueil à la création d’une BAL
- Dans la boite de dialogue de récupération d’une BAL
- Dans chaque onglet de la partie "Besoin d’aide"

Ainsi qu’un lien vers le peertube dans le menu de navigation.

Le composant `VideoContainer` possède une fonction qui permet de transformer un lien de partage en vidéo intégrée.

Fix  #123 

Captures : 

![image](https://user-images.githubusercontent.com/56537238/189314271-c96905bb-9709-4c0e-9865-8d47512a4856.png)

![image](https://user-images.githubusercontent.com/56537238/189314320-e66f0721-2502-4d73-8ab7-360a7e47abf6.png)

![image](https://user-images.githubusercontent.com/56537238/189314543-75186555-843c-4dcb-b614-992cfdf8051d.png)

![image](https://user-images.githubusercontent.com/56537238/189314579-2a16d23a-cfae-4987-9afa-cdc57d453424.png)


