### PR TITLE
Correction du renouvellement de l'habitation pour les BAL en conflit

### DIFF
--- a/components/sub-header/index.js
+++ b/components/sub-header/index.js
@@ -42,7 +42,7 @@ const SubHeader = React.memo(({commune}) => {
   }
 
   const handleHabilitation = async () => {
-    let isReadyToPublish = ['published', 'ready-to-publish'].includes(baseLocale.status)
+    let isReadyToPublish = ['published', 'ready-to-publish', 'replaced'].includes(baseLocale.status)
 
     if (baseLocale.status === 'draft') {
       const updated = await handleChangeStatus('ready-to-publish')


### PR DESCRIPTION
## Contexte
Le support a remonté un problème concernant une commune qui ne pouvait plus publier sa BAL en conflit. En cliquant sur le bouton "Publier" rien ne se passe.

Après une rapide investigation, il s'avère que ce problème concerne les BAL avec pour statut `replaced` dont l'habilitation a expirée.

## Correction
Le statut `replaced` a été ajouté aux statuts acceptés pour demander une nouvelle habilitation.

## Reproduire
1. Créer une BAL
2. Publier la BAL
3. Rendre obsolète son habilitation
4. Passer son status à `replaced`