### PR TITLE
Correct bug editable marker not working

### DIFF
--- a/components/map/editable-marker.js
+++ b/components/map/editable-marker.js
@@ -65,13 +65,11 @@ function EditableMarker({size, style, idVoie, isToponyme, viewport}) {
   }, [markers, updateMarker, suggestedMarkerNumero, setSuggestedNumero])
 
   const onDrag = useCallback((event, idx) => {
-    if (idx === 0) {
-      const {_id, type} = markers[idx]
-      const coords = [event.lngLat.lng, event.lngLat.lat]
-      const suggestion = computeSuggestedNumero(coords)
-      setSuggestedMarkerNumero(suggestion)
-      updateMarker(_id, {longitude: event.lngLat.lng, latitude: event.lngLat.lat, type})
-    }
+    const {_id, type} = markers[idx]
+    const coords = [event.lngLat.lng, event.lngLat.lat]
+    const suggestion = computeSuggestedNumero(coords)
+    setSuggestedMarkerNumero(suggestion)
+    updateMarker(_id, {longitude: event.lngLat.lng, latitude: event.lngLat.lat, type})
   }, [setSuggestedMarkerNumero, computeSuggestedNumero, markers, updateMarker])
 
   useEffect(() => {


### PR DESCRIPTION
## Context

Lors de l'édition de la deuxième position d'un numéro, les coordonées de cette dernière n'était modifiable sur la map.