### PR TITLE
Ajoute le tracking Matomo

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -5,4 +5,6 @@ NEXT_PUBLIC_ADRESSE_URL=https://adresse.data.gouv.fr
 NEXT_PUBLIC_API_BAN_URL=https://plateforme.adresse.data.gouv.fr
 NEXT_PUBLIC_BAN_API_DEPOT=https://plateforme.adresse.data.gouv.fr/api-depot
 NEXT_PUBLIC_PEERTUBE=https://peertube.adresse.data.gouv.fr
+NEXT_PUBLIC_MATOMO_SITE_ID=
+NEXT_PUBLIC_MATOMO_TRACKER_URL=https://stats.beta.gouv.fr/
 PORT=3000

--- a/hooks/matomo-tracker.js
+++ b/hooks/matomo-tracker.js
@@ -1,0 +1,55 @@
+import {useEffect, useState} from 'react'
+
+export default function useMatomoTracker({siteId, trackerUrl, trackingEnabled}, pageProps) {
+  const [matomoState, setMatomoState] = useState(null)
+
+  // Load matomo script
+  useEffect(() => {
+    if (!trackingEnabled) {
+      return
+    }
+
+    const matomoScriptElem = document.createElement('script')
+    const firstScriptElem = document.querySelectorAll('script')[0]
+    matomoScriptElem.async = true
+    matomoScriptElem.src = `${trackerUrl}matomo.js`
+    matomoScriptElem.addEventListener('load', () => {
+      setMatomoState('loaded')
+    })
+
+    firstScriptElem.parentNode.insertBefore(matomoScriptElem, firstScriptElem)
+  }, [trackerUrl, trackingEnabled])
+
+  // Init matomo tracker with site configuration
+  useEffect(() => {
+    if (matomoState === 'loaded') {
+      window.Matomo.addTracker()
+      window._paq.push(['setTrackerUrl', `${trackerUrl}matomo.php`], ['setSiteId', `${siteId}`])
+      setMatomoState('initialized')
+    }
+  }, [matomoState, trackerUrl, siteId])
+
+  // Track pages when pageProps change
+  useEffect(() => {
+    if (matomoState === 'initialized') {
+      const {commune} = pageProps
+      let urlToTrack = location.href
+      const balEditorPageRe = /\/bal\/.*/
+      const isOnBalEditor = balEditorPageRe.test(location.pathname)
+      if (isOnBalEditor) {
+        // Prevent the tracker from tracking the bal page and children
+        const pageWithTokenPathRE = /\/bal\/[A-Za-z\d]{24}\/[A-Za-z\d]{20}/
+        const isOnTokenRoute = pageWithTokenPathRE.test(location.pathname)
+        if (isOnTokenRoute || !commune) {
+          return
+        }
+
+        // Replace the balId by the commune code if we are on the bal editor page
+        const pathToTrack = location.pathname.split('/').map((pathPart, index) => index === 2 ? commune.code : pathPart).join('/')
+        urlToTrack = `${location.origin}${pathToTrack}`
+      }
+
+      window._paq.push(['setCustomUrl', urlToTrack], ['trackPageView'])
+    }
+  }, [matomoState, pageProps])
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -19,9 +19,16 @@ import Editor from '@/layouts/editor'
 import Header from '@/components/header'
 import IEWarning from '@/components/ie-warning'
 import Help from '@/components/help'
+import useMatomoTracker from '@/hooks/matomo-tracker'
 
 function App({error, Component, pageProps, query}) {
   const [isMobileWarningDisplayed, setIsMobileWarningDisplayed] = useState(false)
+
+  useMatomoTracker({
+    trackingEnabled: process.env.NODE_ENV === 'production',
+    siteId: process.env.NEXT_PUBLIC_MATOMO_SITE_ID,
+    trackerUrl: process.env.NEXT_PUBLIC_MATOMO_TRACKER_URL
+  }, pageProps)
 
   return (
     <>


### PR DESCRIPTION
# Contexte
Afin de mesurer l'utilisation du site mes-adresses, nous ajoutons le tracker Matomo

# Fonctionnalité
- Création d'un hook "useMatomoTracker" pour gérer le tracking de l'application (track la page sur laquelle l'utilisateur arrive et toutes les pages qu'il visite)
- La page contenant le token d'une BAL dans l'URL n'est pas trackée

# Pour tester
- Ajouter NEXT_PUBLIC_MATOMO_SITE_ID et NEXT_PUBLIC_MATOMO_TRACKER_URL dans le .env et passer "trackingEnabled" à true