### PR TITLE
feat: add card recover access in onglet voies and toponymes

### DIFF
--- a/components/bal/toponymes-list.tsx
+++ b/components/bal/toponymes-list.tsx
@@ -16,6 +16,7 @@ import { normalizeSort } from "@/lib/normalize";
 
 import BalDataContext from "@/contexts/bal-data";
 import TokenContext from "@/contexts/token";
+import ReadOnlyInfos from "./read-only-infos";
 
 import DeleteWarning from "@/components/delete-warning";
 import {
@@ -100,33 +101,36 @@ function ToponymesList({
         }}
         onConfirm={handleRemove}
       />
-      <Pane
-        flexShrink={0}
-        elevation={0}
-        backgroundColor="white"
-        paddingX={16}
-        display="flex"
-        alignItems="center"
-        minHeight={50}
-      >
-        <Pane marginLeft="auto">
-          <Button
-            iconBefore={token ? AddIcon : LockIcon}
-            appearance="primary"
-            intent="success"
-            disabled={token && isEditing}
-            onClick={() => {
-              if (token) {
-                openForm();
-              } else {
-                openRecoveryDialog();
-              }
-            }}
-          >
-            Ajouter un toponyme
-          </Button>
+      {!token && (
+        <Pane flexShrink={0} elevation={0} backgroundColor="white">
+          <ReadOnlyInfos openRecoveryDialog={openRecoveryDialog} />
         </Pane>
-      </Pane>
+      )}
+      {token && (
+        <Pane
+          flexShrink={0}
+          elevation={0}
+          backgroundColor="white"
+          paddingX={16}
+          display="flex"
+          alignItems="center"
+          minHeight={50}
+        >
+          <Pane marginLeft="auto">
+            <Button
+              iconBefore={AddIcon}
+              appearance="primary"
+              intent="success"
+              disabled={token && isEditing}
+              onClick={() => {
+                openForm();
+              }}
+            >
+              Ajouter un toponyme
+            </Button>
+          </Pane>
+        </Pane>
+      )}
       <Table display="flex" flex={1} flexDirection="column" overflowY="auto">
         <Table.Head>
           <Table.SearchHeaderCell

--- a/components/bal/voies-list.tsx
+++ b/components/bal/voies-list.tsx
@@ -23,6 +23,7 @@ import TokenContext from "@/contexts/token";
 
 import CommentsContent from "@/components/comments-content";
 import DeleteWarning from "@/components/delete-warning";
+import ReadOnlyInfos from "./read-only-infos";
 
 import { ExtendedVoieDTO, VoiesService } from "@/lib/openapi-api-bal";
 import LayoutContext from "@/contexts/layout";
@@ -107,33 +108,36 @@ function VoiesList({
         onConfirm={handleRemove}
         isDisabled={isDisabled}
       />
-      <Pane
-        flexShrink={0}
-        elevation={0}
-        backgroundColor="white"
-        paddingX={16}
-        display="flex"
-        alignItems="center"
-        minHeight={50}
-      >
-        <Pane marginLeft="auto">
-          <Button
-            iconBefore={token ? AddIcon : LockIcon}
-            appearance="primary"
-            intent="success"
-            disabled={token && isEditing}
-            onClick={() => {
-              if (token) {
-                openForm();
-              } else {
-                openRecoveryDialog();
-              }
-            }}
-          >
-            Ajouter une voie
-          </Button>
+      {!token && (
+        <Pane flexShrink={0} elevation={0} backgroundColor="white">
+          <ReadOnlyInfos openRecoveryDialog={openRecoveryDialog} />
         </Pane>
-      </Pane>
+      )}
+      {token && (
+        <Pane
+          flexShrink={0}
+          elevation={0}
+          backgroundColor="white"
+          paddingX={16}
+          display="flex"
+          alignItems="center"
+          minHeight={50}
+        >
+          <Pane marginLeft="auto">
+            <Button
+              iconBefore={AddIcon}
+              appearance="primary"
+              intent="success"
+              disabled={token && isEditing}
+              onClick={() => {
+                openForm();
+              }}
+            >
+              Ajouter une voie
+            </Button>
+          </Pane>
+        </Pane>
+      )}
       <Table display="flex" flex={1} flexDirection="column" overflowY="auto">
         <Table.Head>
           <Table.SearchHeaderCell


### PR DESCRIPTION
## PROBLEME

On a eu quelque message au support de commune qui ne comprenait pas quand elles étaient en mode consultation et qui étaient perdus

## SOLUTION

Ajouter la card pour `Récupérer les accès`sur les onglets voies et toponymes

![Capture d’écran 2025-03-19 à 10 12 38](https://github.com/user-attachments/assets/f21e9ce8-6e86-40db-be53-1e96bafbf3d3)

![Capture d’écran 2025-03-19 à 10 12 43](https://github.com/user-attachments/assets/91c62e47-dbb0-4972-a6ff-0e05340398e1)
