### PR TITLE
disbaled page dashboard

### DIFF
--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -38,7 +38,13 @@ function Index({basesLocales, basesLoclesStats}) {
   )
 }
 
-Index.getInitialProps = async () => {
+Index.getInitialProps = async ({res}) => {
+  if (res) {
+    res.statusCode = 404
+    res.end('Not found')
+    return
+  }
+
   const basesLocales = await getBasesLocales()
   const basesLoclesStats = await getBasesLocalesStats()
   const basesLocalesWithoutDemo = basesLocales.filter((b => b.status !== 'demo'))

--- a/pages/dashboard/departement.js
+++ b/pages/dashboard/departement.js
@@ -73,7 +73,13 @@ function Departement({departement, filteredCommunesInBAL, basesLocalesDepartemen
   )
 }
 
-Departement.getInitialProps = async ({query}) => {
+Departement.getInitialProps = async ({res, query}) => {
+  if (res) {
+    res.statusCode = 404
+    res.end('Not found')
+    return
+  }
+
   const {codeDepartement} = query
 
   const departement = await getDepartement(codeDepartement)


### PR DESCRIPTION
## Context

Comme la route /couverture-tiles/:z/:x/:y.pbf contient toutes les geojson de toute les communes de france et qu'il y a plusieurs instance de mes-adresses-api en prod, cela fait exploser la RAM

Exemple après connection a la page https://mes-adresses.data.gouv.fr//dashboard

<img width="1452" alt="Capture d’écran 2023-08-02 à 14 32 39" src="https://github.com/BaseAdresseNationale/mes-adresses-api/assets/8143924/cc23028d-b9b9-41d2-9dc6-c615cdf59518">

## Fix

Désactivation de la route /couverture-tiles/:z/:x/:y.pbf avant fix final
