### PR TITLE
Amélioration: Ajouter un check du token pour lire les commentaires

### DIFF
--- a/components/table-row/table-row-notifications.js
+++ b/components/table-row/table-row-notifications.js
@@ -1,10 +1,14 @@
+import {useContext} from 'react'
 import PropTypes from 'prop-types'
 import {Table, Position, Tooltip, EndorsedIcon, WarningSignIcon, CommentIcon} from 'evergreen-ui'
+import TokenContext from '@/contexts/token'
 
 function TableRowNotifications({certification, comment, warning}) {
+  const {token} = useContext(TokenContext)
+
   return (
     <>
-      {comment && (
+      {comment && token && (
         <Table.Cell flex='0 1 1'>
           <Tooltip
             content={comment}


### PR DESCRIPTION
## Contexte

Les commentaire des numéro (ou il peut y avoir de l'information privé) peuvent être vu seulement dans les liste des voies et des toponyme sans avoir le token le la BAL.

## Amélioration

On check le token pour afficher les commentaires

## Résultat

### Sans token

<img width="1189" alt="Capture d’écran 2023-03-27 à 15 23 42" src="https://user-images.githubusercontent.com/8143924/227928151-cd3edc8f-0b32-41d4-b074-c755a84a771b.png">

### Avec token

<img width="1189" alt="Capture d’écran 2023-03-27 à 15 23 55" src="https://user-images.githubusercontent.com/8143924/227928248-e66ed70c-50c8-4573-aa84-8bbf7d1f5dc1.png">

Fix https://github.com/BaseAdresseNationale/mes-adresses/issues/753

