### PR TITLE
Affiche la popup d’habilitation au clic sur le bouton "publier"

### DIFF
--- a/components/mass-deletion-dialog.js
+++ b/components/mass-deletion-dialog.js
@@ -4,7 +4,7 @@ import {Dialog, Pane, Paragraph, Strong, VideoIcon} from 'evergreen-ui'
 
 import {PEERTUBE_LINK} from '@/components/help/video-container'
 
-function MassDeletionDialog({isShown, handleConfirm, handleCancel}) {
+function MassDeletionDialog({isShown, handleConfirm, handleCancel, onClose}) {
   const onConfirm = useCallback(() => {
     handleConfirm()
     handleCancel() // Pass isShown to false
@@ -19,6 +19,7 @@ function MassDeletionDialog({isShown, handleConfirm, handleCancel}) {
       confirmLabel='Continuer'
       onConfirm={onConfirm}
       onCancel={handleCancel}
+      onCloseComplete={onClose}
     >
       <Pane>
         <Paragraph>Vous avez <Strong>supprimé au moins 50% des adresses</Strong> connues actuellement dans la Base Adresse Nationale.</Paragraph>
@@ -33,13 +34,15 @@ function MassDeletionDialog({isShown, handleConfirm, handleCancel}) {
 
 MassDeletionDialog.defaultProps = {
   handleConfirm: null,
-  handleCancel: null
+  handleCancel: null,
+  onClose: null
 }
 
 MassDeletionDialog.propTypes = {
   isShown: PropTypes.bool.isRequired,
   handleConfirm: PropTypes.func,
-  handleCancel: PropTypes.func
+  handleCancel: PropTypes.func,
+  onClose: PropTypes.func
 }
 
 export default MassDeletionDialog

--- a/components/sub-header/index.js
+++ b/components/sub-header/index.js
@@ -113,6 +113,7 @@ const SubHeader = React.memo(({commune}) => {
         isShown={Boolean(massDeletionConfirm)}
         handleConfirm={massDeletionConfirm}
         handleCancel={() => setMassDeletionConfirm(null)}
+        onClose={() => setMassDeletionConfirm(null)}
       />
 
       <Pane

--- a/components/sub-header/index.js
+++ b/components/sub-header/index.js
@@ -60,9 +60,12 @@ const SubHeader = React.memo(({commune}) => {
   const handleChangeStatus = async status => {
     const isMassDeletionDetected = await checkMassDeletion()
     if (status === 'ready-to-publish' && isMassDeletionDetected) {
-      setMassDeletionConfirm(() => (() => updateStatus(status)))
+      setMassDeletionConfirm(() => (async () => {
+        const updated = await updateStatus(status)
+        setIsHabilitationDisplayed(updated)
+      }))
     } else {
-      updateStatus(status)
+      return updateStatus(status)
     }
   }
 


### PR DESCRIPTION
Cette PR modifie le schéma de publication d’une Base Adresse Locale.

Précédemment, l’utilisateur devait cliquer deux fois sur le bouton "publier" pour voir apparaître la boite de dialogue proposant l’habilitation.

La demande d’habilitation s’affiche maintenant directement au moment de cliquer sur le bouton "publier".

![Enregistrement de l’écran 2022-10-28 à 11 45 17](https://user-images.githubusercontent.com/56537238/198558416-ca1ce9c0-c331-4cc7-85e6-a740cd33fbe7.gif)
