### PR TITLE
Supprime le zoom sur la commune quand on navigue sur une page voie ou toponyme qui n'a pas de position

### DIFF
--- a/components/map/hooks/bounds.js
+++ b/components/map/hooks/bounds.js
@@ -39,9 +39,7 @@ function useBounds(commune, voie, toponyme) {
         features: geojsonFeatures.current.filter(feature => feature.properties.idVoie === voieId)
       }
     }
-
-    return commune.contour // Fallback when voie has no position or numeros
-  }, [commune])
+  }, [])
 
   const getToponymeBounds = useCallback(toponymeId => {
     let features
@@ -59,9 +57,7 @@ function useBounds(commune, voie, toponyme) {
         features
       }
     }
-
-    return commune.contour // Fallback when toponyme has no position or numeros
-  }, [toponyme, commune])
+  }, [toponyme])
 
   useEffect(() => { // Get bounds on page load
     let data


### PR DESCRIPTION
# Contexte :

https://github.com/orgs/BaseAdresseNationale/projects/5/views/1?pane=issue&itemId=29249893

Issue :
https://github.com/BaseAdresseNationale/mes-adresses/issues/789