### PR TITLE
feat: add creation demo BAL

### DIFF
--- a/src/components/demo-warning.tsx
+++ b/src/components/demo-warning.tsx
@@ -20,50 +20,11 @@ import { ExtendedBaseLocaleDTO } from "@/lib/openapi-api-bal";
 import LayoutContext from "@/contexts/layout";
 
 interface DemoWarningProps {
-  baseLocale: ExtendedBaseLocaleDTO;
-  communeName: string;
   isReadonly: boolean;
 }
 
-function DemoWarning({
-  baseLocale,
-  communeName,
-  isReadonly,
-}: DemoWarningProps) {
-  const [isShown, setIsShown] = useState(false);
-  const [isLoading, setIsLoading] = useState(false);
-  const [nom, setNom] = useState(`Adresses de ${communeName}`);
-  const [email, onEmailChange] = useInput();
-  const [ref, setIsFocus] = useFocus();
-  const { isMobile, pushToast } = useContext(LayoutContext);
-
-  const { reloadBaseLocale } = useContext(BalDataContext);
-
-  const onSubmit = useCallback(
-    async (e) => {
-      e.preventDefault();
-      setIsLoading(true);
-
-      try {
-        await BasesLocalesService.updateBaseLocaleDemoToDraft(baseLocale.id, {
-          nom: nom ? nom.trim() : null,
-          email,
-        });
-
-        await reloadBaseLocale();
-      } catch (error: unknown) {
-        pushToast({
-          title: "Erreur",
-          message: "Impossible de conserver cette Base Adresse Locale",
-          intent: "danger",
-        });
-      }
-
-      setIsShown(false);
-      setIsLoading(false);
-    },
-    [baseLocale.id, email, nom, reloadBaseLocale, pushToast]
-  );
+function DemoWarning({ isReadonly }: DemoWarningProps) {
+  const { isMobile } = useContext(LayoutContext);
 
   return (
     <Pane
@@ -86,70 +47,6 @@ function DemoWarning({
         Cette Base Adresse Locale de démonstration sera supprimée d’ici 24
         heures sans modifications
       </Text>
-
-      <Dialog
-        isShown={isShown}
-        title="Sauvegarder mes modifications"
-        cancelLabel="Annuler"
-        intent="success"
-        isConfirmLoading={isLoading}
-        confirmLabel="Conserver"
-        hasFooter={false}
-        onCloseComplete={() => {
-          setIsShown(false);
-        }}
-        onOpenComplete={() => {
-          setIsFocus(true);
-        }}
-      >
-        <form onSubmit={onSubmit}>
-          <TextInputField
-            ref={ref}
-            required
-            autoComplete="new-password" // Hack to bypass chrome autocomplete
-            name="nom"
-            id="nom"
-            disabled={isLoading}
-            value={nom}
-            label="Nom de la Base Adresse Locale"
-            placeholder={communeName}
-            onChange={(e) => {
-              setNom(e.target.value as string);
-            }}
-          />
-
-          <TextInputField
-            required
-            type="email"
-            name="email"
-            id="email"
-            disabled={isLoading}
-            value={email}
-            label="Votre adresse email"
-            placeholder="nom@example.com"
-            onChange={onEmailChange}
-          />
-          <Button
-            appearance="primary"
-            intent="success"
-            isLoading={isLoading}
-            type="submit"
-          >
-            Sauvegarder
-          </Button>
-        </form>
-      </Dialog>
-
-      <Button
-        height={24}
-        marginX=".5em"
-        width="fit-content"
-        onClick={() => {
-          setIsShown(true);
-        }}
-      >
-        Je souhaite la conserver
-      </Button>
     </Pane>
   );
 }

--- a/src/components/new/commune-publication-infos.tsx
+++ b/src/components/new/commune-publication-infos.tsx
@@ -1,7 +1,7 @@
 import { ApiDepotService } from "@/lib/api-depot";
 import { Revision } from "@/lib/api-depot/types";
 import { CommuneType } from "@/types/commune";
-import { Button, Link, Pane, Spinner, Text } from "evergreen-ui";
+import { Button, LabTestIcon, Link, Pane, Spinner, Text } from "evergreen-ui";
 import { useEffect, useState } from "react";
 import AlertPublishedBALMesAdresses from "./alert-published-bal/alert-published-bal-mes-adresses";
 import AlertPublishedBALMoissoneur from "./alert-published-bal/alert-published-bal-moissoneur";
@@ -16,7 +16,7 @@ interface CommunePublicationInfosProps {
   commune: CommuneType;
   outdatedApiDepotClients: string[];
   outdatedHarvestSources: string[];
-  onCreateNewBAL: () => void;
+  onCreateNewBAL: (isDemoForce?: boolean) => void;
 }
 
 function CommunePublicationInfos({
@@ -118,13 +118,27 @@ function CommunePublicationInfos({
               Créer une nouvelle Base Adresse Locale
             </Button>
           ) : (
-            <Text is="div" color="muted" marginTop={16}>
-              Si vous rencontrer un problème vous pouvez contacter notre
-              support:{" "}
-              <Link href="mailto:adresse@data.gouv.fr">
-                adresse@data.gouv.fr
-              </Link>
-            </Text>
+            <>
+              <Text is="div" color="muted" marginTop={16}>
+                Si vous rencontrer un problème vous pouvez contacter notre
+                support:{" "}
+                <Link href="mailto:adresse@data.gouv.fr">
+                  adresse@data.gouv.fr
+                </Link>
+              </Text>
+              <Button
+                marginTop={32}
+                intent="none"
+                onClick={onCreateNewBAL}
+                iconAfter={LabTestIcon}
+              >
+                Créer une Base Adresse Locale de démonstration
+              </Button>
+              <Text is="div" color="muted" marginTop={8}>
+                Cette BAL ne pourra jamais être publiée et ne sera pas
+                sauvegardée
+              </Text>
+            </>
           )}
         </>
       )}

--- a/src/components/new/index.tsx
+++ b/src/components/new/index.tsx
@@ -46,6 +46,7 @@ export default function NewPageComponent({
   const [balName, setBalName] = useState<string | null>(null);
   const [adminEmails, setAdminEmails] = useState<string[]>([]);
   const [newEmailInput, setNewEmailInput] = useState("");
+  const [forceDemoMode, setForceDemoMode] = useState<boolean | null>(false);
   const [isDemoMode, setIsDemoMode] = useState(false);
   const { importFromCSVFile, importFromBAN } = useBALDataImport();
   const router = useRouter();
@@ -181,7 +182,11 @@ export default function NewPageComponent({
             <Pane flex={1} display="flex" flexDirection="column">
               {currentStepIndex === 0 && (
                 <SearchCommuneStep
-                  onCreateNewBAL={onNextStep}
+                  onCreateNewBAL={(isDemoMode?: boolean) => {
+                    setForceDemoMode(Boolean(isDemoMode));
+                    setIsDemoMode(Boolean(isDemoMode));
+                    onNextStep();
+                  }}
                   commune={commune}
                   setCommune={setCommune}
                   outdatedApiDepotClients={outdatedApiDepotClients}
@@ -208,6 +213,7 @@ export default function NewPageComponent({
                   isLoading={isLoading}
                   isDemoMode={isDemoMode}
                   setIsDemoMode={setIsDemoMode}
+                  forceDemoMode={forceDemoMode}
                 />
               )}
               {currentStepIndex !== 0 && (

--- a/src/components/new/steps/bal-infos-step.tsx
+++ b/src/components/new/steps/bal-infos-step.tsx
@@ -20,6 +20,7 @@ interface BALInfosStepProps {
   isLoading?: boolean;
   isDemoMode: boolean;
   setIsDemoMode: React.Dispatch<React.SetStateAction<boolean>>;
+  forceDemoMode: boolean;
 }
 
 function BALInfosStep({
@@ -32,6 +33,7 @@ function BALInfosStep({
   isLoading,
   isDemoMode,
   setIsDemoMode,
+  forceDemoMode,
 }: BALInfosStepProps) {
   return (
     <Pane>
@@ -46,19 +48,21 @@ function BALInfosStep({
           onChange={(e) => setBalName(e.target.value)}
           disabled={isLoading}
         />
-        <FormField
-          display="flex"
-          marginBottom={24}
-          label="Créer un Base locale de Demo ?"
-          description="Elle ne sera pas sauvegardée."
-        >
-          <Switch
-            marginLeft={8}
-            checked={isDemoMode}
-            onChange={() => setIsDemoMode(!isDemoMode)}
-          />
-        </FormField>
-        {!isDemoMode ? (
+        {!forceDemoMode && (
+          <FormField
+            display="flex"
+            marginBottom={24}
+            label="Créer un Base locale de Demo ?"
+            description="Cette BAL ne pourra jamais être publiée et ne sera pas sauvegardée."
+          >
+            <Switch
+              marginLeft={8}
+              checked={isDemoMode}
+              onChange={() => setIsDemoMode(!isDemoMode)}
+            />
+          </FormField>
+        )}
+        {!forceDemoMode && !isDemoMode ? (
           <AdminEmailsField
             adminEmails={adminEmails}
             setAdminEmails={setAdminEmails}

--- a/src/components/new/steps/search-commune-step.tsx
+++ b/src/components/new/steps/search-commune-step.tsx
@@ -9,7 +9,7 @@ interface SearchCommuneStepProps {
   setCommune: (commune: CommuneType | null) => void;
   outdatedApiDepotClients: string[];
   outdatedHarvestSources: string[];
-  onCreateNewBAL: () => void;
+  onCreateNewBAL: (isDemoForce?: boolean) => void;
 }
 
 function SearchCommuneStep({

--- a/src/contexts/bal-data.tsx
+++ b/src/contexts/bal-data.tsx
@@ -144,8 +144,11 @@ export function BalDataContextProvider({
           initialBaseLocale.id
         );
         const commune = await getCommuneWithBBox(initialBaseLocale, voies);
-        if (!initialBaseLocale.settings.otherBalPublishedIgnored) {
-          await _setBalAlreadyPublished(commune.code);
+        if (
+          !initialBaseLocale.settings.otherBalPublishedIgnored &&
+          initialBaseLocale.status !== ExtendedBaseLocaleDTO.status.DEMO
+        ) {
+          _setBalAlreadyPublished(commune.code);
         }
         setVoies(voies);
         setToponymes(toponymes);

--- a/src/layouts/editor.tsx
+++ b/src/layouts/editor.tsx
@@ -126,13 +126,7 @@ function Editor({ children }: EditorProps) {
                 />
               )}
               {isReadonly && <ReadonlyWarning />}
-              {!isReadonly && isDemo && (
-                <DemoWarning
-                  baseLocale={baseLocale}
-                  communeName={commune.nom}
-                  isReadonly={isReadonly}
-                />
-              )}
+              {!isReadonly && isDemo && <DemoWarning isReadonly={isReadonly} />}
               {!isDemo && Boolean(otherBalIdPublished) && (
                 <AlreadyBalPublishedWarning
                   otherBalIdPublished={otherBalIdPublished}


### PR DESCRIPTION
## CONTEXT

- On remet la possibilité de créer une BAL de demo

<img width="1199" height="899" alt="Capture d’écran 2026-04-29 à 16 15 58" src="https://github.com/user-attachments/assets/06b9565e-fc25-4369-bbba-d1566e4a8e93" />


<img width="1289" height="693" alt="Capture d’écran 2026-04-29 à 16 16 04" src="https://github.com/user-attachments/assets/8e13c39b-6c61-41b5-843f-2542d2d247e3" />


- On enlève la possibilité de transformer une demo en brouillon

<img width="1915" height="971" alt="Capture d’écran 2026-04-29 à 16 15 44" src="https://github.com/user-attachments/assets/c178e829-b49f-422b-91e4-14531ced0982" />
