### PR TITLE
feat: delete dependance api-geo to contour commune

### DIFF
--- a/components/map/hooks/bounds.ts
+++ b/components/map/hooks/bounds.ts
@@ -4,7 +4,7 @@ import type { Map } from "maplibre-gl";
 
 import BalDataContext from "@/contexts/bal-data";
 import { NextRouter } from "next/router";
-import { ExtendedBaseLocaleDTO, Toponyme, Voie } from "@/lib/openapi-api-bal";
+import { Toponyme, Voie } from "@/lib/openapi-api-bal";
 import { CommuneType } from "@/types/commune";
 
 function useBounds(
@@ -14,13 +14,7 @@ function useBounds(
   voie: Voie,
   toponyme: Toponyme
 ) {
-  const communeBbox: number[] = useMemo(
-    () => (commune.contour ? bbox(commune.contour) : null),
-    [commune.contour]
-  );
-
-  const [bounds, setBounds] = useState<number[]>(communeBbox);
-
+  const [bounds, setBounds] = useState<number[]>(commune.bbox);
   const { editingItem } = useContext(BalDataContext);
 
   const [wasCenteredOnCommuneOnce, setWasCenteredOnCommuneOnce] =
@@ -45,10 +39,10 @@ function useBounds(
     if (editingItem) {
       setBounds(bboxForItem(editingItem));
     } else if (!wasCenteredOnCommuneOnce) {
-      setBounds(communeBbox);
+      setBounds(commune.bbox);
       setWasCenteredOnCommuneOnce(true);
     }
-  }, [editingItem, wasCenteredOnCommuneOnce, map, bboxForItem, communeBbox]);
+  }, [editingItem, wasCenteredOnCommuneOnce, map, bboxForItem, commune.bbox]);
 
   useEffect(() => {
     const { idVoie, idToponyme } = router.query;

--- a/lib/openapi-api-bal/models/ExtendedBaseLocaleDTO.ts
+++ b/lib/openapi-api-bal/models/ExtendedBaseLocaleDTO.ts
@@ -25,7 +25,6 @@ export type ExtendedBaseLocaleDTO = {
     voies: Array<Voie>;
     toponymes: Array<Toponyme>;
     numeros: Array<Numero>;
-    bbox: Array<number>;
     nbNumeros: number;
     nbNumerosCertifies: number;
     isAllCertified: boolean;

--- a/lib/openapi-api-bal/models/ExtendedVoieDTO.ts
+++ b/lib/openapi-api-bal/models/ExtendedVoieDTO.ts
@@ -18,7 +18,7 @@ export type ExtendedVoieDTO = {
     typeNumerotation: ExtendedVoieDTO.typeNumerotation;
     centroid: Record<string, any>;
     trace: Record<string, any>;
-    bbox: Array<string>;
+    bbox: Array<number>;
     comment: string;
     baseLocale: BaseLocale;
     numeros: Array<Numero>;

--- a/lib/openapi-api-bal/models/Voie.ts
+++ b/lib/openapi-api-bal/models/Voie.ts
@@ -18,7 +18,7 @@ export type Voie = {
     typeNumerotation: Voie.typeNumerotation;
     centroid: Record<string, any>;
     trace: Record<string, any>;
-    bbox: Array<string>;
+    bbox: Array<number>;
     comment: string;
     baseLocale: BaseLocale;
     numeros: Array<Numero>;

--- a/pages/bal/[balId]/signalements/index.tsx
+++ b/pages/bal/[balId]/signalements/index.tsx
@@ -93,13 +93,10 @@ function SignalementsPage({
       return;
     }
 
-    const communeBbox: number[] = commune.contour
-      ? bbox(commune.contour)
-      : null;
-    if (communeBbox) {
+    if (commune.bbox) {
       const center = [
-        (communeBbox[0] + communeBbox[2]) / 2,
-        (communeBbox[1] + communeBbox[3]) / 2,
+        (commune.bbox[0] + commune.bbox[2]) / 2,
+        (commune.bbox[1] + commune.bbox[3]) / 2,
       ] as [number, number];
       map.flyTo({
         center,
@@ -108,7 +105,7 @@ function SignalementsPage({
         screenSpeed: 2,
       });
     }
-  }, [commune.contour, map]);
+  }, [commune.bbox, map]);
 
   useEffect(() => {
     if (isStyleLoaded) {

--- a/types/commune.ts
+++ b/types/commune.ts
@@ -1,5 +1,5 @@
 import { CommuneDTO } from "@/lib/openapi-api-bal";
 
 export type CommuneType = CommuneDTO & {
-  contour: { type: "Polygon"; coordinates: number[][][] };
+  bbox?: number[];
 };


### PR DESCRIPTION
## CONTEXT

Lorsque l'api-geo ne répond pas, cela fait planter mes-adresses car on ne récupère pas le contour dans la fonction `getBaseEditorProps` de `editor.tsx`.
De même on ne peut pas aller sur les BALs des ancienne commune

## FIX

Catch si l'api-geo ne répond pas et calculer la `bbox` par rapport au bbox des voies de la BAL

## PR

- [ ] https://github.com/BaseAdresseNationale/mes-adresses-api/pull/521