### PR TITLE
fix: hide bal deleted with link /bal

### DIFF
--- a/layouts/editor.tsx
+++ b/layouts/editor.tsx
@@ -129,7 +129,7 @@ export async function getBaseEditorProps(
   balId: string
 ): Promise<BaseEditorProps> {
   const baseLocale: ExtendedBaseLocaleDTO =
-    await BasesLocalesService.findBaseLocale(balId);
+    await BasesLocalesService.findBaseLocale(balId, true);
 
   const communeExtras: CommuneExtraDTO = await CommuneService.findCommune(
     baseLocale.commune


### PR DESCRIPTION
## CONTEXT

On peut accéder a une BAL supprimé via le lien d'admin

## FIX

Ajouter query params dans la requète GET /bases_locales pour préciser que la BALs doit exister

<img width="1133" alt="Capture d’écran 2024-09-30 à 10 46 11" src="https://github.com/user-attachments/assets/77cbf752-b303-4efd-9635-1e701d32ce00">
