### PR TITLE
fix: bug commentaire voie

### DIFF
--- a/contexts/bal-data.tsx
+++ b/contexts/bal-data.tsx
@@ -59,6 +59,7 @@ interface BALDataContextType {
   setIsHabilitationProcessDisplayed: (
     isHabilitationProcessDisplayed: boolean
   ) => void;
+  reloadVoieNumeros: (voieId: string) => Promise<void>;
 }
 
 const BalDataContext = React.createContext<BALDataContextType | null>(null);
@@ -124,6 +125,11 @@ export function BalDataContextProvider({
       await BasesLocalesService.findBaseLocaleToponymes(baseLocale.id);
     setToponymes(toponymes);
   }, [baseLocale.id]);
+
+  const reloadVoieNumeros = useCallback(async (voieId: string) => {
+    const numeros: Numero[] = await VoiesService.findVoieNumeros(voieId);
+    setNumeros(numeros);
+  }, []);
 
   const reloadNumeros = useCallback(async () => {
     let numeros: Numero[];
@@ -306,6 +312,7 @@ export function BalDataContextProvider({
       habilitationIsLoading,
       isHabilitationProcessDisplayed,
       setIsHabilitationProcessDisplayed,
+      reloadVoieNumeros,
     }),
     [
       isEditing,
@@ -340,6 +347,7 @@ export function BalDataContextProvider({
       habilitationIsLoading,
       isHabilitationProcessDisplayed,
       setIsHabilitationProcessDisplayed,
+      reloadVoieNumeros,
     ]
   );
 

--- a/pages/bal/[balId]/voies/[idVoie].tsx
+++ b/pages/bal/[balId]/voies/[idVoie].tsx
@@ -18,7 +18,6 @@ import {
   VoieMetas,
   VoiesService,
 } from "@/lib/openapi-api-bal";
-// Import BALRecoveryContext from '@/contexts/bal-recovery'
 
 interface VoiePageProps {
   commune: CommuneType;
@@ -30,7 +29,8 @@ function VoiePage({ commune }: VoiePageProps) {
   useHelp(3);
 
   const { token } = useContext(TokenContext);
-  const { voie, setVoie, numeros, reloadNumeros } = useContext(BalDataContext);
+  const { voie, setVoie, numeros, reloadVoieNumeros } =
+    useContext(BalDataContext);
 
   useEffect(() => {
     async function addCommentsToVoies() {
@@ -44,7 +44,7 @@ function VoiePage({ commune }: VoiePageProps) {
 
     if (token) {
       addCommentsToVoies();
-      reloadNumeros();
+      reloadVoieNumeros(voie.id);
     }
   }, [token]);
 


### PR DESCRIPTION
Corrige deux bugs :
- Quand on est sur un toponyme et on clique sur une voie via la map, les numéros du toponyme sont gardés pour la voie.
https://www.loom.com/share/b5d22541251244b58159c4a4e6cbc854
- Le champ commentaire apparait vide pour les numéros
https://www.loom.com/share/f0d9199dd93a478ea27c9f3ef469a300