### PR TITLE
feat: prevent from update bal when other bal published

### DIFF
--- a/src/components/bal/bal-summary.tsx
+++ b/src/components/bal/bal-summary.tsx
@@ -9,6 +9,7 @@ import LanguagePreview from "../bal/language-preview";
 import TokenContext from "@/contexts/token";
 import BalDataContext from "@/contexts/bal-data";
 import { CommuneType } from "@/types/commune";
+import BALRecoveryContext from "@/contexts/bal-recovery";
 
 interface BALSummaryProps {
   baseLocale: ExtendedBaseLocaleDTO;
@@ -27,6 +28,7 @@ function BALSummary({
   communeFlag,
   onEditNomsAlt,
 }: BALSummaryProps) {
+  const { otherBalIdPublished } = useContext(BALRecoveryContext);
   const { token } = useContext(TokenContext);
   const { isEditing } = useContext(BalDataContext);
   const { nbNumeros } = baseLocale;
@@ -56,7 +58,7 @@ function BALSummary({
           />
           {commune.nom} - {commune.code}
         </Pane>
-        {!isEditing && token && (
+        {!isEditing && token && !Boolean(otherBalIdPublished) &&(
           <IconButton
             icon={EditIcon}
             marginTop={-4}

--- a/src/components/bal/bal-summary.tsx
+++ b/src/components/bal/bal-summary.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import { useContext } from "react";
 import { Heading, Pane, Text, IconButton, EditIcon } from "evergreen-ui";
 import {
   ExtendedBaseLocaleDTO,
@@ -58,7 +58,7 @@ function BALSummary({
           />
           {commune.nom} - {commune.code}
         </Pane>
-        {!isEditing && token && !Boolean(otherBalIdPublished) &&(
+        {!isEditing && token && !Boolean(otherBalIdPublished) && (
           <IconButton
             icon={EditIcon}
             marginTop={-4}

--- a/src/components/drawer-content.tsx
+++ b/src/components/drawer-content.tsx
@@ -25,7 +25,9 @@ function DrawerContent() {
   const isAdmin = Boolean(token);
 
   const tabs = [
-    ...(baseLocale.status !== BaseLocale.status.DEMO && isAdmin && !Boolean(otherBalIdPublished)
+    ...(baseLocale.status !== BaseLocale.status.DEMO &&
+    isAdmin &&
+    !Boolean(otherBalIdPublished)
       ? [
           {
             label: "Paramètres",

--- a/src/components/drawer-content.tsx
+++ b/src/components/drawer-content.tsx
@@ -12,8 +12,10 @@ import Settings from "@/components/settings";
 import Trash from "@/components/trash";
 import LayoutContext from "@/contexts/layout";
 import { BaseLocale } from "@/lib/openapi-api-bal";
+import BALRecoveryContext from "@/contexts/bal-recovery";
 
 function DrawerContent() {
+  const { otherBalIdPublished } = useContext(BALRecoveryContext);
   const { isMobile } = useContext(LayoutContext);
   const [selectedIndex, setSelectedIndex] = useState(0);
   const { drawerDisplayed, setDrawerDisplayed } = useContext(DrawerContext);
@@ -23,7 +25,7 @@ function DrawerContent() {
   const isAdmin = Boolean(token);
 
   const tabs = [
-    ...(baseLocale.status !== BaseLocale.status.DEMO && isAdmin
+    ...(baseLocale.status !== BaseLocale.status.DEMO && isAdmin && !Boolean(otherBalIdPublished)
       ? [
           {
             label: "Paramètres",
@@ -37,7 +39,7 @@ function DrawerContent() {
       key: "downloads",
       content: <Downloads baseLocale={baseLocale} />,
     },
-    ...(isAdmin
+    ...(isAdmin && !Boolean(otherBalIdPublished)
       ? [
           {
             label: "Corbeille",


### PR DESCRIPTION
## CONTEXT

Pour le moment, même si la BAL est en brouillon (avec une BAL published) on peut toujours modifier certains paramètre sur la BAL

- Bloqué l'édition du nom de la BAL
- Bloqué les paramètre et la corbeille 

<img width="1474" height="971" alt="Capture d’écran 2026-05-19 à 14 58 58" src="https://github.com/user-attachments/assets/4306904d-57a9-4475-b433-b6ce7059dbdb" />
