### PR TITLE
Déplace les fonctions de publication d'une BAL dans un hook dédié

### DIFF
--- a/contexts/bal-data.js
+++ b/contexts/bal-data.js
@@ -37,7 +37,7 @@ export const BalDataContextProvider = React.memo(({
 
   const {token} = useContext(TokenContext)
 
-  const [habilitation, reloadHabilitation, isHabilitationValid, habilitationIsLoading] = useHabilitation(initialBaseLocale, token)
+  const [habilitation, reloadHabilitation, isHabilitationValid, habilitationIsLoading, isHabilitationDisplayed, setIsHabilitationDisplayed] = useHabilitation(initialBaseLocale, token)
 
   const reloadParcelles = useCallback(async () => {
     const parcelles = await getParcelles(baseLocale._id)
@@ -177,7 +177,9 @@ export const BalDataContextProvider = React.memo(({
     setVoie,
     setToponyme,
     certifyAllNumeros,
-    habilitationIsLoading
+    habilitationIsLoading,
+    isHabilitationDisplayed,
+    setIsHabilitationDisplayed
   }), [
     isEditing,
     editingId,
@@ -208,7 +210,9 @@ export const BalDataContextProvider = React.memo(({
     certifyAllNumeros,
     isRefrehSyncStat,
     refreshBALSync,
-    habilitationIsLoading
+    habilitationIsLoading,
+    isHabilitationDisplayed,
+    setIsHabilitationDisplayed
   ])
 
   return (

--- a/hooks/habilitation.js
+++ b/hooks/habilitation.js
@@ -1,10 +1,13 @@
 import {useState, useCallback, useEffect, useRef} from 'react'
 import {toaster} from 'evergreen-ui'
+import {useRouter} from 'next/router'
 
 import {getHabilitation} from '@/lib/bal-api'
 
 export default function useHabilitation(baseLocale, token) {
+  const {query} = useRouter()
   const [habilitation, setHabilitation] = useState(null)
+  const [isHabilitationDisplayed, setIsHabilitationDisplayed] = useState(query['france-connect'] === '1')
   const [isValid, setIsValid] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
 
@@ -53,7 +56,7 @@ export default function useHabilitation(baseLocale, token) {
     }
   }, [baseLocale._id, token, handleInvalidHabilitation])
 
-  useEffect(async () => {
+  useEffect(() => {
     async function handleReloadHabilitation() {
       setIsLoading(true)
       await reloadHabilitation()
@@ -63,5 +66,5 @@ export default function useHabilitation(baseLocale, token) {
     handleReloadHabilitation()
   }, [token, reloadHabilitation])
 
-  return [habilitation, reloadHabilitation, isValid, isLoading]
+  return [habilitation, reloadHabilitation, isValid, isLoading, isHabilitationDisplayed, setIsHabilitationDisplayed]
 }

--- a/hooks/publish-process.js
+++ b/hooks/publish-process.js
@@ -1,0 +1,95 @@
+import {useState, useContext} from 'react'
+import {toaster} from 'evergreen-ui'
+
+import {createHabilitation, sync, updateBaseLocale} from '@/lib/bal-api'
+import {getBANCommune} from '@/lib/api-ban'
+import BalDataContext from '@/contexts/bal-data'
+import TokenContext from '@/contexts/token'
+
+export default function usePublishProcess(commune) {
+  const [massDeletionConfirm, setMassDeletionConfirm] = useState()
+
+  const {
+    baseLocale,
+    habilitation,
+    reloadBaseLocale,
+    reloadHabilitation,
+    isHabilitationValid,
+    setIsHabilitationDisplayed
+  } = useContext(BalDataContext)
+  const {token} = useContext(TokenContext)
+
+  const checkMassDeletion = async () => {
+    try {
+      const communeBAN = await getBANCommune(commune.code)
+      return (baseLocale.nbNumeros / communeBAN.nbNumeros) * 100 <= 50
+    } catch (error) {
+      toaster.danger('Impossible de récupérer les données de la Base Adresse Nationale', {
+        description: error
+      })
+
+      return false
+    }
+  }
+
+  const updateStatus = async status => {
+    const updated = await updateBaseLocale(baseLocale._id, {status}, token)
+    await reloadBaseLocale()
+
+    return updated
+  }
+
+  const handleChangeStatus = async status => {
+    const isMassDeletionDetected = await checkMassDeletion()
+    if (status === 'ready-to-publish' && isMassDeletionDetected) {
+      setMassDeletionConfirm(() => (async () => {
+        const updated = await updateStatus(status)
+        setIsHabilitationDisplayed(updated)
+      }))
+    } else {
+      return updateStatus(status)
+    }
+  }
+
+  const handleShowHabilitationProcess = async () => {
+    let isReadyToPublish = ['published', 'ready-to-publish', 'replaced'].includes(baseLocale.status)
+
+    if (baseLocale.status === 'draft') {
+      const updated = await handleChangeStatus('ready-to-publish')
+      isReadyToPublish = Boolean(updated)
+    }
+
+    if (isReadyToPublish && (!habilitation || !isHabilitationValid) && !commune.isCOM) {
+      const habilitation = await createHabilitation(token, baseLocale._id)
+
+      if (habilitation) {
+        await reloadHabilitation()
+      }
+    }
+
+    setIsHabilitationDisplayed(isReadyToPublish)
+  }
+
+  const handleSync = async () => {
+    await sync(baseLocale._id, token)
+    await reloadBaseLocale()
+  }
+
+  const handlePublication = async () => {
+    const isMassDeletionDetected = await checkMassDeletion()
+
+    if (isMassDeletionDetected) {
+      setMassDeletionConfirm(() => handleSync)
+    } else {
+      await handleSync()
+    }
+  }
+
+  return {
+    massDeletionConfirm,
+    setMassDeletionConfirm,
+    handleChangeStatus,
+    handleShowHabilitationProcess,
+    handlePublication
+  }
+}


### PR DESCRIPTION
# Contexte

Dans le cadre du chantier sur le panneau d'information, nous avons besoin mutualiser les fonctions de publication d'une BAL entre plusieurs composants.

# Refacto

Il s'agit déplacer les fonctions qui gèrent la publication d'une BAL dans le hook usePublishProcess

# A tester

S'assurer qu'il n'y ait pas de régression sur les fonctionnalités actuelles