### PR TITLE
fix: bug token when change bal

### DIFF
--- a/components/base-locale-card/index.tsx
+++ b/components/base-locale-card/index.tsx
@@ -97,6 +97,7 @@ function BaseLocaleCard({
         setHabilitation(null);
         setIsHabilitationValid(false);
       }
+      Object.assign(OpenAPI, { TOKEN: null });
     };
 
     void fetchCommune();

--- a/contexts/token.tsx
+++ b/contexts/token.tsx
@@ -63,9 +63,12 @@ export function TokenContextProvider({
         addBalAccess(balId, _token);
         void Router.push(`/bal/${balId}`);
       } else {
-        const token: string = getBalToken(balId);
-        void verify(token);
+        const tokenStorage: string = getBalToken(balId);
+        void verify(tokenStorage);
       }
+    } else {
+      Object.assign(OpenAPI, { TOKEN: null });
+      setToken(null);
     }
   }, [verify, balId, _token, addBalAccess, getBalToken]);
 


### PR DESCRIPTION
## CONTEXT

Lorsque l'on est sur /bal/... qui est `en cours de mise a jour` et que l'on revient sur l'accueil

<img width="1119" alt="Capture d’écran 2024-08-21 à 17 25 17" src="https://github.com/user-attachments/assets/170bbdc5-25bc-4336-90ee-34c34e744933">

Et qu'on reclique sur la bal en question

<img width="1122" alt="Capture d’écran 2024-08-21 à 17 25 33" src="https://github.com/user-attachments/assets/5f7e06e6-099f-4981-8a35-ab21085f7609">

Celle ci est maintenant `en attente d'habilitation`

## EXPLICATION

Lorsque l'on retourne sur l'accueil, nous forcons le OpenApi.TOKEN (pour savoir si les bal sont habilité), le token est alors désynchro entre celui de OpenApi.TOKEN et du TokenContext.
Comme le Token du TokenContext n'a pas changé, le reloadHabilitation ce lance avec un OpenApi.TOKEN erroné, ce qui nous donne un une 403.

## RESOLUTION

On set le token de OpenApi.TOKEN et du TokenContext a null quand il n'y a pas de balId (dans la requète)
