### PR TITLE
feat: toponyme must have position

### DIFF
--- a/components/bal/position-editor.tsx
+++ b/components/bal/position-editor.tsx
@@ -97,7 +97,7 @@ function PositionEditor({
               <PositionItem
                 key={marker.id}
                 marker={marker}
-                isRemovable={isToponyme ? false : markers.length === 1}
+                isRemovable={markers.length === 1}
                 handleChange={updateMarker}
                 onRemove={removeMarker}
               />

--- a/components/bal/toponyme-editor.tsx
+++ b/components/bal/toponyme-editor.tsx
@@ -254,7 +254,9 @@ function ToponymeEditor({
 
         <FormInput ref={refs?.positions}>
           <PositionEditor
-            initialPositions={initialValue?.positions}
+            {...(initialValue?.positions.length > 0 && {
+              initialPositions: initialValue?.positions,
+            })}
             isToponyme
             validationMessage={getValidationMessage("positions")}
           />


### PR DESCRIPTION
## CONTEXT

Le toponymes sans position ne remonte pas dans la BAN, on ne veut donc plus de toponyme sans position

## FONCTIONNALITE

- Ajout automatique d'une position a l'ouverture d'un toponyme sans position
- Impossible de supprimer la position du toponyme si il y en a qu'une