### PR TITLE
Mise à jour des URL vers l'API dépôt

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -3,6 +3,6 @@ NEXT_PUBLIC_BAL_API_URL=https://api-bal.adresse.data.gouv.fr/v1
 NEXT_PUBLIC_GEO_API_URL=https://geo.api.gouv.fr
 NEXT_PUBLIC_ADRESSE_URL=https://adresse.data.gouv.fr
 NEXT_PUBLIC_API_BAN_URL=https://plateforme.adresse.data.gouv.fr
-NEXT_PUBLIC_BAN_API_DEPOT=https://plateforme.adresse.data.gouv.fr/api-depot
+NEXT_PUBLIC_BAN_API_DEPOT=https://plateforme-bal.adresse.data.gouv.fr/api-depot
 NEXT_PUBLIC_PEERTUBE=https://peertube.adresse.data.gouv.fr
 PORT=3000

--- a/lib/ban-api-depot.js
+++ b/lib/ban-api-depot.js
@@ -1,4 +1,4 @@
-const BAN_API_DEPOT = process.env.NEXT_PUBLIC_BAN_API_DEPOT || 'https://plateforme.adresse.data.gouv.fr/api-depot'
+const BAN_API_DEPOT = process.env.NEXT_PUBLIC_BAN_API_DEPOT || 'https://plateforme-bal.adresse.data.gouv.fr/api-depot'
 
 async function request(url) {
   const res = await fetch(`${BAN_API_DEPOT}${url}`)


### PR DESCRIPTION
## Contexte
Les appels vers l'API dépôt sont aujourd'hui redirigés de https://plateforme.adresse.data.gouv.fr/api-depot vers https://plateforme-bal.adresse.data.gouv.fr/api-depot.

## Évolution
Cette PR met à jour la variable d'environnement et l'URL de fallback pour pointer directement vers la nouvelle URL https://plateforme-bal.adresse.data.gouv.fr/api-depot
