### PR TITLE
fix: bug multi markers in metrique voie

### DIFF
--- a/components/map/editable-marker.tsx
+++ b/components/map/editable-marker.tsx
@@ -62,9 +62,11 @@ function EditableMarker({
   const onDrag = useCallback(
     (event, idx) => {
       const { _id, type } = markers[idx];
-      const coords = [event.lngLat.lng, event.lngLat.lat];
-      const suggestion = computeSuggestedNumero(coords);
-      setSuggestedNumero(suggestion);
+      if (idx === 0) {
+        const coords = [event.lngLat.lng, event.lngLat.lat];
+        const suggestion = computeSuggestedNumero(coords);
+        setSuggestedNumero(suggestion);
+      }
       updateMarker(_id, {
         longitude: event.lngLat.lng,
         latitude: event.lngLat.lat,

--- a/lib/utils/numero.ts
+++ b/lib/utils/numero.ts
@@ -1,7 +1,10 @@
 export const computeCompletNumero = (
-  numero: number | string,
+  numero: number | string | undefined,
   suffixe: string
 ) => {
+  if (!numero) {
+    return null;
+  }
   if (suffixe && Number.isNaN(suffixe)) {
     return `${numero}${suffixe.toLowerCase()}`;
   }


### PR DESCRIPTION
## FIX

- A la création, le numero change toujours lorsque l'on bouge une position supplémentaire sur les voie métrique
- A la création, le numero est marqué `undefined` sur la map