### PR TITLE
Fixé les button de la popup pendant la requète convertToToponyme

### DIFF
--- a/components/convert-voie-warning.js
+++ b/components/convert-voie-warning.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import {Dialog} from 'evergreen-ui'
 
-function ConvertVoieWarning({isShown, content, onCancel, onConfirm}) {
+function ConvertVoieWarning({isShown, content, isLoading, onCancel, onConfirm}) {
   return (
     <Dialog
       isShown={isShown}
@@ -11,6 +11,9 @@ function ConvertVoieWarning({isShown, content, onCancel, onConfirm}) {
       onCloseComplete={onCancel}
       onCancel={onCancel}
       onConfirm={onConfirm}
+      hasCancel={!isLoading}
+      hasClose={!isLoading}
+      isConfirmLoading={isLoading}
     >
       {content}
     </Dialog>
@@ -20,6 +23,7 @@ function ConvertVoieWarning({isShown, content, onCancel, onConfirm}) {
 ConvertVoieWarning.propTypes = {
   isShown: PropTypes.bool,
   content: PropTypes.node.isRequired,
+  isLoading: PropTypes.bool,
   onCancel: PropTypes.func.isRequired,
   onConfirm: PropTypes.func.isRequired
 }

--- a/components/convert-voie-warning.js
+++ b/components/convert-voie-warning.js
@@ -14,6 +14,8 @@ function ConvertVoieWarning({isShown, content, isLoading, onCancel, onConfirm}) 
       hasCancel={!isLoading}
       hasClose={!isLoading}
       isConfirmLoading={isLoading}
+      shouldCloseOnOverlayClick={!isLoading}
+      shouldCloseOnEscapePress={!isLoading}
     >
       {content}
     </Dialog>

--- a/pages/bal.js
+++ b/pages/bal.js
@@ -22,6 +22,7 @@ const BaseLocale = React.memo(({baseLocale, commune}) => {
   const [isFormOpen, setIsFormOpen] = useState(false)
   const [toRemove, setToRemove] = useState(null)
   const [toConvert, setToConvert] = useState(null)
+  const [onConvertLoading, setOnConvertLoading] = useState(false)
   const [selectedTab, setSelectedTab] = useState('voie')
 
   const {token} = useContext(TokenContext)
@@ -66,6 +67,7 @@ const BaseLocale = React.memo(({baseLocale, commune}) => {
   }, [reloadVoies, refreshBALSync, reloadToponymes, reloadGeojson, reloadParcelles, selectedTab, toRemove, token])
 
   const onConvert = useCallback(async () => {
+    setOnConvertLoading(true)
     const res = await convertVoieToToponyme(toConvert, token)
     if (!res.error) {
       await reloadVoies()
@@ -73,6 +75,7 @@ const BaseLocale = React.memo(({baseLocale, commune}) => {
       await reloadParcelles()
       await reloadGeojson()
       refreshBALSync()
+      setOnConvertLoading(false)
       setSelectedTab('toponyme')
       setEditedItem(res)
       setIsFormOpen(true)
@@ -124,6 +127,7 @@ const BaseLocale = React.memo(({baseLocale, commune}) => {
             Êtes vous bien sûr de vouloir convertir cette voie en toponyme ?
           </Paragraph>
         )}
+        isLoading={onConvertLoading}
         onCancel={() => setToConvert(null)}
         onConfirm={onConvert}
       />


### PR DESCRIPTION
## Context

Lors de la conversion d'une voie en toponyme, comme la requète convertToToponyme peut être long, on pouvait cliqué sur `confirmé` et ensuite fermer la popup en pensant que rien ne c'était passé.

## Fonctionnalité

Ajout d'un loader sur le bouton `confirmé` et disabled des bouton `cancel` et `close` pendant la requète