### PR TITLE
Nouvel ajout de caractères dans l'outil d'aide à la saisi des noms de voie

### DIFF
--- a/components/accent-tool.js
+++ b/components/accent-tool.js
@@ -9,9 +9,11 @@ const ACCENTS = [
   'è',
   'ê',
   'ë',
+  'ì',
   'í',
   'î',
   'ï',
+  'ò',
   'ó',
   'ô',
   'ö',
@@ -30,9 +32,11 @@ const ACCENTS = [
   'È',
   'Ê',
   'Ë',
+  'Ì',
   'Í',
   'Î',
   'Ï',
+  'Ò',
   'Ó',
   'Ô',
   'Ö',
@@ -58,10 +62,10 @@ function AccentTool({input, handleAccent, updateCaret, forwadedRef, isDisabled})
   return (
     <Popover
       content={({close}) => (
-        <Pane width={290} height={290} onClick={close}>
-          <Pane display='grid' gridTemplateColumns='repeat(auto-fit, minmax(34px, auto))' gridGap={10}>
+        <Pane width={300} height={300} onClick={close}>
+          <Pane display='grid' gridTemplateColumns='repeat(auto-fit, 44px)' gridGap={6}>
             {ACCENTS.map(accent => (
-              <Button key={accent} appearance='minimal' value={accent} onClick={handleClick}>
+              <Button fontSize='large' key={accent} appearance='minimal' value={accent} onClick={handleClick}>
                 {accent}
               </Button>
             ))}


### PR DESCRIPTION
## Contexte
Ajout des caractères suivant (et leurs majuscules)  : 
- `ì` (`Ì`)
- `ò` (`Ò`)

La taille de la police a également était agrandi afin de mieux voir la différence entre certains accents.

### Prévisualisation
![Capture d’écran 2022-11-16 à 09 59 35](https://user-images.githubusercontent.com/7040549/202135954-901e8520-f061-4e3f-9fcf-dd431c880ba8.png)
