### PR TITLE
Disbabled button force sync lorsque qu'une requête est en cour

### DIFF
--- a/components/habilitation-process/index.js
+++ b/components/habilitation-process/index.js
@@ -31,6 +31,7 @@ function HabilitationProcess({token, baseLocale, commune, habilitation, handlePu
   const [step, setStep] = useState(getStep(habilitation))
   const [isLoading, setIsLoading] = useState(false)
   const [isConflicted, setIsConflicted] = useState(false)
+  const [isLoadingPublish, setIsLoadingPublish] = useState(false)
 
   const {reloadHabilitation} = useContext(BalDataContext)
 
@@ -101,11 +102,13 @@ function HabilitationProcess({token, baseLocale, commune, habilitation, handlePu
     resetHabilitationProcess()
   }
 
-  const handleConfirm = () => {
+  const handleConfirm = async () => {
+    setIsLoadingPublish(true)
     if (habilitation.status === 'accepted') {
-      handlePublication()
+      await handlePublication()
     }
 
+    setIsLoadingPublish(false)
     handleClose()
   }
 
@@ -134,6 +137,7 @@ function HabilitationProcess({token, baseLocale, commune, habilitation, handlePu
       confirmLabel={habilitation.status === 'accepted' ? (isConflicted ? 'Forcer la publication' : 'Publier') : 'Fermer'}
       cancelLabel='Attendre'
       onConfirm={handleConfirm}
+      isConfirmDisabled={isLoadingPublish}
       onCloseComplete={handleClose}
     >
       <Pane>

--- a/components/sub-header/bal-status/ban-sync/sync-button.js
+++ b/components/sub-header/bal-status/ban-sync/sync-button.js
@@ -5,6 +5,13 @@ import {Pane, Button, Checkbox, CircleArrowUpIcon, PlayIcon, PauseIcon, Automati
 function SyncButton({isSync, isConflicted, isPaused, handleSync, togglePause}) {
   const [isActionHovered, setIsActionHovered] = useState(false)
   const [isManualActionConfirmed, setIsManuelActionConfirmed] = useState(false)
+  const [isDisabled, setIsDisabled] = useState(false)
+
+  const handleDisabledButton = async () => {
+    setIsDisabled( true )
+    await handleSync()
+    setIsDisabled( false )
+  }
 
   if (isConflicted) {
     return (
@@ -13,8 +20,8 @@ function SyncButton({isSync, isConflicted, isPaused, handleSync, togglePause}) {
           width='100%'
           intent='danger'
           appearance='primary'
-          onClick={handleSync}
-          disabled={!isManualActionConfirmed}
+          onClick={handleDisabledButton}
+          disabled={!isManualActionConfirmed || isDisabled}
         >
           Forcer la mise à jour
         </Button>

--- a/components/sub-header/bal-status/ban-sync/sync-button.js
+++ b/components/sub-header/bal-status/ban-sync/sync-button.js
@@ -8,9 +8,9 @@ function SyncButton({isSync, isConflicted, isPaused, handleSync, togglePause}) {
   const [isDisabled, setIsDisabled] = useState(false)
 
   const handleDisabledButton = async () => {
-    setIsDisabled( true )
+    setIsDisabled(true)
     await handleSync()
-    setIsDisabled( false )
+    setIsDisabled(false)
   }
 
   if (isConflicted) {

--- a/components/sub-header/bal-status/ban-sync/sync-button.js
+++ b/components/sub-header/bal-status/ban-sync/sync-button.js
@@ -5,12 +5,12 @@ import {Pane, Button, Checkbox, CircleArrowUpIcon, PlayIcon, PauseIcon, Automati
 function SyncButton({isSync, isConflicted, isPaused, handleSync, togglePause}) {
   const [isActionHovered, setIsActionHovered] = useState(false)
   const [isManualActionConfirmed, setIsManuelActionConfirmed] = useState(false)
-  const [isDisabled, setIsDisabled] = useState(false)
+  const [isLoading, setIsLoading] = useState(false)
 
-  const handleDisabledButton = async () => {
-    setIsDisabled(true)
+  const onSync = async () => {
+    setIsLoading(true)
     await handleSync()
-    setIsDisabled(false)
+    setIsLoading(false)
   }
 
   if (isConflicted) {
@@ -20,8 +20,8 @@ function SyncButton({isSync, isConflicted, isPaused, handleSync, togglePause}) {
           width='100%'
           intent='danger'
           appearance='primary'
-          onClick={handleDisabledButton}
-          disabled={!isManualActionConfirmed || isDisabled}
+          onClick={onSync}
+          disabled={!isManualActionConfirmed || isLoading}
         >
           Forcer la mise à jour
         </Button>

--- a/components/sub-header/index.js
+++ b/components/sub-header/index.js
@@ -103,7 +103,7 @@ const SubHeader = React.memo(({commune}) => {
     if (isMassDeletionDetected) {
       setMassDeletionConfirm(() => handleSync)
     } else {
-      handleSync()
+      await handleSync()
     }
   }
 


### PR DESCRIPTION
## Context

Lors d'un conflit de BAL, on peut appuyer frénétiquement sur le bouton `Forcer la mise à jour`, ce qui lance plein de requêtes `/bases-locales/${balId}/sync/exec`concurentes.

## Fix

Bloquer le bouton  `Forcer la mise à jour` pendant qu'une requête est en cour