### PR TITLE
feat: identify parcelles that no exist

### DIFF
--- a/components/bal/numero-editor/select-parcelles.tsx
+++ b/components/bal/numero-editor/select-parcelles.tsx
@@ -32,6 +32,7 @@ function SelectParcelles({
     hoveredParcelles,
     handleHoveredParcelles,
     handleParcelles,
+    communeParcelles,
   } = useContext(ParcellesContext);
   const addressType = isToponyme ? "toponyme" : "numéro";
 
@@ -43,6 +44,15 @@ function SelectParcelles({
       setIsParcelleSelectionEnabled(false);
     };
   }, [setHighlightedParcelles, setIsParcelleSelectionEnabled]);
+
+  const computeColorParcelles = (parcelle: string, isHovered: boolean) => {
+    if (isHovered) {
+      return "red";
+    } else if (!communeParcelles.has(parcelle)) {
+      return "orange";
+    }
+    return "green";
+  };
 
   return (
     <Pane display="flex" flexDirection="column">
@@ -60,7 +70,7 @@ function SelectParcelles({
               <Badge
                 key={parcelle}
                 isInteractive
-                color={isHovered ? "red" : "green"}
+                color={computeColorParcelles(parcelle, isHovered)}
                 margin={4}
                 onClick={() => handleParcelles([parcelle])}
                 onMouseEnter={() => handleHoveredParcelles([parcelle])}

--- a/components/table-row/table-row-notifications.tsx
+++ b/components/table-row/table-row-notifications.tsx
@@ -1,4 +1,4 @@
-import { useContext } from "react";
+import { useContext, useMemo } from "react";
 import {
   Table,
   Position,
@@ -7,14 +7,17 @@ import {
   WarningSignIcon,
   CommentIcon,
   OfficeIcon,
+  ControlIcon,
 } from "evergreen-ui";
 import TokenContext from "@/contexts/token";
+import ParcellesContext from "@/contexts/parcelles";
 
 interface TableRowNotificationsProps {
   certification?: string;
   comment?: string | React.ReactNode;
   warning?: string;
   communeDeleguee?: string;
+  parcelles?: string[];
 }
 
 function TableRowNotifications({
@@ -22,8 +25,16 @@ function TableRowNotifications({
   comment,
   warning,
   communeDeleguee,
+  parcelles,
 }: TableRowNotificationsProps) {
   const { token } = useContext(TokenContext);
+  const { communeParcelles } = useContext(ParcellesContext);
+
+  const parcellesIsInCommune = useMemo(
+    () => parcelles?.every((parcelle) => communeParcelles.has(parcelle)),
+    [parcelles, communeParcelles]
+  );
+
   return (
     <>
       {communeDeleguee && (
@@ -45,6 +56,17 @@ function TableRowNotifications({
         <Table.TextCell flex="0 1 1" paddingLeft="8px" paddingRight="8px">
           <Tooltip content={certification} position={Position.BOTTOM}>
             <EndorsedIcon color="success" style={{ verticalAlign: "bottom" }} />
+          </Tooltip>
+        </Table.TextCell>
+      )}
+
+      {parcelles?.length > 0 && !parcellesIsInCommune && (
+        <Table.TextCell flex="0 1 1" paddingLeft="8px" paddingRight="8px">
+          <Tooltip
+            content="Une parcelle ne correspond pas"
+            position={Position.BOTTOM}
+          >
+            <ControlIcon color="warning" />
           </Tooltip>
         </Table.TextCell>
       )}

--- a/components/voie/numeros-list.tsx
+++ b/components/voie/numeros-list.tsx
@@ -333,6 +333,7 @@ function NumerosList({
                     : null
                 }
                 comment={numero.comment}
+                parcelles={numero.parcelles}
               />
 
               {isEditingEnabled && (

--- a/lib/api-cadastre.ts
+++ b/lib/api-cadastre.ts
@@ -1,0 +1,18 @@
+const API_CADASTRE =
+  process.env.NEXT_PUBLIC_API_CADASTRE_URL ||
+  "https://cadastre.data.gouv.fr/bundler";
+
+async function request(url) {
+  const res = await fetch(`${API_CADASTRE}${url}`);
+
+  if (!res.ok) {
+    const error = await res.json();
+    throw new Error(error.message);
+  }
+
+  return res.json();
+}
+
+export async function getGeoJsonCommuneParcelles(codeCommune) {
+  return request(`/cadastre-etalab/communes/${codeCommune}/geojson/parcelles`);
+}


### PR DESCRIPTION
## CONTEXT

Pouvoir identifier les numéro qui ont des parcelles qui n'existent plus

## FONCIOTNNALITE

- Fetch les parcelles de la commune dans ParcelleContext
- Sur la liste de numéro: ajouter une notif sur les numéros dont les parcelles n'existe plus
- Sur l'édition du numéro: Mettre la parcelle dui n'existe plus en orange par default (et non vert)