### PR TITLE
Correction de l'écrasement des toponymes dans l'édition multiple

### DIFF
--- a/components/grouped-actions.js
+++ b/components/grouped-actions.js
@@ -89,9 +89,12 @@ function GroupedActions({idVoie, numeros, selectedNumerosIds, resetSelectedNumer
 
     const changes = {
       voie: idVoie === selectedVoieId ? null : selectedVoieId,
-      toponyme: selectedToponymeId === '' ? null : selectedToponymeId,
       comment: commentCondition(comment),
       certifie: getIsCertifie(certifie)
+    }
+
+    if (hasUniqToponyme) {
+      changes.toponyme = selectedToponymeId === '' ? null : selectedToponymeId
     }
 
     if (positionType) {
@@ -106,7 +109,7 @@ function GroupedActions({idVoie, numeros, selectedNumerosIds, resetSelectedNumer
     setIsLoading(false)
     setIsShown(false)
     resetSelectedNumerosIds()
-  }, [comment, selectedVoieId, certifie, selectedToponymeId, onSubmit, positionType, removeAllComments, resetSelectedNumerosIds, baseLocale, selectedNumerosIds, idVoie])
+  }, [comment, selectedVoieId, certifie, hasUniqToponyme, selectedToponymeId, onSubmit, positionType, removeAllComments, resetSelectedNumerosIds, baseLocale, selectedNumerosIds, idVoie])
 
   useEffect(() => {
     if (!isShown) {


### PR DESCRIPTION
## Contexte
Lorsque plusieurs numéros sont édités et qu'ils ont différents toponymes, la sauvegarde entrainera nécessaire une suppression de tous les toponymes.

Cette suppression vient du fait que le champ `toponyme` est toujours attribué aux changements demandés alors que ce champ est `null` lorsque plusieurs toponymes sont présents.

## Correction
Le champ `toponymes` n'est attribué aux changements que si un unique toponyme est détecté pour les numéros sélectionnés.
