### PR TITLE
fix: percentage certified numero

### DIFF
--- a/components/bal/certification-infos.tsx
+++ b/components/bal/certification-infos.tsx
@@ -36,7 +36,7 @@ function CertificationInfos({ openRecoveryDialog }: CertificationInfosProps) {
   const [isLoading, setIsLoading] = useState(false);
   const { nbNumeros, nbNumerosCertifies } = baseLocale;
   const percentCertified =
-    nbNumeros > 0 ? Math.round((nbNumerosCertifies * 100) / nbNumeros) : 0;
+    nbNumeros > 0 ? Math.floor((nbNumerosCertifies * 100) / nbNumeros) : 0;
 
   // Reload base local when the tab is mounted to be sure to have the updated number
   // of certified adresses


### PR DESCRIPTION
## CONTEXT

Quand il manque un numero certifié, le pourcentage est quand même a 100%

<img width="500" height="514" alt="Capture d’écran 2025-08-18 à 15 51 07" src="https://github.com/user-attachments/assets/8486f2d8-dd2f-4803-80f2-a0efd6e9a643" />


Utilisation de Math.floor() plutot que Math.round()

<img width="503" height="705" alt="Capture d’écran 2025-08-18 à 15 51 11" src="https://github.com/user-attachments/assets/08b26f98-1d05-4029-a0cc-d6162fbef7ba" />
