### PR TITLE
feat: mode pause

### DIFF
--- a/components/habilitation-process/index.tsx
+++ b/components/habilitation-process/index.tsx
@@ -53,7 +53,7 @@ function HabilitationProcess({
   const [isConflicted, setIsConflicted] = useState(false);
   const [isLoadingPublish, setIsLoadingPublish] = useState(false);
 
-  const { reloadHabilitation } = useContext(BalDataContext);
+  const { reloadHabilitation, reloadBaseLocale } = useContext(BalDataContext);
 
   const sendCode = async () =>
     HabilitationService.sendPinCodeHabilitation(baseLocale._id);
@@ -120,6 +120,7 @@ function HabilitationProcess({
     }
 
     await reloadHabilitation();
+    await reloadBaseLocale();
 
     setIsLoading(false);
   };

--- a/components/habilitation-process/index.tsx
+++ b/components/habilitation-process/index.tsx
@@ -14,7 +14,11 @@ import ValidateAuthentication from "@/components/habilitation-process/validate-a
 import StrategySelection from "@/components/habilitation-process/strategy-selection";
 import AcceptedDialog from "@/components/habilitation-process/accepted-dialog";
 import RejectedDialog from "@/components/habilitation-process/rejected-dialog";
-import { BaseLocale, HabilitationService } from "@/lib/openapi";
+import {
+  BaseLocale,
+  BasesLocalesService,
+  HabilitationService,
+} from "@/lib/openapi";
 import { CommuneType } from "@/types/commune";
 
 function getStep(habilitation) {
@@ -116,6 +120,10 @@ function HabilitationProcess({
       });
     } else if (validated) {
       checkConflictingRevision();
+      // SET RESUME BAL IF HABILITATION CODE
+      if (baseLocale.sync?.isPaused == true) {
+        await BasesLocalesService.resumeBaseLocale(baseLocale._id);
+      }
       setStep(2);
     }
 

--- a/contexts/bal-data.tsx
+++ b/contexts/bal-data.tsx
@@ -25,6 +25,7 @@ import {
 import TokenContext from "@/contexts/token";
 import useHabilitation from "@/hooks/habilitation";
 import { ChildrenProps } from "@/types/context";
+import { useRouter } from "next/router";
 
 interface BALDataContextType {
   isEditing: boolean;
@@ -79,6 +80,7 @@ export function BalDataContextProvider({
   initialNumeros,
   ...props
 }: BalDataContextProviderProps) {
+  const { query } = useRouter();
   const [isEditing, setIsEditing] = useState<boolean>(false);
   const [editingId, _setEditingId] = useState<string>(null);
   const [parcelles, setParcelles] = useState<Array<string>>([]);
@@ -230,6 +232,17 @@ export function BalDataContextProvider({
     reloadParcelles();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  useEffect(() => {
+    async function resumeBal() {
+      await BasesLocalesService.resumeBaseLocale(baseLocale._id);
+      await reloadBaseLocale();
+    }
+    // SET RESUME BAL IF HABILITATION FRANCE_CONNECT
+    if (query["france-connect"] === "1" && habilitation?.status === HabilitationDTO.status.ACCEPTED && baseLocale.sync?.isPaused == true) {
+      resumeBal();
+    }
+  }, [baseLocale._id, baseLocale.sync?.isPaused, habilitation?.status, query, reloadBaseLocale]);
 
   const value = useMemo(
     () => ({

--- a/lib/statuses.ts
+++ b/lib/statuses.ts
@@ -39,6 +39,16 @@ const STATUSES: { [key: string]: StatusType } = {
     intent: "danger",
     icon: ErrorIcon,
   },
+  "waiting-habilitation": {
+    label: "En attente d'habilitation",
+    title:
+      "Cette Base Adresse Locale a besoin d'une habilitation pour alimenter la Base Adresse Nationale",
+    content:
+      "De nouvelles modifications ont été détectées mais vous n'êtes pas habilité, les modifications ne seront pas répercutées dans la Base Adresse Nationale.",
+    color: "yellow",
+    intent: "none",
+    icon: TimeIcon,
+  },
   paused: {
     label: "Suspendue",
     title:
@@ -82,16 +92,6 @@ const STATUSES: { [key: string]: StatusType } = {
     intent: "danger",
     icon: LabTestIcon,
   },
-  "waiting-habilitation": {
-    label: "En attente d'habilitation",
-    title:
-      "Cette Base Adresse Locale a besoin d'une habilitation pour alimenter la Base Adresse Nationale",
-    content:
-      "De nouvelles modifications ont été détectées mais vous n'êtes pas habilité, les modifications ne seront pas répercutées dans la Base Adresse Nationale.",
-    color: "yellow",
-    intent: "none",
-    icon: TimeIcon,
-  },
 };
 
 export function computeStatus(
@@ -106,15 +106,21 @@ export function computeStatus(
     return STATUSES.conflict;
   }
 
+  if (
+    balStatus === BaseLocale.status.PUBLISHED &&
+    sync.status === Sync.status.OUTDATED &&
+    !isHabilitationValid
+  ) {
+    return STATUSES["waiting-habilitation"];
+  }
+
   if (sync?.isPaused) {
     return STATUSES.paused;
   }
 
   if (balStatus === BaseLocale.status.PUBLISHED) {
-    if (sync.status === Sync.status.OUTDATED && !isHabilitationValid) {
-      return STATUSES["waiting-habilitation"];
-    }
     return STATUSES[sync.status];
   }
+
   return STATUSES[balStatus];
 }


### PR DESCRIPTION
## FONTIONNALITE

- Comme on active le mode `pause` lorsque l'habilitation est erroné, il faut que le èn attente d'habilitation` overwrite le status `pause`
- Lorsque que l'on valide une habilitation on reload la BAL pour vérifié si le `isPaused` a changé