### PR TITLE
Corrige le recentrage intempestif de la caméra

### DIFF
--- a/components/map/hooks/bounds.js
+++ b/components/map/hooks/bounds.js
@@ -1,4 +1,4 @@
-import {useMemo, useContext, useState, useEffect, useRef} from 'react'
+import {useMemo, useContext, useState, useEffect} from 'react'
 import bbox from '@turf/bbox'
 
 import BalDataContext from '@/contexts/bal-data'
@@ -7,26 +7,26 @@ import {useRouter} from 'next/router'
 function useBounds(commune, toponyme) {
   const {geojson, editingItem} = useContext(BalDataContext)
   const [data, setData] = useState(commune.contour)
+  const [isGeojsonLoaded, setIsGeojsonLoaded] = useState(Boolean(geojson))
 
   const router = useRouter()
-  const geojsonFeatures = useRef(geojson?.features)
 
   useEffect(() => {
-    geojsonFeatures.current = geojson?.features
+    setIsGeojsonLoaded(Boolean(geojson))
   }, [geojson])
 
   useEffect(() => {
     let data
     const {idVoie, idToponyme} = router.query
 
-    if (geojsonFeatures.current) {
+    if (isGeojsonLoaded) {
       if (idVoie) {
         data = {
           type: 'FeatureCollection',
-          features: geojsonFeatures.current.filter(feature => feature.properties.idVoie === router.query.idVoie)
+          features: geojson.features.filter(feature => feature.properties.idVoie === router.query.idVoie)
         }
       } else if (idToponyme) {
-        const numeroToponyme = geojsonFeatures.current.filter(feature => feature.properties.idToponyme === idToponyme)
+        const numeroToponyme = geojson.features.filter(feature => feature.properties.idToponyme === idToponyme)
         data = {
           type: 'FeatureCollection',
           features: numeroToponyme.length === 0 && toponyme.positions.length === 1 ?
@@ -40,12 +40,13 @@ function useBounds(commune, toponyme) {
       }
     }
 
-    if (!geojsonFeatures.current || (!router.query.idVoie && !router.query.idToponyme)) {
+    if (!geojson || (!router.query.idVoie && !router.query.idToponyme)) {
       data = commune.contour
     }
 
     setData(data)
-  }, [commune.contour, router.query, toponyme])
+  }, [commune.contour, router.query, isGeojsonLoaded, toponyme]) // eslint-disable-line react-hooks/exhaustive-deps
+  // Use hasBound as hook instead of geojson to prevent fitBounds on numero update
 
   useEffect(() => {
     if (editingItem?.positions?.length > 1) {

--- a/components/map/map.js
+++ b/components/map/map.js
@@ -111,7 +111,7 @@ function Map({commune, isAddressFormOpen, handleAddressForm}) {
 
   const [handleHover, handleMouseLeave] = useHovered(map)
   const [voieTraceData, positionsData, voiesData] = useSources(isStyleLoaded)
-  const bounds = useBounds(commune, voie, toponyme)
+  const bounds = useBounds(commune, toponyme)
 
   const prevStyle = useRef(defaultStyle)
 
@@ -228,24 +228,18 @@ function Map({commune, isAddressFormOpen, handleAddressForm}) {
   }, [isStyleLoaded, updatePositionsLayer])
 
   useEffect(() => {
-    if (map) {
-      if (bounds) {
-        const camera = map.cameraForBounds(bounds, {
-          padding: 100
-        })
+    if (map && bounds) {
+      const camera = map.cameraForBounds(bounds, {
+        padding: 100
+      })
 
-        if (camera) {
-          setViewport(viewport => ({
-            ...viewport,
-            bearing: camera.bearing,
-            longitude: camera.center.lng,
-            latitude: camera.center.lat,
-            zoom: camera.zoom
-          }))
-        }
-      } else {
-        setViewport(viewport => ({...viewport}))
-      }
+      setViewport(viewport => ({
+        ...viewport,
+        bearing: camera.bearing,
+        longitude: camera.center.lng,
+        latitude: camera.center.lat,
+        zoom: camera.zoom
+      }))
     }
   }, [map, bounds, setViewport])
 

--- a/components/map/map.js
+++ b/components/map/map.js
@@ -111,7 +111,7 @@ function Map({commune, isAddressFormOpen, handleAddressForm}) {
 
   const [handleHover, handleMouseLeave] = useHovered(map)
   const [voieTraceData, positionsData, voiesData] = useSources(isStyleLoaded)
-  const bounds = useBounds(commune, toponyme)
+  const bounds = useBounds(commune, voie, toponyme)
 
   const prevStyle = useRef(defaultStyle)
 

--- a/contexts/map.js
+++ b/contexts/map.js
@@ -1,4 +1,4 @@
-import React, {useEffect, useCallback, useState, useMemo} from 'react'
+import React, {useCallback, useState, useMemo} from 'react'
 
 const MapContext = React.createContext()
 
@@ -18,12 +18,6 @@ export function MapContextProvider(props) {
   const [isCadastreDisplayed, setIsCadastreDisplayed] = useState(false)
 
   const [isStyleLoaded, setIsStyleLoaded] = useState(false)
-
-  useEffect(() => {
-    if (!viewport) {
-      setViewport(defaultViewport)
-    }
-  }, [viewport])
 
   const handleMapRef = useCallback(ref => {
     if (ref) {


### PR DESCRIPTION
## Contexte
Depuis l'ajout du recentrage de la caméra sur les numéros et toponymes multi-positions, le recentrage de la caméra se faisait de manière automatique sur l'élément de contexte restant. Dans le cas de l'édition de différents numéros d'une voie, l'utilisateur se retrouvé à être "dézoomé" au niveau de la voie après chaque édition. 

Ce comportement dégrade fortement le confort d'édition, notamment dans le cas de longue voie.

## Évolution
Le centrage de la caméra est dorénavant déclenché par le changement de contexte, comme la sélection d'une voie, le retour à la commune ou l'édition d'un numéro/toponyme à plusieurs positions. Ce de fait, l'utilisateur obtient une mise au point à la sélection du contexte et peut ensuite gérer lui-même sa caméra sans être recentré de force.

fix #708