### PR TITLE
feat: decertifie all numeros

### DIFF
--- a/components/bal/certification-infos.tsx
+++ b/components/bal/certification-infos.tsx
@@ -24,9 +24,14 @@ interface CertificationInfosProps {
 }
 
 function CertificationInfos({ openRecoveryDialog }: CertificationInfosProps) {
-  const { certifyAllNumeros, baseLocale, reloadBaseLocale } =
-    useContext(BalDataContext);
-  const [isDialogShown, setIsDialogShown] = useState(false);
+  const {
+    certifyAllNumeros,
+    uncertifyAllNumeros,
+    baseLocale,
+    reloadBaseLocale,
+  } = useContext(BalDataContext);
+  const [isDialogCertifieShown, setIsDialogCertifieShown] = useState(false);
+  const [isDialogUncertifieShown, setIsDialogUncertifieShown] = useState(false);
   const [isInfosShown, setIsInfosShown] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const { nbNumeros, nbNumerosCertifies } = baseLocale;
@@ -39,86 +44,131 @@ function CertificationInfos({ openRecoveryDialog }: CertificationInfosProps) {
   }, [reloadBaseLocale]);
 
   const handleCertification = async () => {
-    setIsDialogShown(false);
+    setIsDialogCertifieShown(false);
     setIsInfosShown(false);
     setIsLoading(true);
     await certifyAllNumeros();
     setIsLoading(false);
   };
 
+  const handleUncertification = async () => {
+    setIsDialogUncertifieShown(false);
+    setIsInfosShown(false);
+    setIsLoading(true);
+    await uncertifyAllNumeros();
+    setIsLoading(false);
+  };
+
   const handleClose = () => {
-    setIsDialogShown(false);
+    setIsDialogUncertifieShown(false);
+    setIsDialogCertifieShown(false);
     setIsInfosShown(false);
   };
 
   return (
     <Pane backgroundColor="white" padding={8} borderRadius={10} margin={8}>
-      {!baseLocale.isAllCertified && (
-        <>
+      {!baseLocale.isAllCertified ? (
+        <Pane>
           <Heading>Nombre d’adresses certifiées</Heading>
-
           <ProgressBar percent={percentCertified} />
+        </Pane>
+      ) : (
+        <Pane display="flex" alignItems="center" marginY="1em" marginX="4px">
+          <EndorsedIcon color="success" size={50} />
+          <Text size={500} paddingLeft={20}>
+            Toutes les adresses sont certifiées par la commune
+          </Text>
+        </Pane>
+      )}
+      <Pane display="flex" justifyContent="center">
+        <Counter
+          label="Adresses certifiées"
+          value={nbNumerosCertifies}
+          color="#52BD95"
+        />
+        <Counter
+          label="Adresses non-certifiées"
+          value={nbNumeros - nbNumerosCertifies}
+          color="#c1c4d6"
+        />
+      </Pane>
 
-          <Pane display="flex" justifyContent="center">
-            <Counter
-              label="Adresses certifiées"
-              value={nbNumerosCertifies}
-              color="#52BD95"
-            />
-            <Counter
-              label="Adresses non-certifiées"
-              value={nbNumeros - nbNumerosCertifies}
-              color="#c1c4d6"
-            />
-          </Pane>
-
-          <Pane>
-            <Dialog
-              isShown={isDialogShown}
-              title="Certification des adresses"
-              onCloseComplete={handleClose}
-              footer={
-                <Pane>
-                  <Button onClick={handleClose}>Annuler</Button>
-                  <Button
-                    isLoading={isLoading}
-                    appearance="primary"
-                    iconAfter={EndorsedIcon}
-                    marginLeft={15}
-                    onClick={handleCertification}
-                  >
-                    Certifier
-                  </Button>
-                </Pane>
-              }
-            >
-              <Pane>
-                <Pane display="flex" alignItems="center">
-                  <WarningSignIcon size={65} margin={20} color="warning" />
-                  <Text size={500}>
-                    Vous vous apprêtez à certifier{" "}
-                    <b>{nbNumeros - nbNumerosCertifies}</b> adresses de votre
-                    commune, <b> cette action ne peut pas être annulée</b>
-                  </Text>
-                </Pane>
-              </Pane>
-            </Dialog>
-
-            <Pane textAlign="center">
+      <Pane>
+        <Dialog
+          isShown={isDialogCertifieShown}
+          title="Certification des adresses"
+          onCloseComplete={handleClose}
+          footer={
+            <Pane>
+              <Button onClick={handleClose}>Annuler</Button>
               <Button
-                iconBefore={LightbulbIcon}
-                iconAfter={isInfosShown ? ChevronUpIcon : ChevronDownIcon}
-                appearance="minimal"
-                onClick={() => {
-                  setIsInfosShown(!isInfosShown);
-                }}
+                isLoading={isLoading}
+                appearance="primary"
+                iconAfter={EndorsedIcon}
+                marginLeft={15}
+                onClick={handleCertification}
               >
-                En savoir plus sur la certification
+                Certifier
               </Button>
             </Pane>
+          }
+        >
+          <Pane>
+            <Pane display="flex" alignItems="center">
+              <WarningSignIcon size={65} margin={20} color="warning" />
+              <Text size={500}>
+                Vous vous apprêtez à certifier{" "}
+                <b>{nbNumeros - nbNumerosCertifies}</b> adresses de votre
+                commune, <b> cette action ne peut pas être annulée</b>
+              </Text>
+            </Pane>
           </Pane>
-        </>
-      )}
+        </Dialog>
+
+        <Dialog
+          isShown={isDialogUncertifieShown}
+          title="Décertification des adresses"
+          onCloseComplete={handleClose}
+          footer={
+            <Pane>
+              <Button onClick={handleClose}>Annuler</Button>
+              <Button
+                isLoading={isLoading}
+                appearance="primary"
+                intent="danger"
+                marginLeft={15}
+                onClick={handleUncertification}
+              >
+                Décertifier
+              </Button>
+            </Pane>
+          }
+        >
+          <Pane>
+            <Pane display="flex" alignItems="center">
+              <WarningSignIcon size={65} margin={20} color="warning" />
+              <Text size={500}>
+                Vous vous apprêtez à décertifier <b>{nbNumerosCertifies}</b>{" "}
+                adresses de votre commune,{" "}
+                <b> cette action ne peut pas être annulée</b>
+              </Text>
+            </Pane>
+          </Pane>
+        </Dialog>
+
+        <Pane textAlign="center">
+          <Button
+            iconBefore={LightbulbIcon}
+            iconAfter={isInfosShown ? ChevronUpIcon : ChevronDownIcon}
+            appearance="minimal"
+            onClick={() => {
+              setIsInfosShown(!isInfosShown);
+            }}
+          >
+            En savoir plus sur la certification
+          </Button>
+        </Pane>
+      </Pane>
 
       {isInfosShown && (
         <Pane paddingTop={15}>
@@ -157,32 +207,43 @@ function CertificationInfos({ openRecoveryDialog }: CertificationInfosProps) {
               </Text>
             </Pane>
             <Pane display="flex" justifyContent="end" paddingTop={15}>
-              <Button
-                isLoading={isLoading}
-                iconBefore={openRecoveryDialog && LockIcon}
-                intent="infos"
-                appearance="primary"
-                onClick={() => {
-                  if (openRecoveryDialog) {
-                    openRecoveryDialog();
-                  } else {
-                    setIsDialogShown(true);
-                  }
-                }}
-              >
-                Certifier mes adresses
-              </Button>
+              {baseLocale.nbNumerosCertifies > 0 && (
+                <Button
+                  isLoading={isLoading}
+                  iconBefore={openRecoveryDialog && LockIcon}
+                  intent="danger"
+                  appearance="primary"
+                  marginRight={5}
+                  onClick={() => {
+                    if (openRecoveryDialog) {
+                      openRecoveryDialog();
+                    } else {
+                      setIsDialogUncertifieShown(true);
+                    }
+                  }}
+                >
+                  Décertifier mes adresses
+                </Button>
+              )}
+              {!baseLocale.isAllCertified && (
+                <Button
+                  isLoading={isLoading}
+                  iconBefore={openRecoveryDialog && LockIcon}
+                  intent="infos"
+                  appearance="primary"
+                  onClick={() => {
+                    if (openRecoveryDialog) {
+                      openRecoveryDialog();
+                    } else {
+                      setIsDialogCertifieShown(true);
+                    }
+                  }}
+                >
+                  Certifier mes adresses
+                </Button>
+              )}
             </Pane>
           </Alert>
-        </Pane>
-      )}
-
-      {baseLocale.isAllCertified && (
-        <Pane display="flex" alignItems="center" marginY="1em" marginX="4px">
-          <EndorsedIcon color="success" size={50} />
-          <Text size={500} paddingLeft={20}>
-            Toutes les adresses sont certifiées par la commune
-          </Text>
         </Pane>
       )}
     </Pane>

--- a/contexts/bal-data.tsx
+++ b/contexts/bal-data.tsx
@@ -53,6 +53,7 @@ interface BALDataContextType {
   isRefrehSyncStat: boolean;
   refreshBALSync: () => Promise<void>;
   certifyAllNumeros: () => Promise<void>;
+  uncertifyAllNumeros: () => Promise<void>;
   habilitationIsLoading: boolean;
   isHabilitationProcessDisplayed: boolean;
   setIsHabilitationProcessDisplayed: (
@@ -206,6 +207,23 @@ export function BalDataContextProvider({
     refreshBALSync,
   ]);
 
+  const uncertifyAllNumeros = useCallback(async () => {
+    await BasesLocalesService.uncertifyAllNumeros(baseLocale._id);
+    await reloadNumeros();
+    await reloadVoies();
+    await reloadToponymes();
+    await reloadBaseLocale();
+
+    await refreshBALSync();
+  }, [
+    baseLocale._id,
+    reloadNumeros,
+    reloadVoies,
+    reloadToponymes,
+    reloadBaseLocale,
+    refreshBALSync,
+  ]);
+
   useEffect(() => {
     setVoie(initialVoie);
   }, [initialVoie]);
@@ -239,10 +257,20 @@ export function BalDataContextProvider({
       await reloadBaseLocale();
     }
     // SET RESUME BAL IF HABILITATION FRANCE_CONNECT
-    if (query["france-connect"] === "1" && habilitation?.status === HabilitationDTO.status.ACCEPTED && baseLocale.sync?.isPaused == true) {
+    if (
+      query["france-connect"] === "1" &&
+      habilitation?.status === HabilitationDTO.status.ACCEPTED &&
+      baseLocale.sync?.isPaused == true
+    ) {
       resumeBal();
     }
-  }, [baseLocale._id, baseLocale.sync?.isPaused, habilitation?.status, query, reloadBaseLocale]);
+  }, [
+    baseLocale._id,
+    baseLocale.sync?.isPaused,
+    habilitation?.status,
+    query,
+    reloadBaseLocale,
+  ]);
 
   const value = useMemo(
     () => ({
@@ -271,6 +299,7 @@ export function BalDataContextProvider({
       setVoie,
       setToponyme,
       certifyAllNumeros,
+      uncertifyAllNumeros,
       habilitationIsLoading,
       isHabilitationProcessDisplayed,
       setIsHabilitationProcessDisplayed,
@@ -301,6 +330,7 @@ export function BalDataContextProvider({
       reloadToponymes,
       toponyme,
       certifyAllNumeros,
+      uncertifyAllNumeros,
       isRefrehSyncStat,
       refreshBALSync,
       habilitationIsLoading,

--- a/lib/openapi/services/BasesLocalesService.ts
+++ b/lib/openapi/services/BasesLocalesService.ts
@@ -369,14 +369,32 @@ export class BasesLocalesService {
     }
 
     /**
+     * Uncertify all numeros in Bal
+     * @param baseLocaleId
+     * @returns any
+     * @throws ApiError
+     */
+    public static uncertifyAllNumeros(
+        baseLocaleId: string,
+    ): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'PUT',
+            url: '/v2/bases-locales/{baseLocaleId}/numeros/uncertify-all',
+            path: {
+                'baseLocaleId': baseLocaleId,
+            },
+        });
+    }
+
+    /**
      * Certify all numeros in Bal
      * @param baseLocaleId
-     * @returns BatchNumeroResponseDTO
+     * @returns any
      * @throws ApiError
      */
     public static certifyAllNumeros(
         baseLocaleId: string,
-    ): CancelablePromise<BatchNumeroResponseDTO> {
+    ): CancelablePromise<any> {
         return __request(OpenAPI, {
             method: 'PUT',
             url: '/v2/bases-locales/{baseLocaleId}/numeros/certify-all',


### PR DESCRIPTION
## Context

Lorsque l'on certifie toutes les adresses, si c'est une erreurs, il n'y a plus cas recréer la BAL

## Fonctionnalité 

Nouveau bouton dans l'accordion `en savoir plus sur la certification` pour décertifier toute la BAL

<img width="1094" alt="Capture d’écran 2024-06-24 à 16 20 17" src="https://github.com/BaseAdresseNationale/mes-adresses/assets/8143924/75f59d35-e3e3-4e3d-a65b-00d300935887">

<img width="1091" alt="Capture d’écran 2024-06-24 à 16 20 26" src="https://github.com/BaseAdresseNationale/mes-adresses/assets/8143924/8a5ac3a6-0c7e-4b25-bc99-be88cf6fb896">

## PR

- [ ] https://github.com/BaseAdresseNationale/mes-adresses-api/pull/464
