### PR TITLE
Corrige l'édition d'une voie sans numéro

### DIFF
--- a/components/map/hooks/bounds.js
+++ b/components/map/hooks/bounds.js
@@ -31,11 +31,17 @@ function useBounds(commune, voie, toponyme) {
   }, [geojson])
 
   const getVoieBounds = useCallback(voieId => {
-    return {
-      type: 'FeatureCollection',
-      features: geojsonFeatures.current.filter(feature => feature.properties.idVoie === voieId)
+    const features = geojsonFeatures.current.filter(feature => feature.properties.idVoie === voieId)
+
+    if (features.length > 0) {
+      return {
+        type: 'FeatureCollection',
+        features: geojsonFeatures.current.filter(feature => feature.properties.idVoie === voieId)
+      }
     }
-  }, [])
+
+    return commune.contour // Fallback when voie has no position or numeros
+  }, [commune])
 
   const getToponymeBounds = useCallback(toponymeId => {
     let features


### PR DESCRIPTION
## Contexte 
Ouvrir voie sans numéro provoque une erreur, car il n'est pas possible de calculer une bbox.

## Correction
Renvoi les contours de la commune pour créer la bbox quand une voie n'a pas de numéro.