### PR TITLE
Mise à jour du validateur de Base Adresse Locale

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@babel/runtime": "^7.17.9",
     "@ban-team/shared-data": "^1.1.0",
-    "@ban-team/validateur-bal": "^2.10.0",
+    "@ban-team/validateur-bal": "^2.11.0",
     "@next/bundle-analyzer": "^12.1.6",
     "@turf/bbox": "^6.5.0",
     "@turf/buffer": "^6.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -304,10 +304,10 @@
   resolved "https://registry.yarnpkg.com/@ban-team/shared-data/-/shared-data-1.1.0.tgz#5c1ee73fd98b86723ee9893a426cbfd9a6e5f6b6"
   integrity sha512-+SnPGySf715hd2pvygtCN24uGZNBMAeY8mNvt1WC7a+sPtjz74HL7+S+ff7SiZIrSYioSJi+OZp5t8QHgk2X/A==
 
-"@ban-team/validateur-bal@^2.10.0":
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/@ban-team/validateur-bal/-/validateur-bal-2.10.0.tgz#47f5f58ce13f2f4ab4b3e490e687ab3bb1d8cdaf"
-  integrity sha512-DPi9hlgbs88exH6UAoJLJ63UyChdBpldD+kzvp0DdXRWYGh7oJwUwroSuw7ixqAB7iXPlSsIfIK3fe6EUle78Q==
+"@ban-team/validateur-bal@^2.11.0":
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/@ban-team/validateur-bal/-/validateur-bal-2.11.0.tgz#3707aab531f720614d9c842db41ff510d92918d8"
+  integrity sha512-jyixz2ZhvFic4TQKzRyUcZoWDCXoiGfxrxp637kVeG4Yt+BIJW65Ze02qWa9F4OCZJxGNwj8asNzP6HJlEnXcA==
   dependencies:
     "@ban-team/shared-data" "^1.1.0"
     "@etalab/project-legal" "^0.6.0"
@@ -315,7 +315,7 @@
     bluebird "^3.7.2"
     chalk "^4.1.2"
     chardet "^1.4.0"
-    date-fns "^2.28.0"
+    date-fns "^2.29.3"
     file-type "^12.4.2"
     iconv-lite "^0.6.3"
     lodash "^4.17.21"
@@ -2371,6 +2371,11 @@ date-fns@^2.28.0:
   version "2.29.2"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.2.tgz#0d4b3d0f3dff0f920820a070920f0d9662c51931"
   integrity sha512-0VNbwmWJDS/G3ySwFSJA3ayhbURMTJLtwM2DTxf9CWondCnh6DTNlO9JgRSq6ibf4eD0lfMJNBxUdEAHHix+bA==
+
+date-fns@^2.29.3:
+  version "2.29.3"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.3.tgz#27402d2fc67eb442b511b70bbdf98e6411cd68a8"
+  integrity sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==
 
 debug@2, debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   version "2.6.9"


### PR DESCRIPTION
Mise à jour du validateur de Base Adresse Locale en version [2.11.0](https://github.com/BaseAdresseNationale/validateur-bal/releases/tag/v2.11.0)