### PR TITLE
Affiche l’habilitation en mode consultation

### DIFF
--- a/components/base-locale-card/index.js
+++ b/components/base-locale-card/index.js
@@ -1,8 +1,9 @@
 import {useState, useEffect} from 'react'
+import NextImage from 'next/image'
 import PropTypes from 'prop-types'
 import {formatDistanceToNow} from 'date-fns'
 import {fr} from 'date-fns/locale'
-import {Heading, Card, Pane, Text, ChevronRightIcon, ChevronDownIcon} from 'evergreen-ui'
+import {Heading, Card, Pane, Text, Tooltip, ChevronRightIcon, ChevronDownIcon} from 'evergreen-ui'
 
 import {getBaseLocale} from '@/lib/bal-api'
 import {getCommune} from '@/lib/geo-api'
@@ -86,6 +87,22 @@ function BaseLocaleCard({baseLocale, isAdmin, userEmail, isDefaultOpen, onSelect
             borderRadius={5}
             alignItems='center'
           >
+            {baseLocale?._habilitation && (
+              <Tooltip content='Les adresses de cette Base Locale sont gérées par la commune'>
+                <Pane
+                  position='relative'
+                  width={45}
+                  height={45}
+                  marginX={12}
+                >
+                  <NextImage
+                    src='/static/images/mairie.svg'
+                    alt='Logo Mairie'
+                    layout='fill'
+                  />
+                </Pane>
+              </Tooltip>
+            )}
             <StatusBadge status={baseLocale.status} sync={baseLocale.sync} />
           </Pane>
         </Pane>
@@ -121,6 +138,7 @@ BaseLocaleCard.propTypes = {
     nom: PropTypes.string.isRequired,
     commune: PropTypes.string.isRequired,
     _updated: PropTypes.string,
+    _habilitation: PropTypes.string,
     status: PropTypes.oneOf([
       'draft', 'ready-to-publish', 'replaced', 'published', 'demo'
     ]),


### PR DESCRIPTION
> ### EDIT  : 
> 
> _Il est actuellement impossible d’exposer publiquement les informations de l’habilitation sans le jeton d’administration de la Base Adresse Locale._
> _Une modification de l’API-dépôt est nécessaire pour corriger ce comportement._


Cette PR ajoute une icône dans la liste des Bases Adresses Locales qui permet de savoir si la BAL est habilitée.

Les propriétaires d’une BAL peuvent également voir la date d’expiration de leur habilitation.

Captures : 

![image](https://user-images.githubusercontent.com/56537238/196476031-f617dd2d-4581-4f68-bac1-7a059cc1251e.png)

Fix #715 
