### PR TITLE
feat: add tracking for bal settings

### DIFF
--- a/components/settings/fond-de-carte/fond-de-carte-field.tsx
+++ b/components/settings/fond-de-carte/fond-de-carte-field.tsx
@@ -80,6 +80,7 @@ function FondDeCarteField({
         value={initialValue.url}
         onChange={(e) => onChange("url", e.target.value)}
         marginBottom={8}
+        marginTop={8}
         placeholder="https://data.geopf.fr/wmts?SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER=ORTHOIMAGERY.ORTHOPHOTOS&STYLE=normal&FORMAT=image/jpeg&TILEMATRIXSET=PM&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}"
         validationMessage={
           errors?.["url"] == false && "L'url du fond de carte est invalide"

--- a/components/settings/index.tsx
+++ b/components/settings/index.tsx
@@ -1,5 +1,5 @@
 import { BaseLocale } from "@/lib/openapi-api-bal";
-import React, { useState } from "react";
+import React, { useContext, useState } from "react";
 import {
   TextInputField,
   Button,
@@ -17,6 +17,10 @@ import RenewTokenDialog from "../renew-token-dialog";
 import { ShareBALAccessDialog } from "./share/share-bal-access-dialog";
 import FondDeCarteList from "./fond-de-carte-list";
 import FondDeCarteDialog from "./fond-de-carte/fond-de-carte-dialog";
+import MatomoTrackingContext, {
+  MatomoEventAction,
+  MatomoEventCategory,
+} from "@/contexts/matomo-tracking";
 
 interface SettingsProps {
   baseLocale: BaseLocale;
@@ -26,6 +30,15 @@ interface SettingsProps {
 function Settings({ baseLocale, token }: SettingsProps) {
   const [showBALAccessDialog, setShowBALAccessDialog] = useState(false);
   const [showFondDeCarteDialog, setShowFondDeCarteDialog] = useState(false);
+  const { matomoTrackEvent } = useContext(MatomoTrackingContext);
+
+  const onShowBALAccessDialog = () => {
+    matomoTrackEvent(
+      MatomoEventCategory.SETTINGS,
+      MatomoEventAction[MatomoEventCategory.SETTINGS].SHARE_ACCESS
+    );
+    setShowBALAccessDialog(true);
+  };
 
   const {
     onSubmit,
@@ -86,7 +99,7 @@ function Settings({ baseLocale, token }: SettingsProps) {
           </Pane>
           <Button
             type="button"
-            onClick={() => setShowBALAccessDialog(true)}
+            onClick={onShowBALAccessDialog}
             width="fit-content"
             alignSelf="flex-end"
           >

--- a/contexts/matomo-tracking.tsx
+++ b/contexts/matomo-tracking.tsx
@@ -15,6 +15,7 @@ export enum MatomoEventCategory {
   GAMIFICATION = "Gamification",
   BAL_EDITOR = "Éditeur BAL",
   HOME_PAGE = "Page d'accueil",
+  SETTINGS = "Paramètres",
 }
 
 export const MatomoEventAction = {
@@ -49,6 +50,13 @@ export const MatomoEventAction = {
     SHOW_NEWS: "show_news",
     OPEN_BAL_WIDGET: "open_bal_widget",
     REGISTER_TO_WEBINAIRE: "register_to_webinaire",
+  },
+  [MatomoEventCategory.SETTINGS]: {
+    SHARE_ACCESS: "share_access",
+    ADD_ADMIN: "add_admin",
+    REMOVE_ADMIN: "remove_admin",
+    UPDATE_CUSTOM_MAP_STYLES: "update_custom_map_styles",
+    UPDATE_BAL_NAME: "update_bal_name",
   },
 };
 


### PR DESCRIPTION
Ajoute le tracking matomo sur les settings de l'éditeur BAL : 
Les nouveaux events traqués sont: 
    SHARE_ACCESS: "share_access",
    ADD_ADMIN: "add_admin",
    REMOVE_ADMIN: "remove_admin",
    UPDATE_CUSTOM_MAP_STYLES: "update_custom_map_styles",
    UPDATE_BAL_NAME: "update_bal_name",