### PR TITLE
feat: button habilitation on bal card

### DIFF
--- a/components/base-locale-card/base-locale-card-content.tsx
+++ b/components/base-locale-card/base-locale-card-content.tsx
@@ -19,7 +19,12 @@ import LocalStorageContext from "@/contexts/local-storage";
 import RecoverBALAlert from "@/components/bal-recovery/recover-bal-alert";
 import CertificationCount from "@/components/certification-count";
 import HabilitationTag from "../habilitation-tag";
-import { ExtendedBaseLocaleDTO, HabilitationDTO } from "@/lib/openapi";
+import {
+  BaseLocale,
+  ExtendedBaseLocaleDTO,
+  HabilitationDTO,
+  BaseLocaleSync,
+} from "@/lib/openapi";
 import { CommuneApiGeoType } from "@/lib/geo-api/type";
 import LayoutContext from "@/contexts/layout";
 
@@ -220,17 +225,33 @@ function BaseLocaleCardContent({
           </Pane>
 
           {hasToken ? (
-            <Button
-              appearance="primary"
-              iconAfter={EditIcon}
-              marginLeft={8}
-              marginRight={8}
-              flexShrink={0}
-              onClick={onSelect}
-              disabled={!onSelect}
-            >
-              {isMobile ? "Gérer" : "Gérer les adresses"}
-            </Button>
+            <div>
+              {baseLocale.status === BaseLocale.status.PUBLISHED &&
+                baseLocale.sync?.status === BaseLocaleSync.status.OUTDATED &&
+                !isHabilitationValid && (
+                  <Button
+                    appearance="primary"
+                    marginLeft={8}
+                    marginRight={8}
+                    flexShrink={0}
+                    onClick={onSelect}
+                    disabled={!onSelect}
+                  >
+                    {isMobile ? "Habiliter" : "Habiliter la BAL"}
+                  </Button>
+                )}
+              <Button
+                appearance="primary"
+                iconAfter={EditIcon}
+                marginLeft={8}
+                marginRight={8}
+                flexShrink={0}
+                onClick={onSelect}
+                disabled={!onSelect}
+              >
+                {isMobile ? "Gérer" : "Gérer les adresses"}
+              </Button>
+            </div>
           ) : (
             <>
               <RecoverBALAlert

--- a/pages/bal/[balId]/index.tsx
+++ b/pages/bal/[balId]/index.tsx
@@ -26,13 +26,16 @@ import { CommuneType } from "@/types/commune";
 import { BaseEditorProps, getBaseEditorProps } from "@/layouts/editor";
 import BALRecoveryContext from "@/contexts/bal-recovery";
 import {
+  BaseLocale,
   BasesLocalesService,
+  BaseLocaleSync,
   Toponyme,
   Voie,
   VoiesService,
 } from "@/lib/openapi";
 import SignalementContext from "@/contexts/signalement";
 import LayoutContext from "@/contexts/layout";
+import usePublishProcess from "@/hooks/publish-process";
 
 interface BaseLocalePageProps {
   commune: CommuneType;
@@ -47,10 +50,12 @@ function BaseLocalePage({ commune }: BaseLocalePageProps) {
 
   const { token } = useContext(TokenContext);
   const { toaster } = useContext(LayoutContext);
-  const { voies, toponymes, baseLocale } = useContext(BalDataContext);
+  const { voies, toponymes, baseLocale, isHabilitationValid } =
+    useContext(BalDataContext);
   const { isMobile } = useContext(LayoutContext);
   const { reloadTiles } = useContext(MapContext);
   const { setIsRecoveryDisplayed } = useContext(BALRecoveryContext);
+  const { handleShowHabilitationProcess } = usePublishProcess(commune);
   const {
     refreshBALSync,
     reloadVoies,
@@ -63,6 +68,17 @@ function BaseLocalePage({ commune }: BaseLocalePageProps) {
   const { signalements } = useContext(SignalementContext);
 
   useHelp(selectedTabIndex);
+
+  useEffect(() => {
+    if (
+      token &&
+      baseLocale.status === BaseLocale.status.PUBLISHED &&
+      baseLocale.sync?.status === BaseLocaleSync.status.OUTDATED &&
+      !isHabilitationValid
+    ) {
+      handleShowHabilitationProcess();
+    }
+  }, [baseLocale.status, baseLocale.sync?.status, isHabilitationValid, token]);
 
   useEffect(() => {
     if (token) {


### PR DESCRIPTION
## CONTEXT

Les communes ne comprennent pas tjs qu'il faut cliquer sur `gérer les adresses` lorsque la BAL est `en attente d'habilitation`

## FONCTIONNALITE

- Ajout d'un bouton `habiliter la BAL`sur la card qui redirige sur la page /bal
- Sur la page /bal, ouvre automatiquement la popup d'habilitation si le status est en `waiting habilitation`

## RESULTAT

<img width="1296" alt="Capture d’écran 2024-08-20 à 16 25 34" src="https://github.com/user-attachments/assets/43bb7ce9-ac01-4fba-8f7c-a5de6c8e9e55">
