### PR TITLE
Nouvelle fonctionalité: convertir voie en toponyme

### DIFF
--- a/components/bal/voies-list.js
+++ b/components/bal/voies-list.js
@@ -1,7 +1,7 @@
 import {useContext, useMemo} from 'react'
 import PropTypes from 'prop-types'
 import {sortBy} from 'lodash'
-import {Table} from 'evergreen-ui'
+import {Table, KeyTabIcon} from 'evergreen-ui'
 
 import {normalizeSort} from '@/lib/normalize'
 
@@ -15,7 +15,7 @@ import CommentsContent from '@/components/comments-content'
 
 import InfiniteScrollList from '../infinite-scroll-list'
 
-function VoiesList({voies, onEnableEditing, onSelect, setToRemove}) {
+function VoiesList({voies, onEnableEditing, onSelect, setToRemove, setToConvert}) {
   const {token} = useContext(TokenContext)
   const {isEditing} = useContext(BalDataContext)
 
@@ -56,7 +56,12 @@ function VoiesList({voies, onEnableEditing, onSelect, setToRemove}) {
             actions={{
               onSelect: () => onSelect(voie._id),
               onEdit: () => onEnableEditing(voie._id),
-              onRemove: () => setToRemove(voie._id)
+              onRemove: () => setToRemove(voie._id),
+              extra: voie.nbNumeros === 0 ? {
+                callback: () => setToConvert(voie._id),
+                icon: KeyTabIcon,
+                text: 'Convertir en toponyme',
+              } : null
             }}
             notifications={{
               certification: voie.isAllCertified ? 'Toutes les adresses de cette voie sont certifiées par la commune' : null,
@@ -74,7 +79,8 @@ VoiesList.propTypes = {
   voies: PropTypes.array.isRequired,
   setToRemove: PropTypes.func.isRequired,
   onEnableEditing: PropTypes.func.isRequired,
-  onSelect: PropTypes.func.isRequired
+  onSelect: PropTypes.func.isRequired,
+  setToConvert: PropTypes.func.isRequired
 }
 
 export default VoiesList

--- a/components/convert-voie-warning.js
+++ b/components/convert-voie-warning.js
@@ -1,0 +1,31 @@
+import PropTypes from 'prop-types'
+import {Dialog} from 'evergreen-ui'
+
+function ConvertVoieWarning({isShown, content, onCancel, onConfirm}) {
+  return (
+    <Dialog
+      isShown={isShown}
+      title='Attention'
+      cancelLabel='Annuler'
+      confirmLabel='Convertir'
+      onCloseComplete={onCancel}
+      onCancel={onCancel}
+      onConfirm={onConfirm}
+    >
+      {content}
+    </Dialog>
+  )
+}
+
+ConvertVoieWarning.propTypes = {
+  isShown: PropTypes.bool,
+  content: PropTypes.node.isRequired,
+  onCancel: PropTypes.func.isRequired,
+  onConfirm: PropTypes.func.isRequired
+}
+
+ConvertVoieWarning.defaultProps = {
+  isShown: false
+}
+
+export default ConvertVoieWarning

--- a/components/table-row/table-row-actions.js
+++ b/components/table-row/table-row-actions.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import {Table, Popover, Menu, Position, IconButton, EditIcon, MoreIcon, SendToMapIcon, TrashIcon} from 'evergreen-ui'
 
-const TableRowActions = React.memo(({onSelect, onEdit, onRemove}) => {
+const TableRowActions = React.memo(({onSelect, onEdit, onRemove, extra}) => {
   return (
     <Table.TextCell flex='0 1 1'>
       <Popover
@@ -18,6 +18,11 @@ const TableRowActions = React.memo(({onSelect, onEdit, onRemove}) => {
               {onEdit && (
                 <Menu.Item icon={EditIcon} onSelect={onEdit}>
                   Modifier
+                </Menu.Item>
+              )}
+              {extra && (
+                <Menu.Item icon={extra.icon} onSelect={extra.callback}>
+                  {extra.text}
                 </Menu.Item>
               )}
               {onRemove && (
@@ -38,13 +43,19 @@ const TableRowActions = React.memo(({onSelect, onEdit, onRemove}) => {
 TableRowActions.propTypes = {
   onSelect: PropTypes.func,
   onEdit: PropTypes.func,
-  onRemove: PropTypes.func
+  onRemove: PropTypes.func,
+  extra: PropTypes.exact({
+    callback: PropTypes.func,
+    icon: PropTypes.elementType,
+    text: PropTypes.string,
+  }),
 }
 
 TableRowActions.defaultProps = {
   onEdit: null,
   onSelect: null,
-  onRemove: null
+  onRemove: null,
+  extra: null
 }
 
 export default TableRowActions

--- a/lib/bal-api/index.js
+++ b/lib/bal-api/index.js
@@ -382,13 +382,31 @@ export async function removeVoie(idVoie, token) {
         authorization: `Token ${token}`
       }
     })
-
     toaster.success('La voie a bien été supprimée')
     return response
   } catch (error) {
     toaster.danger('La voie n’a pas pu être supprimée', {
       description: error.message
     })
+  }
+}
+
+export async function convertVoieToToponyme(idVoie, token) {
+  try {
+    const response = await request(`/voies/${idVoie}/convert-to-toponyme`, {
+      method: 'PUT',
+      headers: {
+        authorization: `Token ${token}`,
+        'content-type': 'application/json'
+      },
+    })
+    toaster.success('La voie a bien été convertie en toponyme')
+    return response
+  } catch (error) {
+    toaster.danger('La voie n’a pas pu être convertie en toponyme', {
+      description: error.message
+    })
+    return {error}
   }
 }
 


### PR DESCRIPTION
## Contexte
Il arrive fréquemment que des communes créent des voies sans adresse qui, dans la grande majorité des cas, devraient être des toponymes. De plus les voies sans adresse ne remonte pas la BAN.

## Évolutions
Permettre de "convertir" une voie sans adresse en toponyme grâce à une action disponible dans le menu de la voie.
Cette opération devra être effectuée par une route dédiée sur mes-adresses-api.

## Fonctionalité

- Ajout de la props `extra: {callback, icon, text}`sur la fonction composant `TableRowActions` qui permet de passer une action supplémentaire.
- Ajout de la fonction `convertVoieToToponyme` dans `bal-api/index.js` qui requète la nouvelle route de api-bal `/voies/${idVoie}/convert-to-toponyme`.
- Ajout d'un useCallback `onConvert` dans la fonction composant `BaseLocal` qui appelle la fonction `convertVoieToToponyme`.
- On passe `onConvert` de `BaseLocal` au composant fils via les props a `VoiesList` -> `TableRow` -> `TableRowActions`
- Création du composant `ConvertVoieWarning`, un dialog pour valider la convertion de la voie en toponyme

## Présentation
<img width="1644" alt="Capture d’écran 2023-03-25 à 11 35 47" src="https://user-images.githubusercontent.com/8143924/227704056-5de5bd3a-ad89-4b3d-9140-64829509f323.png">

## Attention
Ne pas merger avant : 
- [ ] https://github.com/BaseAdresseNationale/mes-adresses-api/pull/374