### PR TITLE
Ajoute un onglet qui affiche les informations de la Base Adresse Locale

### DIFF
--- a/components/bal/bal-infos.js
+++ b/components/bal/bal-infos.js
@@ -1,0 +1,42 @@
+import {useContext} from 'react'
+import PropTypes from 'prop-types'
+import {Pane, Heading} from 'evergreen-ui'
+
+import BalDataContext from '@/contexts/bal-data'
+
+import Counter from '@/components/counter'
+import CertificationInfos from '@/components/bal/certification-infos'
+
+function BalInfos({nbVoies, nbToponymes}) {
+  const {baseLocale} = useContext(BalDataContext)
+  const {nbNumeros} = baseLocale
+
+  return (
+    <Pane
+      display='flex'
+      flexDirection='column'
+      padding={15}
+      overflow='auto'
+    >
+      <Heading size={600} textAlign='center' paddingY={10}>Les adresses de la commune en quelques chiffres :</Heading>
+      <Pane display='flex' justifyContent='center'>
+        <Counter label='numéros' value={nbNumeros} hasBorder hasBigLabel color='#2053b3' />
+        <Counter label='voies' value={nbVoies} hasBorder hasBigLabel color='#2053b3' />
+        <Counter label='toponymes' value={nbToponymes} hasBorder hasBigLabel color='#2053b3' />
+      </Pane>
+      <CertificationInfos />
+    </Pane>
+  )
+}
+
+BalInfos.defaultProps = {
+  nbVoies: 0,
+  nbToponymes: 0
+}
+
+BalInfos.propTypes = {
+  nbVoies: PropTypes.number,
+  nbToponymes: PropTypes.number
+}
+
+export default BalInfos

--- a/components/bal/certification-infos.js
+++ b/components/bal/certification-infos.js
@@ -1,0 +1,190 @@
+import {useState, useContext} from 'react'
+import {Pane, Heading, Dialog, Button, Text, Alert, EndorsedIcon, WarningSignIcon, LightbulbIcon, ChevronUpIcon, ChevronDownIcon, BanCircleIcon} from 'evergreen-ui'
+
+import BalDataContext from '@/contexts/bal-data'
+
+import ProgressBar from '@/components/progress-bar'
+import Counter from '@/components/counter'
+
+function CertificationInfos() {
+  const {certifyAllNumeros, reloadBaseLocale, baseLocale} = useContext(BalDataContext)
+  const [isDialogShown, setIsDialogShown] = useState(false)
+  const [isInfosShown, setIsInfosShown] = useState(false)
+  const [isLoading, setIsLoading] = useState(false)
+  const {nbNumeros, nbNumerosCertifies} = baseLocale
+  const percentCertified = Math.round((nbNumerosCertifies * 100) / nbNumeros)
+
+  const handleCertification = async () => {
+    setIsDialogShown(false)
+    setIsInfosShown(false)
+    setIsLoading(true)
+
+    await certifyAllNumeros()
+    await reloadBaseLocale()
+
+    setIsLoading(false)
+  }
+
+  const handleClose = () => {
+    setIsDialogShown(false)
+    setIsInfosShown(false)
+  }
+
+  return (
+    <>
+      {!baseLocale.isAllCertified && nbNumerosCertifies > 0 && (
+        <>
+          <Pane textAlign='center' paddingTop={30}>
+            <Heading>Nombre d’adresses certifiées</Heading>
+          </Pane>
+
+          <ProgressBar percent={percentCertified} />
+
+          <Pane display='flex' justifyContent='center'>
+            <Counter
+              label='Adresses certifiées'
+              value={nbNumerosCertifies}
+              color='#52BD95'
+            />
+            <Counter
+              label='Adresses non-certifiées'
+              value={nbNumeros - nbNumerosCertifies}
+              color='#FFB020'
+            />
+          </Pane>
+
+          <Pane>
+            <Dialog
+              isShown={isDialogShown}
+              title='Certification des adresses'
+              onCloseComplete={handleClose}
+              footer={
+                <Pane>
+                  <Button
+                    onClick={handleClose}
+                  >
+                    Annuler
+                  </Button>
+                  <Button
+                    isLoading={isLoading}
+                    appearance='primary'
+                    iconAfter={EndorsedIcon}
+                    marginLeft={15}
+                    onClick={handleCertification}
+                  >
+                    Certifier toutes les adresses de ma commune
+                  </Button>
+                </Pane>
+              }
+            >
+              <Pane>
+                <Pane
+                  display='flex'
+                  alignItems='center'
+                >
+                  <WarningSignIcon
+                    size={65}
+                    margin={20}
+                    color='warning'
+                  />
+                  <Text size={500}>
+                    Vous vous apprêtez à certifier <b>{nbNumeros - nbNumerosCertifies}</b> adresses de votre commune, <b> cette action ne peut pas être annulée</b>
+                  </Text>
+                </Pane>
+              </Pane>
+            </Dialog>
+
+            <Pane textAlign='center'>
+              <Button
+                iconBefore={LightbulbIcon}
+                iconAfter={isInfosShown ? ChevronUpIcon : ChevronDownIcon}
+                appearance='minimal'
+                onClick={() => setIsInfosShown(!isInfosShown)}
+              >
+                En savoir plus sur la certification
+              </Button>
+            </Pane>
+          </Pane>
+        </>
+      )}
+
+      {isInfosShown && (
+        <Pane paddingTop={15}>
+          <Alert>
+            <Heading size={400}>
+              Pour faciliter la réutilisation des adresses, <u>il est conseillé de les certifier</u>.
+            </Heading>
+            <br />
+            <Text>
+              Il est tout à fait possible de publier une Base Adresse Locale dont l’ensemble des <u>numéros n’ont pas encore été vérifiés : ils doivent rester non-certifiés.</u>
+              <br />
+            </Text>
+            <Pane paddingTop={15}>
+              <Text>
+                En revanche, les numéros qui auront été authentifiés par la commune <u>devront être certifiés</u>, qu’ils soient nouvellement crées par la commune ou que leur correspondance avec la liste officielle qui ressort du Conseil municipal, soit avérée.
+              </Text>
+            </Pane>
+            <Heading paddingY={15}>
+              Toutes les adresses de votre commune ont été vérifiées ?
+            </Heading>
+            <Pane>
+              <Text>
+                Si vous avez déjà procédé à la vérification de toutes les adresses de votre commune, cliquez sur le bouton «certifier mes adresses».
+              </Text>
+            </Pane>
+            <Pane
+              display='flex'
+              justifyContent='end'
+              paddingTop={15}
+            >
+              <Button
+                isLoading={isLoading}
+                intent='infos'
+                appearance='primary'
+                onClick={() => setIsDialogShown(true)}
+              >
+                Certifier mes adresses
+              </Button>
+            </Pane>
+          </Alert>
+        </Pane>
+      )}
+
+      {nbNumerosCertifies === 0 && (
+        <Pane
+          display='flex'
+          alignItems='center'
+          border='4px solid #2053b3'
+          borderRadius='10px'
+          padding='1em'
+          marginY='1em'
+          marginX='4px'
+        >
+          <BanCircleIcon color='danger' size={40} />
+          <Text size={600} paddingLeft={20}>
+            Aucune adresse n’est certifiée par la commune
+          </Text>
+        </Pane>
+      )}
+
+      {baseLocale.isAllCertified && (
+        <Pane
+          display='flex'
+          alignItems='center'
+          border='4px solid #2053b3'
+          borderRadius='10px'
+          padding='1em'
+          marginY='1em'
+          marginX='4px'
+        >
+          <EndorsedIcon color='success' size={50} />
+          <Text size={600} paddingLeft={20}>
+            Toutes les adresses sont certifiées par la commune
+          </Text>
+        </Pane>
+      )}
+    </>
+  )
+}
+
+export default CertificationInfos

--- a/components/bal/certification-infos.js
+++ b/components/bal/certification-infos.js
@@ -1,4 +1,4 @@
-import {useState, useContext} from 'react'
+import {useState, useContext, useEffect} from 'react'
 import {Pane, Heading, Dialog, Button, Text, Alert, EndorsedIcon, WarningSignIcon, LightbulbIcon, ChevronUpIcon, ChevronDownIcon, BanCircleIcon} from 'evergreen-ui'
 
 import BalDataContext from '@/contexts/bal-data'
@@ -7,7 +7,7 @@ import ProgressBar from '@/components/progress-bar'
 import Counter from '@/components/counter'
 
 function CertificationInfos() {
-  const {certifyAllNumeros, reloadBaseLocale, baseLocale} = useContext(BalDataContext)
+  const {certifyAllNumeros, reloadBaseLocale, baseLocale, reloadVoies, reloadToponymes} = useContext(BalDataContext)
   const [isDialogShown, setIsDialogShown] = useState(false)
   const [isInfosShown, setIsInfosShown] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
@@ -20,7 +20,9 @@ function CertificationInfos() {
     setIsLoading(true)
 
     await certifyAllNumeros()
-    await reloadBaseLocale()
+    reloadVoies()
+    reloadToponymes()
+    reloadBaseLocale()
 
     setIsLoading(false)
   }
@@ -29,6 +31,10 @@ function CertificationInfos() {
     setIsDialogShown(false)
     setIsInfosShown(false)
   }
+
+  useEffect(() => {
+    reloadBaseLocale()
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <>

--- a/components/counter.js
+++ b/components/counter.js
@@ -1,0 +1,42 @@
+import PropTypes from 'prop-types'
+import {Heading, Text} from 'evergreen-ui'
+
+function Counter({label, value, hasBorder, color, hasBigLabel}) {
+  return (
+    <div className={`counter ${hasBorder ? 'border' : ''}`}>
+      <Heading size={900} color={color}>{value}</Heading>
+      <Text fontSize={`${hasBigLabel ? '1.3em' : '.9em'}`} marginTop={4}>{label}</Text>
+      <style jsx>{`
+        .counter {
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          padding: 10px .5em;
+          margin: 5px;
+          width: 100%;
+        }
+
+        .border {
+          border: 4px solid #2053b3;
+          border-radius: 10px;
+        }
+      `}</style>
+    </div>
+  )
+}
+
+Counter.defaultProps = {
+  hasBorder: false,
+  color: null,
+  hasBigLabel: false
+}
+
+Counter.propTypes = {
+  label: PropTypes.string.isRequired,
+  value: PropTypes.number.isRequired,
+  hasBorder: PropTypes.bool,
+  color: PropTypes.string,
+  hasBigLabel: PropTypes.bool
+}
+
+export default Counter

--- a/components/progress-bar.js
+++ b/components/progress-bar.js
@@ -1,0 +1,42 @@
+import PropTypes from 'prop-types'
+import {Pane, Text} from 'evergreen-ui'
+
+function ProgressBar({percent}) {
+  return (
+    <Pane
+      display='flex'
+      marginTop={15}
+    >
+      <Pane
+        flex={1}
+        height={35}
+        background='orange500'
+        borderRadius={5}
+      >
+        <Pane
+          display='flex'
+          alignItems='center'
+          height={35}
+          width={`${percent}%`}
+          borderRadius={5}
+          background='green500'
+        />
+      </Pane>
+      <Text
+        display='flex'
+        alignItems='center'
+        justifyContent='center'
+        paddingLeft='15px'
+        size={500}
+      >
+        <b>{percent} %</b>
+      </Text>
+    </Pane>
+  )
+}
+
+ProgressBar.propTypes = {
+  percent: PropTypes.number.isRequired
+}
+
+export default ProgressBar

--- a/pages/bal.js
+++ b/pages/bal.js
@@ -1,7 +1,7 @@
 import React, {useState, useCallback, useContext} from 'react'
 import PropTypes from 'prop-types'
 import {useRouter} from 'next/router'
-import {Pane, Heading, Text, Paragraph, Button, AddIcon} from 'evergreen-ui'
+import {Pane, Heading, Text, Paragraph, Button, AddIcon, GroupedBarChartIcon} from 'evergreen-ui'
 
 import {populateCommune, removeVoie, removeToponyme} from '@/lib/bal-api'
 
@@ -15,12 +15,13 @@ import VoiesList from '@/components/bal/voies-list'
 import VoieEditor from '@/components/bal/voie-editor'
 import ToponymesList from '@/components/bal/toponymes-list'
 import ToponymeEditor from '@/components/bal/toponyme-editor'
+import BalInfos from '@/components/bal/bal-infos'
 
 const BaseLocale = React.memo(({baseLocale, commune}) => {
   const [editedItem, setEditedItem] = useState(null)
   const [isFormOpen, setIsFormOpen] = useState(false)
   const [toRemove, setToRemove] = useState(null)
-  const [selectedTab, setSelectedTab] = useState('voie')
+  const [selectedTab, setSelectedTab] = useState('bal')
 
   const {token} = useContext(TokenContext)
   const router = useRouter()
@@ -130,6 +131,9 @@ const BaseLocale = React.memo(({baseLocale, commune}) => {
           justifyContent='space-around'
           height={38}
         >
+          <div className={`tab small ${selectedTab === 'bal' ? 'selected' : ''}`} onClick={() => setSelectedTab('bal')}>
+            <Heading><GroupedBarChartIcon /></Heading>
+          </div>
           <div className={`tab ${selectedTab === 'voie' ? 'selected' : ''}`} onClick={() => setSelectedTab('voie')}>
             <Heading>Liste des voies</Heading>
           </div>
@@ -138,38 +142,49 @@ const BaseLocale = React.memo(({baseLocale, commune}) => {
           </div>
         </Pane>
 
-        <Pane
-          flexShrink={0}
-          elevation={0}
-          backgroundColor='white'
-          paddingX={16}
-          display='flex'
-          alignItems='center'
-          minHeight={50}
-        >
-          {token && (
-            <Pane marginLeft='auto'>
-              <Button
-                iconBefore={AddIcon}
-                appearance='primary'
-                intent='success'
-                disabled={isEditing}
-                onClick={() => setIsFormOpen(true)}
-              >
-                Ajouter {selectedTab === 'voie' ? 'une voie' : 'un toponyme'}
-              </Button>
-            </Pane>
-          )}
-        </Pane>
+        {selectedTab !== 'bal' && (
+          <Pane
+            flexShrink={0}
+            elevation={0}
+            backgroundColor='white'
+            paddingX={16}
+            display='flex'
+            alignItems='center'
+            minHeight={50}
+          >
+            {token && (
+              <Pane marginLeft='auto'>
+                <Button
+                  iconBefore={AddIcon}
+                  appearance='primary'
+                  intent='success'
+                  disabled={isEditing}
+                  onClick={() => setIsFormOpen(true)}
+                >
+                  Ajouter {selectedTab === 'voie' ? 'une voie' : 'un toponyme'}
+                </Button>
+              </Pane>
+            )}
+          </Pane>
+        )}
 
-        {selectedTab === 'voie' ? (
+        {selectedTab === 'bal' && (
+          <BalInfos
+            nbVoies={voies.length}
+            nbToponymes={toponymes.length}
+          />
+        )}
+
+        {selectedTab === 'voie' && (
           <VoiesList
             voies={voies}
             setToRemove={setToRemove}
             onEnableEditing={onEdit}
             onSelect={onSelect}
           />
-        ) : (
+        )}
+
+        {selectedTab === 'toponyme' && (
           <ToponymesList
             toponymes={toponymes}
             commune={commune}
@@ -218,6 +233,10 @@ const BaseLocale = React.memo(({baseLocale, commune}) => {
 
         .tab .selected:hover {
           background: #E4E7EB;
+        }
+
+        .small {
+          width: 40%;
         }
       `}</style>
     </>


### PR DESCRIPTION
Cette PR ajoute un onglet qui présente à l'utilisateur différentes informations à propos de sa Base Adresse Locale :
- le nombre de numéros
- le nombre de voies
- le nombre de toponymes
- les informations sur la certification, ainsi que la possibilité de certifier ces adresses lorsque c'est possible

Captures : 

![image](https://user-images.githubusercontent.com/56537238/200002182-453edfb0-1c16-42b2-8152-30287597b0cb.png)

![image](https://user-images.githubusercontent.com/56537238/200002443-346a0d04-a5a2-4b91-a629-db07df265428.png)

![image](https://user-images.githubusercontent.com/56537238/200002893-c6c57dae-805f-4034-8498-aff3f6a76baa.png)

