### PR TITLE
fix: disbaled button sync during exec

### DIFF
--- a/components/sub-header/bal-status/ban-sync/sync-button.tsx
+++ b/components/sub-header/bal-status/ban-sync/sync-button.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import {
   Pane,
   Button,
@@ -7,46 +7,14 @@ import {
   PlayIcon,
   PauseIcon,
   AutomaticUpdatesIcon,
-  RefreshIcon,
 } from "evergreen-ui";
+
+import RefreshIconRotate from "../refresh-icon-rotate/refresh-icon-rotate";
 
 function SyncButtonIsLoading() {
   return (
     <Pane display="flex" alignItems="center">
-      Synchronisation en cours{" "}
-      <span>
-        <RefreshIcon size={16} />
-      </span>
-      <style jsx>{`
-        /* Safari 4.0 - 8.0 */
-        @-webkit-keyframes rotate {
-          0% {
-            -webkit-transform: rotate(0deg);
-          }
-          100% {
-            -webkit-transform: rotate(360deg);
-          }
-        }
-
-        /* Standard syntax */
-        @keyframes rotate {
-          0% {
-            -webkit-transform: rotate(0deg);
-          }
-          100% {
-            -webkit-transform: rotate(360deg);
-          }
-        }
-
-        span {
-          display: flex;
-          width: 16px;
-          height: 16px;
-          margin-left: 8px;
-          -webkit-animation: rotate 2s linear infinite; /* Safari */
-          animation: rotate 2s linear infinite;
-        }
-      `}</style>
+      Synchronisation en cours <RefreshIconRotate />
     </Pane>
   );
 }

--- a/components/sub-header/bal-status/refresh-icon-rotate/refresh-icon-rotate.module.css
+++ b/components/sub-header/bal-status/refresh-icon-rotate/refresh-icon-rotate.module.css
@@ -1,0 +1,28 @@
+/* Safari 4.0 - 8.0 */
+@-webkit-keyframes rotate {
+  0% {
+    -webkit-transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(360deg);
+  }
+}
+
+/* Standard syntax */
+@keyframes rotate {
+  0% {
+    -webkit-transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(360deg);
+  }
+}
+
+.rotateIcon {
+  display: flex;
+  width: 14px;
+  height: 14px;
+  margin-left: 8px;
+  -webkit-animation: rotate 2s linear infinite; /* Safari */
+  animation: rotate 2s linear infinite;
+}

--- a/components/sub-header/bal-status/refresh-icon-rotate/refresh-icon-rotate.tsx
+++ b/components/sub-header/bal-status/refresh-icon-rotate/refresh-icon-rotate.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { RefreshIcon } from "evergreen-ui";
+import styles from "./refresh-icon-rotate.module.css";
+
+function RefreshIconRotate() {
+  return (
+    <span className={styles.rotateIcon}>
+      <RefreshIcon size={14} />
+    </span>
+  );
+}
+
+export default React.memo(RefreshIconRotate);

--- a/components/sub-header/bal-status/refresh-sync-badge.tsx
+++ b/components/sub-header/bal-status/refresh-sync-badge.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { Pane, Badge, RefreshIcon } from "evergreen-ui";
+import { Pane, Badge } from "evergreen-ui";
+import RefreshIconRotate from "./refresh-icon-rotate/refresh-icon-rotate";
 
 function RefreshSyncBadge() {
   return (
@@ -11,41 +12,8 @@ function RefreshSyncBadge() {
       width="100%"
     >
       <Pane display="flex" alignItems="center">
-        Synchronisation en cours{" "}
-        <span>
-          <RefreshIcon size={14} />
-        </span>
+        Synchronisation en cours <RefreshIconRotate />
       </Pane>
-
-      <style jsx>{`
-        /* Safari 4.0 - 8.0 */
-        @-webkit-keyframes rotate {
-          0% {
-            -webkit-transform: rotate(0deg);
-          }
-          100% {
-            -webkit-transform: rotate(360deg);
-          }
-        }
-
-        /* Standard syntax */
-        @keyframes rotate {
-          0% {
-            -webkit-transform: rotate(0deg);
-          }
-          100% {
-            -webkit-transform: rotate(360deg);
-          }
-        }
-
-        span {
-          margin-left: 4px;
-          width: 14px;
-          height: 14px;
-          -webkit-animation: rotate 2s linear infinite; /* Safari */
-          animation: rotate 2s linear infinite;
-        }
-      `}</style>
     </Badge>
   );
 }


### PR DESCRIPTION
## Context

On peut appuyer plusieurs fois de suite sur le Button `mettre à jour` lorsque la BAL est outdated.
Le fix disabled le Button durant la requète et attend son retour avec une mini animation

<img width="553" height="451" alt="Capture d’écran 2025-10-27 à 12 00 36" src="https://github.com/user-attachments/assets/bae19cda-71ec-4d42-9caa-7f2d16075f7b" />
