### PR TITLE
feat: add button convert toponyme in tooltip

### DIFF
--- a/components/table-row/table-row-notifications.tsx
+++ b/components/table-row/table-row-notifications.tsx
@@ -13,7 +13,7 @@ import TokenContext from "@/contexts/token";
 interface TableRowNotificationsProps {
   certification?: string;
   comment?: string | React.ReactNode;
-  warning?: string;
+  warning?: string | React.ReactNode;
   communeDeleguee?: string;
 }
 

--- a/pages/bal/[balId]/voies/index.tsx
+++ b/pages/bal/[balId]/voies/index.tsx
@@ -2,7 +2,6 @@ import { useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { sortBy } from "lodash";
 import {
   Table,
-  KeyTabIcon,
   Paragraph,
   Pane,
   AddIcon,
@@ -12,6 +11,7 @@ import {
   Tooltip,
   FilterIcon,
   FilterRemoveIcon,
+  Button,
 } from "evergreen-ui";
 import { useRouter } from "next/router";
 import NextLink from "next/link";
@@ -291,7 +291,11 @@ function VoiesPage({ baseLocale }: VoiesPageProps) {
                 }
                 warning={
                   voie.nbNumeros === 0
-                    ? "Cette voie ne contient aucun numéro"
+                    ? (<>
+                        <Text style={{ color: 'white' }}>Cette voie ne contient aucun numéro</Text>
+                        <br /><br />
+                        <Button onClick={() => setToConvert(voie.id)}>Convertir en toponyme</Button>
+                      </>)
                     : null
                 }
               />
@@ -307,17 +311,6 @@ function VoiesPage({ baseLocale }: VoiesPageProps) {
                   onRemove={() => {
                     setToRemove(voie.id);
                   }}
-                  extra={
-                    voie.nbNumeros === 0
-                      ? {
-                          callback: () => {
-                            setToConvert(voie.id);
-                          },
-                          icon: KeyTabIcon,
-                          text: "Convertir en toponyme",
-                        }
-                      : null
-                  }
                 />
               )}
 


### PR DESCRIPTION
## EXPLICATION

C'est impossible de deviner pour les utilisateur que lorsque qu'il y a marqué "Cette voie ne contient aucun numéro" qu'il faut cliquer sur les 3 points pour `convertir en toponyme`

## FONCTIONNALITE

- Ajout du Button `convertir en toponyme` directement dans le tooltip et suppression dans les 3 petits points

![Capture d’écran 2025-07-09 à 16 35 28](https://github.com/user-attachments/assets/f0c48aa2-46b3-468f-b73b-1d95191135ac)

