### PR TITLE
Correction de l'ouverture des formulaires d'édition en mode consultation

### DIFF
--- a/components/toponyme/toponyme-heading.js
+++ b/components/toponyme/toponyme-heading.js
@@ -16,7 +16,7 @@ function ToponymeHeading({toponyme, commune}) {
   const {isEditing, editingId, numeros} = useContext(BalDataContext)
 
   const onEnableToponymeEditing = () => {
-    if (!isEditing) {
+    if (!isEditing && token) {
       setIsFormOpen(true)
       setHovered(false)
     }

--- a/components/voie/voie-heading.js
+++ b/components/voie/voie-heading.js
@@ -16,11 +16,11 @@ function VoieHeading({voie}) {
   const {editingId, isEditing, numeros} = useContext(BalDataContext)
 
   const onEnableVoieEditing = useCallback(() => {
-    if (!isEditing) {
+    if (!isEditing && token) {
       setIsFormOpen(true)
       setHovered(false)
     }
-  }, [isEditing])
+  }, [isEditing, token])
 
   useEffect(() => {
     if (editingId === voie._id) {

--- a/pages/bal/toponyme.js
+++ b/pages/bal/toponyme.js
@@ -113,15 +113,17 @@ function Toponyme({baseLocale, commune}) {
           >
             <Heading>Liste des numéros</Heading>
             <Pane marginLeft='auto'>
-              <Button
-                iconBefore={AddIcon}
-                appearance='primary'
-                intent='success'
-                disabled={isEditing}
-                onClick={onEnableAdding}
-              >
-                Ajouter des numéros
-              </Button>
+              {token && (
+                <Button
+                  iconBefore={AddIcon}
+                  appearance='primary'
+                  intent='success'
+                  disabled={isEditing}
+                  onClick={onEnableAdding}
+                >
+                  Ajouter des numéros
+                </Button>
+              )}
             </Pane>
           </Pane>
         )}


### PR DESCRIPTION
## Contexte
Cette PR est un quickfix qui a pour objectif de résoudre #745.

## Modifications
- S'assure que le `token` est bien présent au clique sur le nom d'une voie ou d'un toponyme.
- Cache le bouton "Ajouter des numéros" aux toponymes lorsque le `token` n'est pas présent


Fix #745