### PR TITLE
Add button habilitation when status is waiting-habilitation

### DIFF
--- a/components/sub-header/bal-status/index.js
+++ b/components/sub-header/bal-status/index.js
@@ -1,6 +1,8 @@
 import PropTypes from "prop-types";
 import { Pane, Button } from "evergreen-ui";
 
+import usePublishProcess from '@/hooks/publish-process'
+
 import { pauseSync, resumeSync } from "@/lib/bal-api";
 
 import StatusBadge from "@/components/status-badge";
@@ -17,6 +19,10 @@ function BALStatus({
   handleHabilitation,
   reloadBaseLocale,
 }) {
+  const {
+    handleShowHabilitationProcess,
+  } = usePublishProcess(commune)
+
   const handlePause = async () => {
     await pauseSync(baseLocale._id, token);
     await reloadBaseLocale();
@@ -53,7 +59,18 @@ function BALStatus({
             isHabilitationValid={isHabilitationValid}
           />
         ) : (
-          baseLocale.status === "draft" && (
+          <>
+          {baseLocale.status === "published" && baseLocale.sync?.status == 'outdated' && !isHabilitationValid && (
+            <Button
+              marginRight={8}
+              height={24}
+              appearance="primary"
+              onClick={handleShowHabilitationProcess}
+            >
+              Habiliter la BAL
+            </Button>
+          )}
+          {baseLocale.status === "draft" && (
             <Button
               marginRight={8}
               height={24}
@@ -62,7 +79,8 @@ function BALStatus({
             >
               Publier
             </Button>
-          )
+          )}
+          </>
         ))}
     </>
   );


### PR DESCRIPTION
## CONTEXT

Le status `en attente d'habilitation` est embrouillant pour les communes, elles ne savent pas quoi faire

## FONCTIONNALITE

Ajout d'un bouton `Habiliter la BAL` qui ouvre la popup d'habilitation lorsque le status est `en attente d'habilitation` a coté du status

<img width="1149" alt="Capture d’écran 2024-01-16 à 14 27 24" src="https://github.com/BaseAdresseNationale/mes-adresses/assets/8143924/d9572cd6-be13-4c27-9a34-f55615c17bde">
