### PR TITLE
Ajouter édition commune déléguée au numéro

### DIFF
--- a/components/bal/numero-editor.js
+++ b/components/bal/numero-editor.js
@@ -41,6 +41,7 @@ function NumeroEditor({initialVoieId, initialValue, commune, hasPreview, closeFo
   const [suffixe, onSuffixeChange] = useInput(initialValue?.suffixe)
   const [comment, onCommentChange] = useInput(initialValue?.comment)
   const [getValidationMessage, setValidationMessages] = useValidationMessage(null)
+  const [communeDeleguee, setCommuneDeleguee] = useState(initialValue?.communeDeleguee || "")
 
   const {token} = useContext(TokenContext)
   const {baseLocale, voies, toponymes, reloadNumeros, reloadGeojson, reloadParcelles, refreshBALSync, reloadVoies} = useContext(BalDataContext)
@@ -77,6 +78,7 @@ function NumeroEditor({initialVoieId, initialValue, commune, hasPreview, closeFo
       suffixe: suffixe.length > 0 ? suffixe.toLowerCase().trim() : null,
       comment: comment.length > 0 ? comment : null,
       parcelles: selectedParcelles,
+      communeDeleguee: communeDeleguee == "" ? null : communeDeleguee,
       certifie: certifie ?? (initialValue?.certifie || false)
     }
 
@@ -106,7 +108,6 @@ function NumeroEditor({initialVoieId, initialValue, commune, hasPreview, closeFo
     try {
       const body = getNumeroBody()
       const voie = await getEditedVoie()
-
       // Add or edit a numero
       const submit = initialValue ?
         async () => editNumero(initialValue._id, {voie: voie._id, ...body}, token) :
@@ -132,7 +133,7 @@ function NumeroEditor({initialVoieId, initialValue, commune, hasPreview, closeFo
     } catch {
       setIsLoading(false)
     }
-  }, [token, getNumeroBody, getEditedVoie, handleGeojsonRefresh, closeForm, reloadNumeros, refreshBALSync, reloadParcelles, initialValue, setValidationMessages, reloadVoies, initialVoieId])
+  }, [token, getNumeroBody, getEditedVoie, handleGeojsonRefresh, closeForm, reloadNumeros, communeDeleguee, refreshBALSync, reloadParcelles, initialValue, setValidationMessages, reloadVoies, initialVoieId])
 
   useEffect(() => {
     setOverrideText(numero ? computeCompletNumero(numero, suffixe) : null)
@@ -249,6 +250,24 @@ function NumeroEditor({initialVoieId, initialValue, commune, hasPreview, closeFo
             />
           </Pane>
         </FormInput>
+
+        {baseLocale.communesDeleguees && (
+          <FormInput>
+            <SelectField
+              value={communeDeleguee}
+              flex={1}
+              label='Commune déléguée'
+              margin={0}
+              display='block'
+              onChange={event => {setCommuneDeleguee(event.target.value)}}
+            >
+              <option value='' >-- Veuillez choisir une commune déléguée --</option>
+              {baseLocale.communesDeleguees.map(communeDeleguee => (
+                <option key={communeDeleguee} value={communeDeleguee}>{communeDeleguee}</option>
+              ))}
+            </SelectField>
+          </FormInput>
+        )}
 
         <FormInput>
           <PositionEditor

--- a/components/grouped-actions.js
+++ b/components/grouped-actions.js
@@ -56,6 +56,18 @@ function GroupedActions({idVoie, numeros, selectedNumerosIds, resetSelectedNumer
 
   const [selectedToponymeId, setSelectedToponymeId] = useState(getDefaultToponyme)
 
+  const selectedCommuneDeleguee = uniq(selectedNumeros.map(numero => (numero.communeDeleguee)))
+  const hasUniqCommuneDeleguee = selectedCommuneDeleguee.length === 1 && selectedCommuneDeleguee[0] != undefined
+
+  const getDefaultCommuneDelegee = useCallback(() => {
+    if (hasUniqCommuneDeleguee) {
+      return selectedCommuneDeleguee[0]
+    }
+
+    return ""
+  }, [hasUniqCommuneDeleguee])
+
+  const [selectedCommuneDelegee, setSelectedCommuneDelegee] = useState(getDefaultCommuneDelegee)
   const handleClick = () => {
     setIsShown(true)
     resetPositionType()
@@ -100,16 +112,18 @@ function GroupedActions({idVoie, numeros, selectedNumerosIds, resetSelectedNumer
     if (positionType) {
       changes.positionType = positionType
     }
+    if (selectedCommuneDelegee) {
+      changes.communeDeleguee = selectedCommuneDelegee
+    }
 
     await onSubmit(baseLocale._id, {
       numerosIds: selectedNumerosIds,
       changes
     })
-
     setIsLoading(false)
     setIsShown(false)
     resetSelectedNumerosIds()
-  }, [comment, selectedVoieId, certifie, hasUniqToponyme, selectedToponymeId, onSubmit, positionType, removeAllComments, resetSelectedNumerosIds, baseLocale, selectedNumerosIds, idVoie])
+  }, [comment, selectedVoieId, certifie, hasUniqToponyme, selectedToponymeId, selectedCommuneDelegee, onSubmit, positionType, removeAllComments, resetSelectedNumerosIds, baseLocale, selectedNumerosIds, idVoie])
 
   useEffect(() => {
     if (!isShown) {
@@ -197,6 +211,26 @@ function GroupedActions({idVoie, numeros, selectedNumerosIds, resetSelectedNumer
                   ))}
                 </SelectField>
               </FormInput>
+
+              {baseLocale.communesDeleguees && (
+                <FormInput>
+                  <SelectField
+                    value={selectedCommuneDelegee}
+                    flex={1}
+                    label='Commune déléguée'
+                    margin={0}
+                    display='block'
+                    onChange={event => setSelectedCommuneDelegee(event.target.value)}
+                  >
+                    {( !hasUniqCommuneDeleguee ) && (
+                      <option value='' >-- Veuillez choisir une commune déléguée --</option>
+                    )}
+                    {baseLocale.communesDeleguees.map(communeDeleguee => (
+                      <option key={communeDeleguee} value={communeDeleguee}>{communeDeleguee}</option>
+                    ))}
+                  </SelectField>
+                </FormInput>
+              )}
 
               {hasMultiposition && (
                 <Alert intent='none' marginBottom={8}>Certains numéros sélectionnés possèdent plusieurs positions. La modification groupée du type de position n’est pas possible. Ils doivent être modifiés séparément.</Alert>


### PR DESCRIPTION
## Context

Une fois que la PR https://github.com/BaseAdresseNationale/mes-adresses-api/pull/378 sur mes-adresses-api sera fini, les bals auront un champs`communesDeleguees` qui sera un Array de codeCommune déléguées si il y en a.

## Fonctionnalité

Ajout un select (avec les codeCommunes déléguées de la bal) à l'édition de masse et simple des numéros, pour leurs attribuer une commune déléguée
