### PR TITLE
Mise en place d'une pagination sur la page /all

### DIFF
--- a/components/bases-locales-list/index.js
+++ b/components/bases-locales-list/index.js
@@ -4,7 +4,6 @@ import Router from 'next/router'
 import {Pane, Table, Paragraph} from 'evergreen-ui'
 
 import {sortBalByUpdate} from '@/lib/sort-bal'
-import {listBasesLocales} from '@/lib/bal-api'
 
 import LocalStorageContext from '@/contexts/local-storage'
 
@@ -108,12 +107,6 @@ function BasesLocalesList({basesLocales, sortBal}) {
       </Pane>
     )
   )
-}
-
-BasesLocalesList.getInitialProps = async () => {
-  return {
-    basesLocales: await listBasesLocales()
-  }
 }
 
 BasesLocalesList.defaultProps = {

--- a/components/bases-locales-list/public-bases-locales-list.js
+++ b/components/bases-locales-list/public-bases-locales-list.js
@@ -1,18 +1,11 @@
-import {useCallback, useMemo, useState} from 'react'
+import {useCallback} from 'react'
 import PropTypes from 'prop-types'
 import Router from 'next/router'
-import {Pane, Table, Button, PlusIcon} from 'evergreen-ui'
-
-import {sortBalByUpdate} from '@/lib/sort-bal'
-import {listBasesLocales} from '@/lib/bal-api'
-
-import useFuse from '@/hooks/fuse'
+import {Pane, Table} from 'evergreen-ui'
 
 import BaseLocaleCard from '@/components/base-locale-card'
 
-function PublicBasesLocalesList({basesLocales, sortBal}) {
-  const [limit, setLimit] = useState(50)
-
+function PublicBasesLocalesList({basesLocales, searchInput, onFilter}) {
   const onBalSelect = useCallback(bal => {
     Router.push(
       `/bal?balId=${bal._id}`,
@@ -20,26 +13,17 @@ function PublicBasesLocalesList({basesLocales, sortBal}) {
     )
   }, [])
 
-  const [filtered, onFilter] = useFuse(basesLocales, 200, {
-    keys: [
-      'nom'
-    ]
-  })
-
-  const slicedBasesLocalesList = useMemo(() => {
-    return sortBal(filtered).slice(0, limit)
-  }, [filtered, sortBal, limit])
-
   return (
     <Pane borderTop>
       <Table>
         <Table.Head>
           <Table.SearchHeaderCell
+            value={searchInput}
             placeholder='Rechercher une Base Adresse Locale'
             onChange={onFilter}
           />
         </Table.Head>
-        {slicedBasesLocalesList.length === 0 && (
+        {basesLocales.length === 0 && (
           <Table.Row>
             <Table.TextCell color='muted' fontStyle='italic'>
               Aucun résultat
@@ -47,7 +31,7 @@ function PublicBasesLocalesList({basesLocales, sortBal}) {
           </Table.Row>
         )}
         <Table.Body background='tint1'>
-          {slicedBasesLocalesList.map(bal => (
+          {basesLocales.map(bal => (
             <BaseLocaleCard
               key={bal._id}
               baseLocale={bal}
@@ -55,37 +39,20 @@ function PublicBasesLocalesList({basesLocales, sortBal}) {
               onSelect={() => onBalSelect(bal)}
             />
           ))}
-          {limit < filtered.length && (
-            <Pane style={{width: '100%', display: 'flex', justifyContent: 'space-around'}}>
-              <Button
-                appearance='minimal'
-                marginBottom='1em'
-                iconAfter={PlusIcon}
-                onClick={() => setLimit(limit => limit + 50)}
-              >
-                Afficher les 50 Bases Locales suivantes
-              </Button>
-            </Pane>
-          )}
         </Table.Body>
       </Table>
     </Pane>
   )
 }
 
-PublicBasesLocalesList.getInitialProps = async () => {
-  return {
-    basesLocales: await listBasesLocales()
-  }
-}
-
-PublicBasesLocalesList.defaultProps = {
-  sortBal: sortBalByUpdate
+PublicBasesLocalesList.propTypes = {
+  searchInput: ''
 }
 
 PublicBasesLocalesList.propTypes = {
   basesLocales: PropTypes.array.isRequired,
-  sortBal: PropTypes.func
+  searchInput: PropTypes.string,
+  onFilter: PropTypes.func
 }
 
 export default PublicBasesLocalesList

--- a/components/bases-locales-list/public-bases-locales-list.js
+++ b/components/bases-locales-list/public-bases-locales-list.js
@@ -19,7 +19,7 @@ function PublicBasesLocalesList({basesLocales, searchInput, onFilter}) {
         <Table.Head>
           <Table.SearchHeaderCell
             value={searchInput}
-            placeholder='Rechercher une Base Adresse Locale'
+            placeholder='Rechercher un code commune'
             onChange={onFilter}
           />
         </Table.Head>

--- a/components/new/create-form.js
+++ b/components/new/create-form.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import Router from 'next/router'
 import {Pane, TextInputField, Checkbox, Button, PlusIcon} from 'evergreen-ui'
 
-import {createBaseLocale, populateCommune, searchBAL} from '@/lib/bal-api'
+import {createBaseLocale, populateCommune, searchBasesLocales} from '@/lib/bal-api'
 
 import LocalStorageContext from '@/contexts/local-storage'
 
@@ -65,10 +65,10 @@ function CreateForm({namePlaceholder, commune, nom, onNomChange, email, onEmailC
   }
 
   const checkUserBALs = async () => {
-    const userBALs = await searchBAL(commune.code, email)
+    const {basesLocales} = await searchBasesLocales({commune: commune.code, email})
 
-    if (userBALs.length > 0) {
-      setUserBALs(userBALs)
+    if (basesLocales.length > 0) {
+      setUserBALs(basesLocales)
       setIsShown(true)
     } else {
       createNewBal()

--- a/components/new/create-form.js
+++ b/components/new/create-form.js
@@ -65,10 +65,10 @@ function CreateForm({namePlaceholder, commune, nom, onNomChange, email, onEmailC
   }
 
   const checkUserBALs = async () => {
-    const {basesLocales} = await searchBasesLocales({commune: commune.code, email})
+    const {results} = await searchBasesLocales({commune: commune.code, email})
 
-    if (basesLocales.length > 0) {
-      setUserBALs(basesLocales)
+    if (results.length > 0) {
+      setUserBALs(results)
       setIsShown(true)
     } else {
       createNewBal()

--- a/components/new/upload-form.js
+++ b/components/new/upload-form.js
@@ -151,9 +151,9 @@ function UploadForm({namePlaceholder, nom, onNomChange, email, onEmailChange, ha
   const checkUserBALs = useCallback(async () => {
     const userBALs = []
 
-    const {basesLocales} = await searchBasesLocales({commune: selectedCodeCommune, email})
-    if (basesLocales.length > 0) {
-      userBALs.push(...basesLocales)
+    const {results} = await searchBasesLocales({commune: selectedCodeCommune, email})
+    if (results.length > 0) {
+      userBALs.push(...results)
     }
 
     if (userBALs.length > 0) {

--- a/components/new/upload-form.js
+++ b/components/new/upload-form.js
@@ -5,7 +5,7 @@ import {validate} from '@ban-team/validateur-bal'
 import {uniqBy} from 'lodash'
 import {Pane, Alert, Button, Dialog, TextInputField, Text, Strong, FormField, PlusIcon, InboxIcon, Paragraph, ShareIcon} from 'evergreen-ui'
 
-import {createBaseLocale, uploadBaseLocaleCsv, searchBAL} from '@/lib/bal-api'
+import {createBaseLocale, uploadBaseLocaleCsv, searchBasesLocales} from '@/lib/bal-api'
 
 import LocalStorageContext from '@/contexts/local-storage'
 
@@ -151,7 +151,7 @@ function UploadForm({namePlaceholder, nom, onNomChange, email, onEmailChange, ha
   const checkUserBALs = useCallback(async () => {
     const userBALs = []
 
-    const basesLocales = await searchBAL(selectedCodeCommune, email)
+    const {basesLocales} = await searchBasesLocales({commune: selectedCodeCommune, email})
     if (basesLocales.length > 0) {
       userBALs.push(...basesLocales)
     }

--- a/lib/bal-api/index.js
+++ b/lib/bal-api/index.js
@@ -129,7 +129,8 @@ export async function getBasesLocales() {
 
 export async function searchBasesLocales(query) {
   const {page = 1, limit = 20, deleted = 0} = query
-  const params = {...query, page, limit, deleted}
+  const offset = (page - 1) * limit
+  const params = {...query, offset, limit, deleted}
 
   const queryString = Object.keys(params).map(key => key + '=' + params[key]).join('&')
 

--- a/lib/bal-api/index.js
+++ b/lib/bal-api/index.js
@@ -121,10 +121,20 @@ export async function validateAuthenticationCode(token, baseLocaleId, code) {
   }
 }
 
-export async function listBasesLocales() {
+export async function getBasesLocales() {
   const allBAL = await request('/bases-locales')
 
   return allBAL.filter(bal => !bal._deleted)
+}
+
+export async function searchBasesLocales(query) {
+  const {page = 1, limit = 20, deleted = 0} = query
+  const params = {...query, page, limit, deleted}
+
+  const queryString = Object.keys(params).map(key => key + '=' + params[key]).join('&')
+
+  const result = await request(`/bases-locales/search?${queryString}`)
+  return result
 }
 
 export async function sync(balId, token) {
@@ -558,12 +568,6 @@ export function renewToken(balId, token) {
 
 export function getContoursCommunes() {
   return request('/stats/couverture-bal')
-}
-
-export async function searchBAL(codeCommune, userEmail) {
-  const allBal = await request(`/bases-locales/search?codeCommune=${codeCommune}&userEmail=${userEmail}`)
-
-  return allBal.filter(bal => !bal._deleted)
 }
 
 export async function getCommuneExtras(codeCommune) {

--- a/pages/all.js
+++ b/pages/all.js
@@ -19,11 +19,13 @@ const PublicBasesLocalesList = dynamic(() => import('@/components/bases-locales-
   )
 })
 
-function All({basesLocales, nom, page, limit, totalPages}) {
+function All({basesLocales, nom, limit, offset, count}) {
   const router = useRouter()
+  const totalPages = Math.ceil(count / limit)
+  const currentPage = Math.ceil((offset - 1) / limit) + 1
 
   const [onFilter] = useDebouncedCallback(async value => {
-    const query = {page, limit}
+    const query = {page: count, limit}
 
     if (value.length >= 2) {
       query.nom = value
@@ -58,11 +60,11 @@ function All({basesLocales, nom, page, limit, totalPages}) {
       {totalPages > 1 && (
         <Pagination
           marginX='auto'
-          page={page}
+          page={currentPage}
           totalPages={totalPages}
-          onPreviousPage={() => handlePageChange(page - 1)}
+          onPreviousPage={() => handlePageChange(currentPage - 1)}
           onPageChange={handlePageChange}
-          onNextPage={() => handlePageChange(page + 1)}
+          onNextPage={() => handlePageChange(currentPage + 1)}
         />
       )}
 
@@ -86,16 +88,16 @@ All.getInitialProps = async ({query}) => {
   return {
     ...result,
     nom: query.nom || '',
-    basesLocales: sortBalByUpdate(result.basesLocales)
+    basesLocales: sortBalByUpdate(result.results)
   }
 }
 
 All.propTypes = {
   basesLocales: PropTypes.array.isRequired,
   nom: PropTypes.string.isRequired,
-  page: PropTypes.number.isRequired,
+  offset: PropTypes.number.isRequired,
   limit: PropTypes.number.isRequired,
-  totalPages: PropTypes.number.isRequired
+  count: PropTypes.number.isRequired
 }
 
 export default All

--- a/pages/all.js
+++ b/pages/all.js
@@ -1,3 +1,4 @@
+import {useEffect, useState} from 'react'
 import Link from 'next/link'
 import PropTypes from 'prop-types'
 import dynamic from 'next/dynamic'
@@ -24,10 +25,12 @@ function All({basesLocales, nom, limit, offset, count}) {
   const totalPages = Math.ceil(count / limit)
   const currentPage = Math.ceil((offset - 1) / limit) + 1
 
-  const [onFilter] = useDebouncedCallback(async value => {
-    const query = {page: count, limit}
+  const [input, setInput] = useState(nom || '')
 
-    if (value.length >= 2) {
+  const [onFilter] = useDebouncedCallback(async value => {
+    const query = {page: currentPage, limit}
+
+    if (value.length > 0) {
       query.nom = value
     }
 
@@ -41,6 +44,12 @@ function All({basesLocales, nom, limit, offset, count}) {
     })
   }
 
+  useEffect(() => {
+    if (input !== nom) {
+      onFilter(input)
+    }
+  }, [input, nom, onFilter])
+
   return (
     <Main>
       <Pane padding={16} backgroundColor='white'>
@@ -53,8 +62,8 @@ function All({basesLocales, nom, limit, offset, count}) {
       <Pane flex={1} overflowY='scroll'>
         <PublicBasesLocalesList
           basesLocales={basesLocales}
-          searchInput={nom}
-          onFilter={onFilter} />
+          searchInput={input}
+          onFilter={setInput} />
       </Pane>
 
       {totalPages > 1 && (

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types'
 import {Heading, Pane, Button} from 'evergreen-ui'
 import {uniq} from 'lodash'
 
-import {getBasesLocalesStats, listBasesLocales} from '@/lib/bal-api'
+import {getBasesLocales, getBasesLocalesStats} from '@/lib/bal-api'
 
 import DashboardLayout from '@/layouts/dashboard'
 
@@ -39,7 +39,7 @@ function Index({basesLocales, basesLoclesStats}) {
 }
 
 Index.getInitialProps = async () => {
-  const basesLocales = await listBasesLocales()
+  const basesLocales = await getBasesLocales()
   const basesLoclesStats = await getBasesLocalesStats()
   const basesLocalesWithoutDemo = basesLocales.filter((b => b.status !== 'demo'))
 


### PR DESCRIPTION
## Contexte
Cette PR utilise l'évolution apportée par BaseAdresseNationale/mes-adresses-api/pull/365 afin de mettre en place une pagination sur la page `/all` et améliorer les performances de celle-ci.

## Modifications
- La méthode `listBasesLocales` a été renommé `getBasesLocales`
- La méthode `searchBAL` a été renommé `searchBasesLocale`
- La méthode `searchBasesLocale` demande `deleted: 0` par défaut en query afin de filtrer les bases locales supprimées.
- La barre permet de rechercher par code commune et non plus par nom

----------

⚠️ Cette PR nécessite les évolutions apportées par BaseAdresseNationale/mes-adresses-api/pull/365