### PR TITLE
Empêche le panneau d’information de la carte de couvrir les contrôles

### DIFF
--- a/components/map/draw.js
+++ b/components/map/draw.js
@@ -1,6 +1,5 @@
 import React, {useCallback, useMemo, useContext, useRef} from 'react'
 import {Editor, EditingMode, DrawLineStringMode} from 'react-map-gl-draw'
-import {Portal, Pane, Alert} from 'evergreen-ui'
 
 import DrawContext from '@/contexts/draw'
 
@@ -10,7 +9,7 @@ const MODES = {
 }
 
 function Draw() {
-  const {drawEnabled, modeId, hint, data, setHint, setData} = useContext(DrawContext)
+  const {drawEnabled, modeId, data, setHint, setData} = useContext(DrawContext)
   const editorRef = useRef()
 
   const _onUpdate = useCallback(({data, editType}) => {
@@ -37,33 +36,15 @@ function Draw() {
   }
 
   return (
-    <>
-      <Editor
-        ref={editorRef}
-        style={{width: '100%', height: '100%'}}
-        clickRadius={12}
-        mode={mode}
-        features={data ? [data] : undefined}
-        editHandleShape='circle'
-        onUpdate={_onUpdate}
-      />
-
-      {hint && (
-        <Portal>
-          <Pane
-            zIndex={999}
-            position='fixed'
-            width='100%'
-            top={116}
-            marginTop='0.2em'
-          >
-            <Pane marginLeft='50%' width='400px'>
-              <Alert title={hint} />
-            </Pane>
-          </Pane>
-        </Portal>
-      )}
-    </>
+    <Editor
+      ref={editorRef}
+      style={{width: '100%', height: '100%'}}
+      clickRadius={12}
+      mode={mode}
+      features={data ? [data] : undefined}
+      editHandleShape='circle'
+      onUpdate={_onUpdate}
+    />
   )
 }
 

--- a/components/map/map.js
+++ b/components/map/map.js
@@ -296,15 +296,12 @@ function Map({commune, isAddressFormOpen, handleAddressForm}) {
       {hint && (
         <Pane
           zIndex={1}
-          position='absolute'
-          width='100%'
-          top={16}
-          right={180}
-          margin='auto'
+          position='fixed'
+          width='400px'
+          top={140}
+          left='55%'
         >
-          <Pane marginLeft='50%' width='400px'>
-            <Alert title={hint} />
-          </Pane>
+          <Alert title={hint} />
         </Pane>
       )}
 

--- a/components/map/map.js
+++ b/components/map/map.js
@@ -4,7 +4,7 @@ import {useRouter} from 'next/router'
 import MapGl from 'react-map-gl'
 import maplibregl from 'maplibre-gl'
 import {fromJS} from 'immutable'
-import {Pane, EyeOffIcon, EyeOpenIcon} from 'evergreen-ui'
+import {Pane, Alert, EyeOffIcon, EyeOpenIcon} from 'evergreen-ui'
 
 import MapContext from '@/contexts/map'
 import BalDataContext from '@/contexts/bal-data'
@@ -104,7 +104,7 @@ function Map({commune, isAddressFormOpen, handleAddressForm}) {
     setEditingId,
     isEditing
   } = useContext(BalDataContext)
-  const {modeId} = useContext(DrawContext)
+  const {modeId, hint} = useContext(DrawContext)
   const {token} = useContext(TokenContext)
 
   const communeHasOrtho = useMemo(() => commune.hasOrtho, [commune])
@@ -290,6 +290,21 @@ function Map({commune, isAddressFormOpen, handleAddressForm}) {
             handleAddressForm={handleAddressForm}
             isDisabled={isEditing && !isAddressFormOpen}
           />
+        </Pane>
+      )}
+
+      {hint && (
+        <Pane
+          zIndex={1}
+          position='absolute'
+          width='100%'
+          top={16}
+          right={180}
+          margin='auto'
+        >
+          <Pane marginLeft='50%' width='400px'>
+            <Alert title={hint} />
+          </Pane>
         </Pane>
       )}
 

--- a/components/map/map.js
+++ b/components/map/map.js
@@ -297,9 +297,8 @@ function Map({commune, isAddressFormOpen, handleAddressForm}) {
         <Pane
           zIndex={1}
           position='fixed'
-          width='400px'
-          top={140}
-          left='55%'
+          alignSelf='center'
+          top={130}
         >
           <Alert title={hint} />
         </Pane>


### PR DESCRIPTION
Cette pull-request modifie le comportement du panneau informatif qui couvre les contrôles de la carte et du panneau d’édition.

Le composant a été déplacé afin de pourvoir être mieux disposé au-dessus de la carte sans empêcher l’utilisation des boutons de contrôle.

### Avant : 

https://user-images.githubusercontent.com/56537238/191232984-4e217c30-df31-451e-bd62-c436df6f65a6.mov

### Après : 

https://user-images.githubusercontent.com/56537238/191233045-f1692642-5d8a-4562-aef3-93d29687b1ab.mov


Fix #699 
