### PR TITLE
Mise à jour du COG 2023

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@babel/runtime": "^7.17.9",
     "@ban-team/shared-data": "^1.2.0",
-    "@ban-team/validateur-bal": "^2.12.0",
+    "@ban-team/validateur-bal": "^2.13.0",
     "@next/bundle-analyzer": "^12.1.6",
     "@turf/bbox": "^6.5.0",
     "@turf/buffer": "^6.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -304,10 +304,10 @@
   resolved "https://registry.yarnpkg.com/@ban-team/shared-data/-/shared-data-1.2.0.tgz#0e29e84a00f7df3b17e5821bde1405a2bfa656b5"
   integrity sha512-35jz6ITHHufUKxXAfa8ReSMl6lZarnfVBkS++wgHpk27e9K52bXyAHo+n3X331n2mSzoIQXxFK7SEcPob7a5cA==
 
-"@ban-team/validateur-bal@^2.12.0":
-  version "2.12.0"
-  resolved "https://registry.yarnpkg.com/@ban-team/validateur-bal/-/validateur-bal-2.12.0.tgz#4d8eb83291cfdfc1cdfa574b36cc9f7ca716bd0f"
-  integrity sha512-+bI65V10UVfJUrKQIH9+R4LfygcWPNz/n08Z6ThDhkX7eWfesgHMJlimIqpKRavrwjaowFtGrHgWaW/qP06rSA==
+"@ban-team/validateur-bal@^2.13.0":
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/@ban-team/validateur-bal/-/validateur-bal-2.13.0.tgz#0d23e8192f631614d59312d265a04697f8fe09db"
+  integrity sha512-+GFoSti7n5dn4l+ZjiWjk19wkdxauhDIFa0gk3uIsDInwE1e3HiCdYxDYkYMAeU5/p1XadxANIVv73CH92YGbg==
   dependencies:
     "@ban-team/shared-data" "^1.2.0"
     "@etalab/project-legal" "^0.6.0"


### PR DESCRIPTION
## Contexte
Mise à jour de `@ban-team/validateur-bal` en version `2.13.0` pour la mise à jour du COG 2023.